### PR TITLE
fix: remove implicit sonnet catch-all in getModelList

### DIFF
--- a/packages/core/src/model-mappings.test.ts
+++ b/packages/core/src/model-mappings.test.ts
@@ -180,6 +180,43 @@ describe("Model Mapping", () => {
 		expect(haikuResult).toBe("lowercase-gpt-3.5");
 		expect(opusResult).toBe("lowercase-gpt-4-turbo");
 	});
+
+	test("mapModelName passes through unmapped model when only sonnet is configured (regression: no implicit sonnet catch-all)", () => {
+		// Regression test: previously, if an account had a sonnet mapping but no haiku mapping,
+		// requesting a haiku model would silently remap it to the sonnet target.
+		const mockAccount: Account = {
+			id: "test",
+			name: "test-account",
+			provider: "openai-compatible",
+			api_key: "test-key",
+			refresh_token: "",
+			access_token: "",
+			expires_at: null,
+			created_at: Date.now(),
+			request_count: 0,
+			total_requests: 0,
+			priority: 10,
+			model_mappings: JSON.stringify({
+				sonnet: "claude-sonnet-4-6", // Only sonnet is mapped; haiku is NOT
+			}),
+			custom_endpoint: null,
+		};
+
+		// Sonnet should be mapped
+		expect(mapModelName("claude-sonnet-4-5", mockAccount)).toBe(
+			"claude-sonnet-4-6",
+		);
+
+		// Haiku has no mapping — must pass through unchanged, NOT remap to sonnet target
+		expect(mapModelName("claude-haiku-4-5", mockAccount)).toBe(
+			"claude-haiku-4-5",
+		);
+
+		// Opus has no mapping — must also pass through unchanged
+		expect(mapModelName("claude-opus-4-5", mockAccount)).toBe(
+			"claude-opus-4-5",
+		);
+	});
 });
 
 describe("Model Validation Utilities", () => {

--- a/packages/core/src/model-mappings.ts
+++ b/packages/core/src/model-mappings.ts
@@ -230,10 +230,6 @@ export function getModelList(
 		return toArray(mappings[family]);
 	}
 
-	// Default: sonnet family — return original model if not mapped
-	const defaultVal = mappings.sonnet;
-	if (defaultVal) return toArray(defaultVal);
-
 	// No mapping for this model — pass through unchanged
 	return [anthropicModel];
 }


### PR DESCRIPTION
## Problem

`getModelList()` in `packages/core/src/model-mappings.ts` contained a hidden catch-all: if an account had any mappings configured (e.g. a `sonnet` key) but the requested model had no exact or family match, the function returned the `sonnet` mapping as a default.

This caused silent unexpected remaps — for example, `claude-haiku-4-5 → claude-sonnet-4-6` when the account only mapped `sonnet` but not `haiku` — with no warning logged anywhere.

## Fix

Removed the two-line implicit default:

```ts
// Before (removed):
const defaultVal = mappings.sonnet;
if (defaultVal) return toArray(defaultVal);
```

Unmapped models now fall through to the existing `return [anthropicModel]` path, passing through unchanged. Users who want a true catch-all default must explicitly configure it (e.g. add a `haiku` key to their mappings).

`packages/providers/src/utils/model-mapping.ts` (`getModelName()`) did not have this catch-all and required no change.

## Tests

Added a regression test: account with only `sonnet` mapped — requesting `haiku` or `opus` must return the original model name, not the sonnet target.