### PR TITLE
fix: use retry-after header for model-exhaustion cooldown

### DIFF
--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -538,6 +538,12 @@ export async function proxyWithAccount(
 						log.warn(
 							`Account ${account.name} rate-limited (429), no model fallbacks — failing over to next account`,
 						);
+						ctx.asyncWriter.enqueue(() =>
+							ctx.dbOps.markAccountRateLimited(
+								account.id,
+								Date.now() + 60 * 60 * 1000,
+							),
+						);
 						return null;
 					}
 					return rawResponse;
@@ -622,6 +628,16 @@ export async function proxyWithAccount(
 			if (await isModelUnavailableError(rawResponse)) {
 				log.warn(
 					`All models exhausted on account ${account.name}, failing over to next account`,
+				);
+				// Mark account rate-limited for 1 hour so that isAccountAvailable()
+				// excludes it from future requests until the cooldown expires.
+				// Without this write the DB state stays stale (rate_limited_until = null)
+				// and the same account is retried on every subsequent request.
+				ctx.asyncWriter.enqueue(() =>
+					ctx.dbOps.markAccountRateLimited(
+						account.id,
+						Date.now() + 60 * 60 * 1000,
+					),
 				);
 				return null;
 			}

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -1,6 +1,6 @@
 import { getModelList, logError, ProviderError } from "@better-ccflare/core";
 import { Logger } from "@better-ccflare/logger";
-import { getProvider } from "@better-ccflare/providers";
+import { getProvider, usageCache } from "@better-ccflare/providers";
 import type { Account, RequestMeta } from "@better-ccflare/types";
 import { cacheBodyStore } from "../cache-body-store";
 import { forwardToClient } from "../response-handler";
@@ -10,6 +10,51 @@ import { handleProxyError, processProxyResponse } from "./response-processor";
 import { getValidAccessToken } from "./token-manager";
 
 const log = new Logger("ProxyOperations");
+
+/**
+ * Determines the cooldown duration (ms from now) to use when marking an account
+ * rate-limited after model exhaustion. Priority:
+ *   1. retry-after / x-ratelimit-reset response header (actual upstream backoff)
+ *   2. usageCache.getRateLimitedUntil — usage-window reset time if known
+ *   3. 1-hour default as last resort
+ *
+ * The result is always clamped to at least 60 seconds to avoid a zero or
+ * negative value when a parsed timestamp is already in the past.
+ */
+function extractCooldownMs(response: Response, accountId: string): number {
+	const MIN_COOLDOWN_MS = 60 * 1000; // 60 seconds floor
+	const DEFAULT_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
+
+	// 1. Check retry-after / x-ratelimit-reset headers
+	const retryAfter =
+		response.headers.get("retry-after") ??
+		response.headers.get("x-ratelimit-reset");
+	if (retryAfter) {
+		const parsed = Number(retryAfter);
+		if (!Number.isNaN(parsed) && parsed > 0) {
+			// Unix timestamp (seconds) if value looks like an epoch (> 1 billion)
+			const isUnixTimestamp = parsed > 1_000_000_000;
+			const cooldownMs = isUnixTimestamp
+				? parsed * 1000 - Date.now()
+				: parsed * 1000;
+			if (cooldownMs > 0) {
+				return Math.max(cooldownMs, MIN_COOLDOWN_MS);
+			}
+		}
+	}
+
+	// 2. Fall back to usage-window reset time if available
+	const rateLimitedUntil = usageCache.getRateLimitedUntil(accountId);
+	if (rateLimitedUntil !== null) {
+		const cooldownMs = rateLimitedUntil - Date.now();
+		if (cooldownMs > 0) {
+			return Math.max(cooldownMs, MIN_COOLDOWN_MS);
+		}
+	}
+
+	// 3. Last resort: 1 hour
+	return DEFAULT_COOLDOWN_MS;
+}
 
 /**
  * Bedrock provider currently returns a synthetic Request containing the
@@ -538,10 +583,11 @@ export async function proxyWithAccount(
 						log.warn(
 							`Account ${account.name} rate-limited (429), no model fallbacks — failing over to next account`,
 						);
+						const cooldownMs = extractCooldownMs(rawResponse, account.id);
 						ctx.asyncWriter.enqueue(() =>
 							ctx.dbOps.markAccountRateLimited(
 								account.id,
-								Date.now() + 60 * 60 * 1000,
+								Date.now() + cooldownMs,
 							),
 						);
 						return null;
@@ -636,10 +682,11 @@ export async function proxyWithAccount(
 				// Only fire for genuine rate-limit responses (429); model-not-found
 				// (404/400) is a configuration issue, not account exhaustion.
 				if (rawResponse.status === 429) {
+					const cooldownMs = extractCooldownMs(rawResponse, account.id);
 					ctx.asyncWriter.enqueue(() =>
 						ctx.dbOps.markAccountRateLimited(
 							account.id,
-							Date.now() + 60 * 60 * 1000,
+							Date.now() + cooldownMs,
 						),
 					);
 				}

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -12,16 +12,16 @@ import { getValidAccessToken } from "./token-manager";
 const log = new Logger("ProxyOperations");
 
 /**
- * Determines the cooldown duration (ms from now) to use when marking an account
- * rate-limited after model exhaustion. Priority:
+ * Determines the absolute epoch timestamp (ms since epoch) until which an account
+ * should be marked rate-limited after model exhaustion. Priority:
  *   1. retry-after / x-ratelimit-reset response header (actual upstream backoff)
  *   2. usageCache.getRateLimitedUntil — usage-window reset time if known
  *   3. 1-hour default as last resort
  *
- * The result is always clamped to at least 60 seconds to avoid a zero or
- * negative value when a parsed timestamp is already in the past.
+ * The result is always clamped to at least 60 seconds in the future to avoid a
+ * zero or negative value when a parsed timestamp is already in the past.
  */
-function extractCooldownMs(response: Response, accountId: string): number {
+function extractCooldownUntil(response: Response, accountId: string): number {
 	const MIN_COOLDOWN_MS = 60 * 1000; // 60 seconds floor
 	const DEFAULT_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
 
@@ -34,26 +34,32 @@ function extractCooldownMs(response: Response, accountId: string): number {
 		if (!Number.isNaN(parsed) && parsed > 0) {
 			// Unix timestamp (seconds) if value looks like an epoch (> 1 billion)
 			const isUnixTimestamp = parsed > 1_000_000_000;
-			const cooldownMs = isUnixTimestamp
-				? parsed * 1000 - Date.now()
-				: parsed * 1000;
-			if (cooldownMs > 0) {
-				return Math.max(cooldownMs, MIN_COOLDOWN_MS);
+			const epochMs = isUnixTimestamp
+				? parsed * 1000
+				: Date.now() + parsed * 1000;
+			if (epochMs > Date.now()) {
+				return Math.max(epochMs, Date.now() + MIN_COOLDOWN_MS);
+			}
+		} else {
+			// Try HTTP-date format (RFC 7231), e.g. "Wed, 21 Oct 2026 07:28:00 GMT"
+			const dateMs = new Date(retryAfter).getTime();
+			if (!Number.isNaN(dateMs)) {
+				const cooldownMs = dateMs - Date.now();
+				if (cooldownMs > 0) {
+					return Math.max(dateMs, Date.now() + MIN_COOLDOWN_MS);
+				}
 			}
 		}
 	}
 
 	// 2. Fall back to usage-window reset time if available
 	const rateLimitedUntil = usageCache.getRateLimitedUntil(accountId);
-	if (rateLimitedUntil !== null) {
-		const cooldownMs = rateLimitedUntil - Date.now();
-		if (cooldownMs > 0) {
-			return Math.max(cooldownMs, MIN_COOLDOWN_MS);
-		}
+	if (rateLimitedUntil !== null && rateLimitedUntil > Date.now()) {
+		return Math.max(rateLimitedUntil, Date.now() + MIN_COOLDOWN_MS);
 	}
 
 	// 3. Last resort: 1 hour
-	return DEFAULT_COOLDOWN_MS;
+	return Date.now() + DEFAULT_COOLDOWN_MS;
 }
 
 /**
@@ -583,12 +589,9 @@ export async function proxyWithAccount(
 						log.warn(
 							`Account ${account.name} rate-limited (429), no model fallbacks — failing over to next account`,
 						);
-						const cooldownMs = extractCooldownMs(rawResponse, account.id);
+						const cooldownUntil = extractCooldownUntil(rawResponse, account.id);
 						ctx.asyncWriter.enqueue(() =>
-							ctx.dbOps.markAccountRateLimited(
-								account.id,
-								Date.now() + cooldownMs,
-							),
+							ctx.dbOps.markAccountRateLimited(account.id, cooldownUntil),
 						);
 						return null;
 					}
@@ -682,12 +685,9 @@ export async function proxyWithAccount(
 				// Only fire for genuine rate-limit responses (429); model-not-found
 				// (404/400) is a configuration issue, not account exhaustion.
 				if (rawResponse.status === 429) {
-					const cooldownMs = extractCooldownMs(rawResponse, account.id);
+					const cooldownUntil = extractCooldownUntil(rawResponse, account.id);
 					ctx.asyncWriter.enqueue(() =>
-						ctx.dbOps.markAccountRateLimited(
-							account.id,
-							Date.now() + cooldownMs,
-						),
+						ctx.dbOps.markAccountRateLimited(account.id, cooldownUntil),
 					);
 				}
 				return null;

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -633,12 +633,16 @@ export async function proxyWithAccount(
 				// excludes it from future requests until the cooldown expires.
 				// Without this write the DB state stays stale (rate_limited_until = null)
 				// and the same account is retried on every subsequent request.
-				ctx.asyncWriter.enqueue(() =>
-					ctx.dbOps.markAccountRateLimited(
-						account.id,
-						Date.now() + 60 * 60 * 1000,
-					),
-				);
+				// Only fire for genuine rate-limit responses (429); model-not-found
+				// (404/400) is a configuration issue, not account exhaustion.
+				if (rawResponse.status === 429) {
+					ctx.asyncWriter.enqueue(() =>
+						ctx.dbOps.markAccountRateLimited(
+							account.id,
+							Date.now() + 60 * 60 * 1000,
+						),
+					);
+				}
 				return null;
 			}
 		}


### PR DESCRIPTION
## Summary

When an account is marked rate-limited after model exhaustion (Problem 4, PR #163), the cooldown duration was hardcoded to 1 hour. This PR makes the cooldown dynamic.

**Note:** This PR cherry-picks the two commits from PR #163 as a foundation, since Problem 5 builds directly on those `markAccountRateLimited` call sites. Once PR #163 merges, this branch can be rebased to drop those commits.

## Changes

Added `extractCooldownMs(response, accountId)` in `packages/proxy/src/handlers/proxy-operations.ts`, used at both `markAccountRateLimited` call sites:

**Priority order:**
1. `retry-after` / `x-ratelimit-reset` response header — uses the actual upstream backoff (handles both relative seconds and Unix timestamps)
2. `usageCache.getRateLimitedUntil(accountId)` — uses the known usage-window reset time as a proxy (added in PR #161)
3. 1-hour default as last resort

The cooldown is always clamped to at least 60 seconds so a stale or already-past timestamp never produces a zero or negative value.

## Affected sites

- **Site 1** (`modelList.length <= 1` + 429): no fallback models configured, account gets the dynamic cooldown instead of fixed 1 hour
- **Site 2** (all fallback models exhausted + 429): same dynamic cooldown logic applied after cycling through the full model list

## Test plan

- [ ] Provider returns `retry-after: 300` → account marked rate-limited for 5 minutes (not 1 hour)
- [ ] Provider returns `x-ratelimit-reset: <unix-ts>` → cooldown computed as `timestamp * 1000 - Date.now()`
- [ ] No rate-limit headers but `usageCache` has a reset time → usage window reset used as cooldown
- [ ] No headers, no cache → falls back to 1-hour default
- [ ] Parsed cooldown ≤ 0 (stale timestamp) → clamps to 60 seconds minimum