### PR TITLE
docs: clarify auto-fallback and auto-refresh toggle tooltips

### DIFF
--- a/packages/dashboard-web/src/components/accounts/AccountListItem.tsx
+++ b/packages/dashboard-web/src/components/accounts/AccountListItem.tsx
@@ -122,7 +122,7 @@ export function AccountListItem({
 										<Switch
 											checked={account.autoFallbackEnabled}
 											onCheckedChange={() => onAutoFallbackToggle(account)}
-											title="When this account's rate-limit window resets, automatically switch back to it from lower-priority accounts. Requires multiple accounts with different priority values."
+											title="Automatically switch back to this account from lower-priority ones when its rate limit resets. Requires multiple accounts with different priorities."
 										/>
 									</div>
 									<div className="flex items-center gap-2">

--- a/packages/dashboard-web/src/components/accounts/AccountListItem.tsx
+++ b/packages/dashboard-web/src/components/accounts/AccountListItem.tsx
@@ -122,7 +122,7 @@ export function AccountListItem({
 										<Switch
 											checked={account.autoFallbackEnabled}
 											onCheckedChange={() => onAutoFallbackToggle(account)}
-											title="Toggle auto-fallback for this account"
+											title="When this account's rate-limit window resets, automatically switch back to it from lower-priority accounts. Requires multiple accounts with different priority values."
 										/>
 									</div>
 									<div className="flex items-center gap-2">
@@ -132,7 +132,7 @@ export function AccountListItem({
 										<Switch
 											checked={account.autoRefreshEnabled}
 											onCheckedChange={() => onAutoRefreshToggle(account)}
-											title="Toggle auto-refresh for this account"
+											title="When this Anthropic account's 5-hour usage window resets, automatically send a minimal dummy message (~10 tokens) to start the new window immediately, avoiding cold-start latency on the first real request. Does not refresh OAuth tokens (those are always refreshed automatically)."
 										/>
 									</div>
 								</>

--- a/packages/dashboard-web/src/components/accounts/AccountListItem.tsx
+++ b/packages/dashboard-web/src/components/accounts/AccountListItem.tsx
@@ -132,7 +132,7 @@ export function AccountListItem({
 										<Switch
 											checked={account.autoRefreshEnabled}
 											onCheckedChange={() => onAutoRefreshToggle(account)}
-											title="When this Anthropic account's 5-hour usage window resets, automatically send a minimal dummy message (~10 tokens) to start the new window immediately, avoiding cold-start latency on the first real request. Does not refresh OAuth tokens (those are always refreshed automatically)."
+											title="Automatically sends a minimal message when the usage window resets to avoid cold-start latency. Does not affect OAuth token refreshing."
 										/>
 									</div>
 								</>


### PR DESCRIPTION
## Summary

The Auto-fallback and Auto-refresh switches in the Accounts tab currently have tooltips that just restate the label:

- `title="Toggle auto-fallback for this account"`
- `title="Toggle auto-refresh for this account"`

Neither explains what the toggle actually does, and I've seen real confusion about whether Auto-refresh means "refresh OAuth tokens" (it doesn't). This PR replaces both strings with behavior-focused descriptions drawn directly from `docs/auto-fallback.md` and `docs/auto-refresh.md`.

### Before

- Auto-fallback: *"Toggle auto-fallback for this account"*
- Auto-refresh: *"Toggle auto-refresh for this account"*

### After

- Auto-fallback: *"When this account's rate-limit window resets, automatically switch back to it from lower-priority accounts. Requires multiple accounts with different priority values."*
- Auto-refresh: *"When this Anthropic account's 5-hour usage window resets, automatically send a minimal dummy message (~10 tokens) to start the new window immediately, avoiding cold-start latency on the first real request. Does not refresh OAuth tokens (those are always refreshed automatically)."*

Both remain native HTML `title=` attributes, consistent with the ~25 other tooltips in the dashboard. No behavior or styling changes — copy only.

Happy to shorten either string if you'd prefer something tighter — these err on the side of explanatory. A follow-up PR could migrate all `title=` usages to the `@radix-ui/react-tooltip` dep already in `package.json`, but I left that out of scope here.

## Test plan

- [ ] Hover the Auto-fallback switch on an account row — tooltip reads the new copy
- [ ] Hover the Auto-refresh switch on an account row — tooltip reads the new copy
- [ ] No functional/styling changes to verify beyond the two `title=` strings