### PR TITLE
fix(proxy): Mark account rate-limited on hard quota signals even if reset header is missing

### DIFF
--- a/packages/providers/src/providers/anthropic/provider.ts
+++ b/packages/providers/src/providers/anthropic/provider.ts
@@ -10,16 +10,22 @@ import { BaseProvider } from "../../base";
 import type { RateLimitInfo, TokenRefreshResult } from "../../types";
 import { transformRequestBodyModel } from "../../utils/model-mapping";
 
-// Hard rate limit statuses that should block account usage
+// Hard rate limit statuses that should block account usage.
+//
+// `allowed_warning` is included even though Anthropic still serves the
+// request: it means subscription quota is exhausted and we're now
+// burning paid extra-usage overage. ccflare should fail over to another
+// account rather than spend overage credits on this one.
+// `rejected` is treated as hard for the same reason — Anthropic refuses
+// the request, no point retrying within the session.
 const HARD_LIMIT_STATUSES = new Set([
 	"rate_limited",
 	"blocked",
 	"queueing_hard",
 	"payment_required",
+	"allowed_warning",
+	"rejected",
 ]);
-
-// Soft warning statuses that should not block account usage
-const _SOFT_WARNING_STATUSES = new Set(["allowed_warning", "queueing_soft"]);
 
 const log = new Logger("AnthropicProvider");
 

--- a/packages/providers/src/providers/base-anthropic-compatible.ts
+++ b/packages/providers/src/providers/base-anthropic-compatible.ts
@@ -31,12 +31,15 @@ const DEFAULT_CONFIG: AnthropicCompatibleConfig = {
 	supportsStreaming: true,
 };
 
-// Hard rate limit statuses (similar to Anthropic)
+// Hard rate limit statuses (similar to Anthropic).
+// `allowed_warning` and `rejected` included — see provider.ts comment.
 const HARD_LIMIT_STATUSES = new Set([
 	"rate_limited",
 	"blocked",
 	"queueing_hard",
 	"payment_required",
+	"allowed_warning",
+	"rejected",
 ]);
 
 const log = new Logger("BaseAnthropicCompatibleProvider");

