### PR TITLE
fix: handle legacy request_payloads timestamp migration on SQLite

### DIFF
--- a/packages/database/src/migrations.test.ts
+++ b/packages/database/src/migrations.test.ts
@@ -37,6 +37,71 @@ describe("Database Migrations - Tier Column Removal", () => {
 		expect(columnNames).not.toContain("account_tier"); // Should not exist initially
 	});
 
+	it("should migrate legacy request_payloads tables before creating the timestamp index", () => {
+		// Simulate an older SQLite schema where request_payloads existed before the
+		// timestamp column was introduced.
+		db.exec(`
+			CREATE TABLE requests (
+				id TEXT PRIMARY KEY,
+				timestamp INTEGER NOT NULL,
+				method TEXT NOT NULL,
+				path TEXT NOT NULL,
+				account_used TEXT,
+				status_code INTEGER,
+				success BOOLEAN,
+				error_message TEXT,
+				response_time_ms INTEGER,
+				failover_attempts INTEGER DEFAULT 0,
+				model TEXT,
+				prompt_tokens INTEGER DEFAULT 0,
+				completion_tokens INTEGER DEFAULT 0,
+				total_tokens INTEGER DEFAULT 0,
+				cost_usd REAL DEFAULT 0,
+				output_tokens_per_second REAL,
+				input_tokens INTEGER DEFAULT 0,
+				cache_read_input_tokens INTEGER DEFAULT 0,
+				cache_creation_input_tokens INTEGER DEFAULT 0,
+				output_tokens INTEGER DEFAULT 0,
+				agent_used TEXT
+			);
+			CREATE TABLE request_payloads (
+				id TEXT PRIMARY KEY,
+				json TEXT NOT NULL,
+				FOREIGN KEY (id) REFERENCES requests(id) ON DELETE CASCADE
+			);
+		`);
+
+		db.prepare(
+			`INSERT INTO requests (id, timestamp, method, path, success, failover_attempts) VALUES (?, ?, ?, ?, ?, ?)`,
+		).run("req-1", 1_700_000_000_000, "POST", "/v1/messages", 1, 0);
+		db.prepare(`INSERT INTO request_payloads (id, json) VALUES (?, ?)`).run(
+			"req-1",
+			JSON.stringify({ request: { body: "test" } }),
+		);
+
+		expect(() => {
+			ensureSchema(db);
+			runMigrations(db);
+		}).not.toThrow();
+
+		const payloadColumns = db
+			.prepare("PRAGMA table_info(request_payloads)")
+			.all() as Array<{ name: string }>;
+		expect(payloadColumns.map((col) => col.name)).toContain("timestamp");
+
+		const payload = db
+			.prepare("SELECT timestamp FROM request_payloads WHERE id = ?")
+			.get("req-1") as { timestamp: number };
+		expect(payload.timestamp).toBe(1_700_000_000_000);
+
+		const payloadIndexes = db
+			.prepare("PRAGMA index_list(request_payloads)")
+			.all() as Array<{ name: string }>;
+		expect(payloadIndexes.map((index) => index.name)).toContain(
+			"idx_request_payloads_timestamp",
+		);
+	});
+
 	it("should remove account_tier column from accounts table if it exists", () => {
 		// Create schema with tier column (simulate old schema)
 		db.exec(`

--- a/packages/database/src/migrations.ts
+++ b/packages/database/src/migrations.ts
@@ -77,11 +77,6 @@ export function ensureSchema(db: Database): void {
 		)
 	`);
 
-	// Index for efficient age-based payload cleanup
-	db.run(
-		`CREATE INDEX IF NOT EXISTS idx_request_payloads_timestamp ON request_payloads(timestamp)`,
-	);
-
 	// Create oauth_sessions table for secure PKCE verifier storage
 	db.run(`
 		CREATE TABLE IF NOT EXISTS oauth_sessions (
@@ -592,7 +587,9 @@ export function runMigrations(db: Database, dbPath?: string): void {
 			(col) => col.name,
 		);
 
-		if (!requestPayloadsColumnNames.includes("timestamp")) {
+		let hasRequestPayloadTimestamp =
+			requestPayloadsColumnNames.includes("timestamp");
+		if (!hasRequestPayloadTimestamp) {
 			db.prepare(
 				"ALTER TABLE request_payloads ADD COLUMN timestamp INTEGER",
 			).run();
@@ -602,13 +599,18 @@ export function runMigrations(db: Database, dbPath?: string): void {
 				SET timestamp = (SELECT timestamp FROM requests WHERE requests.id = request_payloads.id)
 				WHERE timestamp IS NULL
 			`).run();
-			// Create index for efficient age-based cleanup
-			db.prepare(
-				`CREATE INDEX IF NOT EXISTS idx_request_payloads_timestamp ON request_payloads(timestamp)`,
-			).run();
+			hasRequestPayloadTimestamp = true;
 			log.info(
 				"Added timestamp column to request_payloads table and backfilled from requests",
 			);
+		}
+
+		if (hasRequestPayloadTimestamp) {
+			// Create index only after the column exists; older SQLite databases may
+			// still have request_payloads without timestamp until this migration runs.
+			db.prepare(
+				`CREATE INDEX IF NOT EXISTS idx_request_payloads_timestamp ON request_payloads(timestamp)`,
+			).run();
 		}
 
 		// Check columns in api_keys table


### PR DESCRIPTION
## Summary
- avoid creating the `request_payloads(timestamp)` index before legacy SQLite databases have the column
- create the payload timestamp index only after migrations have added/backfilled the column
- add a regression test covering older `request_payloads` tables without `timestamp`

## Root cause
Recent changes introduced a `timestamp` column on `request_payloads`, but SQLite startup still called `ensureSchema()` before the migration that adds that column for existing databases. `ensureSchema()` attempted to create `idx_request_payloads_timestamp` unconditionally, so older databases failed at startup with `SQLite error: no such column: timestamp` before `runMigrations()` could apply the `ALTER TABLE`.

## Verification
- `bun test packages/database/src/migrations.test.ts -t "should migrate legacy request_payloads tables before creating the timestamp index"`
- `bun run typecheck`
- `bunx --bun biome check packages/database/src/migrations.ts packages/database/src/migrations.test.ts`

## Notes
`bun run lint` still reports unrelated pre-existing issues elsewhere in the repo and was not changed by this PR.