### PR TITLE
fix(proxy): fix restart() listener removal and add missing cache tests

### DIFF
--- a/packages/dashboard-web/src/components/overview/CacheKeepaliveCard.tsx
+++ b/packages/dashboard-web/src/components/overview/CacheKeepaliveCard.tsx
@@ -57,9 +57,9 @@ export function CacheKeepaliveCard() {
 				</Select>
 				{currentValue > 0 && (
 					<p className="text-xs text-muted-foreground mt-2">
-						Keepalive runs every {currentValue - 1} minute
-						{currentValue - 1 !== 1 ? "s" : ""}, refreshing cached prompts for
-						accounts that used caching recently.
+						Keepalive runs every {Math.max(1, currentValue - 1)} minute
+						{Math.max(1, currentValue - 1) !== 1 ? "s" : ""}, refreshing cached
+						prompts for accounts that used caching recently.
 					</p>
 				)}
 			</CardContent>

--- a/packages/proxy/src/__tests__/cache-body-store.test.ts
+++ b/packages/proxy/src/__tests__/cache-body-store.test.ts
@@ -485,6 +485,95 @@ describe("CacheBodyStore", () => {
 	});
 
 	// -----------------------------------------------------------------------
+	// evictStaleEntries
+	// -----------------------------------------------------------------------
+
+	describe("evictStaleEntries", () => {
+		it("evicts entries older than ttlMinutes * ageMultiplier", () => {
+			cacheBodyStore.stageRequest(
+				"req-stale",
+				"account-stale",
+				makeBody(),
+				makeHeaders(),
+				"/v1/messages",
+			);
+			cacheBodyStore.onSummary("req-stale", 5);
+
+			// Manually backdate the entry's timestamp so it appears very old.
+			const entry = cacheBodyStore.getLastCachedRequest("account-stale");
+			expect(entry).not.toBeNull();
+			// Mutate timestamp to be 1 hour in the past.
+			(entry as { timestamp: number }).timestamp = Date.now() - 60 * 60 * 1000;
+
+			// TTL=5 min, multiplier=3 → threshold = 15 min. Entry is 60 min old → evicted.
+			cacheBodyStore.evictStaleEntries(5);
+
+			expect(cacheBodyStore.getLastCachedRequest("account-stale")).toBeNull();
+			expect(cacheBodyStore.getAllCachedAccounts()).not.toContain(
+				"account-stale",
+			);
+		});
+
+		it("retains entries newer than the threshold", () => {
+			cacheBodyStore.stageRequest(
+				"req-fresh",
+				"account-fresh",
+				makeBody(),
+				makeHeaders(),
+				"/v1/messages",
+			);
+			cacheBodyStore.onSummary("req-fresh", 5);
+
+			// The entry was just created (timestamp ≈ now) — well within the 15-min window.
+			cacheBodyStore.evictStaleEntries(5);
+
+			expect(
+				cacheBodyStore.getLastCachedRequest("account-fresh"),
+			).not.toBeNull();
+		});
+
+		it("is a no-op when the map is empty", () => {
+			// Ensure map is empty.
+			expect(cacheBodyStore.getAllCachedAccounts()).toHaveLength(0);
+
+			// Should not throw.
+			expect(() => cacheBodyStore.evictStaleEntries(5)).not.toThrow();
+
+			expect(cacheBodyStore.getAllCachedAccounts()).toHaveLength(0);
+		});
+
+		it("evicts only stale entries and retains fresh ones", () => {
+			// Stale entry.
+			cacheBodyStore.stageRequest(
+				"req-old",
+				"account-old",
+				makeBody(),
+				makeHeaders(),
+				"/v1/messages",
+			);
+			cacheBodyStore.onSummary("req-old", 5);
+			const oldEntry = cacheBodyStore.getLastCachedRequest("account-old");
+			(oldEntry as { timestamp: number }).timestamp =
+				Date.now() - 60 * 60 * 1000;
+
+			// Fresh entry.
+			cacheBodyStore.stageRequest(
+				"req-new",
+				"account-new",
+				makeBody(),
+				makeHeaders(),
+				"/v1/messages",
+			);
+			cacheBodyStore.onSummary("req-new", 5);
+
+			cacheBodyStore.evictStaleEntries(5);
+
+			expect(cacheBodyStore.getLastCachedRequest("account-old")).toBeNull();
+			expect(cacheBodyStore.getLastCachedRequest("account-new")).not.toBeNull();
+		});
+	});
+
+	// -----------------------------------------------------------------------
 	// Multiple accounts
 	// -----------------------------------------------------------------------
 

--- a/packages/proxy/src/__tests__/cache-keepalive-scheduler.test.ts
+++ b/packages/proxy/src/__tests__/cache-keepalive-scheduler.test.ts
@@ -288,6 +288,36 @@ describe("CacheKeepaliveScheduler", () => {
 			scheduler.stop();
 		});
 
+		it("multiple sequential TTL changes — each triggers a restart without losing the listener", () => {
+			// This test would have caught the restart() listener-removal bug:
+			// the original restart() called stop() which nulled boundConfigChangeHandler,
+			// so the second config change was silently dropped.
+			const { config, fireTtlChange } = makeConfig(5);
+			const scheduler = new CacheKeepaliveScheduler(makeProxyContext(), config);
+			scheduler.start();
+
+			expect(mockRegisterHeartbeat).toHaveBeenCalledTimes(1);
+			expect(capturedSeconds).toBe(240); // (5-1)*60
+
+			// First TTL change: 5 → 10
+			fireTtlChange(10);
+
+			expect(mockUnregister).toHaveBeenCalledTimes(1);
+			expect(mockRegisterHeartbeat).toHaveBeenCalledTimes(2);
+			expect(capturedSeconds).toBe(540); // (10-1)*60
+
+			// Second TTL change: 10 → 30
+			// Before the fix, the listener was removed after the first change and
+			// this would be a no-op.
+			fireTtlChange(30);
+
+			expect(mockUnregister).toHaveBeenCalledTimes(2);
+			expect(mockRegisterHeartbeat).toHaveBeenCalledTimes(3);
+			expect(capturedSeconds).toBe(1740); // (30-1)*60
+
+			scheduler.stop();
+		});
+
 		it("unrelated config key change is ignored", () => {
 			let listener: ConfigChangeListener | null = null;
 			const config = {

--- a/packages/proxy/src/cache-keepalive-scheduler.ts
+++ b/packages/proxy/src/cache-keepalive-scheduler.ts
@@ -48,18 +48,22 @@ export class CacheKeepaliveScheduler {
 	}
 
 	stop(): void {
-		if (this.unregisterInterval) {
-			this.unregisterInterval();
-			this.unregisterInterval = null;
-		}
+		this.stopInterval();
 		if (this.boundConfigChangeHandler) {
 			this.config.off("change", this.boundConfigChangeHandler);
 			this.boundConfigChangeHandler = null;
 		}
 	}
 
+	private stopInterval(): void {
+		if (this.unregisterInterval) {
+			this.unregisterInterval();
+			this.unregisterInterval = null;
+		}
+	}
+
 	private restart(): void {
-		this.stop();
+		this.stopInterval();
 		this.startInterval();
 	}
 


### PR DESCRIPTION
## Summary

- **P1 bug fix**: `restart()` was calling `stop()` which unregistered `boundConfigChangeHandler` from the config emitter and nulled it out. After the first TTL change, all subsequent config changes were silently ignored. Fixed by introducing a private `stopInterval()` method that only tears down the heartbeat interval — `restart()` now calls `stopInterval()` instead of `stop()`. `stop()` retains full teardown behaviour (interval + listener) for use on scheduler destroy.

- **UI fix**: `CacheKeepaliveCard` displayed "0 minutes" when TTL=1 because the label computed `currentValue - 1`. The display value is now clamped to `Math.max(1, currentValue - 1)`.

- **New tests for `evictStaleEntries`**: Added 4 tests to `cache-body-store.test.ts` covering stale entry eviction, fresh entry retention, empty-map no-op, and mixed stale+fresh behaviour.

- **Regression test for sequential TTL changes**: Added a test to `cache-keepalive-scheduler.test.ts` that fires two sequential config changes and asserts the scheduler restarts both times — this test would have caught the `restart()` listener-removal bug.

## Test plan

- [ ] All 53 proxy tests pass: `bun test packages/proxy/src/__tests__/cache-body-store.test.ts packages/proxy/src/__tests__/cache-keepalive-scheduler.test.ts`
- [ ] Typecheck passes: `bun run typecheck`
- [ ] Manually verify: start server, set a TTL in the dashboard, change it again, confirm the scheduler interval updates both times (previously the second change was a no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)