### PR TITLE
Improve Anthropic/Codex reauth and fix P2 review issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Automated release system uses commit prefixes for changelog:
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **better-ccflare** (5058 symbols, 11350 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **better-ccflare** (8366 symbols, 14741 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -104,44 +104,12 @@ This project is indexed by GitNexus as **better-ccflare** (5058 symbols, 11350 r
 - When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
 - When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
-## When Debugging
-
-1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
-2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
-3. `READ gitnexus://repo/better-ccflare/process/{processName}` — trace the full execution flow step by step
-4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
-
-## When Refactoring
-
-- **Renaming**: MUST use `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` first. Review the preview — graph edits are safe, text_search edits need manual review. Then run with `dry_run: false`.
-- **Extracting/Splitting**: MUST run `gitnexus_context({name: "target"})` to see all incoming/outgoing refs, then `gitnexus_impact({target: "target", direction: "upstream"})` to find all external callers before moving code.
-- After any refactor: run `gitnexus_detect_changes({scope: "all"})` to verify only expected files changed.
-
 ## Never Do
 
 - NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
 - NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
 - NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
-
-## Tools Quick Reference
-
-| Tool | When to use | Command |
-|------|-------------|---------|
-| `query` | Find code by concept | `gitnexus_query({query: "auth validation"})` |
-| `context` | 360-degree view of one symbol | `gitnexus_context({name: "validateUser"})` |
-| `impact` | Blast radius before editing | `gitnexus_impact({target: "X", direction: "upstream"})` |
-| `detect_changes` | Pre-commit scope check | `gitnexus_detect_changes({scope: "staged"})` |
-| `rename` | Safe multi-file rename | `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` |
-| `cypher` | Custom graph queries | `gitnexus_cypher({query: "MATCH ..."})` |
-
-## Impact Risk Levels
-
-| Depth | Meaning | Action |
-|-------|---------|--------|
-| d=1 | WILL BREAK — direct callers/importers | MUST update these |
-| d=2 | LIKELY AFFECTED — indirect deps | Should test |
-| d=3 | MAY NEED TESTING — transitive | Test if critical path |
 
 ## Resources
 
@@ -151,32 +119,6 @@ This project is indexed by GitNexus as **better-ccflare** (5058 symbols, 11350 r
 | `gitnexus://repo/better-ccflare/clusters` | All functional areas |
 | `gitnexus://repo/better-ccflare/processes` | All execution flows |
 | `gitnexus://repo/better-ccflare/process/{name}` | Step-by-step execution trace |
-
-## Self-Check Before Finishing
-
-Before completing any code modification task, verify:
-1. `gitnexus_impact` was run for all modified symbols
-2. No HIGH/CRITICAL risk warnings were ignored
-3. `gitnexus_detect_changes()` confirms changes match expected scope
-4. All d=1 (WILL BREAK) dependents were updated
-
-## Keeping the Index Fresh
-
-After committing code changes, the GitNexus index becomes stale. Re-run analyze to update it:
-
-```bash
-npx gitnexus analyze
-```
-
-If the index previously included embeddings, preserve them by adding `--embeddings`:
-
-```bash
-npx gitnexus analyze --embeddings
-```
-
-To check whether embeddings exist, inspect `.gitnexus/meta.json` — the `stats.embeddings` field shows the count (0 means no embeddings). **Running analyze without `--embeddings` will delete any previously generated embeddings.**
-
-> Claude Code users: A PostToolUse hook handles this automatically after `git commit` and `git merge`.
 
 ## CLI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Automated release system uses commit prefixes for changelog:
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **better-ccflare** (8366 symbols, 14741 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **better-ccflare** (5058 symbols, 11350 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -104,12 +104,44 @@ This project is indexed by GitNexus as **better-ccflare** (8366 symbols, 14741 r
 - When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
 - When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
+## When Debugging
+
+1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
+2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
+3. `READ gitnexus://repo/better-ccflare/process/{processName}` — trace the full execution flow step by step
+4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
+
+## When Refactoring
+
+- **Renaming**: MUST use `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` first. Review the preview — graph edits are safe, text_search edits need manual review. Then run with `dry_run: false`.
+- **Extracting/Splitting**: MUST run `gitnexus_context({name: "target"})` to see all incoming/outgoing refs, then `gitnexus_impact({target: "target", direction: "upstream"})` to find all external callers before moving code.
+- After any refactor: run `gitnexus_detect_changes({scope: "all"})` to verify only expected files changed.
+
 ## Never Do
 
 - NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
 - NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
 - NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Tools Quick Reference
+
+| Tool | When to use | Command |
+|------|-------------|---------|
+| `query` | Find code by concept | `gitnexus_query({query: "auth validation"})` |
+| `context` | 360-degree view of one symbol | `gitnexus_context({name: "validateUser"})` |
+| `impact` | Blast radius before editing | `gitnexus_impact({target: "X", direction: "upstream"})` |
+| `detect_changes` | Pre-commit scope check | `gitnexus_detect_changes({scope: "staged"})` |
+| `rename` | Safe multi-file rename | `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` |
+| `cypher` | Custom graph queries | `gitnexus_cypher({query: "MATCH ..."})` |
+
+## Impact Risk Levels
+
+| Depth | Meaning | Action |
+|-------|---------|--------|
+| d=1 | WILL BREAK — direct callers/importers | MUST update these |
+| d=2 | LIKELY AFFECTED — indirect deps | Should test |
+| d=3 | MAY NEED TESTING — transitive | Test if critical path |
 
 ## Resources
 
@@ -119,6 +151,32 @@ This project is indexed by GitNexus as **better-ccflare** (8366 symbols, 14741 r
 | `gitnexus://repo/better-ccflare/clusters` | All functional areas |
 | `gitnexus://repo/better-ccflare/processes` | All execution flows |
 | `gitnexus://repo/better-ccflare/process/{name}` | Step-by-step execution trace |
+
+## Self-Check Before Finishing
+
+Before completing any code modification task, verify:
+1. `gitnexus_impact` was run for all modified symbols
+2. No HIGH/CRITICAL risk warnings were ignored
+3. `gitnexus_detect_changes()` confirms changes match expected scope
+4. All d=1 (WILL BREAK) dependents were updated
+
+## Keeping the Index Fresh
+
+After committing code changes, the GitNexus index becomes stale. Re-run analyze to update it:
+
+```bash
+npx gitnexus analyze
+```
+
+If the index previously included embeddings, preserve them by adding `--embeddings`:
+
+```bash
+npx gitnexus analyze --embeddings
+```
+
+To check whether embeddings exist, inspect `.gitnexus/meta.json` — the `stats.embeddings` field shows the count (0 means no embeddings). **Running analyze without `--embeddings` will delete any previously generated embeddings.**
+
+> Claude Code users: A PostToolUse hook handles this automatically after `git commit` and `git merge`.
 
 ## CLI
 

--- a/packages/dashboard-web/src/api.ts
+++ b/packages/dashboard-web/src/api.ts
@@ -1881,6 +1881,67 @@ class API extends HttpClient {
 		}
 	}
 
+	async initCodexReauth(data: { accountId: string }): Promise<{
+		sessionId: string;
+		verificationUrl: string;
+		userCode: string;
+	}> {
+		const url = "/api/oauth/codex/reauth";
+		this.logger.debug(`→ POST ${url}`, { data });
+		try {
+			const response = await this.post<{
+				sessionId: string;
+				verificationUrl: string;
+				userCode: string;
+			}>(url, data);
+			this.logger.debug(`← POST ${url} - 200`);
+			return response;
+		} catch (error) {
+			this.logger.error(`✗ POST ${url} - ERROR`, { error });
+			if (error instanceof HttpError) throw new Error(error.message);
+			throw error;
+		}
+	}
+
+	async initAnthropicReauth(
+		accountId: string,
+	): Promise<{ authUrl: string; sessionId: string }> {
+		const url = "/api/oauth/anthropic/reauth/init";
+		this.logger.debug(`→ POST ${url}`, { accountId });
+		try {
+			const response = await this.post<{ authUrl: string; sessionId: string }>(
+				url,
+				{ accountId },
+			);
+			this.logger.debug(`← POST ${url} - 200`);
+			return response;
+		} catch (error) {
+			this.logger.error(`✗ POST ${url} - ERROR`, { error });
+			if (error instanceof HttpError) throw new Error(error.message);
+			throw error;
+		}
+	}
+
+	async completeAnthropicReauth(
+		sessionId: string,
+		code: string,
+	): Promise<{ success: boolean; message: string }> {
+		const url = "/api/oauth/anthropic/reauth/callback";
+		this.logger.debug(`→ POST ${url}`, { sessionId });
+		try {
+			const response = await this.post<{ success: boolean; message: string }>(
+				url,
+				{ sessionId, code },
+			);
+			this.logger.debug(`← POST ${url} - 200`);
+			return response;
+		} catch (error) {
+			this.logger.error(`✗ POST ${url} - ERROR`, { error });
+			if (error instanceof HttpError) throw new Error(error.message);
+			throw error;
+		}
+	}
+
 	async getQwenAuthStatus(
 		sessionId: string,
 	): Promise<{ status: "pending" | "complete" | "error"; error?: string }> {

--- a/packages/dashboard-web/src/components/AccountsTab.tsx
+++ b/packages/dashboard-web/src/components/AccountsTab.tsx
@@ -9,6 +9,8 @@ import {
 	AccountList,
 	AccountModelMappingsDialog,
 	AccountPriorityDialog,
+	AnthropicReauthDialog,
+	CodexReauthDialog,
 	DeleteConfirmationDialog,
 	QwenReauthDialog,
 	RenameAccountDialog,
@@ -71,6 +73,20 @@ export function AccountsTab() {
 		account: null,
 	});
 	const [qwenReauthDialog, setQwenReauthDialog] = useState<{
+		isOpen: boolean;
+		account: Account | null;
+	}>({
+		isOpen: false,
+		account: null,
+	});
+	const [anthropicReauthDialog, setAnthropicReauthDialog] = useState<{
+		isOpen: boolean;
+		account: Account | null;
+	}>({
+		isOpen: false,
+		account: null,
+	});
+	const [codexReauthDialog, setCodexReauthDialog] = useState<{
 		isOpen: boolean;
 		account: Account | null;
 	}>({
@@ -452,6 +468,14 @@ export function AccountsTab() {
 		setQwenReauthDialog({ isOpen: true, account });
 	};
 
+	const handleAnthropicReauth = (account: Account) => {
+		setAnthropicReauthDialog({ isOpen: true, account });
+	};
+
+	const handleCodexReauth = (account: Account) => {
+		setCodexReauthDialog({ isOpen: true, account });
+	};
+
 	const handleUpdateCustomEndpoint = async (
 		accountId: string,
 		customEndpoint: string | null,
@@ -561,6 +585,8 @@ export function AccountsTab() {
 						onCustomEndpointChange={handleCustomEndpointChange}
 						onModelMappingsChange={handleModelMappingsChange}
 						onReauth={handleReauth}
+						onAnthropicReauth={handleAnthropicReauth}
+						onCodexReauth={handleCodexReauth}
 					/>
 				</CardContent>
 			</Card>
@@ -644,6 +670,26 @@ export function AccountsTab() {
 				onSuccess={() => {
 					loadAccounts();
 					setQwenReauthDialog({ isOpen: false, account: null });
+				}}
+			/>
+			<AnthropicReauthDialog
+				isOpen={anthropicReauthDialog.isOpen}
+				account={anthropicReauthDialog.account}
+				onClose={() =>
+					setAnthropicReauthDialog({ isOpen: false, account: null })
+				}
+				onSuccess={() => {
+					loadAccounts();
+					setAnthropicReauthDialog({ isOpen: false, account: null });
+				}}
+			/>
+			<CodexReauthDialog
+				isOpen={codexReauthDialog.isOpen}
+				account={codexReauthDialog.account}
+				onClose={() => setCodexReauthDialog({ isOpen: false, account: null })}
+				onSuccess={() => {
+					loadAccounts();
+					setCodexReauthDialog({ isOpen: false, account: null });
 				}}
 			/>
 		</div>

--- a/packages/dashboard-web/src/components/accounts/AccountList.tsx
+++ b/packages/dashboard-web/src/components/accounts/AccountList.tsx
@@ -16,6 +16,8 @@ interface AccountListProps {
 	onCustomEndpointChange?: (account: Account) => void;
 	onModelMappingsChange?: (account: Account) => void;
 	onReauth?: (account: Account) => void;
+	onAnthropicReauth?: (account: Account) => void;
+	onCodexReauth?: (account: Account) => void;
 }
 
 export function AccountList({
@@ -33,6 +35,8 @@ export function AccountList({
 	onCustomEndpointChange,
 	onModelMappingsChange,
 	onReauth,
+	onAnthropicReauth,
+	onCodexReauth,
 }: AccountListProps) {
 	if (!accounts || accounts.length === 0) {
 		return <p className="text-muted-foreground">No accounts configured</p>;
@@ -75,6 +79,8 @@ export function AccountList({
 					onCustomEndpointChange={onCustomEndpointChange}
 					onModelMappingsChange={onModelMappingsChange}
 					onReauth={onReauth}
+					onAnthropicReauth={onAnthropicReauth}
+					onCodexReauth={onCodexReauth}
 				/>
 			))}
 		</div>

--- a/packages/dashboard-web/src/components/accounts/AccountListItem.tsx
+++ b/packages/dashboard-web/src/components/accounts/AccountListItem.tsx
@@ -46,6 +46,8 @@ interface AccountListItemProps {
 	onCustomEndpointChange?: (account: Account) => void;
 	onModelMappingsChange?: (account: Account) => void;
 	onReauth?: (account: Account) => void;
+	onAnthropicReauth?: (account: Account) => void;
+	onCodexReauth?: (account: Account) => void;
 }
 
 export function AccountListItem({
@@ -64,6 +66,8 @@ export function AccountListItem({
 	onCustomEndpointChange,
 	onModelMappingsChange,
 	onReauth,
+	onAnthropicReauth,
+	onCodexReauth,
 }: AccountListItemProps) {
 	const [isRefreshingUsage, setIsRefreshingUsage] = useState(false);
 	const presenter = new AccountPresenter(account);
@@ -321,6 +325,28 @@ export function AccountListItem({
 							size="sm"
 							onClick={() => onReauth(account)}
 							title="Re-authenticate this Qwen account (preserves all metadata)"
+						>
+							<KeyRound className="h-4 w-4" />
+						</Button>
+					)}
+					{account.provider === "anthropic" &&
+						account.hasRefreshToken &&
+						onAnthropicReauth && (
+							<Button
+								variant="ghost"
+								size="sm"
+								onClick={() => onAnthropicReauth(account)}
+								title="Re-authenticate this Anthropic account (preserves all metadata)"
+							>
+								<KeyRound className="h-4 w-4" />
+							</Button>
+						)}
+					{account.provider === "codex" && onCodexReauth && (
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={() => onCodexReauth(account)}
+							title="Re-authenticate this Codex account (preserves all metadata)"
 						>
 							<KeyRound className="h-4 w-4" />
 						</Button>

--- a/packages/dashboard-web/src/components/accounts/AnthropicReauthDialog.tsx
+++ b/packages/dashboard-web/src/components/accounts/AnthropicReauthDialog.tsx
@@ -36,13 +36,13 @@ export function AnthropicReauthDialog({
 
 	const handleStart = async () => {
 		if (!account) return;
-		setStep("awaiting-code");
 		setError("");
 
 		try {
 			const result = await api.initAnthropicReauth(account.id);
 			setAuthUrl(result.authUrl);
 			setSessionId(result.sessionId);
+			setStep("awaiting-code");
 			window.open(result.authUrl, "_blank");
 		} catch (err) {
 			setStep("error");

--- a/packages/dashboard-web/src/components/accounts/AnthropicReauthDialog.tsx
+++ b/packages/dashboard-web/src/components/accounts/AnthropicReauthDialog.tsx
@@ -1,0 +1,176 @@
+import { useState } from "react";
+import type { Account } from "../../api";
+import { api } from "../../api";
+import { Button } from "../ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "../ui/dialog";
+import { Input } from "../ui/input";
+import { Label } from "../ui/label";
+
+interface AnthropicReauthDialogProps {
+	account: Account | null;
+	isOpen: boolean;
+	onClose: () => void;
+	onSuccess: () => void;
+}
+
+type Step = "idle" | "awaiting-code" | "submitting" | "complete" | "error";
+
+export function AnthropicReauthDialog({
+	account,
+	isOpen,
+	onClose,
+	onSuccess,
+}: AnthropicReauthDialogProps) {
+	const [step, setStep] = useState<Step>("idle");
+	const [authUrl, setAuthUrl] = useState("");
+	const [sessionId, setSessionId] = useState("");
+	const [code, setCode] = useState("");
+	const [error, setError] = useState("");
+
+	const handleStart = async () => {
+		if (!account) return;
+		setStep("awaiting-code");
+		setError("");
+
+		try {
+			const result = await api.initAnthropicReauth(account.id);
+			setAuthUrl(result.authUrl);
+			setSessionId(result.sessionId);
+			window.open(result.authUrl, "_blank");
+		} catch (err) {
+			setStep("error");
+			setError(
+				err instanceof Error ? err.message : "Failed to start authentication",
+			);
+		}
+	};
+
+	const handleComplete = async () => {
+		if (!sessionId || !code.trim()) return;
+		setStep("submitting");
+		setError("");
+
+		try {
+			await api.completeAnthropicReauth(sessionId, code.trim());
+			setStep("complete");
+			setTimeout(() => {
+				onSuccess();
+				handleClose();
+			}, 1500);
+		} catch (err) {
+			setStep("error");
+			setError(
+				err instanceof Error
+					? err.message
+					: "Failed to complete authentication",
+			);
+		}
+	};
+
+	const handleClose = () => {
+		setStep("idle");
+		setAuthUrl("");
+		setSessionId("");
+		setCode("");
+		setError("");
+		onClose();
+	};
+
+	return (
+		<Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Re-authenticate Anthropic Account</DialogTitle>
+					<DialogDescription>
+						{account?.name
+							? `Re-authenticate "${account.name}". All account metadata (usage stats, priority, settings) will be preserved.`
+							: "Re-authenticate Anthropic account."}
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="py-4">
+					{step === "idle" && (
+						<p className="text-sm text-muted-foreground">
+							Click the button below to start the Anthropic OAuth flow. A
+							browser window will open for you to authorize. After approving,
+							paste the authorization code here.
+						</p>
+					)}
+
+					{step === "awaiting-code" && (
+						<div className="space-y-4">
+							<p className="text-sm text-muted-foreground">
+								A browser window has opened for authorization. After approving,
+								copy the authorization code and paste it below.
+							</p>
+							{authUrl && (
+								<a
+									href={authUrl}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="text-sm text-primary underline break-all"
+								>
+									Open authorization page
+								</a>
+							)}
+							<div className="space-y-2">
+								<Label htmlFor="auth-code">Authorization Code</Label>
+								<Input
+									id="auth-code"
+									placeholder="Paste the authorization code here"
+									value={code}
+									onChange={(e) => setCode(e.target.value)}
+									onKeyDown={(e) => {
+										if (e.key === "Enter" && code.trim()) {
+											handleComplete();
+										}
+									}}
+								/>
+							</div>
+						</div>
+					)}
+
+					{step === "submitting" && (
+						<p className="text-sm text-muted-foreground">
+							Completing re-authentication...
+						</p>
+					)}
+
+					{step === "complete" && (
+						<p className="text-sm text-green-600">
+							Re-authentication successful! Tokens updated.
+						</p>
+					)}
+
+					{step === "error" && (
+						<div className="space-y-2">
+							<p className="text-sm text-destructive">{error}</p>
+						</div>
+					)}
+				</div>
+
+				<DialogFooter>
+					{step === "idle" && (
+						<Button onClick={handleStart}>Start Re-authentication</Button>
+					)}
+					{step === "awaiting-code" && (
+						<Button onClick={handleComplete} disabled={!code.trim()}>
+							Complete Re-authentication
+						</Button>
+					)}
+					{step === "error" && <Button onClick={handleStart}>Try Again</Button>}
+					<Button variant="outline" onClick={handleClose}>
+						{step === "complete" ? "Close" : "Cancel"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/packages/dashboard-web/src/components/accounts/CodexReauthDialog.tsx
+++ b/packages/dashboard-web/src/components/accounts/CodexReauthDialog.tsx
@@ -1,0 +1,172 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Account } from "../../api";
+import { api } from "../../api";
+import { Button } from "../ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "../ui/dialog";
+
+interface CodexReauthDialogProps {
+	account: Account | null;
+	isOpen: boolean;
+	onClose: () => void;
+	onSuccess: () => void;
+}
+
+type Step = "idle" | "pending" | "complete" | "error";
+
+export function CodexReauthDialog({
+	account,
+	isOpen,
+	onClose,
+	onSuccess,
+}: CodexReauthDialogProps) {
+	const [step, setStep] = useState<Step>("idle");
+	const [verificationUrl, setVerificationUrl] = useState("");
+	const [userCode, setUserCode] = useState("");
+	const [error, setError] = useState("");
+	const sessionIdRef = useRef<string>("");
+	const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+	const stopPolling = useCallback(() => {
+		if (pollIntervalRef.current !== null) {
+			clearInterval(pollIntervalRef.current);
+			pollIntervalRef.current = null;
+		}
+	}, []);
+
+	// Clean up on unmount or close
+	useEffect(() => {
+		if (!isOpen) {
+			stopPolling();
+		}
+		return () => stopPolling();
+	}, [isOpen, stopPolling]);
+
+	const handleStart = async () => {
+		if (!account) return;
+		setStep("pending");
+		setError("");
+
+		try {
+			const result = await api.initCodexReauth({ accountId: account.id });
+			sessionIdRef.current = result.sessionId;
+			setVerificationUrl(result.verificationUrl);
+			setUserCode(result.userCode);
+
+			window.open(result.verificationUrl, "_blank");
+
+			pollIntervalRef.current = setInterval(async () => {
+				try {
+					const status = await api.getCodexAuthStatus(sessionIdRef.current);
+					if (status.status === "complete") {
+						stopPolling();
+						setStep("complete");
+						setTimeout(() => {
+							onSuccess();
+							handleClose();
+						}, 1500);
+					} else if (status.status === "error") {
+						stopPolling();
+						setStep("error");
+						setError(status.error || "Authentication failed");
+					}
+				} catch {
+					// transient poll error — keep trying
+				}
+			}, 3000);
+		} catch (err) {
+			setStep("error");
+			setError(
+				err instanceof Error ? err.message : "Failed to start authentication",
+			);
+		}
+	};
+
+	const handleClose = () => {
+		stopPolling();
+		setStep("idle");
+		setVerificationUrl("");
+		setUserCode("");
+		setError("");
+		onClose();
+	};
+
+	return (
+		<Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Re-authenticate Codex Account</DialogTitle>
+					<DialogDescription>
+						{account?.name
+							? `Re-authenticate "${account.name}". All account metadata (usage stats, priority, settings) will be preserved.`
+							: "Re-authenticate Codex account."}
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="py-4">
+					{step === "idle" && (
+						<p className="text-sm text-muted-foreground">
+							Click the button below to start the Codex device flow. A browser
+							window will open for you to authorize.
+						</p>
+					)}
+
+					{step === "pending" && (
+						<div className="space-y-3">
+							<p className="text-sm text-muted-foreground">
+								Waiting for authorization in browser...
+							</p>
+							{userCode && (
+								<div className="flex items-center gap-2">
+									<span className="text-sm text-muted-foreground">
+										User code:
+									</span>
+									<code className="text-sm font-mono bg-muted px-2 py-0.5 rounded">
+										{userCode}
+									</code>
+								</div>
+							)}
+							{verificationUrl && (
+								<a
+									href={verificationUrl}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="text-sm text-primary underline break-all"
+								>
+									Open authorization page
+								</a>
+							)}
+						</div>
+					)}
+
+					{step === "complete" && (
+						<p className="text-sm text-green-600">
+							Re-authentication successful! Tokens updated.
+						</p>
+					)}
+
+					{step === "error" && (
+						<div className="space-y-2">
+							<p className="text-sm text-destructive">{error}</p>
+						</div>
+					)}
+				</div>
+
+				<DialogFooter>
+					{(step === "idle" || step === "error") && (
+						<Button onClick={handleStart}>Start Re-authentication</Button>
+					)}
+					<Button variant="outline" onClick={handleClose}>
+						{step === "complete" ? "Close" : "Cancel"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/packages/dashboard-web/src/components/accounts/index.ts
+++ b/packages/dashboard-web/src/components/accounts/index.ts
@@ -4,6 +4,8 @@ export { AccountList } from "./AccountList";
 export { AccountListItem } from "./AccountListItem";
 export { AccountModelMappingsDialog } from "./AccountModelMappingsDialog";
 export { AccountPriorityDialog } from "./AccountPriorityDialog";
+export { AnthropicReauthDialog } from "./AnthropicReauthDialog";
+export { CodexReauthDialog } from "./CodexReauthDialog";
 export { DeleteConfirmationDialog } from "./DeleteConfirmationDialog";
 export { QwenReauthDialog } from "./QwenReauthDialog";
 export { RateLimitProgress } from "./RateLimitProgress";

--- a/packages/http-api/src/handlers/oauth.ts
+++ b/packages/http-api/src/handlers/oauth.ts
@@ -423,6 +423,124 @@ export function createCodexDeviceFlowInitHandler(dbOps: DatabaseOperations) {
 }
 
 /**
+ * Create a Codex re-authentication handler.
+ * Re-runs the device flow for an existing Codex account, updating tokens in-place.
+ * Returns { verificationUrl, userCode, sessionId } immediately, then polls in background.
+ */
+export function createCodexReauthHandler(dbOps: DatabaseOperations) {
+	return async (req: Request): Promise<Response> => {
+		try {
+			const body = await req.json();
+
+			const accountId = validateString(body.accountId, "accountId", {
+				required: true,
+				minLength: 1,
+				maxLength: 100,
+			});
+
+			if (!accountId) {
+				return errorResponse(BadRequest("Valid accountId is required"));
+			}
+
+			// Look up the account
+			const account = await dbOps.getAdapter().get<{
+				id: string;
+				name: string;
+				provider: string;
+			}>("SELECT id, name, provider FROM accounts WHERE id = ?", [accountId]);
+
+			if (!account) {
+				return errorResponse(NotFound("Account not found"));
+			}
+
+			if (account.provider !== "codex") {
+				return errorResponse(
+					BadRequest(
+						"Re-authentication via device flow is only supported for Codex accounts",
+					),
+				);
+			}
+
+			let deviceFlow: Awaited<ReturnType<typeof initiateCodexDeviceFlow>>;
+			try {
+				deviceFlow = await initiateCodexDeviceFlow();
+			} catch (err) {
+				log.error("Codex reauth device flow initiation failed:", err);
+				return errorResponse(
+					InternalServerError(
+						`Failed to initiate Codex device flow: ${(err as Error).message}`,
+					),
+				);
+			}
+
+			const sessionId = crypto.randomUUID();
+			codexSessions.set(sessionId, {
+				status: "pending",
+				accountName: account.name,
+			});
+
+			// Poll in background — do not await
+			(async () => {
+				try {
+					const tokens = await pollCodexForToken(
+						deviceFlow.deviceAuthId,
+						deviceFlow.userCode,
+						deviceFlow.interval,
+						180,
+					);
+
+					await dbOps.getAdapter().run(
+						`UPDATE accounts SET
+							refresh_token = ?,
+							access_token = ?,
+							expires_at = ?
+						WHERE id = ?`,
+						[
+							tokens.refresh_token,
+							tokens.access_token,
+							Date.now() + tokens.expires_in * 1000,
+							account.id,
+						],
+					);
+
+					codexSessions.set(sessionId, {
+						status: "complete",
+						accountName: account.name,
+					});
+					log.info(
+						`Codex account '${account.name}' re-authenticated via web device flow`,
+					);
+
+					setTimeout(() => codexSessions.delete(sessionId), 10 * 60 * 1000);
+				} catch (err) {
+					log.error(`Codex reauth polling failed for '${account.name}':`, err);
+					codexSessions.set(sessionId, {
+						status: "error",
+						accountName: account.name,
+						error: (err as Error).message,
+					});
+					setTimeout(() => codexSessions.delete(sessionId), 10 * 60 * 1000);
+				}
+			})();
+
+			return jsonResponse({
+				success: true,
+				sessionId,
+				verificationUrl: deviceFlow.verificationUrl,
+				userCode: deviceFlow.userCode,
+			});
+		} catch (error) {
+			log.error("Codex reauth error:", error);
+			return errorResponse(
+				error instanceof Error
+					? error
+					: new Error("Failed to initialize Codex re-authentication"),
+			);
+		}
+	};
+}
+
+/**
  * Create a Codex device flow status handler.
  * Returns { status, error? } for the given sessionId.
  */
@@ -436,6 +554,181 @@ export function createCodexDeviceFlowStatusHandler() {
 			return jsonResponse({ status: "error", error: session.error });
 		}
 		return jsonResponse({ status: session.status });
+	};
+}
+
+/**
+ * Create an Anthropic re-authentication init handler.
+ * Starts an OAuth flow for an existing Anthropic (claude-oauth) account.
+ * Returns { authUrl, sessionId } immediately.
+ */
+export function createAnthropicReauthInitHandler(dbOps: DatabaseOperations) {
+	return async (req: Request): Promise<Response> => {
+		try {
+			const body = await req.json();
+
+			const accountId = validateString(body.accountId, "accountId", {
+				required: true,
+				minLength: 1,
+				maxLength: 100,
+			});
+
+			if (!accountId) {
+				return errorResponse(BadRequest("Valid accountId is required"));
+			}
+
+			// Look up the account
+			const account = await dbOps.getAdapter().get<{
+				id: string;
+				name: string;
+				provider: string;
+				refresh_token: string | null;
+			}>(
+				"SELECT id, name, provider, refresh_token FROM accounts WHERE id = ?",
+				[accountId],
+			);
+
+			if (!account) {
+				return errorResponse(NotFound("Account not found"));
+			}
+
+			if (account.provider !== "anthropic") {
+				return errorResponse(
+					BadRequest(
+						"Re-authentication is only supported for Anthropic OAuth accounts",
+					),
+				);
+			}
+
+			const config = new Config();
+			const oauthFlow = await createOAuthFlow(dbOps, config);
+
+			try {
+				const flowResult = await oauthFlow.begin({
+					name: account.name,
+					mode: "claude-oauth",
+					skipAccountCheck: true,
+				});
+
+				// Store session; use accountName field so callback can look it up by name
+				dbOps.createOAuthSession(
+					flowResult.sessionId,
+					account.name,
+					flowResult.pkce.verifier,
+					"claude-oauth",
+					undefined,
+					10,
+				);
+
+				return jsonResponse({
+					success: true,
+					authUrl: flowResult.authUrl,
+					sessionId: flowResult.sessionId,
+				});
+			} catch (error) {
+				return errorResponse(InternalServerError((error as Error).message));
+			}
+		} catch (error) {
+			log.error("Anthropic reauth init error:", error);
+			return errorResponse(
+				error instanceof Error
+					? error
+					: new Error("Failed to initialize Anthropic re-authentication"),
+			);
+		}
+	};
+}
+
+/**
+ * Create an Anthropic re-authentication callback handler.
+ * Exchanges the authorization code and UPDATEs existing account tokens in place.
+ */
+export function createAnthropicReauthCallbackHandler(
+	dbOps: DatabaseOperations,
+) {
+	return async (req: Request): Promise<Response> => {
+		if (req.method !== "POST") {
+			return errorResponse(
+				BadRequest("Only POST requests are supported for OAuth callback"),
+			);
+		}
+
+		try {
+			const body = await req.json();
+
+			const sessionId = validateString(body.sessionId, "sessionId", {
+				required: true,
+				pattern: patterns.uuid,
+			})!;
+
+			const code = validateString(body.code, "code", {
+				required: true,
+				minLength: 1,
+			})!;
+
+			// Get stored session
+			const oauthSession = await dbOps.getOAuthSession(sessionId);
+			if (!oauthSession) {
+				return errorResponse(
+					BadRequest("OAuth session expired or invalid. Please try again."),
+				);
+			}
+
+			const { accountName: name, verifier } = oauthSession;
+
+			try {
+				const config = new Config();
+				const oauthFlow = await createOAuthFlow(dbOps, config);
+
+				const oauthProvider = await import("@better-ccflare/providers").then(
+					(m) => m.getOAuthProvider("anthropic"),
+				);
+				if (!oauthProvider) {
+					throw new Error("OAuth provider not found");
+				}
+				const runtime = config.getRuntime();
+				const oauthConfig = oauthProvider.getOAuthConfig("claude-oauth");
+				oauthConfig.clientId = runtime.clientId;
+
+				const flowData = {
+					sessionId,
+					authUrl: "",
+					pkce: { verifier, challenge: "" },
+					oauthConfig,
+					mode: "claude-oauth" as const,
+				};
+
+				log.debug(`Completing Anthropic reauth for account '${name}'`);
+
+				await oauthFlow.completeReauth({ sessionId, code, name }, flowData);
+
+				dbOps.deleteOAuthSession(sessionId);
+
+				log.info(`Successfully re-authenticated Anthropic account '${name}'`);
+
+				return jsonResponse({
+					success: true,
+					message: `Account '${name}' re-authenticated successfully!`,
+				});
+			} catch (error) {
+				log.error(
+					`Anthropic reauth callback failed for account '${name}':`,
+					error,
+				);
+				return errorResponse(
+					error instanceof Error
+						? error
+						: new Error("Failed to complete Anthropic re-authentication"),
+				);
+			}
+		} catch (error) {
+			log.error("Anthropic reauth callback validation error:", error);
+			return errorResponse(
+				error instanceof Error
+					? error
+					: new Error("Failed to process Anthropic reauth callback"),
+			);
+		}
 	};
 }
 

--- a/packages/http-api/src/handlers/oauth.ts
+++ b/packages/http-api/src/handlers/oauth.ts
@@ -562,7 +562,10 @@ export function createCodexDeviceFlowStatusHandler() {
  * Starts an OAuth flow for an existing Anthropic (claude-oauth) account.
  * Returns { authUrl, sessionId } immediately.
  */
-export function createAnthropicReauthInitHandler(dbOps: DatabaseOperations) {
+export function createAnthropicReauthInitHandler(
+	dbOps: DatabaseOperations,
+	config: Config,
+) {
 	return async (req: Request): Promise<Response> => {
 		try {
 			const body = await req.json();
@@ -600,7 +603,6 @@ export function createAnthropicReauthInitHandler(dbOps: DatabaseOperations) {
 				);
 			}
 
-			const config = new Config();
 			const oauthFlow = await createOAuthFlow(dbOps, config);
 
 			try {
@@ -645,6 +647,7 @@ export function createAnthropicReauthInitHandler(dbOps: DatabaseOperations) {
  */
 export function createAnthropicReauthCallbackHandler(
 	dbOps: DatabaseOperations,
+	config: Config,
 ) {
 	return async (req: Request): Promise<Response> => {
 		if (req.method !== "POST") {
@@ -659,12 +662,18 @@ export function createAnthropicReauthCallbackHandler(
 			const sessionId = validateString(body.sessionId, "sessionId", {
 				required: true,
 				pattern: patterns.uuid,
-			})!;
+			});
+			if (!sessionId) {
+				return errorResponse(BadRequest("Valid sessionId is required"));
+			}
 
 			const code = validateString(body.code, "code", {
 				required: true,
 				minLength: 1,
-			})!;
+			});
+			if (!code) {
+				return errorResponse(BadRequest("Valid code is required"));
+			}
 
 			// Get stored session
 			const oauthSession = await dbOps.getOAuthSession(sessionId);
@@ -676,8 +685,17 @@ export function createAnthropicReauthCallbackHandler(
 
 			const { accountName: name, verifier } = oauthSession;
 
+			// Look up the account by name to get its id for the UPDATE
+			const account = await dbOps
+				.getAdapter()
+				.get<{ id: string }>("SELECT id FROM accounts WHERE name = ?", [name]);
+			if (!account) {
+				return errorResponse(
+					BadRequest(`Account '${name}' not found. It may have been deleted.`),
+				);
+			}
+
 			try {
-				const config = new Config();
 				const oauthFlow = await createOAuthFlow(dbOps, config);
 
 				const oauthProvider = await import("@better-ccflare/providers").then(
@@ -700,7 +718,10 @@ export function createAnthropicReauthCallbackHandler(
 
 				log.debug(`Completing Anthropic reauth for account '${name}'`);
 
-				await oauthFlow.completeReauth({ sessionId, code, name }, flowData);
+				await oauthFlow.completeReauth(
+					{ sessionId, code, name, id: account.id },
+					flowData,
+				);
 
 				dbOps.deleteOAuthSession(sessionId);
 

--- a/packages/http-api/src/router.ts
+++ b/packages/http-api/src/router.ts
@@ -75,8 +75,11 @@ import {
 	createCompactHandler,
 } from "./handlers/maintenance";
 import {
+	createAnthropicReauthCallbackHandler,
+	createAnthropicReauthInitHandler,
 	createCodexDeviceFlowInitHandler,
 	createCodexDeviceFlowStatusHandler,
+	createCodexReauthHandler,
 	createOAuthCallbackHandler,
 	createOAuthInitHandler,
 	createQwenDeviceFlowInitHandler,
@@ -160,6 +163,10 @@ export class APIRouter {
 		const qwenDeviceFlowInitHandler = createQwenDeviceFlowInitHandler(dbOps);
 		const qwenReauthHandler = createQwenReauthHandler(dbOps);
 		const codexDeviceFlowInitHandler = createCodexDeviceFlowInitHandler(dbOps);
+		const codexReauthHandler = createCodexReauthHandler(dbOps);
+		const anthropicReauthInitHandler = createAnthropicReauthInitHandler(dbOps);
+		const anthropicReauthCallbackHandler =
+			createAnthropicReauthCallbackHandler(dbOps);
 		const agentsHandler = createAgentsListHandler(dbOps);
 		const workspacesHandler = createWorkspacesListHandler();
 		const requestsStreamHandler = createRequestsStreamHandler();
@@ -237,8 +244,17 @@ export class APIRouter {
 		this.handlers.set("POST:/api/oauth/qwen/reauth", (req) =>
 			qwenReauthHandler(req),
 		);
+		this.handlers.set("POST:/api/oauth/anthropic/reauth/init", (req) =>
+			anthropicReauthInitHandler(req),
+		);
+		this.handlers.set("POST:/api/oauth/anthropic/reauth/callback", (req) =>
+			anthropicReauthCallbackHandler(req),
+		);
 		this.handlers.set("POST:/api/oauth/codex/init", (req) =>
 			codexDeviceFlowInitHandler(req),
+		);
+		this.handlers.set("POST:/api/oauth/codex/reauth", (req) =>
+			codexReauthHandler(req),
 		);
 		this.handlers.set("GET:/api/requests", (_req, url) => {
 			const limitParam = url.searchParams.get("limit");

--- a/packages/http-api/src/router.ts
+++ b/packages/http-api/src/router.ts
@@ -164,9 +164,14 @@ export class APIRouter {
 		const qwenReauthHandler = createQwenReauthHandler(dbOps);
 		const codexDeviceFlowInitHandler = createCodexDeviceFlowInitHandler(dbOps);
 		const codexReauthHandler = createCodexReauthHandler(dbOps);
-		const anthropicReauthInitHandler = createAnthropicReauthInitHandler(dbOps);
-		const anthropicReauthCallbackHandler =
-			createAnthropicReauthCallbackHandler(dbOps);
+		const anthropicReauthInitHandler = createAnthropicReauthInitHandler(
+			dbOps,
+			config,
+		);
+		const anthropicReauthCallbackHandler = createAnthropicReauthCallbackHandler(
+			dbOps,
+			config,
+		);
 		const agentsHandler = createAgentsListHandler(dbOps);
 		const workspacesHandler = createWorkspacesListHandler();
 		const requestsStreamHandler = createRequestsStreamHandler();

--- a/packages/oauth-flow/src/index.ts
+++ b/packages/oauth-flow/src/index.ts
@@ -26,6 +26,7 @@ export interface CompleteOptions {
 	sessionId: string;
 	code: string;
 	name: string; // Required to properly create the account
+	id?: string; // Account ID for re-authentication (UPDATE by id instead of name)
 	priority?: number;
 	customEndpoint?: string; // Custom API endpoint
 }
@@ -187,7 +188,11 @@ export class OAuthFlow {
 		opts: CompleteOptions,
 		flowData: BeginResult,
 	): Promise<void> {
-		const { code, name } = opts;
+		const { code, id } = opts;
+
+		if (!id) {
+			throw new Error("Account id is required for re-authentication");
+		}
 
 		// Get OAuth provider
 		const oauthProvider = getOAuthProvider("anthropic");
@@ -207,17 +212,17 @@ export class OAuthFlow {
 		// Handle console mode — create new API key and update account
 		if (flowData.mode === "console" || !tokens.refreshToken) {
 			const apiKey = await this.createAnthropicApiKey(tokens.accessToken);
-			await adapter.run(`UPDATE accounts SET api_key = ? WHERE name = ?`, [
+			await adapter.run(`UPDATE accounts SET api_key = ? WHERE id = ?`, [
 				apiKey,
-				name,
+				id,
 			]);
 			return;
 		}
 
 		// Handle claude-oauth mode — update OAuth tokens in place
 		await adapter.run(
-			`UPDATE accounts SET refresh_token = ?, access_token = ?, expires_at = ? WHERE name = ?`,
-			[tokens.refreshToken, tokens.accessToken, tokens.expiresAt, name],
+			`UPDATE accounts SET refresh_token = ?, access_token = ?, expires_at = ? WHERE id = ?`,
+			[tokens.refreshToken, tokens.accessToken, tokens.expiresAt, id],
 		);
 	}
 

--- a/packages/oauth-flow/src/index.ts
+++ b/packages/oauth-flow/src/index.ts
@@ -174,6 +174,54 @@ export class OAuthFlow {
 	}
 
 	/**
+	 * Completes re-authentication for an existing Anthropic account.
+	 *
+	 * Exchanges the authorization code for tokens and UPDATEs the existing account
+	 * in place, preserving all metadata (stats, priority, settings).
+	 *
+	 * @param opts - Completion options (sessionId, code, name — the existing account name)
+	 * @param flowData - Flow data returned from {@link begin}
+	 * @throws {Error} If OAuth provider not found or token exchange fails
+	 */
+	async completeReauth(
+		opts: CompleteOptions,
+		flowData: BeginResult,
+	): Promise<void> {
+		const { code, name } = opts;
+
+		// Get OAuth provider
+		const oauthProvider = getOAuthProvider("anthropic");
+		if (!oauthProvider) {
+			throw new Error("Anthropic OAuth provider not found");
+		}
+
+		// Exchange authorization code for tokens
+		const tokens = await oauthProvider.exchangeCode(
+			code,
+			flowData.pkce.verifier,
+			flowData.oauthConfig,
+		);
+
+		const adapter = this.dbOps.getAdapter();
+
+		// Handle console mode — create new API key and update account
+		if (flowData.mode === "console" || !tokens.refreshToken) {
+			const apiKey = await this.createAnthropicApiKey(tokens.accessToken);
+			await adapter.run(`UPDATE accounts SET api_key = ? WHERE name = ?`, [
+				apiKey,
+				name,
+			]);
+			return;
+		}
+
+		// Handle claude-oauth mode — update OAuth tokens in place
+		await adapter.run(
+			`UPDATE accounts SET refresh_token = ?, access_token = ?, expires_at = ? WHERE name = ?`,
+			[tokens.refreshToken, tokens.accessToken, tokens.expiresAt, name],
+		);
+	}
+
+	/**
 	 * Creates an API key using the Anthropic console endpoint.
 	 *
 	 * This is used for "console" mode accounts where users want a static API key


### PR DESCRIPTION
## Summary
- Cherry-picks the Anthropic/Codex dashboard re-authentication feature (in-dashboard reauth for Anthropic OAuth and Codex accounts, preserving account metadata instead of delete/re-add).
- Fixes P2 issue in `OAuthFlow.completeReauth` by updating accounts using `id` instead of `name`, and threads account id through the Anthropic reauth callback path.
- Fixes P2 safety/UX issues by removing non-null assertions in Anthropic reauth callback validation, injecting shared router `config` into Anthropic reauth handlers (instead of `new Config()` per request), and advancing the Anthropic reauth dialog to `awaiting-code` only after init API success.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run format`
- [x] `bun run lint` (currently fails due to pre-existing repo-wide Biome violations unrelated to this PR)
- [ ] Start server and verify Anthropic reauth flow: init -> authorize -> callback updates existing account tokens in place
- [ ] Verify Codex reauth flow updates tokens in place and preserves metadata
- [ ] Verify Anthropic reauth dialog does not show "browser opened" step until init API returns success

🤖 Generated with [Claude Code](https://claude.com/claude-code)