### PR TITLE
fix: make GET /api/accounts cache-only and await usage fetch in refresh endpoint

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -341,6 +341,33 @@ function startUsagePollingWithRefresh(
 							),
 						);
 				},
+				(accountId) => {
+					// Usage API shows available capacity (<100%). If rate_limited_until is
+					// set in the future (seat-reassignment case), clear it now rather than
+					// waiting for the natural expiry timer — the polling loop has confirmed
+					// the seat is available again.
+					proxyContext.dbOps
+						.getAccount(accountId)
+						.then((acc) => {
+							if (
+								acc?.rate_limited_until &&
+								Number(acc.rate_limited_until) > Date.now()
+							) {
+								return proxyContext.dbOps
+									.forceResetAccountRateLimit(accountId)
+									.then(() => {
+										logger.info(
+											`Cleared stale rate_limited_until for account ${acc.name} (${accountId}): usage polling shows available capacity (seat reassignment or early reset)`,
+										);
+									});
+							}
+						})
+						.catch((err) =>
+							logger.warn(
+								`Failed to check/clear rate_limited_until for account ${accountId} on capacity restore: ${err}`,
+							),
+						);
+				},
 			);
 
 			// Reset retry count on success

--- a/packages/dashboard-web/src/components/AccountsTab.tsx
+++ b/packages/dashboard-web/src/components/AccountsTab.tsx
@@ -385,8 +385,6 @@ export function AccountsTab() {
 	const handleRefreshUsage = async (account: Account) => {
 		try {
 			await api.refreshUsage(account.id);
-			// Wait briefly then reload so fresh usage data has time to arrive
-			await new Promise((resolve) => setTimeout(resolve, 5000));
 			await loadAccounts();
 			setActionError(null);
 		} catch (err) {

--- a/packages/http-api/src/handlers/accounts.ts
+++ b/packages/http-api/src/handlers/accounts.ts
@@ -3118,17 +3118,19 @@ export function createAccountRefreshUsageHandler(dbOps: DatabaseOperations) {
 
 			clearAccountRefreshCache(accountId);
 			const pollingRestarted = await restartUsagePollingForAccount(accountId);
-			await usageCache.refreshNow(accountId);
+			const cacheRefreshed = await usageCache.refreshNow(accountId);
 
 			log.info(
-				`Usage refresh requested for account '${account.name}' (polling restarted: ${pollingRestarted})`,
+				`Usage refresh requested for account '${account.name}' (polling restarted: ${pollingRestarted}, cache refreshed: ${cacheRefreshed})`,
 			);
 
 			return jsonResponse({
 				success: true,
 				message: pollingRestarted
 					? `Usage polling restarted for account '${account.name}'. Fresh usage data is now available.`
-					: `Usage cache refreshed for account '${account.name}'.`,
+					: cacheRefreshed
+						? `Usage cache refreshed for account '${account.name}'.`
+						: `Polling could not be restarted for account '${account.name}' — usage data may not update.`,
 				pollingRestarted,
 			});
 		} catch (error) {

--- a/packages/http-api/src/handlers/accounts.ts
+++ b/packages/http-api/src/handlers/accounts.ts
@@ -210,76 +210,6 @@ export function createAccountsListHandler(dbOps: DatabaseOperations) {
 			[now, now, now, sessionDuration],
 		);
 
-		// Fetch usage data for all Claude CLI OAuth accounts (those with refresh tokens)
-		// API key accounts don't have usage tracking available
-		const oauthAccounts = accounts.filter(
-			(acc) =>
-				acc.provider === "anthropic" &&
-				acc.access_token &&
-				acc.refresh_token &&
-				acc.refresh_token !== acc.access_token, // Exclude API key accounts where they're the same
-		);
-
-		// Fetch usage data in parallel for all OAuth accounts that don't have fresh cache data
-		// Cache is considered stale after 90 seconds (aligned with auto-refresh scheduler polling)
-		const CACHE_FRESHNESS_THRESHOLD_MS = 90000;
-		await Promise.all(
-			oauthAccounts.map(async (account) => {
-				// Check if we already have cached data and if it's still fresh
-				const cacheAge = usageCache.getAge(account.id);
-				const isCacheFresh =
-					cacheAge !== null && cacheAge < CACHE_FRESHNESS_THRESHOLD_MS;
-
-				if (!isCacheFresh && account.access_token) {
-					// Fetch usage data if cache is stale or missing
-					try {
-						const { data: usageData } = await fetchUsageData(
-							account.access_token,
-						);
-						if (usageData) {
-							// Update the cache using the public set method
-							usageCache.set(account.id, usageData);
-							log.debug(
-								`Fetched usage data for ${account.name}: 5h=${usageData.five_hour.utilization}%, 7d=${usageData.seven_day.utilization}%`,
-							);
-
-							// If the usage API shows available capacity but the DB still has
-							// rate_limited_until in the future, clear the stale state. This
-							// handles seat reassignment: when an org admin reassigns a seat,
-							// Anthropic resets usage mid-window before the stored expiry fires.
-							const utilization = getRepresentativeUtilization(usageData);
-							const limitedUntil = account.rate_limited_until
-								? Number(account.rate_limited_until)
-								: null;
-							if (
-								utilization !== null &&
-								utilization < 100 &&
-								limitedUntil !== null &&
-								limitedUntil > Date.now()
-							) {
-								await db.run(
-									"UPDATE accounts SET rate_limited_until = NULL WHERE id = ?",
-									[account.id],
-								);
-								// Also update the in-memory object so the API response returned
-								// by this handler immediately reflects the cleared state.
-								account.rate_limited_until = null;
-								account.rate_limited = 0;
-								log.info(
-									`Cleared stale rate_limited_until for ${account.name}: usage API shows ${utilization}% utilization (seat reassignment or early reset)`,
-								);
-							}
-						}
-					} catch (error) {
-						log.warn(
-							`Failed to fetch usage data for account ${account.name}:`,
-							error,
-						);
-					}
-				}
-			}),
-		);
-
 		// Fetch session-window token stats only for providers with session-based limits
 		const sessionStatsMap = await dbOps
 			.getStatsRepository()
@@ -3188,6 +3118,7 @@ export function createAccountRefreshUsageHandler(dbOps: DatabaseOperations) {
 
 			clearAccountRefreshCache(accountId);
 			const pollingRestarted = await restartUsagePollingForAccount(accountId);
+			await usageCache.refreshNow(accountId);
 
 			log.info(
 				`Usage refresh requested for account '${account.name}' (polling restarted: ${pollingRestarted})`,
@@ -3196,8 +3127,8 @@ export function createAccountRefreshUsageHandler(dbOps: DatabaseOperations) {
 			return jsonResponse({
 				success: true,
 				message: pollingRestarted
-					? `Usage polling restarted for account '${account.name}'. Fresh usage data will appear within 5-10 seconds.`
-					: `Usage cache cleared for account '${account.name}'. Note: server-side polling could not be restarted - usage data may not update until a request is proxied.`,
+					? `Usage polling restarted for account '${account.name}'. Fresh usage data is now available.`
+					: `Usage cache refreshed for account '${account.name}'.`,
 				pollingRestarted,
 			});
 		} catch (error) {

--- a/packages/providers/src/usage-fetcher.ts
+++ b/packages/providers/src/usage-fetcher.ts
@@ -335,6 +335,10 @@ class UsageCache {
 	private providerTypes = new Map<string, string>(); // Track provider type for each account
 	private customEndpoints = new Map<string, string | null>(); // Track custom endpoints
 	private windowResetCallbacks = new Map<string, (accountId: string) => void>();
+	private capacityRestoredCallbacks = new Map<
+		string,
+		(accountId: string) => void
+	>();
 
 	/**
 	 * Schedule the next poll with exponential backoff on failures.
@@ -411,6 +415,7 @@ class UsageCache {
 		intervalMs?: number,
 		customEndpoint?: string | null,
 		onWindowReset?: (accountId: string) => void,
+		onCapacityRestored?: (accountId: string) => void,
 	) {
 		// Check if provider supports usage tracking
 		if (provider && !supportsUsageTracking(provider)) {
@@ -450,6 +455,11 @@ class UsageCache {
 			this.windowResetCallbacks.set(accountId, onWindowReset);
 		} else {
 			this.windowResetCallbacks.delete(accountId);
+		}
+		if (onCapacityRestored) {
+			this.capacityRestoredCallbacks.set(accountId, onCapacityRestored);
+		} else {
+			this.capacityRestoredCallbacks.delete(accountId);
 		}
 
 		// Default to 90s if not provided
@@ -513,6 +523,7 @@ class UsageCache {
 			this.tokenProviders.delete(accountId);
 			this.failureCounts.delete(accountId);
 			this.windowResetCallbacks.delete(accountId);
+			this.capacityRestoredCallbacks.delete(accountId);
 			// Clean up cache entry when polling stops to prevent memory leaks
 			this.cache.delete(accountId);
 			log.info(
@@ -657,6 +668,16 @@ class UsageCache {
 					const utilization = getRepresentativeUtilization(
 						result.data as UsageData,
 					);
+					// If utilization is below 100%, notify any capacity-restored listener.
+					// This handles the seat-reassignment case: when an org admin reassigns
+					// a seat, Anthropic resets usage mid-window. The polling loop detects
+					// the available capacity here and lets the caller clear any stale
+					// rate_limited_until stored in the DB.
+					if (utilization !== null && utilization < 100) {
+						const capacityCallback =
+							this.capacityRestoredCallbacks.get(accountId);
+						if (capacityCallback) capacityCallback(accountId);
+					}
 					const window = getRepresentativeWindow(result.data as UsageData);
 					log.debug(
 						`Successfully fetched usage data for account ${accountId}: ${utilization}% (${window} window)`,


### PR DESCRIPTION
## Problem

Three related issues caused a poor usage-refresh UX and unnecessary live HTTP traffic:

1. `GET /api/accounts` called `fetchUsageData` directly (inside a `Promise.all`) for every Anthropic OAuth account whose cache was stale. This meant every dashboard page load could fire live requests to Anthropic — bypassing the polling loop, which is the intended sole owner of live fetches.

2. `POST /api/accounts/:id/refresh-usage` called `restartUsagePollingForAccount` and returned immediately, before the first fetch completed. The frontend had no way to know when the cache was actually populated.

3. `AccountsTab.tsx` compensated for (2) with a hardcoded 5-second `setTimeout` before calling `loadAccounts()`. This was a blind wait — too long on fast connections, too short on slow ones.

## Changes

### `packages/http-api/src/handlers/accounts.ts` — accounts list handler (Change 1)

Remove the `Promise.all` block (~70 lines) that called `fetchUsageData` for stale-cache accounts. The handler now reads only from `usageCache.get(account.id)`. If the cache is empty, `usageData` is `null`. The polling loop (started at account-add/reload time) remains the sole owner of live Anthropic fetches.

### `packages/http-api/src/handlers/accounts.ts` — refresh-usage handler (Change 2)

After `restartUsagePollingForAccount`, call `await usageCache.refreshNow(accountId)`. `refreshNow` calls `fetchAndCache` and awaits it — and thanks to the in-flight dedup fix already in main, if the polling restart already fired a fetch, `refreshNow` joins the same in-flight promise rather than issuing a second HTTP request. The handler now returns only after the cache is populated.

### `packages/dashboard-web/src/components/AccountsTab.tsx` — frontend (Change 3)

Remove the `await new Promise((resolve) => setTimeout(resolve, 5000))` line. Since the backend now blocks until the fetch is done, `loadAccounts()` is called immediately when `api.refreshUsage()` resolves.

## Result

- `GET /api/accounts` is now a pure cache read — no live Anthropic traffic, no latency spikes on page load.
- The "Refresh Usage" button reflects real data as soon as it completes, not after a blind 5-second wait.
- The polling loop remains the sole source of live usage fetches for the accounts list.