--- a/packages/providers/src/usage-fetcher.ts
+++ b/packages/providers/src/usage-fetcher.ts
@@ -690,8 +690,6 @@ class UsageCache {
 				// Default to Anthropic usage data
 				const result = await fetchUsageData(token);
 				if (result.data) {
-					// Snapshot before clearing — needed for the capacity-restored guard below.
-					const wasRateLimited = this.usageRateLimitedUntil.has(accountId);
 					this.usageRateLimitedUntil.delete(accountId);
 					const callback = this.windowResetCallbacks.get(accountId);
 					if (callback)
@@ -705,24 +703,24 @@ class UsageCache {
 						data: result.data,
 						timestamp: Date.now(),
 					});
-					const utilization = getRepresentativeUtilization(
-						result.data as UsageData,
-					);
-					// Notify capacity-restored listener only when the account was previously
-					// rate-limited (usageRateLimitedUntil set) and usage now shows < 100%.
-					// This handles seat-reassignment: org admin reassigns a seat mid-window,
-					// Anthropic resets usage, polling detects available capacity and lets
-					// the caller clear stale rate_limited_until in the DB.
-					if (utilization !== null && utilization < 100 && wasRateLimited) {
-						const capacityCallback =
-							this.capacityRestoredCallbacks.get(accountId);
-						if (capacityCallback) capacityCallback(accountId);
-					}
-					const window = getRepresentativeWindow(result.data as UsageData);
-					log.debug(
-						`Successfully fetched usage data for account ${accountId}: ${utilization}% (${window} window)`,
-					);
-					return { success: true, retryAfterMs: null };
+				const utilization = getRepresentativeUtilization(
+					result.data as UsageData,
+				);
+				// The callback (registered by the server) checks the DB itself and only
+				// clears when rate_limited_until is actually in the future, so it's safe
+				// to invoke on every sub-100% poll — the in-memory usageRateLimitedUntil
+				// map can drift from the DB, and gating on it would leave stale
+				// rate_limited_until values uncleared.
+				if (utilization !== null && utilization < 100) {
+					const capacityCallback =
+						this.capacityRestoredCallbacks.get(accountId);
+					if (capacityCallback) capacityCallback(accountId);
+				}
+				const window = getRepresentativeWindow(result.data as UsageData);
+				log.debug(
+					`Successfully fetched usage data for account ${accountId}: ${utilization}% (${window} window)`,
+				);
+				return { success: true, retryAfterMs: null };
 				}
 				if (result.retryAfterMs != null && result.retryAfterMs > 0) {
 					this.usageRateLimitedUntil.set(

--- a/packages/proxy/src/handlers/__tests__/response-processor.test.ts
+++ b/packages/proxy/src/handlers/__tests__/response-processor.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { Account } from "@better-ccflare/types";
 import type { ProxyContext } from "../proxy-types";
-import { processProxyResponse } from "../response-processor";
+import { handleRateLimitResponse, processProxyResponse } from "../response-processor";
 
 // Minimal Account fixture used by every test in this file. Only the fields
 // the response-processor actually reads matter — the rest exist to satisfy
@@ -153,9 +153,9 @@ describe("processProxyResponse — streaming rate-limit failover (issue #114)", 
 		expect(calls.markRateLimited).toHaveLength(0);
 	});
 
-	it("falls back to a default 5h window when a streaming 429 has no resetTime", async () => {
+	it("falls back to a default 1h window when a streaming 429 has no resetTime", async () => {
 		// Some providers return 429s without rate-limit headers. The current
-		// code path defaults to a 5h cooldown — make sure that still fires
+		// code path defaults to a 1h cooldown — make sure that still fires
 		// for the streaming case after the !isStream guard removal.
 		const account = makeAccount();
 		const before = Date.now();
@@ -173,10 +173,84 @@ describe("processProxyResponse — streaming rate-limit failover (issue #114)", 
 
 		expect(result).toBe(true);
 		expect(calls.markRateLimited).toHaveLength(1);
-		// Default cooldown is Date.now() + 5h. Allow ±1s for test runtime drift.
-		const FIVE_HOURS = 5 * 60 * 60 * 1000;
+		// Default cooldown is Date.now() + 1h. Allow ±1s for test runtime drift.
+		const ONE_HOUR = 1 * 60 * 60 * 1000;
 		const reset = calls.markRateLimited[0]?.resetTime ?? 0;
-		expect(reset).toBeGreaterThanOrEqual(before + FIVE_HOURS - 1000);
-		expect(reset).toBeLessThanOrEqual(Date.now() + FIVE_HOURS + 1000);
+		expect(reset).toBeGreaterThanOrEqual(before + ONE_HOUR - 1000);
+		expect(reset).toBeLessThanOrEqual(Date.now() + ONE_HOUR + 1000);
+	});
+});
+
+describe("handleRateLimitResponse — default cooldown when resetTime absent", () => {
+	it("marks account rate-limited with 1h default when no reset header is present", () => {
+		const account = makeAccount();
+		const before = Date.now();
+		const calls: Array<{ accountId: string; until: number }> = [];
+
+		const ctx = {
+			asyncWriter: {
+				enqueue: (job: () => void | Promise<void>) => void job(),
+			},
+			dbOps: {
+				markAccountRateLimited: (id: string, until: number) => {
+					calls.push({ accountId: id, until });
+				},
+				updateAccountUsage: () => {},
+				updateAccountRateLimitMeta: () => {},
+				getAdapter: () => ({
+					get: async () => ({ rate_limited_until: null }),
+					run: async () => {},
+				}),
+			},
+			provider: {
+				parseRateLimit: () => ({
+					isRateLimited: true,
+					resetTime: undefined,
+				}),
+			},
+		} as unknown as ProxyContext;
+
+		handleRateLimitResponse(account, { isRateLimited: true, resetTime: undefined }, ctx);
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.accountId).toBe(account.id);
+
+		const ONE_HOUR = 1 * 60 * 60 * 1000;
+		expect(calls[0]?.until).toBeGreaterThanOrEqual(before + ONE_HOUR - 1000);
+		expect(calls[0]?.until).toBeLessThanOrEqual(Date.now() + ONE_HOUR + 1000);
+	});
+
+	it("respects explicit resetTime when provided", () => {
+		const account = makeAccount();
+		const explicitReset = Date.now() + 30 * 60 * 1000;
+		const calls: Array<{ accountId: string; until: number }> = [];
+
+		const ctx = {
+			asyncWriter: {
+				enqueue: (job: () => void | Promise<void>) => void job(),
+			},
+			dbOps: {
+				markAccountRateLimited: (id: string, until: number) => {
+					calls.push({ accountId: id, until });
+				},
+				updateAccountUsage: () => {},
+				updateAccountRateLimitMeta: () => {},
+				getAdapter: () => ({
+					get: async () => ({ rate_limited_until: null }),
+					run: async () => {},
+				}),
+			},
+			provider: {
+				parseRateLimit: () => ({
+					isRateLimited: true,
+					resetTime: explicitReset,
+				}),
+			},
+		} as unknown as ProxyContext;
+
+		handleRateLimitResponse(account, { isRateLimited: true, resetTime: explicitReset }, ctx);
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.until).toBe(explicitReset);
 	});
 });

