### PR TITLE
fix: clear stale rate_limited_until when usage API shows capacity restored

### DIFF
--- a/packages/http-api/src/handlers/accounts.ts
+++ b/packages/http-api/src/handlers/accounts.ts
@@ -261,6 +261,10 @@ export function createAccountsListHandler(dbOps: DatabaseOperations) {
 									"UPDATE accounts SET rate_limited_until = NULL WHERE id = ?",
 									[account.id],
 								);
+								// Also update the in-memory object so the API response returned
+								// by this handler immediately reflects the cleared state.
+								account.rate_limited_until = null;
+								account.rate_limited = 0;
 								log.info(
 									`Cleared stale rate_limited_until for ${account.name}: usage API shows ${utilization}% utilization (seat reassignment or early reset)`,
 								);

--- a/packages/http-api/src/handlers/accounts.ts
+++ b/packages/http-api/src/handlers/accounts.ts
@@ -242,6 +242,29 @@ export function createAccountsListHandler(dbOps: DatabaseOperations) {
 							log.debug(
 								`Fetched usage data for ${account.name}: 5h=${usageData.five_hour.utilization}%, 7d=${usageData.seven_day.utilization}%`,
 							);
+
+							// If the usage API shows available capacity but the DB still has
+							// rate_limited_until in the future, clear the stale state. This
+							// handles seat reassignment: when an org admin reassigns a seat,
+							// Anthropic resets usage mid-window before the stored expiry fires.
+							const utilization = getRepresentativeUtilization(usageData);
+							const limitedUntil = account.rate_limited_until
+								? Number(account.rate_limited_until)
+								: null;
+							if (
+								utilization !== null &&
+								utilization < 100 &&
+								limitedUntil !== null &&
+								limitedUntil > Date.now()
+							) {
+								await db.run(
+									"UPDATE accounts SET rate_limited_until = NULL WHERE id = ?",
+									[account.id],
+								);
+								log.info(
+									`Cleared stale rate_limited_until for ${account.name}: usage API shows ${utilization}% utilization (seat reassignment or early reset)`,
+								);
+							}
 						}
 					} catch (error) {
 						log.warn(

--- a/packages/proxy/src/handlers/response-processor.ts
+++ b/packages/proxy/src/handlers/response-processor.ts
@@ -87,28 +87,9 @@ export function updateAccountMetadata(
 				rateLimitInfo.remaining,
 			),
 		);
-	} else {
-		// Successful response with no rate-limit header: clear rate_limited_until unconditionally.
-		// A successful upstream response proves the account is usable regardless of any stored
-		// expiry timestamp — covers early resets such as seat reassignment.
-		ctx.asyncWriter.enqueue(async () => {
-			const db = ctx.dbOps.getAdapter();
-			const result = await db.get<{ rate_limited_until: number | null }>(
-				"SELECT rate_limited_until FROM accounts WHERE id = ?",
-				[account.id],
-			);
-
-			if (result?.rate_limited_until) {
-				await db.run(
-					"UPDATE accounts SET rate_limited_until = NULL WHERE id = ?",
-					[account.id],
-				);
-				log.debug(
-					`Cleared rate_limited_until for account ${account.name} on successful response`,
-				);
-			}
-		});
 	}
