### PR TITLE
test: add coverage for PR-149 busy-retry, cleanup response, and LEFT JOIN fix

### DIFF
--- a/packages/database/src/adapters/__tests__/bun-sql-adapter-busy-retry.test.ts
+++ b/packages/database/src/adapters/__tests__/bun-sql-adapter-busy-retry.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests for BunSqlAdapter.withBusyRetry (exercised through public methods).
+ *
+ * withBusyRetry is private, but it is called by query(), get(), run(), and
+ * runWithChanges() for every SQLite operation.  We simulate SQLITE_BUSY by
+ * replacing the internal sqliteDb methods with stubs that throw once before
+ * succeeding, using `(adapter as any).sqliteDb` to reach the private field.
+ */
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { BunSqlAdapter } from "../bun-sql-adapter";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeBusyError(): Error {
+	return Object.assign(new Error("database is locked"), {
+		code: "SQLITE_BUSY",
+	});
+}
+
+/**
+ * Replace a method on the underlying sqliteDb with a stub that throws
+ * SQLITE_BUSY on the first call and delegates to the real method thereafter.
+ *
+ * Returns a cleanup function that restores the original.
+ */
+function stubBusyOnce(sqliteDb: Database, method: "run" | "query"): () => void {
+	const original = sqliteDb[method].bind(sqliteDb);
+	let calls = 0;
+	// biome-ignore lint/suspicious/noExplicitAny: test stub replacing internal DB method
+	(sqliteDb as any)[method] = (...args: any[]) => {
+		calls++;
+		if (calls === 1) throw makeBusyError();
+		// biome-ignore lint/suspicious/noExplicitAny: delegating to real implementation
+		return (original as any)(...args);
+	};
+	return () => {
+		// biome-ignore lint/suspicious/noExplicitAny: restoring original method
+		(sqliteDb as any)[method] = original;
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("BunSqlAdapter withBusyRetry", () => {
+	let db: Database;
+	let adapter: BunSqlAdapter;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		db.run("CREATE TABLE IF NOT EXISTS t (id INTEGER PRIMARY KEY, val TEXT)");
+		adapter = new BunSqlAdapter(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	describe("query() retries on SQLITE_BUSY", () => {
+		it("returns result on second attempt after one SQLITE_BUSY", async () => {
+			db.run("INSERT INTO t (id, val) VALUES (1, 'hello')");
+
+			const sqliteDb = (adapter as any).sqliteDb as Database;
+			const restore = stubBusyOnce(sqliteDb, "query");
+			try {
+				const rows = await adapter.query<{ id: number; val: string }>(
+					"SELECT id, val FROM t",
+				);
+				expect(rows).toHaveLength(1);
+				expect(rows[0].val).toBe("hello");
+			} finally {
+				restore();
+			}
+		});
+	});
+
+	describe("get() retries on SQLITE_BUSY", () => {
+		it("returns the row on second attempt after one SQLITE_BUSY", async () => {
+			db.run("INSERT INTO t (id, val) VALUES (2, 'world')");
+
+			const sqliteDb = (adapter as any).sqliteDb as Database;
+			const restore = stubBusyOnce(sqliteDb, "query");
+			try {
+				const row = await adapter.get<{ id: number; val: string }>(
+					"SELECT id, val FROM t WHERE id = ?",
+					[2],
+				);
+				expect(row).not.toBeNull();
+				expect(row?.val).toBe("world");
+			} finally {
+				restore();
+			}
+		});
+	});
+
+	describe("run() retries on SQLITE_BUSY", () => {
+		it("completes successfully on second attempt after one SQLITE_BUSY", async () => {
+			const sqliteDb = (adapter as any).sqliteDb as Database;
+			const restore = stubBusyOnce(sqliteDb, "run");
+			try {
+				await adapter.run("INSERT INTO t (id, val) VALUES (?, ?)", [
+					3,
+					"retry-run",
+				]);
+				const row = db.query("SELECT val FROM t WHERE id = 3").get() as {
+					val: string;
+				} | null;
+				expect(row?.val).toBe("retry-run");
+			} finally {
+				restore();
+			}
+		});
+	});
+
+	describe("runWithChanges() retries on SQLITE_BUSY", () => {
+		it("returns affected-row count on second attempt after one SQLITE_BUSY", async () => {
+			db.run("INSERT INTO t (id, val) VALUES (4, 'before')");
+
+			const sqliteDb = (adapter as any).sqliteDb as Database;
+			const restore = stubBusyOnce(sqliteDb, "run");
+			try {
+				const changes = await adapter.runWithChanges(
+					"UPDATE t SET val = ? WHERE id = ?",
+					["after", 4],
+				);
+				expect(changes).toBe(1);
+			} finally {
+				restore();
+			}
+		});
+	});
+
+	describe("non-SQLITE_BUSY errors are not retried", () => {
+		it("propagates a non-busy error immediately without retrying", async () => {
+			// Inject an error whose code is NOT SQLITE_BUSY
+			const sqliteDb = (adapter as any).sqliteDb as Database;
+			const original = sqliteDb.query.bind(sqliteDb);
+			let calls = 0;
+			// biome-ignore lint/suspicious/noExplicitAny: test stub
+			(sqliteDb as any).query = (...args: any[]) => {
+				calls++;
+				throw Object.assign(new Error("disk I/O error"), {
+					code: "SQLITE_IOERR",
+				});
+				// biome-ignore lint/correctness/noUnreachable: intentional unreachable for type
+				return (original as any)(...args);
+			};
+
+			try {
+				await expect(adapter.query("SELECT id FROM t")).rejects.toThrow(
+					"disk I/O error",
+				);
+				// Should have thrown immediately — only one call
+				expect(calls).toBe(1);
+			} finally {
+				// biome-ignore lint/suspicious/noExplicitAny: restoring original
+				(sqliteDb as any).query = original;
+			}
+		});
+	});
+
+	describe("SQLITE_BUSY past deadline is propagated", () => {
+		it("throws SQLITE_BUSY when Date.now() is already past the retry deadline", async () => {
+			const sqliteDb = (adapter as any).sqliteDb as Database;
+			const originalQuery = sqliteDb.query.bind(sqliteDb);
+			const originalDateNow = Date.now;
+
+			// Make every query call throw SQLITE_BUSY
+			// biome-ignore lint/suspicious/noExplicitAny: test stub
+			(sqliteDb as any).query = (..._args: any[]) => {
+				throw makeBusyError();
+			};
+			// Make the deadline already expired by putting Date.now far in the future
+			// relative to the deadline check: deadline = Date.now() + 10min, so if
+			// Date.now() returns a value 11min ahead on the *second* check, the retry
+			// is skipped.
+			let callCount = 0;
+			Date.now = () => {
+				callCount++;
+				// First call (setting deadline): return real time.
+				// Subsequent calls (deadline check): return real time + 11 minutes.
+				return callCount === 1
+					? originalDateNow()
+					: originalDateNow() + 11 * 60 * 1000;
+			};
+
+			try {
+				await expect(adapter.query("SELECT id FROM t")).rejects.toMatchObject({
+					code: "SQLITE_BUSY",
+				});
+			} finally {
+				// biome-ignore lint/suspicious/noExplicitAny: restoring original
+				(sqliteDb as any).query = originalQuery;
+				Date.now = originalDateNow;
+			}
+		});
+	});
+});

--- a/packages/database/src/repositories/__tests__/request-payload-left-join.test.ts
+++ b/packages/database/src/repositories/__tests__/request-payload-left-join.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for RequestRepository.listPayloadsWithAccountNames after the
+ * INNER JOIN → LEFT JOIN fix.
+ *
+ * Before the fix, any request that lacked a row in request_payloads was
+ * silently excluded.  After the fix, all requests appear; those without a
+ * payload have json=null in the result.
+ */
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { BunSqlAdapter } from "../../adapters/bun-sql-adapter";
+import { ensureSchema, runMigrations } from "../../migrations";
+import { RequestRepository } from "../request.repository";
+
+// ---------------------------------------------------------------------------
+// Schema setup
+// ---------------------------------------------------------------------------
+
+function makeDb(): Database {
+	const db = new Database(":memory:");
+	ensureSchema(db);
+	runMigrations(db);
+	return db;
+}
+
+// ---------------------------------------------------------------------------
+// Insert helpers
+// ---------------------------------------------------------------------------
+
+function insertRequest(db: Database, id: string, timestamp: number): void {
+	db.run(
+		`INSERT INTO requests
+			(id, timestamp, method, path, account_used, status_code, success,
+			 error_message, response_time_ms, failover_attempts)
+		 VALUES (?, ?, 'POST', '/v1/messages', NULL, 200, 1, NULL, 100, 0)`,
+		[id, timestamp],
+	);
+}
+
+function insertRequestWithPayload(
+	db: Database,
+	id: string,
+	timestamp: number,
+	json: string,
+): void {
+	insertRequest(db, id, timestamp);
+	db.run(
+		`INSERT INTO request_payloads (id, json, timestamp) VALUES (?, ?, ?)`,
+		[id, json, timestamp],
+	);
+}
+
+function insertAccount(db: Database, id: string, name: string): void {
+	db.run(
+		`INSERT INTO accounts
+			(id, name, provider, created_at, priority)
+		 VALUES (?, ?, 'anthropic-compatible', ?, 0)`,
+		[id, name, Date.now()],
+	);
+}
+
+function linkAccountToRequest(
+	db: Database,
+	requestId: string,
+	accountId: string,
+): void {
+	db.run(`UPDATE requests SET account_used = ? WHERE id = ?`, [
+		accountId,
+		requestId,
+	]);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("RequestRepository.listPayloadsWithAccountNames", () => {
+	let db: Database;
+	let repo: RequestRepository;
+
+	beforeEach(() => {
+		db = makeDb();
+		repo = new RequestRepository(new BunSqlAdapter(db));
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("returns requests that have no payload (json=null)", async () => {
+		const now = Date.now();
+		insertRequest(db, "req-no-payload", now);
+
+		const results = await repo.listPayloadsWithAccountNames(10);
+
+		expect(results).toHaveLength(1);
+		expect(results[0].id).toBe("req-no-payload");
+		expect(results[0].json).toBeNull();
+	});
+
+	it("returns requests that have a payload (json is present/non-null)", async () => {
+		const now = Date.now();
+		const payloadData = JSON.stringify({ model: "claude-3", messages: [] });
+		insertRequestWithPayload(db, "req-with-payload", now, payloadData);
+
+		const results = await repo.listPayloadsWithAccountNames(10);
+
+		expect(results).toHaveLength(1);
+		expect(results[0].id).toBe("req-with-payload");
+		// json may be returned as-is or re-serialized after decrypt; it must be non-null
+		expect(results[0].json).not.toBeNull();
+	});
+
+	it("timestamp field is present and correct for requests without payload", async () => {
+		const ts = 1_700_000_000_000;
+		insertRequest(db, "req-ts", ts);
+
+		const results = await repo.listPayloadsWithAccountNames(10);
+
+		expect(results[0].timestamp).toBe(ts);
+	});
+
+	it("timestamp field is present and correct for requests with payload", async () => {
+		const ts = 1_700_100_000_000;
+		insertRequestWithPayload(db, "req-ts-payload", ts, "{}");
+
+		const results = await repo.listPayloadsWithAccountNames(10);
+
+		expect(results[0].timestamp).toBe(ts);
+	});
+
+	it("results are ordered by timestamp DESC", async () => {
+		const base = 1_700_000_000_000;
+		insertRequest(db, "oldest", base);
+		insertRequest(db, "middle", base + 1000);
+		insertRequest(db, "newest", base + 2000);
+
+		const results = await repo.listPayloadsWithAccountNames(10);
+
+		expect(results.map((r) => r.id)).toEqual(["newest", "middle", "oldest"]);
+	});
+
+	it("account_name is null when no account is linked", async () => {
+		insertRequest(db, "req-no-acct", Date.now());
+
+		const results = await repo.listPayloadsWithAccountNames(10);
+
+		expect(results[0].account_name).toBeNull();
+	});
+
+	it("account_name is set when an account is linked", async () => {
+		const now = Date.now();
+		insertAccount(db, "acct-1", "my-account");
+		insertRequest(db, "req-acct", now);
+		linkAccountToRequest(db, "req-acct", "acct-1");
+
+		const results = await repo.listPayloadsWithAccountNames(10);
+
+		expect(results[0].account_name).toBe("my-account");
+	});
+
+	it("limit param is respected", async () => {
+		const base = 1_700_000_000_000;
+		for (let i = 0; i < 5; i++) {
+			insertRequest(db, `req-${i}`, base + i * 1000);
+		}
+
+		const results = await repo.listPayloadsWithAccountNames(3);
+
+		expect(results).toHaveLength(3);
+	});
+
+	it("returns both payload and non-payload requests in the same result set", async () => {
+		const base = 1_700_000_000_000;
+		insertRequest(db, "no-payload", base);
+		insertRequestWithPayload(db, "has-payload", base + 1000, "{}");
+
+		const results = await repo.listPayloadsWithAccountNames(10);
+
+		expect(results).toHaveLength(2);
+		const noPayload = results.find((r) => r.id === "no-payload");
+		const hasPayload = results.find((r) => r.id === "has-payload");
+		expect(noPayload?.json).toBeNull();
+		expect(hasPayload?.json).not.toBeNull();
+	});
+});

--- a/packages/http-api/src/handlers/__tests__/maintenance.test.ts
+++ b/packages/http-api/src/handlers/__tests__/maintenance.test.ts
@@ -12,10 +12,15 @@ import { createCleanupHandler } from "../maintenance";
 // Stubs
 // ---------------------------------------------------------------------------
 
-function makeConfig(payloadDays = 3, requestDays = 90) {
+function makeConfig(
+	payloadDays = 3,
+	requestDays = 90,
+	storePayloads?: boolean,
+) {
 	return {
 		getDataRetentionDays: () => payloadDays,
 		getRequestRetentionDays: () => requestDays,
+		getStorePayloads: () => storePayloads ?? true,
 	} as unknown as import("@better-ccflare/config").Config;
 }
 
@@ -28,10 +33,14 @@ function makeDbOps(
 		vacuumed: true,
 		error: undefined as string | undefined,
 	},
+	tableRowCounts?: Array<{ name: string; rowCount: number }>,
+	dbSizeBytes?: number,
 ) {
 	return {
 		cleanupOldRequests: mock(async () => cleanupResult),
 		compact: mock(async () => compactResult),
+		getTableRowCounts: mock(async () => tableRowCounts ?? []),
+		getDbSizeBytes: mock(async () => dbSizeBytes ?? 0),
 	} as unknown as import("@better-ccflare/database").DatabaseOperations;
 }
 
@@ -154,6 +163,84 @@ describe("createCleanupHandler", () => {
 			// Since e2b9d07 cleanup and compact were decoupled into separate HTTP
 			// endpoints so that compact errors don't block cleanup responses.
 			expect(dbOps.compact).toHaveBeenCalledTimes(0);
+		});
+	});
+
+	describe("PR-149 additions", () => {
+		it("dbSizeBytes appears in response body as a number", async () => {
+			const dbOps = makeDbOps(
+				{ removedRequests: 0, removedPayloads: 0 },
+				undefined,
+				[],
+				12345,
+			);
+			const handler = createCleanupHandler(dbOps, makeConfig());
+			const response = await handler();
+			const body = (await response.json()) as Record<string, unknown>;
+
+			expect(body).toHaveProperty("dbSizeBytes");
+			expect(typeof body.dbSizeBytes).toBe("number");
+			expect(body.dbSizeBytes).toBe(12345);
+		});
+
+		it("tableRowCounts appears in response body as an array", async () => {
+			const counts = [
+				{ name: "requests", rowCount: 42 },
+				{ name: "accounts", rowCount: 3 },
+			];
+			const dbOps = makeDbOps(
+				{ removedRequests: 0, removedPayloads: 0 },
+				undefined,
+				counts,
+				0,
+			);
+			const handler = createCleanupHandler(dbOps, makeConfig());
+			const response = await handler();
+			const body = (await response.json()) as Record<string, unknown>;
+
+			expect(Array.isArray(body.tableRowCounts)).toBe(true);
+			expect(body.tableRowCounts).toEqual(counts);
+		});
+
+		it("payloadCutoffIso is null when storePayloads=false", async () => {
+			const dbOps = makeDbOps();
+			const handler = createCleanupHandler(dbOps, makeConfig(3, 90, false));
+			const response = await handler();
+			const body = (await response.json()) as Record<string, unknown>;
+
+			expect(body.payloadCutoffIso).toBeNull();
+		});
+
+		it("cleanupOldRequests called with payloadMs=0 when storePayloads=false", async () => {
+			const dbOps = makeDbOps();
+			const handler = createCleanupHandler(dbOps, makeConfig(3, 90, false));
+			await handler();
+
+			expect(dbOps.cleanupOldRequests).toHaveBeenCalledTimes(1);
+			const [payloadMs] = (dbOps.cleanupOldRequests as ReturnType<typeof mock>)
+				.mock.calls[0];
+			expect(payloadMs).toBe(0);
+		});
+
+		it("payloadCutoffIso is a valid ISO string when storePayloads=true", async () => {
+			const dbOps = makeDbOps();
+			const handler = createCleanupHandler(dbOps, makeConfig(3, 90, true));
+			const response = await handler();
+			const body = (await response.json()) as Record<string, unknown>;
+
+			expect(typeof body.payloadCutoffIso).toBe("string");
+			expect(Number.isNaN(Date.parse(body.payloadCutoffIso as string))).toBe(
+				false,
+			);
+		});
+
+		it("getTableRowCounts and getDbSizeBytes are each called once per cleanup", async () => {
+			const dbOps = makeDbOps();
+			const handler = createCleanupHandler(dbOps, makeConfig());
+			await handler();
+
+			expect(dbOps.getTableRowCounts).toHaveBeenCalledTimes(1);
+			expect(dbOps.getDbSizeBytes).toHaveBeenCalledTimes(1);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- Add `withBusyRetry` tests via all four adapter methods (`query`, `get`, `run`, `runWithChanges`), non-busy error propagation, and deadline expiry
- Add `listPayloadsWithAccountNames` LEFT JOIN tests: requests with/without payloads, timestamps, account names, ordering, limit
- Extend `maintenance.test.ts` with `dbSizeBytes`, `tableRowCounts`, `payloadCutoffIso=null` when storage disabled, `payloadMs=0` call, and call-count assertions

## Test plan

- [x] 31 tests pass, 0 failures
- [x] lint/typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)