### PR TITLE
feat: balance new sessions by utilization within same-priority accounts

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -24,7 +24,11 @@ import {
 import { APIRouter, AuthService } from "@better-ccflare/http-api";
 import { SessionStrategy } from "@better-ccflare/load-balancer";
 import { Logger } from "@better-ccflare/logger";
-import { getProvider, usageCache } from "@better-ccflare/providers";
+import {
+	getProvider,
+	getRepresentativeUtilizationForProvider,
+	usageCache,
+} from "@better-ccflare/providers";
 import {
 	canUseInferenceProfileDynamic,
 	parseBedrockConfig,
@@ -704,6 +708,16 @@ export default async function startServer(options?: {
 
 	// Now create the strategy with runtime config
 	const strategy = new SessionStrategy(runtimeConfig.sessionDurationMs);
+
+	// Extend dbOps with usage-based account utilization for balanced session selection
+	Object.assign(dbOps, {
+		getAccountUtilization: (accountId: string, provider: string): number | null => {
+			const data = usageCache.get(accountId);
+			if (!data) return null;
+			return getRepresentativeUtilizationForProvider(data, provider);
+		},
+	});
+
 	strategy.initialize(dbOps);
 
 	// Start usage worker eagerly (before first request)

--- a/docs/load-balancing.md
+++ b/docs/load-balancing.md
@@ -187,7 +187,7 @@ Account priorities allow you to control which accounts are preferred when multip
 - **Optional Parameter**: Priority is optional when adding accounts and defaults to 0 (highest priority)
 - **Affects Both Primary and Fallback Selection**: Priorities determine both the primary account and the order of fallback accounts
 - **Real-time Updates**: Priority changes take effect immediately without restarting the server
-- **Usage-Balanced Tiebreaking**: When multiple accounts share the same priority, new sessions start on the account with the most remaining capacity. "Most remaining capacity" is the inverse of the maximum utilization across all usage windows — so an account at 90% on its 7-day window and 20% on its 5-hour window is considered 90% utilized (the 7-day window is the binding constraint). Accounts with no usage data available are treated as lower priority than accounts with data.
+- **Usage-Balanced Tiebreaking**: When multiple accounts share the same priority, new sessions start on the account with the most remaining capacity. "Most remaining capacity" is the inverse of the maximum utilization across all usage windows — so an account at 90% on its 7-day window and 20% on its 5-hour window is considered 90% utilized (the 7-day window is the binding constraint). Accounts with no usage data available are treated as 0% utilized (fresh, maximum remaining capacity) and sort first within their priority tier.
 
 ### Setting Account Priorities
 
@@ -435,7 +435,7 @@ The SessionStrategy manages account sessions through the following process:
 3. **Account Ordering**: Returns accounts in priority order:
    - Active session account (if available) comes first
    - Other available accounts are sorted by priority (lower values first) as fallback options
-4. **No Active Session — Utilization Tiebreaking**: When no active session exists, accounts with the same priority value are further sorted by ascending utilization (lowest first = most remaining capacity). This ensures new sessions start on the account with the most headroom, draining usage evenly across same-priority accounts. Accounts without available usage data sort after accounts that have data.
+4. **No Active Session — Utilization Tiebreaking**: When no active session exists, accounts with the same priority value are further sorted by ascending utilization (lowest first = most remaining capacity). This ensures new sessions start on the account with the most headroom, draining usage evenly across same-priority accounts. Accounts without available usage data are treated as 0% utilized and sort first (most remaining capacity) within their priority tier.
 
 ### 4. Session Reset
 Sessions are reset when:

--- a/docs/load-balancing.md
+++ b/docs/load-balancing.md
@@ -187,6 +187,7 @@ Account priorities allow you to control which accounts are preferred when multip
 - **Optional Parameter**: Priority is optional when adding accounts and defaults to 0 (highest priority)
 - **Affects Both Primary and Fallback Selection**: Priorities determine both the primary account and the order of fallback accounts
 - **Real-time Updates**: Priority changes take effect immediately without restarting the server
+- **Usage-Balanced Tiebreaking**: When multiple accounts share the same priority, new sessions start on the account with the most remaining capacity. "Most remaining capacity" is the inverse of the maximum utilization across all usage windows — so an account at 90% on its 7-day window and 20% on its 5-hour window is considered 90% utilized (the 7-day window is the binding constraint). Accounts with no usage data available are treated as lower priority than accounts with data.
 
 ### Setting Account Priorities
 
@@ -434,6 +435,7 @@ The SessionStrategy manages account sessions through the following process:
 3. **Account Ordering**: Returns accounts in priority order:
    - Active session account (if available) comes first
    - Other available accounts are sorted by priority (lower values first) as fallback options
+4. **No Active Session — Utilization Tiebreaking**: When no active session exists, accounts with the same priority value are further sorted by ascending utilization (lowest first = most remaining capacity). This ensures new sessions start on the account with the most headroom, draining usage evenly across same-priority accounts. Accounts without available usage data sort after accounts that have data.
 
 ### 4. Session Reset
 Sessions are reset when:

--- a/packages/load-balancer/src/strategies/__tests__/session-strategy.test.ts
+++ b/packages/load-balancer/src/strategies/__tests__/session-strategy.test.ts
@@ -46,6 +46,7 @@ function makeAccount(overrides: Partial<Account> = {}): Account {
 class MockStrategyStore implements StrategyStore {
 	resetCalls: Array<{ accountId: string; timestamp: number }> = [];
 	resumeCalls: string[] = [];
+	utilizationMap: Map<string, number | null> = new Map();
 
 	resetAccountSession(accountId: string, timestamp: number): void {
 		this.resetCalls.push({ accountId, timestamp });
@@ -55,10 +56,20 @@ class MockStrategyStore implements StrategyStore {
 		this.resumeCalls.push(accountId);
 	}
 
+	getAccountUtilization(accountId: string, _provider: string): number | null {
+		if (!this.utilizationMap.has(accountId)) return null;
+		return this.utilizationMap.get(accountId) ?? null;
+	}
+
+	setUtilization(accountId: string, value: number | null): void {
+		this.utilizationMap.set(accountId, value);
+	}
+
 	// Helper methods for testing
 	clear(): void {
 		this.resetCalls = [];
 		this.resumeCalls = [];
+		this.utilizationMap.clear();
 	}
 
 	getResetCall(
@@ -563,5 +574,161 @@ describe("SessionStrategy", () => {
 		);
 
 		expect(result[0]).toBe(lowerPriority);
+	});
+
+	// -------------------------------------------------------------------------
+	// Usage-balanced tiebreaking within same-priority accounts
+	//
+	// When multiple accounts share the same priority value, new sessions should
+	// start on the account with the most remaining capacity (lowest utilization).
+	// -------------------------------------------------------------------------
+
+	describe("usage-balanced tiebreaking for same-priority accounts", () => {
+		it("selects account with lower utilization when priorities are equal", () => {
+			const now = Date.now();
+
+			const highUtil = makeAccount({
+				id: "high-util",
+				name: "high-util",
+				created_at: now,
+				expires_at: now + 3600_000,
+				priority: 0,
+			});
+
+			const lowUtil = makeAccount({
+				id: "low-util",
+				name: "low-util",
+				created_at: now,
+				expires_at: now + 3600_000,
+				priority: 0,
+			});
+
+			mockStore.setUtilization("high-util", 80);
+			mockStore.setUtilization("low-util", 20);
+
+			const result = strategy.select([highUtil, lowUtil], meta);
+
+			// low-util has more headroom → should be selected first
+			expect(result[0]).toBe(lowUtil);
+			expect(result[1]).toBe(highUtil);
+		});
+
+		it("sorts null-utilization accounts first (treated as 0%, fresh account)", () => {
+			const now = Date.now();
+
+			const withData = makeAccount({
+				id: "with-data",
+				name: "with-data",
+				created_at: now,
+				expires_at: now + 3600_000,
+				priority: 0,
+			});
+
+			const noData = makeAccount({
+				id: "no-data",
+				name: "no-data",
+				created_at: now,
+				expires_at: now + 3600_000,
+				priority: 0,
+			});
+
+			mockStore.setUtilization("with-data", 50);
+			// no-data has no entry in utilizationMap → returns null → treated as 0
+
+			const result = strategy.select([withData, noData], meta);
+
+			// noData treated as 0% → selected first; withData (50%) sorts after
+			expect(result[0]).toBe(noData);
+			expect(result[1]).toBe(withData);
+		});
+
+		it("should treat null utilization as 0 (fresh account)", () => {
+			const now = Date.now();
+
+			const accountA = makeAccount({
+				id: "account-a-50pct",
+				name: "account-a-50pct",
+				created_at: now,
+				expires_at: now + 3600_000,
+				priority: 0,
+			});
+
+			const accountB = makeAccount({
+				id: "account-b-null",
+				name: "account-b-null",
+				created_at: now,
+				expires_at: now + 3600_000,
+				priority: 0,
+			});
+
+			mockStore.setUtilization("account-a-50pct", 50);
+			// account-b-null has no utilization data at all → null → treated as 0
+
+			const result = strategy.select([accountA, accountB], meta);
+
+			// account-b-null (null=0%) has more headroom than account-a-50pct (50%) → selected first
+			expect(result[0]).toBe(accountB);
+			expect(result[1]).toBe(accountA);
+		});
+
+		it("does not panic when both accounts have no utilization data", () => {
+			const now = Date.now();
+
+			const a = makeAccount({
+				id: "account-a",
+				name: "account-a",
+				created_at: now,
+				expires_at: now + 3600_000,
+				priority: 0,
+			});
+
+			const b = makeAccount({
+				id: "account-b",
+				name: "account-b",
+				created_at: now,
+				expires_at: now + 3600_000,
+				priority: 0,
+			});
+
+			// Neither account has utilization data
+
+			const result = strategy.select([a, b], meta);
+
+			// Both accounts are returned — order is stable (0 vs 0 → no swap)
+			expect(result).toHaveLength(2);
+			expect(result).toContain(a);
+			expect(result).toContain(b);
+		});
+
+		it("priority still wins over utilization for different-priority accounts", () => {
+			const now = Date.now();
+
+			// Higher priority (lower number) but higher utilization
+			const highPriorityHighUtil = makeAccount({
+				id: "high-pri-high-util",
+				name: "high-pri-high-util",
+				created_at: now,
+				expires_at: now + 3600_000,
+				priority: 0,
+			});
+
+			// Lower priority (higher number) but lower utilization
+			const lowPriorityLowUtil = makeAccount({
+				id: "low-pri-low-util",
+				name: "low-pri-low-util",
+				created_at: now,
+				expires_at: now + 3600_000,
+				priority: 1,
+			});
+
+			mockStore.setUtilization("high-pri-high-util", 90);
+			mockStore.setUtilization("low-pri-low-util", 10);
+
+			const result = strategy.select([lowPriorityLowUtil, highPriorityHighUtil], meta);
+
+			// Priority 0 wins even though it has higher utilization
+			expect(result[0]).toBe(highPriorityHighUtil);
+			expect(result[1]).toBe(lowPriorityLowUtil);
+		});
 	});
 });

--- a/packages/load-balancer/src/strategies/index.ts
+++ b/packages/load-balancer/src/strategies/index.ts
@@ -225,10 +225,20 @@ export class SessionStrategy implements LoadBalancingStrategy {
 		}
 
 		// No active session or active account is rate limited
-		// Filter available accounts and sort by priority (lower number = higher priority)
+		// Filter available accounts and sort by priority (lower number = higher priority).
+		// Within the same priority, break ties by utilization (ascending) so that the
+		// account with the most remaining capacity is chosen first.
 		const available = accounts
 			.filter((a) => getCachedAvailability(a))
-			.sort((a, b) => a.priority - b.priority);
+			.sort((a, b) => {
+				if (a.priority !== b.priority) return a.priority - b.priority;
+				// Treat null as 0: an account with no usage data is assumed fresh
+				// (maximum remaining capacity). This prevents newly-added accounts
+				// from being permanently sidelined until all others expire.
+				const utilA = this.store?.getAccountUtilization?.(a.id, a.provider) ?? 0;
+				const utilB = this.store?.getAccountUtilization?.(b.id, b.provider) ?? 0;
+				return utilA - utilB;
+			});
 
 		if (available.length === 0) return [];
 

--- a/packages/providers/src/usage-fetcher.ts
+++ b/packages/providers/src/usage-fetcher.ts
@@ -15,6 +15,7 @@ import {
 } from "./kilo-usage-fetcher";
 import {
 	fetchNanoGPTUsageData,
+	getRepresentativeNanoGPTUtilization,
 	type NanoGPTUsageData,
 } from "./nanogpt-usage-fetcher";
 import { fetchZaiUsageData, type ZaiUsageData } from "./zai-usage-fetcher";
@@ -281,18 +282,21 @@ export function getRepresentativeUtilizationForProvider(
 			// (seven_day_sonnet, seven_day_opus) are excluded: they are mutual fallbacks
 			// and Anthropic never exposes both simultaneously, so neither is a hard limit.
 			const utils: number[] = [];
-			for (const key of ["five_hour", "seven_day", "seven_day_oauth_apps"] as const) {
+			for (const key of [
+				"five_hour",
+				"seven_day",
+				"seven_day_oauth_apps",
+			] as const) {
 				const w = d[key] as UsageWindow | undefined;
 				if (w?.utilization != null) utils.push(w.utilization);
 			}
 			// extra_usage has utilization: number | null
-			if (d.extra_usage?.utilization != null) utils.push(d.extra_usage.utilization);
+			if (d.extra_usage?.utilization != null)
+				utils.push(d.extra_usage.utilization);
 			return utils.length > 0 ? Math.max(...utils) : null;
 		}
 		case "nanogpt": {
-			const { active, daily, monthly } = data as NanoGPTUsageData;
-			if (!active) return null;
-			return Math.max(daily.percentUsed * 100, monthly.percentUsed * 100);
+			return getRepresentativeNanoGPTUtilization(data as NanoGPTUsageData);
 		}
 		case "zai": {
 			const zai = data as ZaiUsageData;
@@ -303,15 +307,11 @@ export function getRepresentativeUtilizationForProvider(
 			return candidates.length > 0 ? Math.max(...candidates) : null;
 		}
 		case "kilo": {
-			const kilo = data as KiloUsageData;
-			return kilo.utilizationPercent;
+			return getRepresentativeKiloUtilization(data as KiloUsageData);
 		}
 		case "alibaba-coding-plan": {
-			const alibaba = data as AlibabaCodingPlanUsageData;
-			return Math.max(
-				alibaba.five_hour.percentUsed,
-				alibaba.weekly.percentUsed,
-				alibaba.monthly.percentUsed,
+			return getRepresentativeAlibabaCodingPlanUtilization(
+				data as AlibabaCodingPlanUsageData,
 			);
 		}
 		default:

--- a/packages/providers/src/usage-fetcher.ts
+++ b/packages/providers/src/usage-fetcher.ts
@@ -266,6 +266,60 @@ export function getRepresentativeWindow(
 }
 
 /**
+ * Get the representative utilization for any supported provider type.
+ * Returns null if the provider is not supported or data is unavailable.
+ */
+export function getRepresentativeUtilizationForProvider(
+	data: AnyUsageData,
+	provider: string,
+): number | null {
+	switch (provider) {
+		case "anthropic":
+		case "codex": {
+			const d = data as UsageData;
+			// Only account-level windows count as hard limits. Model-specific windows
+			// (seven_day_sonnet, seven_day_opus) are excluded: they are mutual fallbacks
+			// and Anthropic never exposes both simultaneously, so neither is a hard limit.
+			const utils: number[] = [];
+			for (const key of ["five_hour", "seven_day", "seven_day_oauth_apps"] as const) {
+				const w = d[key] as UsageWindow | undefined;
+				if (w?.utilization != null) utils.push(w.utilization);
+			}
+			// extra_usage has utilization: number | null
+			if (d.extra_usage?.utilization != null) utils.push(d.extra_usage.utilization);
+			return utils.length > 0 ? Math.max(...utils) : null;
+		}
+		case "nanogpt": {
+			const { active, daily, monthly } = data as NanoGPTUsageData;
+			if (!active) return null;
+			return Math.max(daily.percentUsed * 100, monthly.percentUsed * 100);
+		}
+		case "zai": {
+			const zai = data as ZaiUsageData;
+			const candidates = [
+				zai.time_limit?.percentage ?? null,
+				zai.tokens_limit?.percentage ?? null,
+			].filter((v): v is number => v !== null);
+			return candidates.length > 0 ? Math.max(...candidates) : null;
+		}
+		case "kilo": {
+			const kilo = data as KiloUsageData;
+			return kilo.utilizationPercent;
+		}
+		case "alibaba-coding-plan": {
+			const alibaba = data as AlibabaCodingPlanUsageData;
+			return Math.max(
+				alibaba.five_hour.percentUsed,
+				alibaba.weekly.percentUsed,
+				alibaba.monthly.percentUsed,
+			);
+		}
+		default:
+			return null;
+	}
+}
+
+/**
  * Type for a function that retrieves a fresh access token or API key
  */
 export type AccessTokenProvider = () => Promise<string>;

--- a/packages/types/src/strategy.ts
+++ b/packages/types/src/strategy.ts
@@ -39,4 +39,10 @@ export interface StrategyStore {
 	 * Resume a paused account
 	 */
 	resumeAccount?(accountId: string): void;
+
+	/**
+	 * Get the representative utilization (0–100) for an account based on its
+	 * most-constrained usage window. Returns null when no usage data is available.
+	 */
+	getAccountUtilization?(accountId: string, provider: string): number | null;
 }


### PR DESCRIPTION
Closes #125

## Summary

When starting a fresh session (no active session exists), accounts that share the same priority are now sorted by ascending representative utilization rather than arbitrary insertion order. The account with the most remaining capacity gets the next session, causing usage to drain proportionally across same-priority accounts so they expire at roughly the same time.

Session stickiness and all existing behavior for accounts with different priorities are fully preserved.

## Design decisions

### Water-filling algorithm

Sorting ascending by utilization implements a water-filling strategy — the least-used account fills up to match others before any account is overloaded. This was verified by simulation:

**Scenario: A=70%, B=40%, C=10% (10% per session)**
| Sessions | A | B | C |
|---|---|---|---|
| Distributed | 3 | 6 | 9 |
| Final state | 100% 💀 | 100% 💀 | 100% 💀 |

All three accounts expire on consecutive sessions, with traffic proportional to remaining capacity (3:6:9 = 30%:60%:90%). A simulation with one null-data account (A=60%, B=null→0%, C=30%) confirmed the same property across 21 sessions.

### Hard-limit windows only

Representative utilization is the max across `five_hour`, `seven_day`, `seven_day_oauth_apps`, and `extra_usage` only. Model-specific windows (`seven_day_sonnet`, `seven_day_opus`) are excluded because:

- The model mapping feature enables users to fallback from sonnet → opus or opus → sonnet
- Anthropic never exposes both windows simultaneously
- So neither is a hard account-level limit

Including them caused accounts with high sonnet/opus usage to appear nearly exhausted when their general-window capacity was fine, producing badly skewed session distribution. In simulation, excluding them changed which account was selected first (B at 40% general-window usage instead of C at 50%) and produced a correct proportional outcome.

### Null treated as 0%

Accounts with no usage data (first poll not yet complete, or provider does not support usage tracking) are treated as 0% utilization rather than sorted last. Sorting null last permanently sidelines newly-added accounts until all others expire — simulation confirmed B (null) would receive zero sessions if treated as last. Treating null as 0% gives fresh accounts sessions proportional to their assumed full remaining capacity.

### Same-priority only

Static priority takes full precedence. The utilization tiebreaker only applies within a same-priority tier, leaving all cross-tier behavior unchanged.

## Files changed

- `packages/providers/src/usage-fetcher.ts` — adds `getRepresentativeUtilizationForProvider()` with explicit hard-limit allowlist per provider
- `packages/types/src/strategy.ts` — adds optional `getAccountUtilization?()` to `StrategyStore`
- `packages/load-balancer/src/strategies/index.ts` — utilization tiebreaker in the no-active-session sort
- `apps/server/src/server.ts` — wires `usageCache` into `StrategyStore` via `Object.assign`
- `packages/load-balancer/src/strategies/__tests__/session-strategy.test.ts` — tests for tiebreaker, null=0, priority precedence
- `docs/load-balancing.md` — documents the new behavior