### PR TITLE
feat: expected usage position indicator on rate limit bars

### DIFF
--- a/packages/dashboard-web/src/components/accounts/RateLimitProgress.tsx
+++ b/packages/dashboard-web/src/components/accounts/RateLimitProgress.tsx
@@ -22,6 +22,62 @@ interface RateLimitProgressProps {
 
 const WINDOW_MS = 5 * 60 * 60 * 1000; // 5 hours in milliseconds
 
+const WINDOW_DURATION_MS: Record<string, number> = {
+	five_hour: 5 * 60 * 60 * 1000,
+	seven_day: 7 * 24 * 60 * 60 * 1000,
+	seven_day_opus: 7 * 24 * 60 * 60 * 1000,
+	seven_day_sonnet: 7 * 24 * 60 * 60 * 1000,
+	weekly: 7 * 24 * 60 * 60 * 1000,
+	daily: 24 * 60 * 60 * 1000,
+	monthly: 30 * 24 * 60 * 60 * 1000,
+	time_limit: 5 * 60 * 60 * 1000,
+	tokens_limit: 5 * 60 * 60 * 1000,
+};
+
+function computeExpectedPct(
+	resetTime: string | null,
+	window: string | null,
+	now: number,
+): number | null {
+	if (!resetTime || !window) return null;
+	const durationMs = WINDOW_DURATION_MS[window];
+	if (!durationMs) return null;
+	const resetMs = new Date(resetTime).getTime();
+	const startMs = resetMs - durationMs;
+	const elapsed = now - startMs;
+	return Math.min(100, Math.max(0, (elapsed / durationMs) * 100));
+}
+
+function formatDuration(ms: number): string {
+	const totalMinutes = Math.round(ms / 60000);
+	const hours = Math.floor(totalMinutes / 60);
+	const minutes = totalMinutes % 60;
+	if (hours > 0) return `${hours}h ${minutes}m`;
+	return `${minutes}m`;
+}
+
+function computeProjectedMessage(
+	resetTime: string | null,
+	window: string | null,
+	percentage: number | null,
+	now: number,
+): string | null {
+	if (!resetTime || !window || percentage === null) return null;
+	const durationMs = WINDOW_DURATION_MS[window];
+	if (!durationMs) return null;
+	const resetMs = new Date(resetTime).getTime();
+	const elapsed = now - (resetMs - durationMs);
+	const remaining = resetMs - now;
+	if (elapsed <= 0 || remaining <= 0) return null;
+	const f = percentage / 100;
+	if (f <= 0) return "No usage recorded yet in this window";
+	const timeToExhaustMs = ((1 - f) / f) * elapsed;
+	if (timeToExhaustMs < remaining) {
+		return `Runs out ${formatDuration(remaining - timeToExhaustMs)} before reset`;
+	}
+	return `Resets ${formatDuration(timeToExhaustMs - remaining)} before exhaustion`;
+}
+
 // Format window name for display
 function formatWindowName(window: string | null): string {
 	if (!window) return "window";
@@ -430,7 +486,54 @@ export function RateLimitProgress({
 								{isAvailable ? `${percentage?.toFixed(0)}%` : "N/A"}
 							</span>
 						</div>
-						<Progress value={isAvailable ? percentage : 0} className="h-2" />
+						{(() => {
+							const expectedPct = computeExpectedPct(
+								usage.resetTime,
+								usage.window,
+								now,
+							);
+							const isOverPacing =
+								expectedPct !== null && (percentage ?? 0) > expectedPct;
+							const windowLabel = usage.window
+								? formatWindowName(usage.window)
+								: "Rate limit";
+							const projectedMessage = computeProjectedMessage(
+								usage.resetTime,
+								usage.window,
+								percentage ?? null,
+								now,
+							);
+							return (
+								<div className="group relative flex items-center" style={{ minHeight: "20px" }}>
+									<div className="pointer-events-none absolute bottom-full z-10 mb-2 hidden w-max max-w-xs -translate-x-1/2 rounded bg-popover px-3 py-2 text-xs text-popover-foreground shadow-md group-hover:block" style={{ left: `${expectedPct ?? 50}%` }}>
+										<div className="mb-1 font-medium">
+											{windowLabel} usage
+										</div>
+										{projectedMessage && (
+											<div className={isOverPacing ? "text-red-400" : "text-green-400"}>
+												{projectedMessage}
+											</div>
+										)}
+									</div>
+									<Progress
+										value={isAvailable ? percentage : 0}
+										className="h-2 w-full"
+									/>
+									{expectedPct !== null && (
+										<div
+											className="absolute w-0.5 pointer-events-none"
+											style={{
+												left: `${expectedPct}%`,
+												top: "-3px",
+												bottom: "-3px",
+												backgroundColor: "rgba(255,255,255,0.95)",
+												boxShadow: "1px 0 2px rgba(0,0,0,0.5), -1px 0 2px rgba(0,0,0,0.5)",
+											}}
+										/>
+									)}
+								</div>
+							);
+						})()}
 						{usage.resetTime && (
 							<div className="flex items-center justify-between">
 								<span className="text-xs text-muted-foreground">

--- a/packages/dashboard-web/src/components/accounts/RateLimitProgress.tsx
+++ b/packages/dashboard-web/src/components/accounts/RateLimitProgress.tsx
@@ -29,7 +29,7 @@ const WINDOW_DURATION_MS: Record<string, number> = {
 	seven_day_sonnet: 7 * 24 * 60 * 60 * 1000,
 	weekly: 7 * 24 * 60 * 60 * 1000,
 	daily: 24 * 60 * 60 * 1000,
-	monthly: 30 * 24 * 60 * 60 * 1000,
+	monthly: 30 * 24 * 60 * 60 * 1000, // approximation; exact billing cycle start is unknown
 	time_limit: 5 * 60 * 60 * 1000,
 	tokens_limit: 5 * 60 * 60 * 1000,
 };
@@ -505,12 +505,12 @@ export function RateLimitProgress({
 							);
 							return (
 								<div className="group relative flex items-center" style={{ minHeight: "20px" }}>
-									<div className="pointer-events-none absolute bottom-full z-10 mb-2 hidden w-max max-w-xs -translate-x-1/2 rounded bg-popover px-3 py-2 text-xs text-popover-foreground shadow-md group-hover:block" style={{ left: `${expectedPct ?? 50}%` }}>
+									<div className="pointer-events-none absolute bottom-full z-10 mb-2 hidden w-max max-w-xs -translate-x-1/2 rounded bg-popover px-3 py-2 text-xs text-popover-foreground shadow-md group-hover:block" style={{ left: `clamp(10%, ${expectedPct ?? 50}%, 90%)` }}>
 										<div className="mb-1 font-medium">
 											{windowLabel} usage
 										</div>
 										{projectedMessage && (
-											<div className={isOverPacing ? "text-red-400" : "text-green-400"}>
+											<div className={(percentage ?? 0) <= 0 ? "text-muted-foreground" : isOverPacing ? "text-red-400" : "text-green-400"}>
 												{projectedMessage}
 											</div>
 										)}

--- a/packages/dashboard-web/src/components/accounts/RateLimitProgress.tsx
+++ b/packages/dashboard-web/src/components/accounts/RateLimitProgress.tsx
@@ -22,17 +22,33 @@ interface RateLimitProgressProps {
 
 const WINDOW_MS = 5 * 60 * 60 * 1000; // 5 hours in milliseconds
 
-const WINDOW_DURATION_MS: Record<string, number> = {
+const FIXED_WINDOW_DURATION_MS: Record<string, number> = {
 	five_hour: 5 * 60 * 60 * 1000,
 	seven_day: 7 * 24 * 60 * 60 * 1000,
 	seven_day_opus: 7 * 24 * 60 * 60 * 1000,
 	seven_day_sonnet: 7 * 24 * 60 * 60 * 1000,
 	weekly: 7 * 24 * 60 * 60 * 1000,
 	daily: 24 * 60 * 60 * 1000,
-	monthly: 30 * 24 * 60 * 60 * 1000, // approximation; exact billing cycle start is unknown
 	time_limit: 5 * 60 * 60 * 1000,
 	tokens_limit: 5 * 60 * 60 * 1000,
 };
+
+function computeWindowStartMs(
+	resetMs: number,
+	window: string,
+): number | null {
+	if (window === "monthly") {
+		const resetDate = new Date(resetMs);
+		return new Date(
+			resetDate.getFullYear(),
+			resetDate.getMonth() - 1,
+			resetDate.getDate(),
+		).getTime();
+	}
+	const durationMs = FIXED_WINDOW_DURATION_MS[window];
+	if (!durationMs) return null;
+	return resetMs - durationMs;
+}
 
 function computeExpectedPct(
 	resetTime: string | null,
@@ -40,10 +56,10 @@ function computeExpectedPct(
 	now: number,
 ): number | null {
 	if (!resetTime || !window) return null;
-	const durationMs = WINDOW_DURATION_MS[window];
-	if (!durationMs) return null;
 	const resetMs = new Date(resetTime).getTime();
-	const startMs = resetMs - durationMs;
+	const startMs = computeWindowStartMs(resetMs, window);
+	if (startMs === null) return null;
+	const durationMs = resetMs - startMs;
 	const elapsed = now - startMs;
 	return Math.min(100, Math.max(0, (elapsed / durationMs) * 100));
 }
@@ -63,10 +79,10 @@ function computeProjectedMessage(
 	now: number,
 ): string | null {
 	if (!resetTime || !window || percentage === null) return null;
-	const durationMs = WINDOW_DURATION_MS[window];
-	if (!durationMs) return null;
 	const resetMs = new Date(resetTime).getTime();
-	const elapsed = now - (resetMs - durationMs);
+	const startMs = computeWindowStartMs(resetMs, window);
+	if (startMs === null) return null;
+	const elapsed = now - startMs;
 	const remaining = resetMs - now;
 	if (elapsed <= 0 || remaining <= 0) return null;
 	const f = percentage / 100;


### PR DESCRIPTION
## Summary

Closes #124

Adds a vertical tick mark on each usage progress bar (5-hour, weekly, Sonnet, Opus, etc.) showing where usage *should* be at this point in the reset window if consumed at a perfectly even rate.

- **Marker:** white 2px line with dark drop shadow, extending slightly above/below the bar so it's visible at a glance
- **Tooltip:** hovering the bar shows a projection anchored above the marker position:
  - 🔴 *"Runs out Xh Ym before reset"* — over-pacing, projected to exhaust before reset
  - 🟢 *"Resets Xh Ym before exhaustion"* — on track, reset will arrive first
  - *"No usage recorded yet in this window"* — no data yet
- **Coverage:** all window types (`five_hour`, `seven_day`, `seven_day_sonnet`, `seven_day_opus`, `weekly`, `daily`, `monthly`, `time_limit`, `tokens_limit`)

## Test plan

- [ ] Open the dashboard and find an account with active Anthropic usage
- [ ] Verify a white tick mark appears on the 5-hour, weekly, and Sonnet bars at the expected position
- [ ] Hover the bar and confirm the tooltip appears above the marker with a green or red projection message
- [ ] Confirm the marker is white regardless of whether usage is over or under the expected position