### PR TITLE
fix: preflight-env space-in-values bug + jw409 acknowledgement

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ SESSION_DURATION_MS=18000000           # Session duration in milliseconds (5 hou
 RETRY_ATTEMPTS=3                       # Number of retry attempts
 RETRY_DELAY_MS=1000                   # Initial retry delay in milliseconds
 RETRY_BACKOFF=2                        # Retry backoff multiplier
+
+# Storage
+STORE_PAYLOADS=false                   # Disable storing request/response bodies (reduces DB size and memory usage)
+                                       # Token counts, costs, model, status and timing are still recorded
 ```
 
 **Security Notes**:
@@ -226,6 +230,9 @@ LOG_FORMAT=pretty
 # Database configuration
 DATA_RETENTION_DAYS=7
 REQUEST_RETENTION_DAYS=365
+
+# Storage (set to false to skip storing request/response bodies, reducing DB size and memory pressure)
+STORE_PAYLOADS=true
 ```
 
 **Usage with different deployment methods**:

--- a/README.md
+++ b/README.md
@@ -743,7 +743,7 @@ Inspired by [snipeship/ccflare](https://github.com/snipeship/ccflare) - thanks f
 - [@bitcoin4cashqc](https://github.com/bitcoin4cashqc) - SSL/HTTPS support implementation with comprehensive documentation
 - [@anonym-uz](https://github.com/anonym-uz) - Critical auto-pause bug fix, analytics performance optimizations, request body truncation, and incremental vacuum implementation
 - [@makhweeb](https://github.com/makhweeb) - Enhanced request handling and analytics improvements
-- [@jw409](https://github.com/jw409) - Fixed OAuth account addition in WSL2 and compiled binaries by replacing unreliable prompt() with readline
+- [@jw409](https://github.com/jw409) - Fixed OAuth account addition in WSL2 and compiled binaries by replacing unreliable prompt() with readline; systemd deployment guide, BUN_JSC_* crash loop analysis, and preflight environment validator (PR #106)
 - [@materemias](https://github.com/materemias) - Testing and validation of Vertex AI provider implementation, thorough debugging of OAuth API key authentication (issue #54), requesting and validating AWS Bedrock support (issue #49), and extensive testing of new releases and features
 - [@tqtensor](https://github.com/tqtensor) - Comprehensive memory leak fix preventing OOM kills with smart chunk capping, memory monitoring, and optimized cleanup (PR #67)
 - [@lunetics](https://github.com/lunetics) - Force-reset rate limit feature allowing manual clearing of stale rate-limit locks via API, CLI, and dashboard with immediate usage polling (PR #68), OOM kill prevention with periodic data retention cleanup, 3-day default retention, and time-scoped stats queries (PR #70), model registry sync removing retired models and adding sonnet-4.6 CLI shortcut (PR #71)

--- a/scripts/preflight-env.sh
+++ b/scripts/preflight-env.sh
@@ -25,8 +25,6 @@
 #
 # POSIX sh compatible — no bashisms.
 
-set -e
-
 # Known-valid BUN_JSC_* variables as of Bun 1.x.
 # Add entries here if Bun documents new stable options.
 ALLOWLIST="BUN_JSC_forceRAMSize BUN_JSC_useJIT BUN_JSC_forceGCSlowPaths"
@@ -41,38 +39,48 @@ is_allowed() {
     return 1
 }
 
-# Scan environment for BUN_JSC_* variables and unset any not on the allowlist.
-# `env` output is parsed line-by-line; we split on the first '=' to get the name.
-env | while IFS='=' read -r name value; do
-    case "$name" in
-        BUN_JSC_*)
-            if ! is_allowed "$name"; then
-                echo "preflight-env: WARNING: unsetting invalid variable $name (not in allowlist)" >&2
-                echo "preflight-env: hint: use --smol flag instead of BUN_JSC_* env vars for memory tuning" >&2
-                unset "$name" 2>/dev/null || true
-            fi
-            ;;
-    esac
-done
+# Collect invalid BUN_JSC_* variable names using null-delimited env output.
+# This handles values containing spaces, newlines, and other special characters.
+# `env -0` prints name=value pairs separated by NUL bytes (POSIX 2008+, available
+# on Linux/macOS). We extract only the names and filter for BUN_JSC_* entries.
+_invalid_vars=""
+if env -0 >/dev/null 2>&1; then
+    # env -0 is available — safe against values with embedded newlines
+    while IFS= read -r -d '' _entry; do
+        _varname="${_entry%%=*}"
+        case "$_varname" in
+            BUN_JSC_*)
+                if ! is_allowed "$_varname"; then
+                    _invalid_vars="$_invalid_vars $_varname"
+                fi
+                ;;
+        esac
+    done < <(env -0)
+else
+    # Fallback: parse env line-by-line. Handles the common case where values
+    # don't contain embedded newlines (rare for BUN_JSC_* vars).
+    while IFS='=' read -r _varname _rest; do
+        case "$_varname" in
+            BUN_JSC_*)
+                if ! is_allowed "$_varname"; then
+                    _invalid_vars="$_invalid_vars $_varname"
+                fi
+                ;;
+        esac
+    done <<EOF
+$(env)
+EOF
+fi
 
-# The while-read-pipe runs in a subshell, so unset does not propagate to the
-# parent. For systemd ExecStartPre= usage this is fine because systemd
-# re-reads the environment from the unit file for ExecStart=. For interactive
-# use, source this script instead:
-#
-#   . /opt/better-ccflare/scripts/preflight-env.sh
-#   exec bun run better-ccflare --smol --serve
-#
-# When sourced, we need a non-subshell approach:
-for _env_line in $(env); do
-    _name="${_env_line%%=*}"
-    case "$_name" in
-        BUN_JSC_*)
-            if ! is_allowed "$_name"; then
-                unset "$_name" 2>/dev/null || true
-            fi
-            ;;
-    esac
+# Unset invalid variables and emit warnings.
+# This works whether the script is executed directly (ExecStartPre=) or sourced.
+# For ExecStartPre= usage, systemd re-reads the environment from the unit file
+# for ExecStart=, so invalid vars set in the unit file itself won't be unset
+# here — remove them from the unit file directly.
+for _varname in $_invalid_vars; do
+    echo "preflight-env: WARNING: unsetting invalid BUN_JSC_* variable: $_varname" >&2
+    echo "preflight-env: hint: use --smol flag instead of BUN_JSC_* env vars for memory tuning" >&2
+    unset "$_varname" 2>/dev/null || true
 done
 
 exit 0


### PR DESCRIPTION
## Summary

- **Fix shell script space-in-values bug**: The original `$(env)` word-split approach in `scripts/preflight-env.sh` broke for env var values containing spaces or newlines. Now uses `env -0` (NUL-delimited output) with a line-by-line fallback, making it safe for any value.
- **Clarify ExecStartPre= limitation**: Added a comment noting that `unset` in `ExecStartPre=` doesn't affect vars set in the unit file itself (systemd re-reads the environment for `ExecStart=`) — those must be removed from the unit file directly.
- **README acknowledgement**: Added jw409 to Acknowledgements for the systemd deployment guide and preflight validator (PR #106).

## Test plan

- [ ] Source the script interactively with a `BUN_JSC_*` var whose value contains spaces — confirm it is unset correctly
- [ ] Verify `env -0` fallback path works on systems where it may not be available

Closes #106 follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)