### PR TITLE
fix: deduplicate concurrent fetchAndCache calls per account

### DIFF
--- a/packages/providers/src/usage-fetcher.ts
+++ b/packages/providers/src/usage-fetcher.ts
@@ -335,6 +335,10 @@ class UsageCache {
 	private providerTypes = new Map<string, string>(); // Track provider type for each account
 	private customEndpoints = new Map<string, string | null>(); // Track custom endpoints
 	private windowResetCallbacks = new Map<string, (accountId: string) => void>();
+	private inFlightFetches = new Map<
+		string,
+		Promise<{ success: boolean; retryAfterMs: number | null }>
+	>();
 
 	/**
 	 * Schedule the next poll with exponential backoff on failures.
@@ -527,6 +531,35 @@ class UsageCache {
 	 * server returns a retry-after header on a 429 response.
 	 */
 	private async fetchAndCache(
+		accountId: string,
+		tokenProvider: AccessTokenProvider,
+		provider?: string,
+		customEndpoint?: string | null,
+	): Promise<{ success: boolean; retryAfterMs: number | null }> {
+		// Deduplicate concurrent fetches for the same account — return the
+		// existing in-flight promise rather than starting a second HTTP request.
+		const inflight = this.inFlightFetches.get(accountId);
+		if (inflight) {
+			log.debug(
+				`Reusing in-flight fetch for account ${accountId} — skipping duplicate request`,
+			);
+			return inflight;
+		}
+
+		const promise = this._doFetchAndCache(
+			accountId,
+			tokenProvider,
+			provider,
+			customEndpoint,
+		);
+		this.inFlightFetches.set(accountId, promise);
+		promise.finally(() => {
+			this.inFlightFetches.delete(accountId);
+		});
+		return promise;
+	}
+
+	private async _doFetchAndCache(
 		accountId: string,
 		tokenProvider: AccessTokenProvider,
 		provider?: string,

--- a/packages/providers/src/usage-fetcher.ts
+++ b/packages/providers/src/usage-fetcher.ts
@@ -519,6 +519,9 @@ class UsageCache {
 			this.windowResetCallbacks.delete(accountId);
 			// Clean up cache entry when polling stops to prevent memory leaks
 			this.cache.delete(accountId);
+			// Clear any in-flight fetch so a subsequent startPolling doesn't
+			// reuse a stale promise that was issued with the old credentials.
+			this.inFlightFetches.delete(accountId);
 			log.info(
 				`Stopped usage polling and cleared cache for account ${accountId}`,
 			);


### PR DESCRIPTION
## Problem

When the user clicks **Refresh Usage**, two independent code paths both call `fetchAndCache` for the same account in close succession:

1. The polling loop restarts and immediately calls `fetchAndCache`.
2. `loadAccounts` fires ~5 seconds later and calls `fetchAndCache` again for the same account.

Because each call creates its own `fetch()` request, this results in duplicate HTTP requests to the Anthropic usage API — wasted bandwidth and unnecessary API load.

## Fix

Added an `inFlightFetches` Map to `UsageCache` (in `packages/providers/src/usage-fetcher.ts`). When `fetchAndCache` is called for an account that already has an in-flight request, the second caller receives the **existing Promise** instead of launching a new HTTP request. Once the request completes (success or failure), the entry is removed from the map so future calls trigger a fresh fetch.

This is a standard request-deduplication / "single-flight" pattern that ensures at most one concurrent HTTP request per account at any given time.

## Changes

- `packages/providers/src/usage-fetcher.ts`: Added `inFlightFetches: Map<string, Promise<void>>` to `UsageCache` and updated `fetchAndCache` to return the existing promise when one is already in flight.