### PR TITLE
feat(anthropic): add OpenAI-compatible finish_reason to Anthropic SSE stream

### DIFF
--- a/packages/providers/src/providers/anthropic/provider.ts
+++ b/packages/providers/src/providers/anthropic/provider.ts
@@ -284,6 +284,91 @@ export class AnthropicProvider extends BaseProvider {
 		};
 	}
 
+	/**
+	 * Transform Anthropic SSE stream to add OpenAI-compatible finish_reason.
+	 * Anthropic uses stop_reason on message_delta events; OpenAI clients expect
+	 * finish_reason. This maps between them without breaking native Anthropic clients
+	 * since both fields are present in the transformed output.
+	 */
+	private async transformStreamToOpenAIFormat(
+		response: Response,
+	): Promise<Response> {
+		const contentType = response.headers.get("content-type");
+
+		// Only transform streaming responses
+		if (!contentType?.includes("text/event-stream")) {
+			return response;
+		}
+
+		const reader = response.body?.getReader();
+		if (!reader) return response;
+
+		const encoder = new TextEncoder();
+		const decoder = new TextDecoder();
+
+		const stream = new ReadableStream({
+			async start(controller) {
+				try {
+					while (true) {
+						const { done, value } = await reader.read();
+						if (done) break;
+
+						const chunk = decoder.decode(value, { stream: true });
+						const lines = chunk.split("\n");
+
+						for (const line of lines) {
+							// Pass through non-data lines unchanged
+							if (!line.startsWith("data: ")) {
+								controller.enqueue(encoder.encode(line + "\n"));
+								continue;
+							}
+
+							const data = line.slice(6).trim();
+
+							// Pass through [DONE] marker
+							if (data === "[DONE]") {
+								controller.enqueue(encoder.encode(line + "\n"));
+								continue;
+							}
+
+							try {
+								const event = JSON.parse(data);
+
+								// Map Anthropic stop_reason -> OpenAI finish_reason on message_delta
+								if (event.type === "message_delta" && event.delta?.stop_reason) {
+									const stopReasonMap: Record<string, string> = {
+										end_turn: "stop",
+										max_tokens: "length",
+										stop_sequence: "stop",
+										tool_use: "tool_calls",
+									};
+									event.finish_reason =
+										stopReasonMap[event.delta.stop_reason] || "stop";
+								}
+
+								const transformed = `data: ${JSON.stringify(event)}\n`;
+								controller.enqueue(encoder.encode(transformed));
+							} catch {
+								// If not JSON, pass through unchanged
+								controller.enqueue(encoder.encode(line + "\n"));
+							}
+						}
+					}
+				} catch (error) {
+					controller.error(error);
+				} finally {
+					controller.close();
+				}
+			},
+		});
+
+		return new Response(stream, {
+			headers: response.headers,
+			status: response.status,
+			statusText: response.statusText,
+		});
+	}
+
 	async processResponse(
 		response: Response,
 		_account: Account | null,
@@ -291,11 +376,14 @@ export class AnthropicProvider extends BaseProvider {
 		// Sanitize headers by removing hop-by-hop headers
 		const headers = sanitizeProxyHeaders(response.headers);
 
-		return new Response(response.body, {
+		const sanitizedResponse = new Response(response.body, {
 			status: response.status,
 			statusText: response.statusText,
 			headers,
 		});
+
+		// Add OpenAI-compatible finish_reason alongside Anthropic's stop_reason
+		return this.transformStreamToOpenAIFormat(sanitizedResponse);
 	}
 
 	async extractTierInfo(response: Response): Promise<number | null> {

--- a/packages/providers/src/providers/anthropic/provider.ts
+++ b/packages/providers/src/providers/anthropic/provider.ts
@@ -306,24 +306,44 @@ export class AnthropicProvider extends BaseProvider {
 		const encoder = new TextEncoder();
 		const decoder = new TextDecoder();
 
+		// stopReasonMap defined once outside the loop for performance
+		const stopReasonMap: Record<string, string> = {
+			end_turn: "stop",
+			max_tokens: "length",
+			stop_sequence: "stop",
+			tool_use: "tool_calls",
+		};
+
 		const stream = new ReadableStream({
 			async start(controller) {
+				// lineBuffer carries incomplete lines across chunk boundaries
+				let lineBuffer = "";
 				try {
 					while (true) {
 						const { done, value } = await reader.read();
-						if (done) break;
+						if (done) {
+							// Flush any remaining buffered content
+							if (lineBuffer) {
+								controller.enqueue(encoder.encode(lineBuffer));
+							}
+							break;
+						}
 
-						const chunk = decoder.decode(value, { stream: true });
-						const lines = chunk.split("\n");
+						// Accumulate decoded bytes into lineBuffer, split on newlines
+						lineBuffer += decoder.decode(value, { stream: true });
+						const lines = lineBuffer.split("\n");
+						// Last element may be an incomplete line — keep it in the buffer
+						lineBuffer = lines.pop() ?? "";
 
 						for (const line of lines) {
-							// Pass through non-data lines unchanged
-							if (!line.startsWith("data: ")) {
+							// Pass through non-data lines (empty lines, event:, id:, comment:)
+							// SSE allows both "data:" and "data: " prefixes
+							if (!line.startsWith("data:")) {
 								controller.enqueue(encoder.encode(line + "\n"));
 								continue;
 							}
 
-							const data = line.slice(6).trim();
+							const data = line.replace(/^data:\s?/, "");
 
 							// Pass through [DONE] marker
 							if (data === "[DONE]") {
@@ -336,20 +356,15 @@ export class AnthropicProvider extends BaseProvider {
 
 								// Map Anthropic stop_reason -> OpenAI finish_reason on message_delta
 								if (event.type === "message_delta" && event.delta?.stop_reason) {
-									const stopReasonMap: Record<string, string> = {
-										end_turn: "stop",
-										max_tokens: "length",
-										stop_sequence: "stop",
-										tool_use: "tool_calls",
-									};
 									event.finish_reason =
-										stopReasonMap[event.delta.stop_reason] || "stop";
+										stopReasonMap[event.delta.stop_reason] ?? "stop";
 								}
 
-								const transformed = `data: ${JSON.stringify(event)}\n`;
-								controller.enqueue(encoder.encode(transformed));
+								controller.enqueue(
+									encoder.encode(`data: ${JSON.stringify(event)}\n`),
+								);
 							} catch {
-								// If not JSON, pass through unchanged
+								// Non-JSON data line — pass through unchanged
 								controller.enqueue(encoder.encode(line + "\n"));
 							}
 						}
@@ -357,8 +372,16 @@ export class AnthropicProvider extends BaseProvider {
 				} catch (error) {
 					controller.error(error);
 				} finally {
-					controller.close();
+					// Guard close() — stream may already be errored
+					try {
+						controller.close();
+					} catch {
+						// ignore: stream is already in errored state
+					}
 				}
+			},
+			cancel(reason) {
+				reader.cancel(reason);
 			},
 		});
 


### PR DESCRIPTION
## Summary

Anthropic `message_delta` events carry `stop_reason`; OpenAI clients (e.g. Kilo, OpenCode) expect `finish_reason`. This PR adds a stream transformer on the Anthropic provider that maps `stop_reason` to its OpenAI equivalent and injects `finish_reason` alongside it.

Both fields are present in the output so native Anthropic clients are unaffected.

**Mapping:**
| Anthropic `stop_reason` | OpenAI `finish_reason` |
|---|---|
| `end_turn` | `stop` |
| `max_tokens` | `length` |
| `stop_sequence` | `stop` |
| `tool_use` | `tool_calls` |

## Changes

- `packages/providers/src/providers/anthropic/provider.ts`: adds `transformStreamToOpenAIFormat()` that wraps the response body in a `TransformStream`, scans each `message_delta` SSE event, and injects `finish_reason` into the JSON payload

## Notes

- This is a clean resubmission of #101, rebased directly onto upstream `main`
- Previous PR was closed due to accidentally committed credentials (now revoked + purged from history)
- The previous submission had a duplicate method bug (merge artifact) and an SSE chunk-boundary issue — both are resolved in this version; the transformer maintains a line buffer across `read()` calls to handle chunk-boundary splits correctly
- The stream transform does **not** affect request bodies — only the response stream