### PR TITLE
fix: use retry-after header for model-exhaustion cooldown

### DIFF
--- a/packages/proxy/src/handlers/__tests__/extract-cooldown-until.test.ts
+++ b/packages/proxy/src/handlers/__tests__/extract-cooldown-until.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "bun:test";
+import { extractCooldownUntil } from "../proxy-operations";
+
+const ACCOUNT_ID = "acct-test";
+const MIN_COOLDOWN_MS = 60 * 1000;
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+function makeResponse(headers: Record<string, string> = {}): Response {
+	return new Response(null, { status: 429, headers });
+}
+
+const noCache = (_id: string): number | null => null;
+
+describe("extractCooldownUntil", () => {
+	it("uses retry-after seconds header", () => {
+		const before = Date.now();
+		const result = extractCooldownUntil(
+			makeResponse({ "retry-after": "300" }),
+			ACCOUNT_ID,
+			noCache,
+		);
+		expect(result).toBeGreaterThanOrEqual(before + 300 * 1000);
+		expect(result).toBeLessThan(before + 300 * 1000 + 5000);
+	});
+
+	it("uses x-ratelimit-reset unix timestamp", () => {
+		const future = Math.floor((Date.now() + 10 * 60 * 1000) / 1000);
+		const result = extractCooldownUntil(
+			makeResponse({ "x-ratelimit-reset": String(future) }),
+			ACCOUNT_ID,
+			noCache,
+		);
+		expect(result).toBe(future * 1000);
+	});
+
+	it("uses HTTP-date retry-after", () => {
+		const futureDate = new Date(Date.now() + 5 * 60 * 1000);
+		// toUTCString() truncates to seconds — compare against second-precision floor
+		const futureDateSec = Math.floor(futureDate.getTime() / 1000) * 1000;
+		const result = extractCooldownUntil(
+			makeResponse({ "retry-after": futureDate.toUTCString() }),
+			ACCOUNT_ID,
+			noCache,
+		);
+		expect(result).toBeGreaterThanOrEqual(futureDateSec);
+	});
+
+	it("falls through stale unix timestamp to usageCache", () => {
+		const staleTs = Math.floor((Date.now() - 60 * 1000) / 1000);
+		const cacheReset = Date.now() + 30 * 60 * 1000;
+		const result = extractCooldownUntil(
+			makeResponse({ "retry-after": String(staleTs) }),
+			ACCOUNT_ID,
+			() => cacheReset,
+		);
+		expect(result).toBe(cacheReset);
+	});
+
+	it("falls through stale HTTP-date to usageCache", () => {
+		const pastDate = new Date(Date.now() - 60 * 1000).toUTCString();
+		const cacheReset = Date.now() + 20 * 60 * 1000;
+		const result = extractCooldownUntil(
+			makeResponse({ "retry-after": pastDate }),
+			ACCOUNT_ID,
+			() => cacheReset,
+		);
+		expect(result).toBe(cacheReset);
+	});
+
+	it("falls back to 1-hour default when no headers and no cache", () => {
+		const before = Date.now();
+		const result = extractCooldownUntil(makeResponse(), ACCOUNT_ID, noCache);
+		expect(result).toBeGreaterThanOrEqual(before + ONE_HOUR_MS);
+		expect(result).toBeLessThan(before + ONE_HOUR_MS + 5000);
+	});
+
+	it("clamps small retry-after to MIN_COOLDOWN_MS", () => {
+		const before = Date.now();
+		const result = extractCooldownUntil(
+			makeResponse({ "retry-after": "1" }),
+			ACCOUNT_ID,
+			noCache,
+		);
+		expect(result).toBeGreaterThanOrEqual(before + MIN_COOLDOWN_MS);
+	});
+
+	it("clamps imminent usageCache reset to MIN_COOLDOWN_MS", () => {
+		const before = Date.now();
+		const almostNow = Date.now() + 1000;
+		const result = extractCooldownUntil(
+			makeResponse(),
+			ACCOUNT_ID,
+			() => almostNow,
+		);
+		expect(result).toBeGreaterThanOrEqual(before + MIN_COOLDOWN_MS);
+	});
+});

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -1,6 +1,6 @@
 import { getModelList, logError, ProviderError } from "@better-ccflare/core";
 import { Logger } from "@better-ccflare/logger";
-import { getProvider } from "@better-ccflare/providers";
+import { getProvider, usageCache } from "@better-ccflare/providers";
 import type { Account, RequestMeta } from "@better-ccflare/types";
 import { cacheBodyStore } from "../cache-body-store";
 import { forwardToClient } from "../response-handler";
