### PR TITLE
fix: track pause reason and prevent unsafe auto-unpause

### DIFF
--- a/packages/database/src/database-operations.ts
+++ b/packages/database/src/database-operations.ts
@@ -418,8 +418,8 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 		);
 	}
 
-	async pauseAccount(accountId: string): Promise<void> {
-		await this.accounts.pause(accountId);
+	async pauseAccount(accountId: string, reason = "manual"): Promise<void> {
+		await this.accounts.pause(accountId, reason);
 	}
 
 	async resumeAccount(accountId: string): Promise<void> {

--- a/packages/database/src/migrations.ts
+++ b/packages/database/src/migrations.ts
@@ -444,6 +444,31 @@ export function runMigrations(db: Database, dbPath?: string): void {
 			log.info("Added auto_pause_on_overage_enabled column to accounts table");
 		}
 
+		// Add pause_reason column to track why an account is paused (issue #139)
+		// Possible values: null (not paused), 'manual' (user paused via CLI/API),
+		// 'failure_threshold' (auto-refresh failures), 'overage' (billing overage)
+		if (!initialAccountsColumnNames.includes("pause_reason")) {
+			db.prepare("ALTER TABLE accounts ADD COLUMN pause_reason TEXT").run();
+			log.info("Added pause_reason column to accounts table");
+
+			// Backfill existing paused accounts:
+			// - If auto_pause_on_overage_enabled = 1 and paused, assume paused for overage
+			// - Otherwise, treat as manually paused
+			db.prepare(`
+				UPDATE accounts
+				SET pause_reason = 'overage'
+				WHERE COALESCE(paused, 0) = 1
+				AND COALESCE(auto_pause_on_overage_enabled, 0) = 1
+			`).run();
+			db.prepare(`
+				UPDATE accounts
+				SET pause_reason = 'manual'
+				WHERE COALESCE(paused, 0) = 1
+				AND COALESCE(auto_pause_on_overage_enabled, 0) = 0
+			`).run();
+			log.info("Backfilled pause_reason for existing paused accounts");
+		}
+
 		// Make refresh_token nullable (was NOT NULL, causing API-key providers to need workarounds)
 		const refreshTokenCol = accountsInfo.find(
 			(col) => col.name === "refresh_token",

--- a/packages/database/src/migrations.ts
+++ b/packages/database/src/migrations.ts
@@ -501,8 +501,9 @@ export function runMigrations(db: Database, dbPath?: string): void {
 					auto_refresh_enabled INTEGER DEFAULT 0,
 					model_mappings TEXT,
 					cross_region_mode TEXT DEFAULT 'geographic',
-				model_fallbacks TEXT,
-				auto_pause_on_overage_enabled INTEGER DEFAULT 0
+					model_fallbacks TEXT,
+					auto_pause_on_overage_enabled INTEGER DEFAULT 0,
+					pause_reason TEXT
 				)
 			`).run();
 
@@ -518,7 +519,7 @@ export function runMigrations(db: Database, dbPath?: string): void {
 					paused, rate_limit_reset, rate_limit_status, rate_limit_remaining,
 					auto_fallback_enabled, custom_endpoint, auto_refresh_enabled,
 					model_mappings, cross_region_mode, model_fallbacks,
-					auto_pause_on_overage_enabled
+					auto_pause_on_overage_enabled, pause_reason
 				FROM accounts
 			`).run();
 
@@ -804,7 +805,8 @@ export function runMigrations(db: Database, dbPath?: string): void {
 			       rate_limited_until, session_start, session_request_count, paused,
 			       rate_limit_reset, rate_limit_status, rate_limit_remaining,
 			       auto_fallback_enabled, custom_endpoint, auto_refresh_enabled, model_mappings,
-			       cross_region_mode, model_fallbacks, billing_type, auto_pause_on_overage_enabled
+			       cross_region_mode, model_fallbacks, billing_type, auto_pause_on_overage_enabled,
+			       pause_reason
 			FROM accounts
 		`).run();
 

--- a/packages/database/src/migrations.ts
+++ b/packages/database/src/migrations.ts
@@ -451,20 +451,12 @@ export function runMigrations(db: Database, dbPath?: string): void {
 			db.prepare("ALTER TABLE accounts ADD COLUMN pause_reason TEXT").run();
 			log.info("Added pause_reason column to accounts table");
 
-			// Backfill existing paused accounts:
-			// - If auto_pause_on_overage_enabled = 1 and paused, assume paused for overage
-			// - Otherwise, treat as manually paused
-			db.prepare(`
-				UPDATE accounts
-				SET pause_reason = 'overage'
-				WHERE COALESCE(paused, 0) = 1
-				AND COALESCE(auto_pause_on_overage_enabled, 0) = 1
-			`).run();
+			// Backfill existing paused accounts conservatively as manual.
+			// We cannot reliably distinguish historical overage pauses from other pauses.
 			db.prepare(`
 				UPDATE accounts
 				SET pause_reason = 'manual'
 				WHERE COALESCE(paused, 0) = 1
-				AND COALESCE(auto_pause_on_overage_enabled, 0) = 0
 			`).run();
 			log.info("Backfilled pause_reason for existing paused accounts");
 		}

--- a/packages/database/src/pause-reason-migration.test.ts
+++ b/packages/database/src/pause-reason-migration.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for the pause_reason migration backfill (issue #139).
+ *
+ * When the pause_reason column is first added by runMigrations():
+ *  - Paused accounts with auto_pause_on_overage_enabled=1  → pause_reason='overage'
+ *  - Paused accounts with auto_pause_on_overage_enabled=0  → pause_reason='manual'
+ *  - Unpaused accounts                                      → pause_reason=NULL
+ */
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { runMigrations } from "./migrations";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an in-memory database that looks like a pre-pause_reason schema:
+ * the accounts table exists but the pause_reason column is absent.
+ */
+function makePreMigrationDb(): Database {
+	const db = new Database(":memory:");
+
+	// Create the accounts table *without* pause_reason (simulates old schema)
+	db.run(`
+		CREATE TABLE accounts (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			provider TEXT DEFAULT 'anthropic',
+			api_key TEXT,
+			refresh_token TEXT DEFAULT '',
+			access_token TEXT,
+			expires_at INTEGER,
+			created_at INTEGER NOT NULL,
+			last_used INTEGER,
+			request_count INTEGER DEFAULT 0,
+			total_requests INTEGER DEFAULT 0,
+			priority INTEGER DEFAULT 0,
+			rate_limited_until INTEGER,
+			session_start INTEGER,
+			session_request_count INTEGER DEFAULT 0,
+			paused INTEGER DEFAULT 0,
+			rate_limit_reset INTEGER,
+			rate_limit_status TEXT,
+			rate_limit_remaining INTEGER,
+			auto_fallback_enabled INTEGER DEFAULT 0,
+			auto_refresh_enabled INTEGER DEFAULT 0,
+			auto_pause_on_overage_enabled INTEGER DEFAULT 0,
+			custom_endpoint TEXT,
+			model_mappings TEXT,
+			cross_region_mode TEXT,
+			model_fallbacks TEXT,
+			billing_type TEXT
+		)
+	`);
+
+	return db;
+}
+
+interface PauseRow {
+	id: string;
+	paused: number;
+	pause_reason: string | null;
+}
+
+function getAccount(db: Database, id: string): PauseRow {
+	return db
+		.query<PauseRow, [string]>(
+			"SELECT id, paused, pause_reason FROM accounts WHERE id = ?",
+		)
+		.get(id) as PauseRow;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Database migration — pause_reason backfill (issue #139)", () => {
+	let db: Database;
+
+	beforeEach(() => {
+		db = makePreMigrationDb();
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("adds the pause_reason column during migration", () => {
+		runMigrations(db);
+
+		const cols = db.prepare("PRAGMA table_info(accounts)").all() as Array<{
+			name: string;
+		}>;
+		const names = cols.map((c) => c.name);
+
+		expect(names).toContain("pause_reason");
+	});
+
+	it("backfills pause_reason='overage' for paused accounts with auto_pause_on_overage_enabled=1", () => {
+		db.run(`
+			INSERT INTO accounts (id, name, created_at, paused, auto_pause_on_overage_enabled)
+			VALUES ('overage-acc', 'overage-acc', ${Date.now()}, 1, 1)
+		`);
+
+		runMigrations(db);
+
+		const row = getAccount(db, "overage-acc");
+		expect(row.paused).toBe(1);
+		expect(row.pause_reason).toBe("overage");
+	});
+
+	it("backfills pause_reason='manual' for paused accounts with auto_pause_on_overage_enabled=0", () => {
+		db.run(`
+			INSERT INTO accounts (id, name, created_at, paused, auto_pause_on_overage_enabled)
+			VALUES ('manual-acc', 'manual-acc', ${Date.now()}, 1, 0)
+		`);
+
+		runMigrations(db);
+
+		const row = getAccount(db, "manual-acc");
+		expect(row.paused).toBe(1);
+		expect(row.pause_reason).toBe("manual");
+	});
+
+	it("leaves pause_reason=NULL for unpaused accounts", () => {
+		db.run(`
+			INSERT INTO accounts (id, name, created_at, paused, auto_pause_on_overage_enabled)
+			VALUES ('active-acc', 'active-acc', ${Date.now()}, 0, 1)
+		`);
+
+		runMigrations(db);
+
+		const row = getAccount(db, "active-acc");
+		expect(row.paused).toBe(0);
+		expect(row.pause_reason).toBeNull();
+	});
+
+	it("handles mixed accounts in a single migration pass", () => {
+		const now = Date.now();
+		db.run(`
+			INSERT INTO accounts (id, name, created_at, paused, auto_pause_on_overage_enabled)
+			VALUES
+				('overage-1', 'overage-1', ${now}, 1, 1),
+				('manual-1',  'manual-1',  ${now}, 1, 0),
+				('active-1',  'active-1',  ${now}, 0, 0),
+				('active-2',  'active-2',  ${now}, 0, 1)
+		`);
+
+		runMigrations(db);
+
+		const overage1 = getAccount(db, "overage-1");
+		const manual1 = getAccount(db, "manual-1");
+		const active1 = getAccount(db, "active-1");
+		const active2 = getAccount(db, "active-2");
+
+		expect(overage1.pause_reason).toBe("overage");
+		expect(manual1.pause_reason).toBe("manual");
+		expect(active1.pause_reason).toBeNull();
+		expect(active2.pause_reason).toBeNull();
+	});
+
+	it("is idempotent — running migrations twice does not corrupt pause_reason", () => {
+		const now = Date.now();
+		db.run(`
+			INSERT INTO accounts (id, name, created_at, paused, auto_pause_on_overage_enabled)
+			VALUES ('overage-idem', 'overage-idem', ${now}, 1, 1)
+		`);
+
+		runMigrations(db);
+
+		// Second run should be a no-op since the column already exists
+		expect(() => runMigrations(db)).not.toThrow();
+
+		const row = getAccount(db, "overage-idem");
+		expect(row.pause_reason).toBe("overage");
+	});
+
+	it("treats accounts with NULL auto_pause_on_overage_enabled as 0 (COALESCE safety)", () => {
+		const now = Date.now();
+		// Insert without setting auto_pause_on_overage_enabled — defaults to 0
+		db.run(`
+			INSERT INTO accounts (id, name, created_at, paused)
+			VALUES ('null-overage-acc', 'null-overage-acc', ${now}, 1)
+		`);
+		// Explicitly set to NULL to test COALESCE
+		db.run(
+			"UPDATE accounts SET auto_pause_on_overage_enabled = NULL WHERE id = 'null-overage-acc'",
+		);
+
+		runMigrations(db);
+
+		const row = getAccount(db, "null-overage-acc");
+		expect(row.paused).toBe(1);
+		// COALESCE(NULL, 0) = 0 → treated as no overage flag → 'manual'
+		expect(row.pause_reason).toBe("manual");
+	});
+});

--- a/packages/database/src/pause-reason-migration.test.ts
+++ b/packages/database/src/pause-reason-migration.test.ts
@@ -2,26 +2,16 @@
  * Tests for the pause_reason migration backfill (issue #139).
  *
  * When the pause_reason column is first added by runMigrations():
- *  - Paused accounts with auto_pause_on_overage_enabled=1  → pause_reason='overage'
- *  - Paused accounts with auto_pause_on_overage_enabled=0  → pause_reason='manual'
+ *  - All pre-existing paused accounts                       → pause_reason='manual'
  *  - Unpaused accounts                                      → pause_reason=NULL
  */
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { runMigrations } from "./migrations";
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Build an in-memory database that looks like a pre-pause_reason schema:
- * the accounts table exists but the pause_reason column is absent.
- */
 function makePreMigrationDb(): Database {
 	const db = new Database(":memory:");
 
-	// Create the accounts table *without* pause_reason (simulates old schema)
 	db.run(`
 		CREATE TABLE accounts (
 			id TEXT PRIMARY KEY,
@@ -71,10 +61,6 @@ function getAccount(db: Database, id: string): PauseRow {
 		.get(id) as PauseRow;
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 describe("Database migration — pause_reason backfill (issue #139)", () => {
 	let db: Database;
 
@@ -97,28 +83,28 @@ describe("Database migration — pause_reason backfill (issue #139)", () => {
 		expect(names).toContain("pause_reason");
 	});
 
-	it("backfills pause_reason='overage' for paused accounts with auto_pause_on_overage_enabled=1", () => {
+	it("backfills paused accounts as manual when auto_pause_on_overage_enabled=1", () => {
 		db.run(`
 			INSERT INTO accounts (id, name, created_at, paused, auto_pause_on_overage_enabled)
-			VALUES ('overage-acc', 'overage-acc', ${Date.now()}, 1, 1)
+			VALUES ('paused-overage-flag', 'paused-overage-flag', ${Date.now()}, 1, 1)
 		`);
 
 		runMigrations(db);
 
-		const row = getAccount(db, "overage-acc");
+		const row = getAccount(db, "paused-overage-flag");
 		expect(row.paused).toBe(1);
-		expect(row.pause_reason).toBe("overage");
+		expect(row.pause_reason).toBe("manual");
 	});
 
-	it("backfills pause_reason='manual' for paused accounts with auto_pause_on_overage_enabled=0", () => {
+	it("backfills paused accounts as manual when auto_pause_on_overage_enabled=0", () => {
 		db.run(`
 			INSERT INTO accounts (id, name, created_at, paused, auto_pause_on_overage_enabled)
-			VALUES ('manual-acc', 'manual-acc', ${Date.now()}, 1, 0)
+			VALUES ('paused-no-overage-flag', 'paused-no-overage-flag', ${Date.now()}, 1, 0)
 		`);
 
 		runMigrations(db);
 
-		const row = getAccount(db, "manual-acc");
+		const row = getAccount(db, "paused-no-overage-flag");
 		expect(row.paused).toBe(1);
 		expect(row.pause_reason).toBe("manual");
 	});
@@ -141,49 +127,40 @@ describe("Database migration — pause_reason backfill (issue #139)", () => {
 		db.run(`
 			INSERT INTO accounts (id, name, created_at, paused, auto_pause_on_overage_enabled)
 			VALUES
-				('overage-1', 'overage-1', ${now}, 1, 1),
-				('manual-1',  'manual-1',  ${now}, 1, 0),
-				('active-1',  'active-1',  ${now}, 0, 0),
-				('active-2',  'active-2',  ${now}, 0, 1)
+				('paused-overage-flag', 'paused-overage-flag', ${now}, 1, 1),
+				('paused-no-overage-flag', 'paused-no-overage-flag', ${now}, 1, 0),
+				('active-1', 'active-1', ${now}, 0, 0),
+				('active-2', 'active-2', ${now}, 0, 1)
 		`);
 
 		runMigrations(db);
 
-		const overage1 = getAccount(db, "overage-1");
-		const manual1 = getAccount(db, "manual-1");
-		const active1 = getAccount(db, "active-1");
-		const active2 = getAccount(db, "active-2");
-
-		expect(overage1.pause_reason).toBe("overage");
-		expect(manual1.pause_reason).toBe("manual");
-		expect(active1.pause_reason).toBeNull();
-		expect(active2.pause_reason).toBeNull();
+		expect(getAccount(db, "paused-overage-flag").pause_reason).toBe("manual");
+		expect(getAccount(db, "paused-no-overage-flag").pause_reason).toBe("manual");
+		expect(getAccount(db, "active-1").pause_reason).toBeNull();
+		expect(getAccount(db, "active-2").pause_reason).toBeNull();
 	});
 
 	it("is idempotent — running migrations twice does not corrupt pause_reason", () => {
 		const now = Date.now();
 		db.run(`
 			INSERT INTO accounts (id, name, created_at, paused, auto_pause_on_overage_enabled)
-			VALUES ('overage-idem', 'overage-idem', ${now}, 1, 1)
+			VALUES ('idem-paused', 'idem-paused', ${now}, 1, 1)
 		`);
 
 		runMigrations(db);
-
-		// Second run should be a no-op since the column already exists
 		expect(() => runMigrations(db)).not.toThrow();
 
-		const row = getAccount(db, "overage-idem");
-		expect(row.pause_reason).toBe("overage");
+		const row = getAccount(db, "idem-paused");
+		expect(row.pause_reason).toBe("manual");
 	});
 
-	it("treats accounts with NULL auto_pause_on_overage_enabled as 0 (COALESCE safety)", () => {
+	it("treats accounts with NULL auto_pause_on_overage_enabled as manual when paused", () => {
 		const now = Date.now();
-		// Insert without setting auto_pause_on_overage_enabled — defaults to 0
 		db.run(`
 			INSERT INTO accounts (id, name, created_at, paused)
 			VALUES ('null-overage-acc', 'null-overage-acc', ${now}, 1)
 		`);
-		// Explicitly set to NULL to test COALESCE
 		db.run(
 			"UPDATE accounts SET auto_pause_on_overage_enabled = NULL WHERE id = 'null-overage-acc'",
 		);
@@ -192,7 +169,6 @@ describe("Database migration — pause_reason backfill (issue #139)", () => {
 
 		const row = getAccount(db, "null-overage-acc");
 		expect(row.paused).toBe(1);
-		// COALESCE(NULL, 0) = 0 → treated as no overage flag → 'manual'
 		expect(row.pause_reason).toBe("manual");
 	});
 });

--- a/packages/database/src/repositories/__tests__/account-pause-reason.test.ts
+++ b/packages/database/src/repositories/__tests__/account-pause-reason.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tests for AccountRepository pause/resume with pause_reason (issue #139).
+ *
+ * Verifies that:
+ *  - pause(id)                     sets paused=1, pause_reason='manual'
+ *  - pause(id, 'failure_threshold') sets paused=1, pause_reason='failure_threshold'
+ *  - pause(id, 'overage')           sets paused=1, pause_reason='overage'
+ *  - resume(id)                    sets paused=0, pause_reason=NULL
+ */
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+// Force @better-ccflare/core to initialise before @better-ccflare/types resolves its
+// circular dependency (types/agent.ts → core → core/strategy.ts → types/StrategyName).
+// Without this the enum is undefined when strategy.ts runs. Same pattern as stats-session-cost.test.ts.
+import "@better-ccflare/core";
+import { BunSqlAdapter } from "../../adapters/bun-sql-adapter";
+import { AccountRepository } from "../account.repository";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(): { db: Database; repo: AccountRepository } {
+	const db = new Database(":memory:");
+
+	// Minimal schema — only the columns AccountRepository touches
+	db.run(`
+		CREATE TABLE accounts (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL,
+			provider TEXT DEFAULT 'anthropic',
+			api_key TEXT,
+			refresh_token TEXT DEFAULT '',
+			access_token TEXT,
+			expires_at INTEGER,
+			created_at INTEGER NOT NULL,
+			last_used INTEGER,
+			request_count INTEGER DEFAULT 0,
+			total_requests INTEGER DEFAULT 0,
+			rate_limited_until INTEGER,
+			session_start INTEGER,
+			session_request_count INTEGER DEFAULT 0,
+			paused INTEGER DEFAULT 0,
+			rate_limit_reset INTEGER,
+			rate_limit_status TEXT,
+			rate_limit_remaining INTEGER,
+			priority INTEGER DEFAULT 0,
+			auto_fallback_enabled INTEGER DEFAULT 0,
+			auto_refresh_enabled INTEGER DEFAULT 0,
+			auto_pause_on_overage_enabled INTEGER DEFAULT 0,
+			custom_endpoint TEXT,
+			model_mappings TEXT,
+			cross_region_mode TEXT,
+			model_fallbacks TEXT,
+			billing_type TEXT,
+			pause_reason TEXT
+		)
+	`);
+
+	const adapter = new BunSqlAdapter(db);
+	const repo = new AccountRepository(adapter);
+	return { db, repo };
+}
+
+function insertAccount(db: Database, id: string, paused = 0): void {
+	db.run(
+		`INSERT INTO accounts (id, name, created_at, paused) VALUES (?, ?, ?, ?)`,
+		[id, id, Date.now(), paused],
+	);
+}
+
+interface RawAccount {
+	paused: number;
+	pause_reason: string | null;
+}
+
+function getAccount(db: Database, id: string): RawAccount {
+	return db
+		.query<RawAccount, [string]>(
+			"SELECT paused, pause_reason FROM accounts WHERE id = ?",
+		)
+		.get(id) as RawAccount;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AccountRepository — pause / resume with pause_reason", () => {
+	let db: Database;
+	let repo: AccountRepository;
+
+	beforeEach(() => {
+		({ db, repo } = makeDb());
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	describe("pause(id) — default reason", () => {
+		it("sets paused=1 and pause_reason='manual' by default", async () => {
+			insertAccount(db, "acc-1");
+
+			await repo.pause("acc-1");
+
+			const row = getAccount(db, "acc-1");
+			expect(row.paused).toBe(1);
+			expect(row.pause_reason).toBe("manual");
+		});
+	});
+
+	describe("pause(id, 'manual')", () => {
+		it("sets paused=1 and pause_reason='manual' when reason is explicit", async () => {
+			insertAccount(db, "acc-2");
+
+			await repo.pause("acc-2", "manual");
+
+			const row = getAccount(db, "acc-2");
+			expect(row.paused).toBe(1);
+			expect(row.pause_reason).toBe("manual");
+		});
+	});
+
+	describe("pause(id, 'failure_threshold')", () => {
+		it("sets paused=1 and pause_reason='failure_threshold'", async () => {
+			insertAccount(db, "acc-3");
+
+			await repo.pause("acc-3", "failure_threshold");
+
+			const row = getAccount(db, "acc-3");
+			expect(row.paused).toBe(1);
+			expect(row.pause_reason).toBe("failure_threshold");
+		});
+	});
+
+	describe("pause(id, 'overage')", () => {
+		it("sets paused=1 and pause_reason='overage'", async () => {
+			insertAccount(db, "acc-4");
+
+			await repo.pause("acc-4", "overage");
+
+			const row = getAccount(db, "acc-4");
+			expect(row.paused).toBe(1);
+			expect(row.pause_reason).toBe("overage");
+		});
+	});
+
+	describe("resume(id)", () => {
+		it("sets paused=0 and clears pause_reason to NULL", async () => {
+			insertAccount(db, "acc-5", 1);
+			db.run("UPDATE accounts SET pause_reason = 'manual' WHERE id = 'acc-5'");
+
+			await repo.resume("acc-5");
+
+			const row = getAccount(db, "acc-5");
+			expect(row.paused).toBe(0);
+			expect(row.pause_reason).toBeNull();
+		});
+
+		it("clears pause_reason=NULL for an overage-paused account", async () => {
+			insertAccount(db, "acc-6", 1);
+			db.run("UPDATE accounts SET pause_reason = 'overage' WHERE id = 'acc-6'");
+
+			await repo.resume("acc-6");
+
+			const row = getAccount(db, "acc-6");
+			expect(row.paused).toBe(0);
+			expect(row.pause_reason).toBeNull();
+		});
+
+		it("clears pause_reason=NULL for a failure_threshold-paused account", async () => {
+			insertAccount(db, "acc-7", 1);
+			db.run(
+				"UPDATE accounts SET pause_reason = 'failure_threshold' WHERE id = 'acc-7'",
+			);
+
+			await repo.resume("acc-7");
+
+			const row = getAccount(db, "acc-7");
+			expect(row.paused).toBe(0);
+			expect(row.pause_reason).toBeNull();
+		});
+	});
+});

--- a/packages/database/src/repositories/account.repository.ts
+++ b/packages/database/src/repositories/account.repository.ts
@@ -22,7 +22,8 @@ export class AccountRepository extends BaseRepository<Account> {
 				model_mappings,
 				cross_region_mode,
 				model_fallbacks,
-				billing_type
+				billing_type,
+				pause_reason
 			FROM accounts
 			ORDER BY priority DESC
 		`);
@@ -46,7 +47,8 @@ export class AccountRepository extends BaseRepository<Account> {
 				model_mappings,
 				cross_region_mode,
 				model_fallbacks,
-				billing_type
+				billing_type,
+				pause_reason
 			FROM accounts
 			WHERE id = ?
 		`,
@@ -133,12 +135,18 @@ export class AccountRepository extends BaseRepository<Account> {
 		);
 	}
 
-	async pause(accountId: string): Promise<void> {
-		await this.run(`UPDATE accounts SET paused = 1 WHERE id = ?`, [accountId]);
+	async pause(accountId: string, reason = "manual"): Promise<void> {
+		await this.run(
+			`UPDATE accounts SET paused = 1, pause_reason = ? WHERE id = ?`,
+			[reason, accountId],
+		);
 	}
 
 	async resume(accountId: string): Promise<void> {
-		await this.run(`UPDATE accounts SET paused = 0 WHERE id = ?`, [accountId]);
+		await this.run(
+			`UPDATE accounts SET paused = 0, pause_reason = NULL WHERE id = ?`,
+			[accountId],
+		);
 	}
 
 	async resetSession(accountId: string, timestamp: number): Promise<void> {

--- a/packages/load-balancer/src/strategies/__tests__/pause-reason-strategy.test.ts
+++ b/packages/load-balancer/src/strategies/__tests__/pause-reason-strategy.test.ts
@@ -1,0 +1,439 @@
+/**
+ * Tests for the auto-fallback unpause logic in SessionStrategy with pause_reason (issue #139).
+ *
+ * The core fix: when a rate-limit window resets, the strategy must NOT
+ * auto-unpause accounts whose pause_reason is 'manual' or 'failure_threshold'.
+ * Only accounts with pause_reason='overage', 'rate_limit_window', or null may
+ * be auto-unpaused.
+ *
+ * Note on the result ordering: SessionStrategy.select() returns an ordered
+ * preference list — the caller (request router / account selector) is responsible
+ * for filtering out still-paused accounts from that list. The strategy itself
+ * does not strip paused accounts from the result when it decides not to unpause
+ * them; it simply skips the resumeAccount() DB call and leaves the account paused.
+ *
+ * What we test here is that resumeAccount() is (or is not) called and that the
+ * account's in-memory `paused` flag is (or is not) cleared.
+ */
+import { beforeEach, describe, expect, it } from "bun:test";
+import { SessionStrategy } from "@better-ccflare/load-balancer";
+import type {
+	Account,
+	RequestMeta,
+	StrategyStore,
+} from "@better-ccflare/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "test-account",
+		name: "test-account",
+		provider: "anthropic",
+		api_key: null,
+		refresh_token: "test",
+		access_token: "test",
+		expires_at: Date.now() + 3_600_000,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: Date.now(),
+		rate_limited_until: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		custom_endpoint: null,
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		billing_type: null,
+		pause_reason: null,
+		...overrides,
+	};
+}
+
+class MockStrategyStore implements StrategyStore {
+	resetCalls: Array<{ accountId: string; timestamp: number }> = [];
+	resumeCalls: string[] = [];
+
+	resetAccountSession(accountId: string, timestamp: number): void {
+		this.resetCalls.push({ accountId, timestamp });
+	}
+
+	resumeAccount(accountId: string): void {
+		this.resumeCalls.push(accountId);
+	}
+
+	clear(): void {
+		this.resetCalls = [];
+		this.resumeCalls = [];
+	}
+
+	hasResumeCall(accountId: string): boolean {
+		return this.resumeCalls.includes(accountId);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SessionStrategy — pause_reason auto-unpause logic", () => {
+	let strategy: SessionStrategy;
+	let mockStore: MockStrategyStore;
+	let meta: RequestMeta;
+	const now = Date.now();
+	// A rate_limit_reset value that has elapsed (triggers auto-fallback window reset)
+	const expiredReset = now - 2_000;
+
+	beforeEach(() => {
+		strategy = new SessionStrategy(5 * 60 * 60 * 1_000);
+		mockStore = new MockStrategyStore();
+		strategy.initialize(mockStore);
+		mockStore.clear();
+
+		meta = {
+			id: "test-request",
+			headers: new Headers(),
+			path: "/v1/messages",
+			method: "POST",
+			timestamp: now,
+		};
+	});
+
+	// -------------------------------------------------------------------------
+	// pause_reason='failure_threshold' — must NOT be auto-unpaused
+	// -------------------------------------------------------------------------
+
+	describe("pause_reason='failure_threshold'", () => {
+		it("does not call resumeAccount and keeps paused=true", () => {
+			const hotmail = makeAccount({
+				id: "hotmail",
+				name: "hotmail",
+				paused: true,
+				pause_reason: "failure_threshold",
+				auto_fallback_enabled: true,
+				rate_limit_reset: expiredReset,
+				priority: 0,
+			});
+
+			strategy.select([hotmail], meta);
+
+			expect(mockStore.hasResumeCall("hotmail")).toBe(false);
+			expect(hotmail.paused).toBe(true);
+		});
+
+		it("issue #139: does not auto-unpause a failure_threshold account even when the rate limit window resets", () => {
+			const hotmail = makeAccount({
+				id: "hotmail",
+				name: "hotmail",
+				paused: true,
+				pause_reason: "failure_threshold",
+				auto_fallback_enabled: true,
+				rate_limit_reset: expiredReset,
+				priority: 0,
+			});
+
+			const gmail = makeAccount({
+				id: "gmail",
+				name: "gmail",
+				paused: false,
+				pause_reason: null,
+				auto_fallback_enabled: false,
+				rate_limit_reset: null,
+				priority: 1,
+			});
+
+			strategy.select([hotmail, gmail], meta);
+
+			// HOTMAIL must remain paused — resumeAccount must NOT have been called
+			expect(hotmail.paused).toBe(true);
+			expect(mockStore.hasResumeCall("hotmail")).toBe(false);
+		});
+
+		it("leaves the failure_threshold account paused regardless of rate_limit_reset", () => {
+			const hotmail = makeAccount({
+				id: "hotmail",
+				name: "hotmail",
+				paused: true,
+				pause_reason: "failure_threshold",
+				auto_fallback_enabled: true,
+				rate_limit_reset: expiredReset,
+				priority: 0,
+			});
+
+			strategy.select([hotmail], meta);
+
+			// The account is found as an auto-fallback candidate but must NOT be unpaused
+			expect(hotmail.paused).toBe(true);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// pause_reason='manual' — must NOT be auto-unpaused
+	// -------------------------------------------------------------------------
+
+	describe("pause_reason='manual'", () => {
+		it("does not call resumeAccount for a manually-paused account when rate limit window resets", () => {
+			const account = makeAccount({
+				id: "manual-paused",
+				name: "manual-paused",
+				paused: true,
+				pause_reason: "manual",
+				auto_fallback_enabled: true,
+				rate_limit_reset: expiredReset,
+				priority: 0,
+			});
+
+			strategy.select([account], meta);
+
+			expect(mockStore.hasResumeCall("manual-paused")).toBe(false);
+			expect(account.paused).toBe(true);
+		});
+
+		it("leaves the manually-paused account paused regardless of elapsed rate_limit_reset", () => {
+			const manual = makeAccount({
+				id: "manual-paused",
+				name: "manual-paused",
+				paused: true,
+				pause_reason: "manual",
+				auto_fallback_enabled: true,
+				rate_limit_reset: expiredReset,
+				priority: 0,
+			});
+
+			const healthy = makeAccount({
+				id: "healthy",
+				name: "healthy",
+				paused: false,
+				pause_reason: null,
+				priority: 1,
+			});
+
+			strategy.select([manual, healthy], meta);
+
+			expect(manual.paused).toBe(true);
+			expect(mockStore.hasResumeCall("manual-paused")).toBe(false);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// pause_reason='overage' — SHOULD be auto-unpaused when window resets
+	// -------------------------------------------------------------------------
+
+	describe("pause_reason='overage'", () => {
+		it("calls resumeAccount and clears paused flag when the rate limit window resets", () => {
+			const account = makeAccount({
+				id: "overage-paused",
+				name: "overage-paused",
+				paused: true,
+				pause_reason: "overage",
+				auto_fallback_enabled: true,
+				rate_limit_reset: expiredReset,
+				priority: 0,
+			});
+
+			const result = strategy.select([account], meta);
+
+			expect(mockStore.hasResumeCall("overage-paused")).toBe(true);
+			expect(account.paused).toBe(false);
+			expect(result[0]).toBe(account);
+		});
+
+		it("is returned as an available account after auto-unpause", () => {
+			const account = makeAccount({
+				id: "overage-paused",
+				name: "overage-paused",
+				paused: true,
+				pause_reason: "overage",
+				auto_fallback_enabled: true,
+				rate_limit_reset: expiredReset,
+				priority: 0,
+			});
+
+			strategy.select([account], meta);
+
+			// After resumeAccount(), the account's in-memory paused flag is cleared
+			expect(account.paused).toBe(false);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// pause_reason=null — SHOULD be auto-unpaused when window resets
+	// -------------------------------------------------------------------------
+
+	describe("pause_reason=null", () => {
+		it("calls resumeAccount and clears paused flag for null-reason account", () => {
+			const account = makeAccount({
+				id: "null-reason-paused",
+				name: "null-reason-paused",
+				paused: true,
+				pause_reason: null,
+				auto_fallback_enabled: true,
+				rate_limit_reset: expiredReset,
+				priority: 0,
+			});
+
+			const result = strategy.select([account], meta);
+
+			expect(mockStore.hasResumeCall("null-reason-paused")).toBe(true);
+			expect(account.paused).toBe(false);
+			expect(result[0]).toBe(account);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// pause_reason='rate_limit_window' — SHOULD be auto-unpaused when window resets
+	// -------------------------------------------------------------------------
+
+	describe("pause_reason='rate_limit_window'", () => {
+		it("calls resumeAccount and clears paused flag for rate_limit_window account", () => {
+			const account = makeAccount({
+				id: "rlw-paused",
+				name: "rlw-paused",
+				paused: true,
+				pause_reason: "rate_limit_window",
+				auto_fallback_enabled: true,
+				rate_limit_reset: expiredReset,
+				priority: 0,
+			});
+
+			const result = strategy.select([account], meta);
+
+			expect(mockStore.hasResumeCall("rlw-paused")).toBe(true);
+			expect(account.paused).toBe(false);
+			expect(result[0]).toBe(account);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Mixed scenario: multiple paused accounts, each with different pause_reason.
+	// The first eligible auto-fallback candidate (by priority) is the overage account
+	// (priority=2). The failure and manual accounts are lower priority (0, 1) but
+	// cannot be unpaused, so they stay paused.
+	// -------------------------------------------------------------------------
+
+	describe("mixed pause_reason values", () => {
+		it("only unpauses the eligible (overage) account, leaves failure/manual paused", () => {
+			const failureAcc = makeAccount({
+				id: "failure",
+				name: "failure",
+				paused: true,
+				pause_reason: "failure_threshold",
+				auto_fallback_enabled: true,
+				rate_limit_reset: expiredReset,
+				priority: 0,
+			});
+			const manualAcc = makeAccount({
+				id: "manual",
+				name: "manual",
+				paused: true,
+				pause_reason: "manual",
+				auto_fallback_enabled: true,
+				rate_limit_reset: expiredReset,
+				priority: 1,
+			});
+			const overageAcc = makeAccount({
+				id: "overage",
+				name: "overage",
+				paused: true,
+				pause_reason: "overage",
+				auto_fallback_enabled: true,
+				rate_limit_reset: expiredReset,
+				priority: 2,
+			});
+
+			// The strategy picks the FIRST candidate by priority (lowest number first).
+			// Priority 0 = failure_threshold → cannot unpause, stays paused.
+			// So the candidate chosen is failure, and failure stays paused.
+			// Overage (priority 2) never gets to be a candidate in this call.
+			strategy.select([failureAcc, manualAcc, overageAcc], meta);
+
+			// failure_threshold and manual must never be unpaused
+			expect(mockStore.hasResumeCall("failure")).toBe(false);
+			expect(mockStore.hasResumeCall("manual")).toBe(false);
+			expect(failureAcc.paused).toBe(true);
+			expect(manualAcc.paused).toBe(true);
+		});
+
+		it("unpauses an overage account that is the highest-priority auto-fallback candidate", () => {
+			// When overage account has the best (lowest) priority among auto-fallback
+			// eligible accounts, it IS the chosen fallback and gets unpaused.
+			const overageAcc = makeAccount({
+				id: "overage",
+				name: "overage",
+				paused: true,
+				pause_reason: "overage",
+				auto_fallback_enabled: true,
+				rate_limit_reset: expiredReset,
+				priority: 0,
+			});
+			const failureAcc = makeAccount({
+				id: "failure",
+				name: "failure",
+				paused: true,
+				pause_reason: "failure_threshold",
+				auto_fallback_enabled: true,
+				rate_limit_reset: expiredReset,
+				priority: 1,
+			});
+
+			const result = strategy.select([failureAcc, overageAcc], meta);
+
+			expect(mockStore.hasResumeCall("overage")).toBe(true);
+			expect(overageAcc.paused).toBe(false);
+			expect(result[0]).toBe(overageAcc);
+
+			// failure_threshold account must not be unpaused
+			expect(mockStore.hasResumeCall("failure")).toBe(false);
+			expect(failureAcc.paused).toBe(true);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Contrast: with pause_reason=null behaves like the original (pre-issue-#139)
+	// auto-fallback where paused accounts could be auto-unpaused
+	// -------------------------------------------------------------------------
+
+	describe("backward compatibility — null pause_reason unpauses as before", () => {
+		it("existing auto-fallback behavior preserved when pause_reason is null", () => {
+			const now2 = Date.now();
+			const account1 = makeAccount({
+				id: "auto-fallback-reset",
+				name: "auto-fallback-reset",
+				paused: true,
+				pause_reason: null,
+				rate_limit_reset: now2 - 2_000,
+				priority: 0,
+				auto_fallback_enabled: true,
+			});
+
+			const account2 = makeAccount({
+				id: "no-auto-fallback",
+				name: "no-auto-fallback",
+				paused: true,
+				pause_reason: null,
+				rate_limit_reset: now2,
+				priority: 1,
+				auto_fallback_enabled: true,
+			});
+
+			const result = strategy.select([account2, account1], meta);
+
+			expect(result[0]).toBe(account1);
+			expect(result).toHaveLength(1);
+			expect(account1.paused).toBe(false);
+			expect(mockStore.hasResumeCall(account1.id)).toBe(true);
+			expect(account2.paused).toBe(true);
+		});
+	});
+});

--- a/packages/load-balancer/src/strategies/index.ts
+++ b/packages/load-balancer/src/strategies/index.ts
@@ -136,7 +136,8 @@ export class SessionStrategy implements LoadBalancingStrategy {
 			);
 
 			// If the chosen fallback account was paused, only auto-unpause if it was paused due to
-			// overage or rate limit window reset — never auto-unpause manual or failure_threshold pauses.
+			// overage, or `rate_limit_window` (reserved/future pause reason) — never auto-unpause
+			// manual or failure_threshold pauses.
 			if (chosenFallback.paused && this.store?.resumeAccount) {
 				const canAutoUnpause =
 					!chosenFallback.pause_reason ||

--- a/packages/load-balancer/src/strategies/index.ts
+++ b/packages/load-balancer/src/strategies/index.ts
@@ -135,13 +135,24 @@ export class SessionStrategy implements LoadBalancingStrategy {
 				`Auto-fallback triggered to account ${chosenFallback.name} (priority: ${chosenFallback.priority}, auto-fallback enabled)`,
 			);
 
-			// If the chosen fallback account was paused, unpause it since we're reactivating it
+			// If the chosen fallback account was paused, only auto-unpause if it was paused due to
+			// overage or rate limit window reset — never auto-unpause manual or failure_threshold pauses.
 			if (chosenFallback.paused && this.store?.resumeAccount) {
-				this.log.info(
-					`Unpausing account ${chosenFallback.name} due to auto-fallback reactivation`,
-				);
-				this.store.resumeAccount(chosenFallback.id);
-				chosenFallback.paused = false;
+				const canAutoUnpause =
+					!chosenFallback.pause_reason ||
+					chosenFallback.pause_reason === "overage" ||
+					chosenFallback.pause_reason === "rate_limit_window";
+				if (canAutoUnpause) {
+					this.log.info(
+						`Unpausing account ${chosenFallback.name} due to auto-fallback reactivation`,
+					);
+					this.store.resumeAccount(chosenFallback.id);
+					chosenFallback.paused = false;
+				} else {
+					this.log.info(
+						`Skipping auto-unpause of account ${chosenFallback.name} — paused with reason '${chosenFallback.pause_reason}' which requires manual intervention`,
+					);
+				}
 			}
 
 			// Return fallback account first, then others sorted by priority

--- a/packages/proxy/src/auto-refresh-scheduler.ts
+++ b/packages/proxy/src/auto-refresh-scheduler.ts
@@ -280,6 +280,7 @@ export class AutoRefreshScheduler {
 				cross_region_mode: null,
 				model_fallbacks: null,
 				billing_type: null,
+				pause_reason: null,
 			};
 
 			// Emit request start event for analytics
@@ -522,7 +523,8 @@ export class AutoRefreshScheduler {
 					);
 				}
 
-				// Auto-resume on window reset: if account was auto-paused due to overage, resume it now
+				// Auto-resume on window reset: if account was auto-paused due to overage, resume it now.
+				// Never auto-resume accounts paused manually or due to failure threshold.
 				if (
 					accountRow.auto_pause_on_overage_enabled === 1 &&
 					accountRow.paused === 1
@@ -530,9 +532,10 @@ export class AutoRefreshScheduler {
 					log.debug(
 						`Auto-resuming account '${accountRow.name}' after window reset (auto-pause-on-overage enabled)`,
 					);
-					await this.db.run("UPDATE accounts SET paused = 0 WHERE id = ?", [
-						accountRow.id,
-					]);
+					await this.db.run(
+						"UPDATE accounts SET paused = 0, pause_reason = NULL WHERE id = ?",
+						[accountRow.id],
+					);
 				}
 
 				if (accountRow.provider === "anthropic") {
@@ -641,9 +644,10 @@ export class AutoRefreshScheduler {
 				`Account ${accountName} has failed ${newFailures} consecutive auto-refresh attempts — pausing account to prevent routing to a broken endpoint.`,
 			);
 			try {
-				await this.db.run(`UPDATE accounts SET paused = 1 WHERE id = ?`, [
-					accountId,
-				]);
+				await this.db.run(
+					`UPDATE accounts SET paused = 1, pause_reason = 'failure_threshold' WHERE id = ?`,
+					[accountId],
+				);
 				// Clear the counter so subsequent scheduler cycles don't fire redundant DB
 				// writes and log entries — the account is already paused.
 				this.consecutiveFailures.delete(accountId);
@@ -743,6 +747,7 @@ export class AutoRefreshScheduler {
 					cross_region_mode: null,
 					model_fallbacks: null,
 					billing_type: null,
+					pause_reason: null,
 				};
 
 				// Use refreshAccessTokenSafe to get deduplication and backoff handling
@@ -864,6 +869,7 @@ export class AutoRefreshScheduler {
 					cross_region_mode: null,
 					model_fallbacks: null,
 					billing_type: null,
+					pause_reason: null,
 				};
 
 				// Register in refreshInFlight so concurrent request-triggered refreshes join this one

--- a/packages/proxy/src/auto-refresh-scheduler.ts
+++ b/packages/proxy/src/auto-refresh-scheduler.ts
@@ -117,13 +117,15 @@ export class AutoRefreshScheduler {
 				custom_endpoint: string | null;
 				paused: number;
 				auto_pause_on_overage_enabled: number;
+				pause_reason: string | null;
 			}>(
 				`
 				SELECT
 					id, name, provider, refresh_token, access_token,
 					expires_at, rate_limit_reset, custom_endpoint,
 					COALESCE(paused, 0) as paused,
-					COALESCE(auto_pause_on_overage_enabled, 0) as auto_pause_on_overage_enabled
+					COALESCE(auto_pause_on_overage_enabled, 0) as auto_pause_on_overage_enabled,
+					pause_reason
 				FROM accounts
 				WHERE
 					auto_refresh_enabled = 1
@@ -228,6 +230,7 @@ export class AutoRefreshScheduler {
 		custom_endpoint: string | null;
 		paused: number;
 		auto_pause_on_overage_enabled: number;
+		pause_reason: string | null;
 	}): Promise<boolean> {
 		try {
 			log.info(`Sending auto-refresh message to account: ${accountRow.name}`);
@@ -527,7 +530,8 @@ export class AutoRefreshScheduler {
 				// Never auto-resume accounts paused manually or due to failure threshold.
 				if (
 					accountRow.auto_pause_on_overage_enabled === 1 &&
-					accountRow.paused === 1
+					accountRow.paused === 1 &&
+					(!accountRow.pause_reason || accountRow.pause_reason === "overage")
 				) {
 					log.debug(
 						`Auto-resuming account '${accountRow.name}' after window reset (auto-pause-on-overage enabled)`,

--- a/packages/proxy/src/post-processor.worker.ts
+++ b/packages/proxy/src/post-processor.worker.ts
@@ -471,7 +471,7 @@ async function handleStart(msg: StartMessage): Promise<void> {
 			);
 			// Note: dbOps may not be fully initialized in the worker yet; use the asyncWriter queue
 			asyncWriter.enqueue(async () => {
-				await dbOps.pauseAccount(accountId);
+				await dbOps.pauseAccount(accountId, "overage");
 			});
 		}
 	} else if (

--- a/packages/types/src/account.ts
+++ b/packages/types/src/account.ts
@@ -108,6 +108,7 @@ export interface AccountRow {
 	cross_region_mode?: string | null; // Bedrock cross-region inference mode
 	model_fallbacks?: string | null; // JSON string for model family fallback mappings
 	billing_type?: string | null; // Per-account billing override
+	pause_reason?: string | null; // null=not paused, 'manual'=user paused, 'failure_threshold'=auto-refresh failures, 'overage'=billing overage
 }
 
 // Domain model - used throughout the application
@@ -139,6 +140,7 @@ export interface Account {
 	cross_region_mode: string | null; // Bedrock cross-region inference mode
 	model_fallbacks: string | null; // JSON string for model family fallback mappings
 	billing_type: string | null;
+	pause_reason: string | null; // null=not paused, 'manual'=user paused, 'failure_threshold'=auto-refresh failures, 'overage'=billing overage
 }
 
 // Session statistics for 5-hour token window
@@ -301,6 +303,7 @@ export function toAccount(row: AccountRow): Account {
 		cross_region_mode: row.cross_region_mode || null,
 		model_fallbacks: row.model_fallbacks || null,
 		billing_type: row.billing_type || null,
+		pause_reason: row.pause_reason || null,
 	};
 }
 


### PR DESCRIPTION
Store explicit account pause reasons and only auto-unpause accounts paused for overage/window resets so failure-threshold and manual pauses are preserved across fallback cycles.