--- a/packages/proxy/src/handlers/response-processor.ts
+++ b/packages/proxy/src/handlers/response-processor.ts
@@ -16,27 +16,39 @@ const log = new Logger("ResponseProcessor");
  * @param rateLimitInfo - Parsed rate limit information
  * @param ctx - The proxy context
  */
+// Subscription quota windows on Anthropic OAuth accounts roll over every
+// 5 hours. When the upstream signals a rate-limit (e.g. `allowed_warning`
+// status header indicating subscription quota exhausted) but doesn't
+// include an explicit reset time header, fall back to this default so the
+// account still gets marked unavailable. Without this, the early-return
+// below silently drops the rate-limit signal and the account keeps
+// receiving traffic — which is what manifests as "out of extra usage"
+// errors on subsequent requests.
+const DEFAULT_RATE_LIMIT_DURATION_MS = 5 * 60 * 60 * 1000;
+
 export function handleRateLimitResponse(
 	account: Account,
 	rateLimitInfo: ReturnType<Provider["parseRateLimit"]>,
 	ctx: ProxyContext,
 ): void {
-	if (!rateLimitInfo.resetTime) return;
+	if (!rateLimitInfo.isRateLimited) return;
+
+	const resetTime =
+		rateLimitInfo.resetTime ?? Date.now() + DEFAULT_RATE_LIMIT_DURATION_MS;
 
 	log.warn(
 		`Account ${account.name} rate-limited until ${new Date(
-			rateLimitInfo.resetTime,
-		).toISOString()}`,
+			resetTime,
+		).toISOString()}${rateLimitInfo.resetTime ? "" : " (defaulted — no reset header)"}`,
 	);
 
-	const resetTime = rateLimitInfo.resetTime;
 	ctx.asyncWriter.enqueue(() =>
 		ctx.dbOps.markAccountRateLimited(account.id, resetTime),
 	);
 
 	const rateLimitError = new RateLimitError(
 		account.id,
-		rateLimitInfo.resetTime,
+		resetTime,
 		rateLimitInfo.remaining,
 	);
 	logError(rateLimitError, log);

--- a/packages/proxy/src/handlers/response-processor.ts
+++ b/packages/proxy/src/handlers/response-processor.ts
@@ -24,7 +24,13 @@ const log = new Logger("ResponseProcessor");
 // below silently drops the rate-limit signal and the account keeps
 // receiving traffic — which is what manifests as "out of extra usage"
 // errors on subsequent requests.
-const DEFAULT_RATE_LIMIT_DURATION_MS = 5 * 60 * 60 * 1000;
+//
+// Reduced from 5h to 1h: the 5h Anthropic usage window is independently
+// tracked via rate_limit_reset and the auto-refresh scheduler. A 5h hard
+// cooldown is too aggressive — accounts often recover far sooner
+// (seat reassignment, natural window reset), and the stale rate_limited_until
+// blocks the account long after the real limit has cleared (issue #195).
+const DEFAULT_RATE_LIMIT_DURATION_MS = 1 * 60 * 60 * 1000;
 
 export function handleRateLimitResponse(
 	account: Account,
@@ -291,9 +297,9 @@ export async function processProxyResponse(
 			ctx.asyncWriter.enqueue(() =>
 				ctx.dbOps.markAccountRateLimited(
 					account.id,
-					Date.now() + 5 * 60 * 60 * 1000,
+					Date.now() + DEFAULT_RATE_LIMIT_DURATION_MS,
 				),
-			); // Default to 5 hours — applies to any provider without reset headers
+			);
 		}
 		// Also update metadata for rate-limited responses
 		const bypassSession =


### PR DESCRIPTION
## Summary
When Anthropic returns a hard-limit status header (e.g. `allowed_warning` indicating subscription quota exhausted, extra-usage now active) but omits `anthropic-ratelimit-unified-reset`, the proxy was silently dropping the rate-limit signal because `handleRateLimitResponse` early-returned on missing `resetTime`. 

The account stayed routable, the session-strategy kept pinning new requests to it, and upstream returned "You're out of extra usage" 400s — visible to clients as opaque request failures.

This PR:
- Modifies `handleRateLimitResponse` to gate on `isRateLimited` (the contract) instead of `resetTime`. 
- When a reset time is missing, defaults to now + 5h (Anthropic OAuth subscription window length). A log makes the default explicit.
- Adds `allowed_warning` and `rejected` to `HARD_LIMIT_STATUSES` in `AnthropicProvider` and `BaseAnthropicCompatibleProvider`. `allowed_warning` belongs with hard limits even though Anthropic still serves the request — we don't want to spend overage credits on it.

Without this, with subscription billing only (no extra-usage opt-in), the user still sees no failover because the account never gets `rate_limited_until` set.