@@ -10,6 +10,51 @@ import { handleProxyError, processProxyResponse } from "./response-processor";
 import { getValidAccessToken } from "./token-manager";
 
 const log = new Logger("ProxyOperations");
+
+/**
+ * Determines the cooldown duration (ms from now) to use when marking an account
+ * rate-limited after model exhaustion. Priority:
+ *   1. retry-after / x-ratelimit-reset response header (actual upstream backoff)
+ *   2. usageCache.getRateLimitedUntil — usage-window reset time if known
+ *   3. 1-hour default as last resort
+ *
+ * The result is always clamped to at least 60 seconds to avoid a zero or
+ * negative value when a parsed timestamp is already in the past.
+ */
+function extractCooldownMs(response: Response, accountId: string): number {
+	const MIN_COOLDOWN_MS = 60 * 1000; // 60 seconds floor
+	const DEFAULT_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
+
+	// 1. Check retry-after / x-ratelimit-reset headers
+	const retryAfter =
+		response.headers.get("retry-after") ??
+		response.headers.get("x-ratelimit-reset");
+	if (retryAfter) {
+		const parsed = Number(retryAfter);
+		if (!Number.isNaN(parsed) && parsed > 0) {
+			// Unix timestamp (seconds) if value looks like an epoch (> 1 billion)
+			const isUnixTimestamp = parsed > 1_000_000_000;
+			const cooldownMs = isUnixTimestamp
+				? parsed * 1000 - Date.now()
+				: parsed * 1000;
+			if (cooldownMs > 0) {
+				return Math.max(cooldownMs, MIN_COOLDOWN_MS);
+			}
+		}
+	}
+
+	// 2. Fall back to usage-window reset time if available
+	const rateLimitedUntil = usageCache.getRateLimitedUntil(accountId);
+	if (rateLimitedUntil !== null) {
+		const cooldownMs = rateLimitedUntil - Date.now();
+		if (cooldownMs > 0) {
+			return Math.max(cooldownMs, MIN_COOLDOWN_MS);
+		}
+	}
+
+	// 3. Last resort: 1 hour
+	return DEFAULT_COOLDOWN_MS;
+}
 
 /**
  * Bedrock provider currently returns a synthetic Request containing the
@@ -538,10 +583,11 @@ export async function proxyWithAccount(
 						log.warn(
 							`Account ${account.name} rate-limited (429), no model fallbacks — failing over to next account`,
 						);
+						const cooldownMs = extractCooldownMs(rawResponse, account.id);
 						ctx.asyncWriter.enqueue(() =>
 							ctx.dbOps.markAccountRateLimited(
 								account.id,
-								Date.now() + 60 * 60 * 1000,
+								Date.now() + cooldownMs,
 							),
 						);
 						return null;
@@ -636,10 +682,11 @@ export async function proxyWithAccount(
 				// Only fire for genuine rate-limit responses (429); model-not-found
 				// (404/400) is a configuration issue, not account exhaustion.
 				if (rawResponse.status === 429) {
+					const cooldownMs = extractCooldownMs(rawResponse, account.id);
 					ctx.asyncWriter.enqueue(() =>
 						ctx.dbOps.markAccountRateLimited(
 							account.id,
-							Date.now() + 60 * 60 * 1000,
+							Date.now() + cooldownMs,
 						),
 					);
 				}

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -15,15 +15,24 @@ const log = new Logger("ProxyOperations");
  * Determines the absolute epoch timestamp (ms since epoch) until which an account
  * should be marked rate-limited after model exhaustion. Priority:
  *   1. retry-after / x-ratelimit-reset response header (actual upstream backoff)
- *   2. usageCache.getRateLimitedUntil — usage-window reset time if known
+ *   2. getRateLimitedUntil — usage-window reset time if known
  *   3. 1-hour default as last resort
  *
  * The result is always clamped to at least 60 seconds in the future to avoid a
  * zero or negative value when a parsed timestamp is already in the past.
+ *
+ * NOTE: getRateLimitedUntil is injected rather than called directly on usageCache
+ * so that callers in production pass usageCache.getRateLimitedUntil.bind(usageCache)
+ * and tests pass a plain stub — avoiding module-mock symlink issues with Bun.
  */