+	// Note: rate_limited_until is cleared unconditionally in processProxyResponse on any
+	// successful response. No need to duplicate that logic here.
 
 	if (account.provider === "codex") {
 		const codexUsage = parseCodexUsageHeaders(response.headers, {
@@ -314,27 +295,21 @@ export async function processProxyResponse(
 		requestMeta?.headers?.get("x-better-ccflare-bypass-session") === "true";
 	updateAccountMetadata(account, response, ctx, requestId, bypassSession);
 
-	// Clear rate_limited_until if the account was previously rate-limited but is now successful.
-	// We clear unconditionally (even if the timestamp is still in the future) because a successful
-	// upstream response proves the account is no longer rate-limited — e.g. after a seat reassignment
-	// that resets usage mid-window before the stored expiry fires.
-	if (!rateLimitInfo.isRateLimited) {
+	// Clear rate_limited_until on any successful upstream response. We clear unconditionally
+	// (even if the timestamp is still in the future) because a successful response proves the
+	// account is usable — e.g. after a seat reassignment that resets usage mid-window before
+	// the stored expiry fires. Only enqueue the DB write when the in-memory account object
+	// already carries a rate_limited_until value to avoid overhead on every normal request.
+	if (!rateLimitInfo.isRateLimited && account.rate_limited_until) {
 		ctx.asyncWriter.enqueue(async () => {
 			const db = ctx.dbOps.getAdapter();
-			const result = await db.get<{ rate_limited_until: number | null }>(
-				"SELECT rate_limited_until FROM accounts WHERE id = ?",
+			await db.run(
+				"UPDATE accounts SET rate_limited_until = NULL WHERE id = ? AND rate_limited_until IS NOT NULL",
 				[account.id],
 			);
-
-			if (result?.rate_limited_until) {
-				await db.run(
-					"UPDATE accounts SET rate_limited_until = NULL WHERE id = ?",
-					[account.id],
-				);
-				log.debug(
-					`Cleared rate_limited_until for account ${account.name} on successful response`,
-				);
-			}
+			log.debug(
+				`Cleared rate_limited_until for account ${account.name} on successful response`,
+			);
 		});
 	}
 

--- a/packages/proxy/src/handlers/response-processor.ts
+++ b/packages/proxy/src/handlers/response-processor.ts
@@ -88,8 +88,9 @@ export function updateAccountMetadata(
 			),
 		);
 	} else {
-		// If there's no rate limit status header (meaning request was successful),
-		// clear the rate_limited_until field if it has expired
+		// Successful response with no rate-limit header: clear rate_limited_until unconditionally.
+		// A successful upstream response proves the account is usable regardless of any stored
+		// expiry timestamp — covers early resets such as seat reassignment.
 		ctx.asyncWriter.enqueue(async () => {
 			const db = ctx.dbOps.getAdapter();
 			const result = await db.get<{ rate_limited_until: number | null }>(
@@ -97,16 +98,13 @@ export function updateAccountMetadata(
 				[account.id],
 			);
 
-			if (
-				result?.rate_limited_until &&
-				result.rate_limited_until < Date.now()
-			) {
+			if (result?.rate_limited_until) {
 				await db.run(
 					"UPDATE accounts SET rate_limited_until = NULL WHERE id = ?",
 					[account.id],
 				);
 				log.debug(
-					`Cleared expired rate_limited_until for account ${account.name} on successful response`,
+					`Cleared rate_limited_until for account ${account.name} on successful response`,
 				);
 			}
 		});
@@ -316,30 +314,26 @@ export async function processProxyResponse(
 		requestMeta?.headers?.get("x-better-ccflare-bypass-session") === "true";
 	updateAccountMetadata(account, response, ctx, requestId, bypassSession);
 
-	// Clear rate_limited_until if the account was previously rate-limited but is now successful
+	// Clear rate_limited_until if the account was previously rate-limited but is now successful.
+	// We clear unconditionally (even if the timestamp is still in the future) because a successful
+	// upstream response proves the account is no longer rate-limited — e.g. after a seat reassignment
+	// that resets usage mid-window before the stored expiry fires.
 	if (!rateLimitInfo.isRateLimited) {
-		// Check if the account had a rate_limited_until value and clear it
 		ctx.asyncWriter.enqueue(async () => {
 			const db = ctx.dbOps.getAdapter();
-			// Only clear rate_limited_until if it's in the past or null (meaning it was rate-limited before)
 			const result = await db.get<{ rate_limited_until: number | null }>(
 				"SELECT rate_limited_until FROM accounts WHERE id = ?",
 				[account.id],
 			);
 
 			if (result?.rate_limited_until) {
-				const now = Date.now();
-				// If the rate limit was in the past (already expired) or if we're just clearing it after success
-				// We clear it regardless if it's expired to ensure the account is no longer marked as rate-limited
-				if (result.rate_limited_until <= now) {
-					await db.run(
-						"UPDATE accounts SET rate_limited_until = NULL WHERE id = ?",
-						[account.id],
-					);
-					log.debug(
-						`Cleared expired rate_limited_until for account ${account.name}`,
-					);
-				}
+				await db.run(
+					"UPDATE accounts SET rate_limited_until = NULL WHERE id = ?",
+					[account.id],
+				);
+				log.debug(
+					`Cleared rate_limited_until for account ${account.name} on successful response`,
+				);
 			}
 		});
 	}


### PR DESCRIPTION
## Summary

Fixes #148

When an org admin reassigns a seat to a user account, Anthropic resets that account's usage limits mid-window — before the `rate_limited_until` timestamp stored in the DB fires. The proxy kept blocking the account because `isAccountAvailable()` checks `rate_limited_until < now`, and a restart didn't help because the value is persisted in SQLite. The only workaround was manually clicking the re-authenticate (key) icon, which happens to call `clearRateLimitState()`.

## Root cause

Two independent caches for rate-limit state got out of sync:

- **`rate_limited_until` in SQLite** — set on 429; `isAccountAvailable()` returns `false` until it expires
- **`usageCache` in memory** — polls the Anthropic usage API every ~90 s; what the Accounts tab reads

After a seat reassignment, the usage API immediately shows available capacity, but `rate_limited_until` is still set to the original 5-hour expiry. The router never tries the account, so `processProxyResponse` (which clears expired rate limits on success) is never reached.

## Fix

Two changes:

**`packages/http-api/src/handlers/accounts.ts`** — when the Accounts tab fetches usage data and sees `utilization < 100%` on an account whose `rate_limited_until` is still in the future, clear the stale DB value. Self-heals within one auto-refresh cycle (~90 s) without requiring manual re-authentication.

**`packages/proxy/src/handlers/response-processor.ts`** — on any successful upstream response, clear `rate_limited_until` unconditionally rather than only when it has already expired. A successful response proves the account is usable regardless of the stored expiry, covering the auto-refresh bypass path and any other early-reset scenario.

## Test plan

- [ ] Add two accounts; mark one rate-limited in the DB (`UPDATE accounts SET rate_limited_until = (strftime('%s','now') + 18000) * 1000 WHERE name = 'account-b'`)
- [ ] Verify the proxy skips account-b (expected before fix)
- [ ] Open the Accounts tab — within the next auto-refresh cycle the log should show `Cleared stale rate_limited_until for account-b`
- [ ] Verify the proxy routes to account-b again