### PR TITLE
Reduce logging verbosity

### DIFF
--- a/packages/core/src/model-mappings.ts
+++ b/packages/core/src/model-mappings.ts
@@ -245,12 +245,15 @@ export function mapModelName(anthropicModel: string, account: Account): string {
 	const mapped = list[0];
 
 	if (
-		mapped !== anthropicModel &&
-		(process.env.DEBUG?.includes("model") ||
-			process.env.DEBUG === "true" ||
-			process.env.NODE_ENV === "development")
+		process.env.DEBUG?.includes("model") ||
+		process.env.DEBUG === "true" ||
+		process.env.NODE_ENV === "development"
 	) {
-		log.info(`Model mapping: ${anthropicModel} -> ${mapped}`);
+		if (mapped !== anthropicModel) {
+			log.info(`Model mapping: ${anthropicModel} -> ${mapped}`);
+		} else {
+			log.debug(`Model mapping: ${anthropicModel} -> ${mapped} (identity)`);
+		}
 	}
 
 	return mapped;

--- a/packages/core/src/model-mappings.ts
+++ b/packages/core/src/model-mappings.ts
@@ -245,9 +245,10 @@ export function mapModelName(anthropicModel: string, account: Account): string {
 	const mapped = list[0];
 
 	if (
-		process.env.DEBUG?.includes("model") ||
-		process.env.DEBUG === "true" ||
-		process.env.NODE_ENV === "development"
+		mapped !== anthropicModel &&
+		(process.env.DEBUG?.includes("model") ||
+			process.env.DEBUG === "true" ||
+			process.env.NODE_ENV === "development")
 	) {
 		log.info(`Model mapping: ${anthropicModel} -> ${mapped}`);
 	}

--- a/packages/load-balancer/src/strategies/index.ts
+++ b/packages/load-balancer/src/strategies/index.ts
@@ -128,6 +128,7 @@ export class SessionStrategy implements LoadBalancingStrategy {
 		// Iterate through all candidates in priority order to find the first usable one.
 		const fallbackCandidates = this.checkForAutoFallbackAccounts(accounts, now);
 		let chosenFallback: Account | null = null;
+		const skippedManualPause: string[] = [];
 		for (const candidate of fallbackCandidates) {
 			// If the candidate is paused, only auto-unpause if it was paused due to
 			// overage, or `rate_limit_window` (reserved/future pause reason) — never auto-unpause
@@ -146,9 +147,7 @@ export class SessionStrategy implements LoadBalancingStrategy {
 					// Invalidate the cache so getCachedAvailability reflects the unpause
 					availabilityCache.delete(candidate.id);
 				} else {
-					this.log.info(
-						`Skipping auto-unpause of account ${candidate.name} — paused with reason '${candidate.pause_reason}' which requires manual intervention`,
-					);
+					skippedManualPause.push(candidate.name);
 					continue;
 				}
 			}
@@ -157,6 +156,12 @@ export class SessionStrategy implements LoadBalancingStrategy {
 				chosenFallback = candidate;
 				break;
 			}
+		}
+
+		if (skippedManualPause.length > 0) {
+			this.log.info(
+				`Skipping auto-unpause of ${skippedManualPause.length} manually paused account(s): ${skippedManualPause.join(", ")}`,
+			);
 		}
 
 		if (chosenFallback !== null) {

--- a/packages/load-balancer/src/strategies/index.ts
+++ b/packages/load-balancer/src/strategies/index.ts
@@ -128,7 +128,7 @@ export class SessionStrategy implements LoadBalancingStrategy {
 		// Iterate through all candidates in priority order to find the first usable one.
 		const fallbackCandidates = this.checkForAutoFallbackAccounts(accounts, now);
 		let chosenFallback: Account | null = null;
-		const skippedManualPause: string[] = [];
+		const skippedByReason = new Map<string, string[]>();
 		for (const candidate of fallbackCandidates) {
 			// If the candidate is paused, only auto-unpause if it was paused due to
 			// overage, or `rate_limit_window` (reserved/future pause reason) — never auto-unpause
@@ -147,7 +147,11 @@ export class SessionStrategy implements LoadBalancingStrategy {
 					// Invalidate the cache so getCachedAvailability reflects the unpause
 					availabilityCache.delete(candidate.id);
 				} else {
-					skippedManualPause.push(candidate.name);
+					const reason = candidate.pause_reason || "unknown";
+					if (!skippedByReason.has(reason)) {
+						skippedByReason.set(reason, []);
+					}
+					skippedByReason.get(reason)!.push(candidate.name);
 					continue;
 				}
 			}
@@ -158,9 +162,9 @@ export class SessionStrategy implements LoadBalancingStrategy {
 			}
 		}
 
-		if (skippedManualPause.length > 0) {
+		for (const [reason, names] of skippedByReason) {
 			this.log.info(
-				`Skipping auto-unpause of ${skippedManualPause.length} manually paused account(s): ${skippedManualPause.join(", ")}`,
+				`Skipping auto-unpause of ${names.length} account(s) paused for '${reason}': ${names.join(", ")}`,
 			);
 		}
 


### PR DESCRIPTION
## Summary

Reduces log noise from two sources of repetitive INFO messages:

- **Auto-unpause skip logs**: When multiple accounts are manually paused, the load balancer logged a separate line for each one every cycle. Now aggregates into a single message listing all skipped accounts (e.g. `Skipping auto-unpause of 6 manually paused account(s): account1, account2, ...`).
- **Identity model mapping logs**: Suppresses `Model mapping: X -> X` lines when the input and output model are identical, only logging when an actual mapping occurs.

## Test plan

- [ ] Start server with multiple manually paused accounts and verify a single aggregated log line appears instead of one per account
- [ ] Verify model mapping logs only appear when the model is actually remapped (not identity mappings)
- [ ] Run `bun run lint && bun run typecheck && bun run format`