### PR TITLE
fix: compact reliability, space breakdown after cleanup, requests tab without payloads

### DIFF
--- a/packages/dashboard-web/src/api.ts
+++ b/packages/dashboard-web/src/api.ts
@@ -1587,7 +1587,7 @@ class API extends HttpClient {
 	async cleanupNow(): Promise<{
 		removedRequests: number;
 		removedPayloads: number;
-		payloadCutoffIso: string;
+		payloadCutoffIso: string | null;
 		requestCutoffIso: string;
 		dbSizeBytes: number;
 		tableRowCounts: Array<{ name: string; rowCount: number; dataBytes?: number }>;
@@ -1601,7 +1601,7 @@ class API extends HttpClient {
 			const response = await this.post<{
 				removedRequests: number;
 				removedPayloads: number;
-				payloadCutoffIso: string;
+				payloadCutoffIso: string | null;
 				requestCutoffIso: string;
 				dbSizeBytes: number;
 				tableRowCounts: Array<{ name: string; rowCount: number; dataBytes?: number }>;

--- a/packages/dashboard-web/src/api.ts
+++ b/packages/dashboard-web/src/api.ts
@@ -1589,6 +1589,8 @@ class API extends HttpClient {
 		removedPayloads: number;
 		payloadCutoffIso: string;
 		requestCutoffIso: string;
+		dbSizeBytes: number;
+		tableRowCounts: Array<{ name: string; rowCount: number; dataBytes?: number }>;
 	}> {
 		const startTime = Date.now();
 		const url = "/api/maintenance/cleanup";
@@ -1601,6 +1603,8 @@ class API extends HttpClient {
 				removedPayloads: number;
 				payloadCutoffIso: string;
 				requestCutoffIso: string;
+				dbSizeBytes: number;
+				tableRowCounts: Array<{ name: string; rowCount: number; dataBytes?: number }>;
 			}>(url, undefined, { timeout: 10 * 60 * 1000 });
 			const duration = Date.now() - startTime;
 			this.logger.debug(`← POST ${url} - 200 (${duration}ms)`);

--- a/packages/dashboard-web/src/components/overview/DataRetentionCard.tsx
+++ b/packages/dashboard-web/src/components/overview/DataRetentionCard.tsx
@@ -147,12 +147,40 @@ export function DataRetentionCard() {
 				)}
 
 				{cleanupNow.data && (
-					<p className="text-xs text-muted-foreground">
-						Removed {cleanupNow.data.removedPayloads} payloads (older than{" "}
-						{new Date(cleanupNow.data.payloadCutoffIso).toLocaleString()}) and{" "}
-						{cleanupNow.data.removedRequests} requests (older than{" "}
-						{new Date(cleanupNow.data.requestCutoffIso).toLocaleString()}).
-					</p>
+					<div className="text-xs text-muted-foreground space-y-1">
+						<p>
+							Removed {cleanupNow.data.removedPayloads} payloads (older than{" "}
+							{new Date(cleanupNow.data.payloadCutoffIso).toLocaleString()}) and{" "}
+							{cleanupNow.data.removedRequests} requests (older than{" "}
+							{new Date(cleanupNow.data.requestCutoffIso).toLocaleString()}).
+						</p>
+						{(cleanupNow.data.dbSizeBytes > 0 || cleanupNow.data.tableRowCounts.length > 0) && (
+							<details>
+								<summary className="cursor-pointer select-none">
+									Space usage
+									{cleanupNow.data.dbSizeBytes > 0 && (
+										<> — {(cleanupNow.data.dbSizeBytes / 1024 / 1024).toFixed(1)} MB on disk</>
+									)}
+								</summary>
+								{cleanupNow.data.tableRowCounts.length > 0 && (
+									<table className="mt-1 w-full text-left">
+										<tbody>
+											{cleanupNow.data.tableRowCounts.map((row) => (
+												<tr key={row.name}>
+													<td className="pr-4 font-mono">{row.name}</td>
+													<td className="text-right">
+														{row.dataBytes !== undefined
+															? `${(row.dataBytes / 1024 / 1024).toFixed(1)} MB`
+															: `${row.rowCount.toLocaleString()} rows`}
+													</td>
+												</tr>
+											))}
+										</tbody>
+									</table>
+								)}
+							</details>
+						)}
+					</div>
 				)}
 
 				{compactDb.isError && (

--- a/packages/dashboard-web/src/components/overview/DataRetentionCard.tsx
+++ b/packages/dashboard-web/src/components/overview/DataRetentionCard.tsx
@@ -149,8 +149,11 @@ export function DataRetentionCard() {
 				{cleanupNow.data && (
 					<div className="text-xs text-muted-foreground space-y-1">
 						<p>
-							Removed {cleanupNow.data.removedPayloads} payloads (older than{" "}
-							{new Date(cleanupNow.data.payloadCutoffIso).toLocaleString()}) and{" "}
+							Removed {cleanupNow.data.removedPayloads} payloads (
+							{cleanupNow.data.payloadCutoffIso
+								? <>older than {new Date(cleanupNow.data.payloadCutoffIso).toLocaleString()}</>
+								: <>all — storage disabled</>
+							}) and{" "}
 							{cleanupNow.data.removedRequests} requests (older than{" "}
 							{new Date(cleanupNow.data.requestCutoffIso).toLocaleString()}).
 						</p>

--- a/packages/database/src/adapters/bun-sql-adapter.ts
+++ b/packages/database/src/adapters/bun-sql-adapter.ts
@@ -109,12 +109,44 @@ export class BunSqlAdapter {
 	}
 
 	/**
+	 * Retry a synchronous SQLite call asynchronously when the database is
+	 * locked by another connection (SQLITE_BUSY / errno 5).
+	 *
+	 * SQLite's built-in busy_timeout retries at the C level via usleep(), which
+	 * blocks the Bun event loop for the entire wait.  This wrapper instead lets
+	 * the busy_timeout exhaust normally (giving the C layer a short chance to
+	 * self-resolve), then catches the resulting error and re-schedules with
+	 * setTimeout so the event loop stays free between attempts.  This is
+	 * necessary when a long-running exclusive operation such as VACUUM is running
+	 * on a separate Worker connection.
+	 */
+	private async withBusyRetry<T>(fn: () => T): Promise<T> {
+		const deadline = Date.now() + 10 * 60 * 1000; // retry for up to 10 minutes
+		while (true) {
+			try {
+				return fn();
+			} catch (err) {
+				const isBusy =
+					err instanceof Error &&
+					"code" in err &&
+					(err as { code?: string }).code === "SQLITE_BUSY";
+				if (isBusy && Date.now() < deadline) {
+					await new Promise<void>((resolve) => setTimeout(resolve, 500));
+					continue;
+				}
+				throw err;
+			}
+		}
+	}
+
+	/**
 	 * Execute a SELECT query returning multiple rows.
 	 */
 	async query<R>(sqlStr: string, params: unknown[] = []): Promise<R[]> {
 		if (this.isSQLite && this.sqliteDb) {
+			const db = this.sqliteDb;
 			// biome-ignore lint/suspicious/noExplicitAny: SQLite params can be any binding type
-			return this.sqliteDb.query<R, any[]>(sqlStr).all(...(params as any[]));
+			return this.withBusyRetry(() => db.query<R, any[]>(sqlStr).all(...(params as any[])));
 		}
 		// PostgreSQL via Bun.SQL unsafe
 		const pgQuery = this.pgSql(sqlStr);
@@ -128,11 +160,9 @@ export class BunSqlAdapter {
 	 */
 	async get<R>(sqlStr: string, params: unknown[] = []): Promise<R | null> {
 		if (this.isSQLite && this.sqliteDb) {
-			const result = this.sqliteDb
-				// biome-ignore lint/suspicious/noExplicitAny: SQLite params can be any binding type
-				.query<R, any[]>(sqlStr)
-				// biome-ignore lint/suspicious/noExplicitAny: SQLite .get() spread params
-				.get(...(params as any[]));
+			const db = this.sqliteDb;
+			// biome-ignore lint/suspicious/noExplicitAny: SQLite params can be any binding type
+			const result = await this.withBusyRetry(() => db.query<R, any[]>(sqlStr).get(...(params as any[])));
 			return (result as R) ?? null;
 		}
 		const pgQuery = this.pgSql(sqlStr);
@@ -146,8 +176,9 @@ export class BunSqlAdapter {
 	 */
 	async run(sqlStr: string, params: unknown[] = []): Promise<void> {
 		if (this.isSQLite && this.sqliteDb) {
+			const db = this.sqliteDb;
 			// biome-ignore lint/suspicious/noExplicitAny: SQLite params can be any binding type
-			this.sqliteDb.run(sqlStr, params as any[]);
+			await this.withBusyRetry(() => db.run(sqlStr, params as any[]));
 			return;
 		}
 		const pgQuery = this.pgSql(sqlStr);
@@ -163,8 +194,9 @@ export class BunSqlAdapter {
 		params: unknown[] = [],
 	): Promise<number> {
 		if (this.isSQLite && this.sqliteDb) {
+			const db = this.sqliteDb;
 			// biome-ignore lint/suspicious/noExplicitAny: SQLite params can be any binding type
-			const result = this.sqliteDb.run(sqlStr, params as any[]);
+			const result = await this.withBusyRetry(() => db.run(sqlStr, params as any[]));
 			return result.changes;
 		}
 		const pgQuery = this.pgSql(sqlStr);

--- a/packages/database/src/database-operations.ts
+++ b/packages/database/src/database-operations.ts
@@ -1,5 +1,6 @@
 import { Database } from "bun:sqlite";
 import { mkdirSync } from "node:fs";
+import { stat } from "node:fs/promises";
 import { dirname } from "node:path";
 import type { RuntimeConfig } from "@better-ccflare/config";
 import type { Disposable } from "@better-ccflare/core";
@@ -593,7 +594,7 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 
 	async listRequestPayloadsWithAccountNames(
 		limit = 50,
-	): Promise<Array<{ id: string; json: string; account_name: string | null }>> {
+	): Promise<Array<{ id: string; json: string | null; timestamp: number; account_name: string | null }>> {
 		return this.requests.listPayloadsWithAccountNames(limit);
 	}
 
@@ -745,6 +746,59 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 			removedRequests,
 			removedPayloads: removedPayloadsByAge + removedOrphans,
 		};
+	}
+
+	async getTableRowCounts(): Promise<
+		Array<{ name: string; rowCount: number; dataBytes?: number }>
+	> {
+		if (!this.adapter.isSQLite) {
+			return [];
+		}
+		try {
+			const tables = await this.adapter.query<{ name: string }>(
+				"SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+			);
+			const rows = await Promise.all(
+				tables.map(async ({ name }) => {
+					const countRow = await this.adapter.get<{ rowCount: number }>(
+						`SELECT COUNT(*) AS rowCount FROM "${name}"`,
+					);
+					const rowCount = countRow?.rowCount ?? 0;
+					// Measure actual data bytes for tables with known large text/blob columns
+					if (name === "request_payloads") {
+						const sizeRow = await this.adapter.get<{ dataBytes: number }>(
+							`SELECT SUM(LENGTH(json)) AS dataBytes FROM "${name}"`,
+						);
+						return { name, rowCount, dataBytes: sizeRow?.dataBytes ?? 0 };
+					}
+					return { name, rowCount };
+				}),
+			);
+			// Sort: tables with dataBytes first (largest first), then by rowCount
+			return rows.sort((a, b) => {
+				if (a.dataBytes !== undefined && b.dataBytes !== undefined)
+					return b.dataBytes - a.dataBytes;
+				if (a.dataBytes !== undefined) return -1;
+				if (b.dataBytes !== undefined) return 1;
+				return b.rowCount - a.rowCount;
+			});
+		} catch (err) {
+			console.debug("[getTableRowCounts] query failed:", err);
+			return [];
+		}
+	}
+
+	async getDbSizeBytes(): Promise<number> {
+		if (!this.adapter.isSQLite || !this.resolvedDbPath) {
+			return 0;
+		}
+		try {
+			const { size } = await stat(this.resolvedDbPath);
+			return size;
+		} catch (err) {
+			console.debug("[getDbSizeBytes] stat failed:", err);
+			return 0;
+		}
 	}
 
 	// Agent preference operations delegated to repository

--- a/packages/database/src/database-operations.ts
+++ b/packages/database/src/database-operations.ts
@@ -159,6 +159,10 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 	private adapter: BunSqlAdapter;
 	/** Raw bun:sqlite Database — only set in SQLite mode */
 	private sqliteDb?: Database;
+	/** Resolved path to the SQLite DB file — used by the vacuum worker */
+	private resolvedDbPath?: string;
+	/** Prevents concurrent compact() calls from spawning multiple vacuum workers */
+	private compacting = false;
 	private runtime?: RuntimeConfig;
 	private dbConfig: DatabaseConfig;
 	private retryConfig: DatabaseRetryConfig;
@@ -223,6 +227,7 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 		} else {
 			this.isSQLite = true;
 			const resolvedPath = dbPath ?? resolveDbPath();
+			this.resolvedDbPath = resolvedPath;
 
 			// Ensure the directory exists
 			const dir = dirname(resolvedPath);
@@ -806,68 +811,69 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 		walTruncateBusy?: number;
 		error?: string;
 	}> {
-		if (!this.sqliteDb) {
+		if (!this.sqliteDb || !this.resolvedDbPath) {
 			return { walBusy: 0, walLog: 0, walCheckpointed: 0, vacuumed: false };
 		}
 
-		let walBusy = 0;
-		let walLog = 0;
-		let walCheckpointed = 0;
-		let vacuumed = false;
-		let walTruncateBusy: number | undefined;
-
-		try {
-			// Step 1: RESTART checkpoint — drains WAL into main DB and resets WAL
-			// write position so the next VACUUM starts with a clean slate.
-			const ckpt = this.sqliteDb
-				.query("PRAGMA wal_checkpoint(RESTART)")
-				.get() as { busy: number; log: number; checkpointed: number } | null;
-
-			if (ckpt) {
-				walBusy = ckpt.busy;
-				walLog = ckpt.log;
-				walCheckpointed = ckpt.checkpointed;
-				if (ckpt.busy > 0) {
-					console.warn(
-						`[compact] WAL checkpoint: ${ckpt.busy} busy reader(s), ` +
-							`${ckpt.checkpointed}/${ckpt.log} frames checkpointed. ` +
-							"VACUUM will still run but WAL may not fully shrink.",
-					);
-				}
-			}
-
-			// Step 2: VACUUM — rewrites the main DB file, reclaiming free pages.
-			this.sqliteDb.exec("VACUUM");
-			vacuumed = true;
-
-			// Step 3: TRUNCATE checkpoint — resets WAL to zero bytes now that
-			// VACUUM has produced a clean main DB.
-			const truncCkpt = this.sqliteDb
-				.query("PRAGMA wal_checkpoint(TRUNCATE)")
-				.get() as { busy: number; log: number; checkpointed: number } | null;
-
-			if (truncCkpt) {
-				walTruncateBusy = truncCkpt.busy;
-				if (truncCkpt.busy > 0) {
-					console.warn(
-						`[compact] TRUNCATE checkpoint: ${truncCkpt.busy} busy reader(s) — WAL file may not be zeroed.`,
-					);
-				}
-			}
-		} catch (err) {
-			const msg = err instanceof Error ? err.message : String(err);
-			console.error(`[compact] Database compaction failed: ${msg}`);
+		if (this.compacting) {
 			return {
-				walBusy,
-				walLog,
-				walCheckpointed,
-				vacuumed,
-				walTruncateBusy,
-				error: msg,
+				walBusy: 0,
+				walLog: 0,
+				walCheckpointed: 0,
+				vacuumed: false,
+				error: "Compaction already in progress",
 			};
 		}
 
-		return { walBusy, walLog, walCheckpointed, vacuumed, walTruncateBusy };
+		// Run the WAL checkpoint + VACUUM + TRUNCATE sequence in a Worker thread
+		// so the main Bun event loop stays free to serve health checks and other
+		// requests during what can be a minutes-long exclusive DB operation.
+		const dbPath = this.resolvedDbPath;
+		const workerUrl = new URL("./vacuum-worker.ts", import.meta.url).href;
+		const worker = new Worker(workerUrl);
+		this.compacting = true;
+
+		try {
+			const result = await new Promise<{
+				ok: boolean;
+				walBusy?: number;
+				walLog?: number;
+				walCheckpointed?: number;
+				walTruncateBusy?: number;
+				error?: string;
+			}>((resolve, reject) => {
+				worker.onmessage = (event: MessageEvent) => resolve(event.data);
+				worker.onerror = (event: ErrorEvent) => reject(new Error(event.message));
+				worker.postMessage({
+					dbPath,
+					busyTimeoutMs: this.dbConfig.busyTimeoutMs ?? 10000,
+				});
+			});
+
+			if (!result.ok) {
+				const msg = result.error ?? "Unknown error in vacuum worker";
+				console.error(`[compact] Database compaction failed: ${msg}`);
+				return {
+					walBusy: result.walBusy ?? 0,
+					walLog: result.walLog ?? 0,
+					walCheckpointed: result.walCheckpointed ?? 0,
+					vacuumed: false,
+					walTruncateBusy: result.walTruncateBusy,
+					error: msg,
+				};
+			}
+
+			return {
+				walBusy: result.walBusy ?? 0,
+				walLog: result.walLog ?? 0,
+				walCheckpointed: result.walCheckpointed ?? 0,
+				vacuumed: true,
+				walTruncateBusy: result.walTruncateBusy,
+			};
+		} finally {
+			this.compacting = false;
+			worker.terminate();
+		}
 	}
 
 	/** Incremental vacuum - reclaims space without blocking (SQLite only) */

--- a/packages/database/src/repositories/request.repository.ts
+++ b/packages/database/src/repositories/request.repository.ts
@@ -263,16 +263,17 @@ export class RequestRepository extends BaseRepository<RequestData> {
 
 	async listPayloadsWithAccountNames(
 		limit = 50,
-	): Promise<Array<{ id: string; json: string; account_name: string | null }>> {
+	): Promise<Array<{ id: string; json: string | null; timestamp: number; account_name: string | null }>> {
 		const rows = await this.query<{
 			id: string;
-			json: string;
+			json: string | null;
+			timestamp: number;
 			account_name: string | null;
 		}>(
 			`
-			SELECT rp.id, rp.json, a.name as account_name
-			FROM request_payloads rp
-			JOIN requests r ON rp.id = r.id
+			SELECT r.id, r.timestamp, rp.json, a.name as account_name
+			FROM requests r
+			LEFT JOIN request_payloads rp ON rp.id = r.id
 			LEFT JOIN accounts a ON r.account_used = a.id
 			ORDER BY r.timestamp DESC
 			LIMIT ?
@@ -282,7 +283,8 @@ export class RequestRepository extends BaseRepository<RequestData> {
 		return Promise.all(
 			rows.map(async (row) => ({
 				id: row.id,
-				json: await decryptForList(row.id, row.json),
+				timestamp: row.timestamp,
+				json: row.json ? await decryptForList(row.id, row.json) : null,
 				account_name: row.account_name,
 			})),
 		);

--- a/packages/database/src/vacuum-worker.ts
+++ b/packages/database/src/vacuum-worker.ts
@@ -1,0 +1,87 @@
+import { Database } from "bun:sqlite";
+
+type VacuumRequest = {
+	dbPath: string;
+	busyTimeoutMs: number;
+};
+
+type VacuumResult =
+	| {
+			ok: true;
+			walBusy: number;
+			walLog: number;
+			walCheckpointed: number;
+			walTruncateBusy?: number;
+	  }
+	| {
+			ok: false;
+			error: string;
+	  };
+
+self.onmessage = (event: MessageEvent<VacuumRequest>) => {
+	const { dbPath, busyTimeoutMs } = event.data;
+	let walBusy = 0;
+	let walLog = 0;
+	let walCheckpointed = 0;
+	let walTruncateBusy: number | undefined;
+
+	let db: Database | undefined;
+	try {
+		db = new Database(dbPath);
+		db.exec(`PRAGMA busy_timeout = ${busyTimeoutMs}`);
+		db.exec("PRAGMA journal_mode = WAL");
+
+		const ckpt = db.query("PRAGMA wal_checkpoint(RESTART)").get() as {
+			busy: number;
+			log: number;
+			checkpointed: number;
+		} | null;
+
+		if (ckpt) {
+			walBusy = ckpt.busy;
+			walLog = ckpt.log;
+			walCheckpointed = ckpt.checkpointed;
+			if (ckpt.busy > 0) {
+				console.warn(
+					`[vacuum-worker] WAL checkpoint: ${ckpt.busy} busy reader(s), ` +
+						`${ckpt.checkpointed}/${ckpt.log} frames checkpointed. ` +
+						"VACUUM will still run but WAL may not fully shrink.",
+				);
+			}
+		}
+
+		db.exec("VACUUM");
+
+		const truncCkpt = db.query("PRAGMA wal_checkpoint(TRUNCATE)").get() as {
+			busy: number;
+			log: number;
+			checkpointed: number;
+		} | null;
+
+		if (truncCkpt) {
+			walTruncateBusy = truncCkpt.busy;
+			if (truncCkpt.busy > 0) {
+				console.warn(
+					`[vacuum-worker] TRUNCATE checkpoint: ${truncCkpt.busy} busy reader(s) — WAL file may not be zeroed.`,
+				);
+			}
+		}
+
+		db.close();
+		db = undefined;
+
+		self.postMessage({
+			ok: true,
+			walBusy,
+			walLog,
+			walCheckpointed,
+			walTruncateBusy,
+		} satisfies VacuumResult);
+	} catch (err) {
+		db?.close();
+		self.postMessage({
+			ok: false,
+			error: err instanceof Error ? err.message : String(err),
+		} satisfies VacuumResult);
+	}
+};

--- a/packages/database/src/vacuum-worker.ts
+++ b/packages/database/src/vacuum-worker.ts
@@ -16,6 +16,10 @@ type VacuumResult =
 	| {
 			ok: false;
 			error: string;
+			walBusy?: number;
+			walLog?: number;
+			walCheckpointed?: number;
+			walTruncateBusy?: number;
 	  };
 
 self.onmessage = (event: MessageEvent<VacuumRequest>) => {
@@ -28,7 +32,7 @@ self.onmessage = (event: MessageEvent<VacuumRequest>) => {
 	let db: Database | undefined;
 	try {
 		db = new Database(dbPath);
-		db.exec(`PRAGMA busy_timeout = ${busyTimeoutMs}`);
+		db.exec(`PRAGMA busy_timeout = ${Math.max(0, Math.trunc(Number(busyTimeoutMs) || 10000))}`);
 		db.exec("PRAGMA journal_mode = WAL");
 
 		const ckpt = db.query("PRAGMA wal_checkpoint(RESTART)").get() as {
@@ -82,6 +86,10 @@ self.onmessage = (event: MessageEvent<VacuumRequest>) => {
 		self.postMessage({
 			ok: false,
 			error: err instanceof Error ? err.message : String(err),
+			walBusy,
+			walLog,
+			walCheckpointed,
+			walTruncateBusy,
 		} satisfies VacuumResult);
 	}
 };

--- a/packages/http-api/src/handlers/maintenance.ts
+++ b/packages/http-api/src/handlers/maintenance.ts
@@ -8,20 +8,29 @@ export function createCleanupHandler(
 	config: Config,
 ) {
 	return async (): Promise<Response> => {
-		const payloadDays = config.getDataRetentionDays();
 		const requestDays = config.getRequestRetentionDays();
-		const payloadMs = payloadDays * 24 * 60 * 60 * 1000;
 		const requestMs = requestDays * 24 * 60 * 60 * 1000;
+		// When payload storage is disabled, delete all existing payloads (cutoff = now).
+		// When enabled, honour the configured retention window.
+		const payloadMs = config.getStorePayloads()
+			? config.getDataRetentionDays() * 24 * 60 * 60 * 1000
+			: 0;
 		const { removedRequests, removedPayloads } = await dbOps.cleanupOldRequests(
 			payloadMs,
 			requestMs,
 		);
+		const [tableRowCounts, dbSizeBytes] = await Promise.all([
+			dbOps.getTableRowCounts(),
+			dbOps.getDbSizeBytes(),
+		]);
 		const now = Date.now();
 		const payload: CleanupResponse = {
 			removedRequests,
 			removedPayloads,
 			payloadCutoffIso: new Date(now - payloadMs).toISOString(),
 			requestCutoffIso: new Date(now - requestMs).toISOString(),
+			dbSizeBytes,
+			tableRowCounts,
 		};
 		return jsonResponse(payload);
 	};

--- a/packages/http-api/src/handlers/maintenance.ts
+++ b/packages/http-api/src/handlers/maintenance.ts
@@ -27,7 +27,11 @@ export function createCleanupHandler(
 		const payload: CleanupResponse = {
 			removedRequests,
 			removedPayloads,
-			payloadCutoffIso: new Date(now - payloadMs).toISOString(),
+			// null signals "all payloads removed" (storage disabled); avoids
+			// rendering a misleading "older than [right now]" timestamp in the UI.
+			payloadCutoffIso: config.getStorePayloads()
+				? new Date(now - payloadMs).toISOString()
+				: null,
 			requestCutoffIso: new Date(now - requestMs).toISOString(),
 			dbSizeBytes,
 			tableRowCounts,

--- a/packages/http-api/src/handlers/requests.ts
+++ b/packages/http-api/src/handlers/requests.ts
@@ -118,7 +118,9 @@ export function createRequestsDetailHandler(dbOps: DatabaseOperations) {
 		const rows = await dbOps.listRequestPayloadsWithAccountNames(safeLimit);
 		const parsed = rows.map((r) => {
 			try {
-				const data = JSON.parse(r.json) as Record<string, unknown>;
+				const data = (
+					r.json ? JSON.parse(r.json) : {}
+				) as Record<string, unknown>;
 
 				const request = data.request as
 					| { body?: string | null; truncated?: boolean }
@@ -131,6 +133,11 @@ export function createRequestsDetailHandler(dbOps: DatabaseOperations) {
 					meta = {};
 				}
 				meta.limitApplied = safeLimit;
+				// Ensure timestamp is always present for UI date rendering,
+				// even when no payload json was stored.
+				if (meta.timestamp === undefined) {
+					meta.timestamp = r.timestamp;
+				}
 
 				if (request?.body) {
 					const { body, truncated } = truncateBase64(request.body);

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -45,7 +45,7 @@ export interface RetentionSetRequest {
 export interface CleanupResponse {
 	removedRequests: number;
 	removedPayloads: number;
-	payloadCutoffIso: string;
+	payloadCutoffIso: string | null;
 	requestCutoffIso: string;
 	dbSizeBytes: number;
 	tableRowCounts: Array<{ name: string; rowCount: number; dataBytes?: number }>;

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -47,6 +47,8 @@ export interface CleanupResponse {
 	removedPayloads: number;
 	payloadCutoffIso: string;
 	requestCutoffIso: string;
+	dbSizeBytes: number;
+	tableRowCounts: Array<{ name: string; rowCount: number; dataBytes?: number }>;
 }
 
 export interface CompactResponse {


### PR DESCRIPTION
## Summary

- **VACUUM runs off the main thread** — offloads WAL checkpoint + VACUUM + WAL checkpoint to a Bun Worker so the event loop isn't blocked during compaction
- **SQLITE_BUSY retried asynchronously** — `BunSqlAdapter` catches `SQLITE_BUSY` errors and retries every 500 ms (up to 10 min) using `setTimeout` instead of blocking the event loop, preventing server crashes during VACUUM
- **Space breakdown after "Clean up now"** — response now includes total DB file size (`dbSizeBytes`) and per-table row counts, with actual byte size for `request_payloads` via `SUM(LENGTH(json))` (note: `dbstat` is not compiled into Bun's SQLite so page-level accounting is unavailable)
- **Cleanup respects `storePayloads` setting** — when payload storage is disabled the cleanup cutoff is set to `now`, removing all existing payloads rather than only those older than the retention window
- **Requests tab works without payloads** — `listPayloadsWithAccountNames` switched from a payload-first `INNER JOIN` to a request-first `LEFT JOIN`; `r.timestamp` is selected and injected into `meta` so the UI never renders "Invalid Date" for payload-less requests

## Test plan

- [ ] Trigger "Compact database" — server should remain responsive throughout; no SQLITE_BUSY crash in logs
- [ ] Trigger "Clean up now" with payload storage **enabled** — collapsible "Space usage" section appears showing `request_payloads` MB and other table row counts
- [ ] Trigger "Clean up now" with payload storage **disabled** — all existing payloads are removed regardless of age
- [ ] With payload storage disabled and after cleanup, open the Requests tab — existing requests appear with correct timestamps, no "Invalid Date"