### PR TITLE
fix: exempt dashboard-internal endpoints from API key auth

### DIFF
--- a/packages/http-api/src/services/auth-service.ts
+++ b/packages/http-api/src/services/auth-service.ts
@@ -152,6 +152,15 @@ export class AuthService {
 			return false;
 		}
 
+		// Dashboard-internal endpoints used by the UI itself — exempt from auth
+		if (
+			path === "/api/version/check" ||
+			path === "/api/system/info" ||
+			path === "/api/system/package-manager"
+		) {
+			return true;
+		}
+
 		// Proxy endpoints (/v1/*, /messages/*, etc.) require authentication if enabled
 		if (path.startsWith("/v1") || path.startsWith("/messages")) {
 			return false;


### PR DESCRIPTION
## Summary

- `/api/version/check`, `/api/system/info`, and `/api/system/package-manager` are called by the dashboard UI itself
- When API key authentication is enabled, all three were returning `401` because they hit the catch-all `/api/*` block in `isPathExempt()` without being whitelisted first
- Dashboard showed "Check Failed" status and the version/package-manager widgets were broken

## Fix

Added an explicit exemption for these three paths in `auth-service.ts` before the `/api` catch-all:

```ts
// Dashboard-internal endpoints used by the UI itself — exempt from auth
if (
  path === "/api/version/check" ||
  path === "/api/system/info" ||
  path === "/api/system/package-manager"
) {
  return true;
}
```

## Test plan

- [ ] Enable API key authentication
- [ ] Open the dashboard — version status should show correctly (not "Check Failed")
- [ ] `GET /api/version/check` returns `{"version":"...","cached":false}` without an API key
- [ ] `GET /api/system/package-manager` returns package manager info without an API key
- [ ] All other `/api/*` endpoints still require authentication

Closes #77