### PR TITLE
fix: coerce PostgreSQL BIGINT to Number before Date construction

### DIFF
--- a/packages/proxy/src/auto-refresh-scheduler.ts
+++ b/packages/proxy/src/auto-refresh-scheduler.ts
@@ -143,7 +143,7 @@ export class AutoRefreshScheduler {
 			// Log accounts being considered
 			accounts.forEach((account) => {
 				log.debug(
-					`Considering account: ${account.name}, reset_time: ${account.rate_limit_reset ? new Date(account.rate_limit_reset).toISOString() : "null"}`,
+					`Considering account: ${account.name}, reset_time: ${account.rate_limit_reset ? new Date(Number(account.rate_limit_reset)).toISOString() : "null"}`,
 				);
 			});
 
@@ -217,7 +217,7 @@ export class AutoRefreshScheduler {
 			}
 
 			log.info(
-				`Current token expires at: ${accountRow.expires_at ? new Date(accountRow.expires_at).toISOString() : "null"}`,
+				`Current token expires at: ${accountRow.expires_at ? new Date(Number(accountRow.expires_at)).toISOString() : "null"}`,
 			);
 			log.info(`Current time: ${new Date().toISOString()}`);
 			log.info(`Access token available: ${!!accountRow.access_token}`);
@@ -231,7 +231,7 @@ export class AutoRefreshScheduler {
 				api_key: null,
 				refresh_token: accountRow.refresh_token,
 				access_token: accountRow.access_token,
-				expires_at: accountRow.expires_at,
+				expires_at: accountRow.expires_at ? Number(accountRow.expires_at) : null,
 				request_count: 0,
 				total_requests: 0,
 				last_used: null,
@@ -240,7 +240,7 @@ export class AutoRefreshScheduler {
 				session_start: null,
 				session_request_count: 0,
 				paused: false,
-				rate_limit_reset: accountRow.rate_limit_reset,
+				rate_limit_reset: accountRow.rate_limit_reset ? Number(accountRow.rate_limit_reset) : null,
 				rate_limit_status: null,
 				rate_limit_remaining: null,
 				priority: 0,
@@ -685,7 +685,7 @@ export class AutoRefreshScheduler {
 		const resetTimeHasPassed = account.rate_limit_reset <= now;
 		if (resetTimeHasPassed) {
 			log.info(
-				`New window detected for account ${account.name}: reset time ${new Date(account.rate_limit_reset).toISOString()} has passed (now: ${new Date(now).toISOString()}), last refresh was at ${new Date(lastResetTime).toISOString()}`,
+				`New window detected for account ${account.name}: reset time ${new Date(Number(account.rate_limit_reset)).toISOString()} has passed (now: ${new Date(now).toISOString()}), last refresh was at ${new Date(lastResetTime).toISOString()}`,
 			);
 			return true;
 		}
@@ -695,7 +695,7 @@ export class AutoRefreshScheduler {
 		const isNewerThanLastRefresh = account.rate_limit_reset > lastResetTime;
 		if (isNewerThanLastRefresh) {
 			log.info(
-				`New window detected for account ${account.name}: current reset ${new Date(account.rate_limit_reset).toISOString()} > last refresh ${new Date(lastResetTime).toISOString()}`,
+				`New window detected for account ${account.name}: current reset ${new Date(Number(account.rate_limit_reset)).toISOString()} > last refresh ${new Date(lastResetTime).toISOString()}`,
 			);
 			return true;
 		}
@@ -704,14 +704,14 @@ export class AutoRefreshScheduler {
 		const oneDayAgo = Date.now() - 24 * 60 * 60 * 1000;
 		if (account.rate_limit_reset < oneDayAgo) {
 			log.info(
-				`Stale reset time detected for account ${account.name}: ${new Date(account.rate_limit_reset).toISOString()} is more than 24h old, forcing refresh`,
+				`Stale reset time detected for account ${account.name}: ${new Date(Number(account.rate_limit_reset)).toISOString()} is more than 24h old, forcing refresh`,
 			);
 			return true;
 		}
 
 		// The window hasn't renewed yet - skip
 		log.debug(
-			`No new window for account ${account.name}: current reset ${new Date(account.rate_limit_reset).toISOString()}, last refresh ${new Date(lastResetTime).toISOString()}, now ${new Date(now).toISOString()}`,
+			`No new window for account ${account.name}: current reset ${new Date(Number(account.rate_limit_reset)).toISOString()}, last refresh ${new Date(lastResetTime).toISOString()}, now ${new Date(now).toISOString()}`,
 		);
 		return false;
 	}


### PR DESCRIPTION
## Summary

- Wraps all DB-sourced BIGINT values (`rate_limit_reset`, `expires_at`) with `Number()` before passing to `new Date()` in the auto-refresh scheduler
- Also coerces values when constructing the `Account` object passed downstream

## Problem

PostgreSQL returns BIGINT columns as **strings** in JavaScript (e.g., `"1712592000000"` instead of `1712592000000`). The `Date` constructor interprets string arguments as date format strings, not Unix timestamps:

```js
new Date(1712592000000)    // ✅ Mon Apr 08 2024 ...
new Date("1712592000000")  // ❌ Invalid Date
```

This causes `RangeError: Invalid Date` at every `.toISOString()` call in `auto-refresh-scheduler.ts` when running with PostgreSQL.

SQLite returns numbers natively, so this only affects PostgreSQL deployments.

## Stack trace

```
[INFO]  Sending auto-refresh message to account: jane-ai
[ERROR] Error sending auto-refresh message to account jane-ai: RangeError: Invalid Date
[ERROR] Auto-refresh stack trace for jane-ai: RangeError: Invalid Date
    at toISOString (unknown)
    at sendDummyMessage (...)
    at checkAndRefresh (...)
```

## Test plan

- [x] Deploy with PostgreSQL backend, verify auto-refresh no longer crashes with `Invalid Date`
- [ ] Verify auto-refresh works correctly on SQLite (no regression)