### PR TITLE
test: add coverage for PR-150 stale rate_limited_until clearing

### DIFF
--- a/packages/http-api/src/handlers/__tests__/accounts-integration.test.ts
+++ b/packages/http-api/src/handlers/__tests__/accounts-integration.test.ts
@@ -280,6 +280,134 @@ describe("Accounts Handler - Dashboard Usage Data Integration", () => {
 		});
 	});
 
+	describe("Stale rate_limited_until Clearing", () => {
+		function makeOAuthAccount(overrides: Record<string, unknown> = {}) {
+			return {
+				id: "oauth-account-1",
+				name: "Claude OAuth Account",
+				provider: "anthropic",
+				access_token: "sk-ant-test",
+				refresh_token: "refresh-token",
+				request_count: 0,
+				total_requests: 0,
+				last_used: Date.now() - 3600000,
+				created_at: Date.now() - 86400000,
+				expires_at: Date.now() + 86400000,
+				rate_limited_until: null,
+				rate_limit_reset: null,
+				rate_limit_status: null,
+				rate_limit_remaining: null,
+				session_start: null,
+				session_request_count: 0,
+				paused: 0,
+				priority: 0,
+				auto_fallback_enabled: 0,
+				auto_refresh_enabled: 0,
+				custom_endpoint: null,
+				model_mappings: null,
+				token_valid: 1,
+				rate_limited: 0,
+				session_info: null,
+				...overrides,
+			};
+		}
+
+		it("clears stale rate_limited_until when usage API shows < 100% and expiry is in the future", async () => {
+			const accountsHandler = createMockAccountsListHandler(90000);
+			const futureExpiry = Date.now() + 3 * 60 * 60 * 1000; // 3h from now
+
+			mockQuery.all = () => [
+				makeOAuthAccount({ rate_limited_until: futureExpiry, rate_limited: 1 }),
+			];
+			mockUsageCache.getAge = () => null; // stale — will fetch
+
+			let clearSqlCalled = false;
+			let clearSqlArgs: unknown[] = [];
+			mockDatabase.run = (sql: string, args: unknown[]) => {
+				if (
+					sql === "UPDATE accounts SET rate_limited_until = NULL WHERE id = ?"
+				) {
+					clearSqlCalled = true;
+					clearSqlArgs = args;
+				}
+			};
+
+			const response = await accountsHandler();
+
+			expect(clearSqlCalled).toBe(true);
+			expect(clearSqlArgs).toEqual(["oauth-account-1"]);
+			expect(response.ok).toBe(true);
+			const body = await response.json();
+			expect(body[0].rateLimitedUntil).toBeNull();
+		});
+
+		it("does NOT clear rate_limited_until when expiry is already in the past", async () => {
+			const accountsHandler = createMockAccountsListHandler(90000);
+			const pastExpiry = Date.now() - 1000; // already expired
+
+			mockQuery.all = () => [
+				makeOAuthAccount({ rate_limited_until: pastExpiry, rate_limited: 1 }),
+			];
+			mockUsageCache.getAge = () => null;
+
+			let dbRunCalledWithClear = false;
+			mockDatabase.run = (sql: string) => {
+				if (
+					sql === "UPDATE accounts SET rate_limited_until = NULL WHERE id = ?"
+				) {
+					dbRunCalledWithClear = true;
+				}
+			};
+
+			const response = await accountsHandler();
+			expect(dbRunCalledWithClear).toBe(false);
+			expect(response.ok).toBe(true);
+		});
+
+		it("does NOT clear rate_limited_until when account has no rate limit set", async () => {
+			const accountsHandler = createMockAccountsListHandler(90000);
+
+			mockQuery.all = () => [makeOAuthAccount({ rate_limited_until: null })];
+			mockUsageCache.getAge = () => null;
+
+			let dbRunCalledWithClear = false;
+			mockDatabase.run = (sql: string) => {
+				if (
+					sql === "UPDATE accounts SET rate_limited_until = NULL WHERE id = ?"
+				) {
+					dbRunCalledWithClear = true;
+				}
+			};
+
+			const response = await accountsHandler();
+			expect(dbRunCalledWithClear).toBe(false);
+			expect(response.ok).toBe(true);
+		});
+
+		it("does NOT clear rate_limited_until when cache is fresh (no usage fetch)", async () => {
+			const accountsHandler = createMockAccountsListHandler(90000);
+			const futureExpiry = Date.now() + 3 * 60 * 60 * 1000;
+
+			mockQuery.all = () => [
+				makeOAuthAccount({ rate_limited_until: futureExpiry, rate_limited: 1 }),
+			];
+			mockUsageCache.getAge = () => 30000; // fresh — skips fetch entirely
+
+			let dbRunCalledWithClear = false;
+			mockDatabase.run = (sql: string) => {
+				if (
+					sql === "UPDATE accounts SET rate_limited_until = NULL WHERE id = ?"
+				) {
+					dbRunCalledWithClear = true;
+				}
+			};
+
+			const response = await accountsHandler();
+			expect(dbRunCalledWithClear).toBe(false);
+			expect(response.ok).toBe(true);
+		});
+	});
+
 	describe("Account Management Integration", () => {
 		it("should clear usage cache when Anthropic account is removed", async () => {
 			const removeHandler = createMockAccountRemoveHandler();
@@ -498,6 +626,29 @@ function createMockAccountsListHandler(CACHE_FRESHNESS_THRESHOLD_MS: number) {
 							mockLog.debug(
 								`Fetched usage data for ${account.name}: 5h=${usageData.five_hour.utilization}%, 7d=${usageData.seven_day.utilization}%`,
 							);
+
+							// If the usage API shows available capacity but the DB still has
+							// rate_limited_until in the future, clear the stale state.
+							const utilization = mockGetRepresentativeUtilization();
+							const limitedUntil = account.rate_limited_until
+								? Number(account.rate_limited_until)
+								: null;
+							if (
+								utilization !== null &&
+								utilization < 100 &&
+								limitedUntil !== null &&
+								limitedUntil > Date.now()
+							) {
+								await mockDatabase.run(
+									"UPDATE accounts SET rate_limited_until = NULL WHERE id = ?",
+									[account.id],
+								);
+								account.rate_limited_until = null;
+								account.rate_limited = 0;
+								mockLog.info(
+									`Cleared stale rate_limited_until for ${account.name}: usage API shows ${utilization}% utilization`,
+								);
+							}
 						}
 					} catch (error) {
 						mockLog.warn(

--- a/packages/http-api/src/handlers/__tests__/accounts-integration.test.ts
+++ b/packages/http-api/src/handlers/__tests__/accounts-integration.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 
 // Mock the usage fetcher functions directly
 const mockUsageCache = {
@@ -42,7 +42,13 @@ const mockFetchUsageData = {
 	seven_day_opus: { utilization: 80, resets_at: null },
 };
 
-const mockGetRepresentativeUtilization = () => 70;
+const mockGetRepresentativeUtilization = (usageData?: typeof mockFetchUsageData | null) => {
+	if (!usageData) return 70;
+	const utils = Object.values(usageData)
+		.filter((v): v is { utilization: number } => v != null && typeof (v as any).utilization === "number")
+		.map((v) => v.utilization);
+	return utils.length > 0 ? Math.max(...utils) : 70;
+};
 const mockGetRepresentativeWindow = () => "seven_day";
 
 const mockLog = {
@@ -281,6 +287,15 @@ describe("Accounts Handler - Dashboard Usage Data Integration", () => {
 	});
 
 	describe("Stale rate_limited_until Clearing", () => {
+		const originalGetAge = mockUsageCache.getAge;
+		const originalDbRun = mockDatabase.run;
+
+		afterEach(() => {
+			mockUsageCache.getAge = originalGetAge;
+			mockDatabase.run = originalDbRun;
+			mockQuery.all = () => [];
+		});
+
 		function makeOAuthAccount(overrides: Record<string, unknown> = {}) {
 			return {
 				id: "oauth-account-1",
@@ -406,6 +421,35 @@ describe("Accounts Handler - Dashboard Usage Data Integration", () => {
 			expect(dbRunCalledWithClear).toBe(false);
 			expect(response.ok).toBe(true);
 		});
+
+		it("does NOT clear rate_limited_until when utilization is >= 100 (account exhausted)", async () => {
+			const exhaustedData = {
+				five_hour: { utilization: 100, resets_at: null },
+				seven_day: { utilization: 100, resets_at: null },
+				seven_day_oauth_apps: { utilization: 100, resets_at: null },
+				seven_day_opus: { utilization: 100, resets_at: null },
+			};
+			const accountsHandler = createMockAccountsListHandler(90000, exhaustedData);
+			const futureExpiry = Date.now() + 3 * 60 * 60 * 1000;
+
+			mockQuery.all = () => [
+				makeOAuthAccount({ rate_limited_until: futureExpiry, rate_limited: 1 }),
+			];
+			mockUsageCache.getAge = () => null; // stale — will fetch
+
+			let dbRunCalledWithClear = false;
+			mockDatabase.run = (sql: string) => {
+				if (
+					sql === "UPDATE accounts SET rate_limited_until = NULL WHERE id = ?"
+				) {
+					dbRunCalledWithClear = true;
+				}
+			};
+
+			const response = await accountsHandler();
+			expect(dbRunCalledWithClear).toBe(false);
+			expect(response.ok).toBe(true);
+		});
 	});
 
 	describe("Account Management Integration", () => {
@@ -481,6 +525,10 @@ describe("Accounts Handler - Dashboard Usage Data Integration", () => {
 				CACHE_FRESHNESS_THRESHOLD_MS,
 			);
 			const futureTimestamp = Date.now() + 86400000; // 24 hours from now
+
+			// Use fresh cache so the usage fetch is skipped — prevents stale-clear logic
+			// from wiping rate_limited_until before the assertion.
+			mockUsageCache.getAge = () => 30000;
 
 			mockQuery.all = () => [
 				{
@@ -588,7 +636,10 @@ describe("Accounts Handler - Dashboard Usage Data Integration", () => {
 });
 
 // Mock factory functions to create handlers with our mocked dependencies
-function createMockAccountsListHandler(CACHE_FRESHNESS_THRESHOLD_MS: number) {
+function createMockAccountsListHandler(
+	CACHE_FRESHNESS_THRESHOLD_MS: number,
+	fetchData: typeof mockFetchUsageData = mockFetchUsageData,
+) {
 	return async (): Promise<Response> => {
 		const now = Date.now();
 		const sessionDuration = 5 * 60 * 60 * 1000; // 5 hours
@@ -620,7 +671,7 @@ function createMockAccountsListHandler(CACHE_FRESHNESS_THRESHOLD_MS: number) {
 				if (!isCacheFresh && account.access_token) {
 					// Fetch usage data if cache is stale or missing
 					try {
-						const usageData = mockFetchUsageData;
+						const usageData = fetchData;
 						if (usageData) {
 							mockUsageCache.set(account.id, usageData);
 							mockLog.debug(
@@ -629,7 +680,7 @@ function createMockAccountsListHandler(CACHE_FRESHNESS_THRESHOLD_MS: number) {
 
 							// If the usage API shows available capacity but the DB still has
 							// rate_limited_until in the future, clear the stale state.
-							const utilization = mockGetRepresentativeUtilization();
+							const utilization = mockGetRepresentativeUtilization(usageData);
 							const limitedUntil = account.rate_limited_until
 								? Number(account.rate_limited_until)
 								: null;
@@ -667,7 +718,7 @@ function createMockAccountsListHandler(CACHE_FRESHNESS_THRESHOLD_MS: number) {
 			let usageWindow: string | null = null;
 
 			if (account.provider === "anthropic" && usageData) {
-				usageUtilization = mockGetRepresentativeUtilization();
+				usageUtilization = mockGetRepresentativeUtilization(usageData);
 				usageWindow = mockGetRepresentativeWindow();
 			}
 

--- a/packages/http-api/src/handlers/__tests__/accounts-integration.test.ts
+++ b/packages/http-api/src/handlers/__tests__/accounts-integration.test.ts
@@ -105,9 +105,13 @@ const mockErrorResponse = (error: any) => ({
 describe("Accounts Handler - Dashboard Usage Data Integration", () => {
 	const CACHE_FRESHNESS_THRESHOLD_MS = 90000; // 90 seconds
 
+	const originalGetAge = mockUsageCache.getAge;
+
 	beforeEach(() => {
-		// Reset all mocks
 		mockUsageCache.clear();
+		mockUsageCache.getAge = originalGetAge;
+		mockDatabase.run = () => {};
+		mockQuery.all = () => [];
 	});
 
 	describe("Proactive Usage Data Fetching", () => {


### PR DESCRIPTION
## Summary

- Extends `createMockAccountsListHandler` in `accounts-integration.test.ts` to mirror the stale-clear logic added in PR #150
- Adds 4 new test cases covering the `utilization < 100 + future rate_limited_until → clear` branch

## Test cases added

- ✅ Clears DB when usage API shows <100% utilization and expiry is in the future (happy path)
- ✅ No-op when `rate_limited_until` is already in the past
- ✅ No-op when account has no `rate_limited_until` set
- ✅ No-op when usage cache is fresh (fetch is skipped entirely)

## Issues from PR review addressed

All other review issues were investigated and resolved as non-issues:
- **Atomic DB update**: no separate `rate_limited` DB column exists — only `rate_limited_until INTEGER`. In-memory `account.rate_limited = 0` is correct.
- **Threshold alignment**: `isAccountAvailable` checks the timestamp only; the `<100%` usage check is complementary, not conflicting.
- **Comment accuracy**: `response-processor.ts:91-92` comment correctly describes the unconditional clear at lines 303-313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)