-function extractCooldownUntil(response: Response, accountId: string): number {
+export function extractCooldownUntil(
+	response: Response,
+	accountId: string,
+	getRateLimitedUntil: (accountId: string) => number | null,
+): number {
 	const MIN_COOLDOWN_MS = 60 * 1000; // 60 seconds floor
 	const DEFAULT_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
+	const now = Date.now();
 
 	// 1. Check retry-after / x-ratelimit-reset headers
 	const retryAfter =
@@ -34,32 +43,29 @@ function extractCooldownUntil(response: Response, accountId: string): number {
 		if (!Number.isNaN(parsed) && parsed > 0) {
 			// Unix timestamp (seconds) if value looks like an epoch (> 1 billion)
 			const isUnixTimestamp = parsed > 1_000_000_000;
-			const epochMs = isUnixTimestamp
-				? parsed * 1000
-				: Date.now() + parsed * 1000;
-			if (epochMs > Date.now()) {
-				return Math.max(epochMs, Date.now() + MIN_COOLDOWN_MS);
+			const epochMs = isUnixTimestamp ? parsed * 1000 : now + parsed * 1000;
+			if (epochMs > now) {
+				return Math.max(epochMs, now + MIN_COOLDOWN_MS);
 			}
+			// epochMs <= now: stale/already-past timestamp — fall through to next priority
 		} else {
 			// Try HTTP-date format (RFC 7231), e.g. "Wed, 21 Oct 2026 07:28:00 GMT"
 			const dateMs = new Date(retryAfter).getTime();
-			if (!Number.isNaN(dateMs)) {
-				const cooldownMs = dateMs - Date.now();
-				if (cooldownMs > 0) {
-					return Math.max(dateMs, Date.now() + MIN_COOLDOWN_MS);
-				}
+			if (!Number.isNaN(dateMs) && dateMs > now) {
+				return Math.max(dateMs, now + MIN_COOLDOWN_MS);
 			}
+			// Invalid or past date — fall through to next priority
 		}
 	}
 
 	// 2. Fall back to usage-window reset time if available
-	const rateLimitedUntil = usageCache.getRateLimitedUntil(accountId);
-	if (rateLimitedUntil !== null && rateLimitedUntil > Date.now()) {
-		return Math.max(rateLimitedUntil, Date.now() + MIN_COOLDOWN_MS);
+	const rateLimitedUntil = getRateLimitedUntil(accountId);
+	if (rateLimitedUntil !== null && rateLimitedUntil > now) {
+		return Math.max(rateLimitedUntil, now + MIN_COOLDOWN_MS);
 	}
 
 	// 3. Last resort: 1 hour
-	return Date.now() + DEFAULT_COOLDOWN_MS;
+	return now + DEFAULT_COOLDOWN_MS;
 }
 
 /**
@@ -589,7 +595,11 @@ export async function proxyWithAccount(
 						log.warn(
 							`Account ${account.name} rate-limited (429), no model fallbacks — failing over to next account`,
 						);
-						const cooldownUntil = extractCooldownUntil(rawResponse, account.id);
+						const cooldownUntil = extractCooldownUntil(
+							rawResponse,
+							account.id,
+							usageCache.getRateLimitedUntil.bind(usageCache),
+						);
 						ctx.asyncWriter.enqueue(() =>
 							ctx.dbOps.markAccountRateLimited(account.id, cooldownUntil),
 						);
@@ -685,7 +695,11 @@ export async function proxyWithAccount(
 				// Only fire for genuine rate-limit responses (429); model-not-found
 				// (404/400) is a configuration issue, not account exhaustion.
 				if (rawResponse.status === 429) {
-					const cooldownUntil = extractCooldownUntil(rawResponse, account.id);
+					const cooldownUntil = extractCooldownUntil(
+						rawResponse,
+						account.id,
+						usageCache.getRateLimitedUntil.bind(usageCache),
+					);
 					ctx.asyncWriter.enqueue(() =>
 						ctx.dbOps.markAccountRateLimited(account.id, cooldownUntil),
 					);

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -12,16 +12,16 @@ import { getValidAccessToken } from "./token-manager";
 const log = new Logger("ProxyOperations");
 
 /**
- * Determines the cooldown duration (ms from now) to use when marking an account
- * rate-limited after model exhaustion. Priority:
+ * Determines the absolute epoch timestamp (ms since epoch) until which an account
+ * should be marked rate-limited after model exhaustion. Priority:
  *   1. retry-after / x-ratelimit-reset response header (actual upstream backoff)
  *   2. usageCache.getRateLimitedUntil — usage-window reset time if known
  *   3. 1-hour default as last resort
  *
- * The result is always clamped to at least 60 seconds to avoid a zero or
- * negative value when a parsed timestamp is already in the past.
+ * The result is always clamped to at least 60 seconds in the future to avoid a
+ * zero or negative value when a parsed timestamp is already in the past.
  */
-function extractCooldownMs(response: Response, accountId: string): number {
+function extractCooldownUntil(response: Response, accountId: string): number {
 	const MIN_COOLDOWN_MS = 60 * 1000; // 60 seconds floor
 	const DEFAULT_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
 
@@ -34,26 +34,32 @@ function extractCooldownMs(response: Response, accountId: string): number {
 		if (!Number.isNaN(parsed) && parsed > 0) {
 			// Unix timestamp (seconds) if value looks like an epoch (> 1 billion)
 			const isUnixTimestamp = parsed > 1_000_000_000;
-			const cooldownMs = isUnixTimestamp
-				? parsed * 1000 - Date.now()
-				: parsed * 1000;
-			if (cooldownMs > 0) {
-				return Math.max(cooldownMs, MIN_COOLDOWN_MS);
+			const epochMs = isUnixTimestamp
+				? parsed * 1000
+				: Date.now() + parsed * 1000;
+			if (epochMs > Date.now()) {
+				return Math.max(epochMs, Date.now() + MIN_COOLDOWN_MS);
+			}
+		} else {
+			// Try HTTP-date format (RFC 7231), e.g. "Wed, 21 Oct 2026 07:28:00 GMT"
+			const dateMs = new Date(retryAfter).getTime();
+			if (!Number.isNaN(dateMs)) {
+				const cooldownMs = dateMs - Date.now();
+				if (cooldownMs > 0) {
+					return Math.max(dateMs, Date.now() + MIN_COOLDOWN_MS);
+				}
 			}
 		}
 	}
 
 	// 2. Fall back to usage-window reset time if available
 	const rateLimitedUntil = usageCache.getRateLimitedUntil(accountId);
-	if (rateLimitedUntil !== null) {
-		const cooldownMs = rateLimitedUntil - Date.now();
-		if (cooldownMs > 0) {
-			return Math.max(cooldownMs, MIN_COOLDOWN_MS);
-		}
+	if (rateLimitedUntil !== null && rateLimitedUntil > Date.now()) {
+		return Math.max(rateLimitedUntil, Date.now() + MIN_COOLDOWN_MS);
 	}
 
 	// 3. Last resort: 1 hour
-	return DEFAULT_COOLDOWN_MS;
+	return Date.now() + DEFAULT_COOLDOWN_MS;
 }
 
 /**
@@ -583,12 +589,9 @@ export async function proxyWithAccount(
 						log.warn(
 							`Account ${account.name} rate-limited (429), no model fallbacks — failing over to next account`,
 						);
-						const cooldownMs = extractCooldownMs(rawResponse, account.id);
+						const cooldownUntil = extractCooldownUntil(rawResponse, account.id);
 						ctx.asyncWriter.enqueue(() =>
-							ctx.dbOps.markAccountRateLimited(
-								account.id,
-								Date.now() + cooldownMs,
-							),
+							ctx.dbOps.markAccountRateLimited(account.id, cooldownUntil),
 						);
 						return null;
 					}
@@ -682,12 +685,9 @@ export async function proxyWithAccount(
 				// Only fire for genuine rate-limit responses (429); model-not-found
 				// (404/400) is a configuration issue, not account exhaustion.
 				if (rawResponse.status === 429) {
-					const cooldownMs = extractCooldownMs(rawResponse, account.id);
+					const cooldownUntil = extractCooldownUntil(rawResponse, account.id);
 					ctx.asyncWriter.enqueue(() =>
-						ctx.dbOps.markAccountRateLimited(
-							account.id,
-							Date.now() + cooldownMs,
-						),
+						ctx.dbOps.markAccountRateLimited(account.id, cooldownUntil),
 					);
 				}
 				return null;


### PR DESCRIPTION
Rebased version of #164 (cowwoc's PR) with cherry-picked #163 commits dropped and review feedback addressed.

## Changes from #164

- `extractCooldownUntil` refactored with `now = Date.now()` captured once — eliminates multi-call skew
- Stale-timestamp fallthrough paths have explicit comments
- JSDoc notes the `usageCache` layering concern
- `getRateLimitedUntil` injected as parameter (DI) instead of calling singleton directly — no module mocking needed in tests
- 8 unit tests added covering all branches: relative seconds, unix timestamp, HTTP-date, stale fallthrough to cache, cache fallback, 1-hour default, MIN_COOLDOWN clamp

## Original PR summary (#164)

When an account is marked rate-limited after model exhaustion, the cooldown duration was hardcoded to 1 hour. This PR makes it dynamic using `retry-after` / `x-ratelimit-reset` headers, falling back to `usageCache.getRateLimitedUntil`, then 1-hour default. Cooldown always clamped to ≥60 seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)