### PR TITLE
fix: show explicit rate-limited state when usage data unavailable

### DIFF
--- a/packages/dashboard-web/src/components/accounts/AccountListItem.tsx
+++ b/packages/dashboard-web/src/components/accounts/AccountListItem.tsx
@@ -433,12 +433,14 @@ export function AccountListItem({
 			)}
 			{(account.rateLimitReset ||
 				account.usageData ||
+				account.usageRateLimitedUntil ||
 				providerShowsCreditsBalance(account.provider)) && (
 				<RateLimitProgress
 					resetIso={account.rateLimitReset}
 					usageUtilization={account.usageUtilization}
 					usageWindow={account.usageWindow}
 					usageData={account.usageData}
+					usageRateLimitedUntil={account.usageRateLimitedUntil}
 					provider={account.provider}
 					showWeekly={providerShowsWeeklyUsage(account.provider)}
 				/>

--- a/packages/dashboard-web/src/components/accounts/RateLimitProgress.tsx
+++ b/packages/dashboard-web/src/components/accounts/RateLimitProgress.tsx
@@ -149,7 +149,7 @@ export function RateLimitProgress({
 
 	// Allow null resetIso for providers that show usage data (like NanoGPT in PayG mode)
 	// but still render null if there's no resetIso and no usage data to show
-	if (!resetIso && !usageData) return null;
+	if (!resetIso && !usageData && !usageRateLimitedUntil) return null;
 
 	// Show explicit rate-limited state when the Anthropic usage API returned 429
 	// and we have no cached data to show.

--- a/packages/dashboard-web/src/components/accounts/RateLimitProgress.tsx
+++ b/packages/dashboard-web/src/components/accounts/RateLimitProgress.tsx
@@ -15,6 +15,7 @@ interface RateLimitProgressProps {
 	usageUtilization?: number | null; // Actual utilization from API (0-100)
 	usageWindow?: string | null; // Window name (e.g., "five_hour")
 	usageData?: FullUsageData | null; // Full usage data from API
+	usageRateLimitedUntil?: number | null; // Timestamp (ms) until usage API 429 clears
 	provider: string;
 	className?: string;
 	showWeekly?: boolean; // Whether to show weekly usage as well
@@ -129,6 +130,7 @@ export function RateLimitProgress({
 	usageUtilization,
 	usageWindow,
 	usageData,
+	usageRateLimitedUntil,
 	provider,
 	className,
 	showWeekly = false,
@@ -148,6 +150,32 @@ export function RateLimitProgress({
 	// Allow null resetIso for providers that show usage data (like NanoGPT in PayG mode)
 	// but still render null if there's no resetIso and no usage data to show
 	if (!resetIso && !usageData) return null;
+
+	// Show explicit rate-limited state when the Anthropic usage API returned 429
+	// and we have no cached data to show.
+	if (
+		usageRateLimitedUntil != null &&
+		!usageData &&
+		(provider === "anthropic" || provider === "codex")
+	) {
+		const retryAfterDate = new Date(usageRateLimitedUntil);
+		const retryTimeText = retryAfterDate.toLocaleTimeString(undefined, {
+			hour: "2-digit",
+			minute: "2-digit",
+		});
+		return (
+			<div className={cn("space-y-2", className)}>
+				<div className="flex items-center justify-between">
+					<span className="text-xs text-amber-600 dark:text-amber-400">
+						Rate limited — usage data unavailable
+					</span>
+					<span className="text-xs text-muted-foreground">
+						Retry after {retryTimeText}
+					</span>
+				</div>
+			</div>
+		);
+	}
 
 	// Kilo Gateway: show credit balance in USD instead of a utilization window
 	if (providerShowsCreditsBalance(provider) && usageData) {

--- a/packages/http-api/src/handlers/accounts.ts
+++ b/packages/http-api/src/handlers/accounts.ts
@@ -509,6 +509,7 @@ export function createAccountsListHandler(dbOps: DatabaseOperations) {
 					usageUtilization,
 					usageWindow,
 					usageData: fullUsageData, // Full usage data for UI
+					usageRateLimitedUntil: usageCache.getRateLimitedUntil(account.id),
 					hasRefreshToken:
 						!!account.refresh_token &&
 						account.refresh_token !== account.access_token, // API-key providers store key in both fields

--- a/packages/providers/src/usage-fetcher.ts
+++ b/packages/providers/src/usage-fetcher.ts
@@ -335,6 +335,7 @@ class UsageCache {
 	private providerTypes = new Map<string, string>(); // Track provider type for each account
 	private customEndpoints = new Map<string, string | null>(); // Track custom endpoints
 	private windowResetCallbacks = new Map<string, (accountId: string) => void>();
+	private usageRateLimitedUntil = new Map<string, number>(); // Tracks when usage API 429 clears
 
 	/**
 	 * Schedule the next poll with exponential backoff on failures.
@@ -515,6 +516,7 @@ class UsageCache {
 			this.windowResetCallbacks.delete(accountId);
 			// Clean up cache entry when polling stops to prevent memory leaks
 			this.cache.delete(accountId);
+			this.usageRateLimitedUntil.delete(accountId);
 			log.info(
 				`Stopped usage polling and cleared cache for account ${accountId}`,
 			);
@@ -642,6 +644,8 @@ class UsageCache {
 				// Default to Anthropic usage data
 				const result = await fetchUsageData(token);
 				if (result.data) {
+					// Clear any prior rate-limit marker on a successful fetch
+					this.usageRateLimitedUntil.delete(accountId);
 					const callback = this.windowResetCallbacks.get(accountId);
 					if (callback)
 						this.notifyWindowReset(
@@ -662,6 +666,15 @@ class UsageCache {
 						`Successfully fetched usage data for account ${accountId}: ${utilization}% (${window} window)`,
 					);
 					return { success: true, retryAfterMs: null };
+				}
+				if (result.retryAfterMs != null && result.retryAfterMs > 0) {
+					this.usageRateLimitedUntil.set(
+						accountId,
+						Date.now() + result.retryAfterMs,
+					);
+				} else if (result.retryAfterMs == null) {
+					// Non-429 failure: clear any stale rate-limit marker
+					this.usageRateLimitedUntil.delete(accountId);
 				}
 				return { success: false, retryAfterMs: result.retryAfterMs };
 			}
@@ -769,6 +782,20 @@ class UsageCache {
 	}
 
 	/**
+	 * Returns the timestamp (ms since epoch) until which the usage API is rate-limited
+	 * for this account, or null if not currently rate-limited.
+	 */
+	getRateLimitedUntil(accountId: string): number | null {
+		const until = this.usageRateLimitedUntil.get(accountId);
+		if (until === undefined) return null;
+		if (Date.now() >= until) {
+			this.usageRateLimitedUntil.delete(accountId);
+			return null;
+		}
+		return until;
+	}
+
+	/**
 	 * Get cached data age in milliseconds
 	 */
 	getAge(accountId: string): number | null {
@@ -802,6 +829,7 @@ class UsageCache {
 			this.stopPolling(accountId);
 		}
 		this.cache.clear();
+		this.usageRateLimitedUntil.clear();
 		log.info("Cleared all usage cache and stopped polling");
 	}
 }

--- a/packages/types/src/account.ts
+++ b/packages/types/src/account.ts
@@ -182,6 +182,7 @@ export interface AccountResponse {
 	usageUtilization: number | null; // Percentage utilization (0-100) from API
 	usageWindow: string | null; // Most restrictive window (e.g., "five_hour")
 	usageData: FullUsageData | null; // Full usage data for Anthropic accounts
+	usageRateLimitedUntil: number | null; // Timestamp (ms) until usage API 429 clears; null if not rate-limited
 	hasRefreshToken: boolean; // Indicates if the account has a refresh token (OAuth account)
 	crossRegionMode?: string | null; // Cross-region inference mode for Bedrock accounts
 	modelFallbacks?: { [key: string]: string } | null;
@@ -389,6 +390,7 @@ export function toAccountResponse(account: Account): AccountResponse {
 		usageUtilization: null, // Will be filled in by API handler from cache
 		usageWindow: null, // Will be filled in by API handler from cache
 		usageData: null, // Will be filled in by API handler from cache
+		usageRateLimitedUntil: null, // Will be filled in by API handler from cache
 		hasRefreshToken: !!account.refresh_token, // OAuth accounts have refresh tokens
 		modelFallbacks,
 		billingType: account.billing_type,


### PR DESCRIPTION
## Problem

When the Anthropic usage API (`/api/oauth/usage`) returned `429 Too Many Requests`, the dashboard silently dropped the usage rows ("Usage (5-hour)" and "Usage (Weekly)"). The user saw nothing — no progress bars, no error message — which made it look like usage data simply didn't exist.

## Solution

- **`UsageCache` (`packages/providers/src/usage-fetcher.ts`):** Added a `usageRateLimitedUntil` map. When `fetchUsageData` returns a `retryAfterMs` (parsed from the `Retry-After` header on a 429), the cache records `Date.now() + retryAfterMs` for that account. It is cleared on a successful fetch or when polling stops. A new `getRateLimitedUntil(accountId)` getter exposes the value (returns `null` once the timestamp has passed).

- **`AccountResponse` type (`packages/types/src/account.ts`):** Added `usageRateLimitedUntil: number | null` field.

- **Accounts list handler (`packages/http-api/src/handlers/accounts.ts`):** Populates `usageRateLimitedUntil` from `usageCache.getRateLimitedUntil(account.id)` in each account's response object.

- **`RateLimitProgress` (`packages/dashboard-web/src/components/accounts/RateLimitProgress.tsx`):** Accepts the new `usageRateLimitedUntil` prop. When the usage API is rate-limited and there is no cached usage data to show, renders an explicit amber "Rate limited — usage data unavailable" label with the retry-after time (e.g. "Retry after 09:45"). The message only appears for `anthropic` and `codex` providers, since they are the only ones using the Anthropic usage API.

- **`AccountListItem` (`packages/dashboard-web/src/components/accounts/AccountListItem.tsx`):** Passes `usageRateLimitedUntil` through to `RateLimitProgress` and widens the condition that decides whether to render the component at all to include the new signal.