### PR TITLE
fix: don't select manually-paused accounts as auto-fallback candidates

### DIFF
--- a/packages/load-balancer/src/strategies/index.ts
+++ b/packages/load-balancer/src/strategies/index.ts
@@ -153,14 +153,21 @@ export class SessionStrategy implements LoadBalancingStrategy {
 					this.log.info(
 						`Skipping auto-unpause of account ${chosenFallback.name} — paused with reason '${chosenFallback.pause_reason}' which requires manual intervention`,
 					);
+					// The account remains paused — fall through to normal selection so only
+					// genuinely available accounts are returned.
 				}
 			}
 
-			// Return fallback account first, then others sorted by priority
-			const others = accounts
-				.filter((a) => a.id !== chosenFallback.id && getCachedAvailability(a))
-				.sort((a, b) => a.priority - b.priority);
-			return [chosenFallback, ...others];
+			// Only use this account as the fallback if it is actually available now
+			// (i.e. it was unpaused above, or it was never paused in the first place).
+			if (!chosenFallback.paused) {
+				// Return fallback account first, then others sorted by priority
+				const others = accounts
+					.filter((a) => a.id !== chosenFallback.id && getCachedAvailability(a))
+					.sort((a, b) => a.priority - b.priority);
+				return [chosenFallback, ...others];
+			}
+			// else: fall through to normal available-accounts selection below
 		}
 
 		// Find account with active session (most recent session_start within window)

--- a/packages/load-balancer/src/strategies/index.ts
+++ b/packages/load-balancer/src/strategies/index.ts
@@ -124,50 +124,54 @@ export class SessionStrategy implements LoadBalancingStrategy {
 			return availabilityCache.get(account.id) || false;
 		};
 
-		// Check for higher priority accounts that have become available due to rate limit reset
+		// Check for higher priority accounts that have become available due to rate limit reset.
+		// Iterate through all candidates in priority order to find the first usable one.
 		const fallbackCandidates = this.checkForAutoFallbackAccounts(accounts, now);
-		if (fallbackCandidates.length > 0) {
-			const chosenFallback = fallbackCandidates[0];
+		let chosenFallback: Account | null = null;
+		for (const candidate of fallbackCandidates) {
+			// If the candidate is paused, only auto-unpause if it was paused due to
+			// overage, or `rate_limit_window` (reserved/future pause reason) — never auto-unpause
+			// manual or failure_threshold pauses.
+			if (candidate.paused && this.store?.resumeAccount) {
+				const canAutoUnpause =
+					!candidate.pause_reason ||
+					candidate.pause_reason === "overage" ||
+					candidate.pause_reason === "rate_limit_window";
+				if (canAutoUnpause) {
+					this.log.info(
+						`Unpausing account ${candidate.name} due to auto-fallback reactivation`,
+					);
+					this.store.resumeAccount(candidate.id);
+					candidate.paused = false;
+					// Invalidate the cache so getCachedAvailability reflects the unpause
+					availabilityCache.delete(candidate.id);
+				} else {
+					this.log.info(
+						`Skipping auto-unpause of account ${candidate.name} — paused with reason '${candidate.pause_reason}' which requires manual intervention`,
+					);
+					continue;
+				}
+			}
+
+			if (getCachedAvailability(candidate)) {
+				chosenFallback = candidate;
+				break;
+			}
+		}
+
+		if (chosenFallback !== null) {
 			if (!bypassSession) {
 				this.resetSessionIfExpired(chosenFallback);
 			}
 			this.log.info(
 				`Auto-fallback triggered to account ${chosenFallback.name} (priority: ${chosenFallback.priority}, auto-fallback enabled)`,
 			);
-
-			// If the chosen fallback account was paused, only auto-unpause if it was paused due to
-			// overage, or `rate_limit_window` (reserved/future pause reason) — never auto-unpause
-			// manual or failure_threshold pauses.
-			if (chosenFallback.paused && this.store?.resumeAccount) {
-				const canAutoUnpause =
-					!chosenFallback.pause_reason ||
-					chosenFallback.pause_reason === "overage" ||
-					chosenFallback.pause_reason === "rate_limit_window";
-				if (canAutoUnpause) {
-					this.log.info(
-						`Unpausing account ${chosenFallback.name} due to auto-fallback reactivation`,
-					);
-					this.store.resumeAccount(chosenFallback.id);
-					chosenFallback.paused = false;
-				} else {
-					this.log.info(
-						`Skipping auto-unpause of account ${chosenFallback.name} — paused with reason '${chosenFallback.pause_reason}' which requires manual intervention`,
-					);
-					// The account remains paused — fall through to normal selection so only
-					// genuinely available accounts are returned.
-				}
-			}
-
-			// Only use this account as the fallback if it is actually available now
-			// (i.e. it was unpaused above, or it was never paused in the first place).
-			if (!chosenFallback.paused) {
-				// Return fallback account first, then others sorted by priority
-				const others = accounts
-					.filter((a) => a.id !== chosenFallback.id && getCachedAvailability(a))
-					.sort((a, b) => a.priority - b.priority);
-				return [chosenFallback, ...others];
-			}
-			// else: fall through to normal available-accounts selection below
+			// Return all available accounts sorted by priority — chosenFallback will appear
+			// first naturally if it is the highest-priority available account, avoiding
+			// priority inversion when other accounts rank higher.
+			return accounts
+				.filter((a) => getCachedAvailability(a))
+				.sort((a, b) => a.priority - b.priority);
 		}
 
 		// Find account with active session (most recent session_start within window)


### PR DESCRIPTION
## Summary

When an account has `auto_fallback_enabled` and its rate-limit window resets, `checkForAutoFallbackAccounts` intentionally includes paused accounts so they can be considered for auto-unpause. However, when the auto-unpause is skipped (pause reason is `manual` or `failure_threshold`), the account remains paused — yet it was still returned as the first selection, bypassing the `isAccountAvailable` guard applied to every other account.

**Symptom from logs:**
```
[INFO] Auto-fallback triggered to account erica_botsforcats_com (priority: 0, auto-fallback enabled)
[INFO] Skipping auto-unpause of account erica_botsforcats_com — paused with reason 'manual' which requires manual intervention
[INFO] Selected 3 accounts: erica_botsforcats_com, sacha_botsforcats_com, gili_tzabari_gmail_com
```

## Root cause

`select()` unconditionally prepended `chosenFallback` to the result list regardless of whether the auto-unpause succeeded:

```typescript
// always ran — even when chosenFallback was still paused
return [chosenFallback, ...others];
```

The `others` list was correctly filtered through `getCachedAvailability`, but `chosenFallback` itself bypassed that check.

## Fix

After the auto-unpause block, guard the early return on `!chosenFallback.paused`. If the account is still paused, fall through to the normal available-accounts selection, which correctly filters via `isAccountAvailable`.

## Test plan

- [ ] Add two accounts; manually pause account A (higher priority, `auto_fallback_enabled`)
- [ ] Wait for account A's `rate_limit_reset` to pass so it appears in `checkForAutoFallbackAccounts`
- [ ] Send a request — verify logs show account B is selected, not account A
- [ ] Manually resume account A and confirm it is selected again