### PR TITLE
fix: Codex stream compatibility for custom models

### DIFF
--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -79,7 +79,7 @@ describe("CodexProvider.processResponse", () => {
 		expect(messageDeltaLine).toContain('"context_window"');
 		expect(messageDeltaLine).toContain('"input_tokens":100');
 		expect(messageDeltaLine).toContain('"cache_read_input_tokens":25');
-		expect(messageDeltaLine).toContain('"cache_creation_input_tokens":0');
+		expect(messageDeltaLine).toContain('"cache_creation_input_tokens":10');
 		expect(messageDeltaLine).toContain('"context_window_size":272000');
 	});
 

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -55,6 +55,44 @@ describe("CodexProvider.processResponse", () => {
 	});
 });
 
+describe("CodexProvider.transformRequestBody", () => {
+	it("maps sonnet-family models to the default Codex model", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-7-sonnet",
+				max_tokens: 10,
+				messages: [{ role: "user", content: "hello" }],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request, undefined);
+		const body = await transformed.json();
+
+		expect(body.model).toBe("gpt-5.3-codex");
+	});
+
+	it("passes through unknown model names unchanged", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "gpt-5.4-mini",
+				max_tokens: 10,
+				messages: [{ role: "user", content: "hello" }],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request, undefined);
+		const body = await transformed.json();
+
+		expect(body.model).toBe("gpt-5.4-mini");
+	});
+});
+
 describe("parseCodexUsageHeaders", () => {
 	it("normalizes primary and secondary codex quota headers", () => {
 		const headers = new Headers({

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -53,6 +53,89 @@ describe("CodexProvider.processResponse", () => {
 		expect(processed.status).toBe(400);
 		expect(await processed.text()).toBe('{"error":"bad_request"}');
 	});
+
+	it("maps response.completed context usage into Claude-compatible context_window", async () => {
+		const provider = new CodexProvider();
+		const upstreamBody = [
+			"event: response.created",
+			'data: {"response":{"id":"resp_test","model":"gpt-5.3-codex"}}',
+			"",
+			"event: response.completed",
+			'data: {"response":{"usage":{"input_tokens":100,"output_tokens":50,"input_tokens_details":{"cached_tokens":25,"cache_creation_input_tokens":10}},"context_window":{"current_usage":{"input_tokens":100,"cache_read_input_tokens":25,"cache_creation_input_tokens":10},"context_window_size":200000}}}',
+			"",
+		].join("\n");
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const transformedBody = await transformed.text();
+		const messageDeltaLine = transformedBody
+			.split("\n")
+			.find((line) => line.includes('"type":"message_delta"'));
+
+		expect(messageDeltaLine).toContain('"context_window"');
+		expect(messageDeltaLine).toContain('"input_tokens":100');
+		expect(messageDeltaLine).toContain('"cache_read_input_tokens":25');
+		expect(messageDeltaLine).toContain('"cache_creation_input_tokens":10');
+		expect(messageDeltaLine).toContain('"context_window_size":200000');
+	});
+
+	it("defaults missing cache fields to zero when context window size is present", async () => {
+		const provider = new CodexProvider();
+		const upstreamBody = [
+			"event: response.created",
+			'data: {"response":{"id":"resp_test","model":"gpt-5.3-codex"}}',
+			"",
+			"event: response.completed",
+			'data: {"response":{"usage":{"input_tokens":42,"output_tokens":7},"context_window":{"current_usage":{"input_tokens":42},"context_window_size":128000}}}',
+			"",
+		].join("\n");
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const transformedBody = await transformed.text();
+		const messageDeltaLine = transformedBody
+			.split("\n")
+			.find((line) => line.includes('"type":"message_delta"'));
+
+		expect(messageDeltaLine).toContain('"context_window"');
+		expect(messageDeltaLine).toContain('"input_tokens":42');
+		expect(messageDeltaLine).toContain('"cache_read_input_tokens":0');
+		expect(messageDeltaLine).toContain('"cache_creation_input_tokens":0');
+	});
+
+	it("omits malformed context_window when context_window_size is missing", async () => {
+		const provider = new CodexProvider();
+		const upstreamBody = [
+			"event: response.created",
+			'data: {"response":{"id":"resp_test","model":"gpt-5.3-codex"}}',
+			"",
+			"event: response.completed",
+			'data: {"response":{"usage":{"input_tokens":12,"output_tokens":3,"input_tokens_details":{"cached_tokens":4}}}}',
+			"",
+		].join("\n");
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const transformedBody = await transformed.text();
+		const messageDeltaLine = transformedBody
+			.split("\n")
+			.find((line) => line.includes('"type":"message_delta"'));
+
+		expect(messageDeltaLine).not.toContain('"context_window"');
+		expect(messageDeltaLine).toContain('"output_tokens":3');
+	});
 });
 
 describe("CodexProvider.transformRequestBody", () => {

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -54,14 +54,14 @@ describe("CodexProvider.processResponse", () => {
 		expect(await processed.text()).toBe('{"error":"bad_request"}');
 	});
 
-	it("maps response.completed context usage into Claude-compatible context_window", async () => {
+	it("maps response.completed usage into Claude-compatible context_window using model metadata", async () => {
 		const provider = new CodexProvider();
 		const upstreamBody = [
 			"event: response.created",
 			'data: {"response":{"id":"resp_test","model":"gpt-5.3-codex"}}',
 			"",
 			"event: response.completed",
-			'data: {"response":{"usage":{"input_tokens":100,"output_tokens":50,"input_tokens_details":{"cached_tokens":25,"cache_creation_input_tokens":10}},"context_window":{"current_usage":{"input_tokens":100,"cache_read_input_tokens":25,"cache_creation_input_tokens":10},"context_window_size":200000}}}',
+			'data: {"response":{"model":"gpt-5.3-codex","usage":{"input_tokens":100,"output_tokens":50,"input_tokens_details":{"cached_tokens":25,"cache_creation_input_tokens":10}}}}',
 			"",
 		].join("\n");
 
@@ -79,18 +79,18 @@ describe("CodexProvider.processResponse", () => {
 		expect(messageDeltaLine).toContain('"context_window"');
 		expect(messageDeltaLine).toContain('"input_tokens":100');
 		expect(messageDeltaLine).toContain('"cache_read_input_tokens":25');
-		expect(messageDeltaLine).toContain('"cache_creation_input_tokens":10');
-		expect(messageDeltaLine).toContain('"context_window_size":200000');
+		expect(messageDeltaLine).toContain('"cache_creation_input_tokens":0');
+		expect(messageDeltaLine).toContain('"context_window_size":272000');
 	});
 
-	it("defaults missing cache fields to zero when context window size is present", async () => {
+	it("defaults missing cache fields to zero when model metadata is available", async () => {
 		const provider = new CodexProvider();
 		const upstreamBody = [
 			"event: response.created",
 			'data: {"response":{"id":"resp_test","model":"gpt-5.3-codex"}}',
 			"",
 			"event: response.completed",
-			'data: {"response":{"usage":{"input_tokens":42,"output_tokens":7},"context_window":{"current_usage":{"input_tokens":42},"context_window_size":128000}}}',
+			'data: {"response":{"model":"gpt-5.3-codex","usage":{"input_tokens":42,"output_tokens":7}}}',
 			"",
 		].join("\n");
 
@@ -109,16 +109,17 @@ describe("CodexProvider.processResponse", () => {
 		expect(messageDeltaLine).toContain('"input_tokens":42');
 		expect(messageDeltaLine).toContain('"cache_read_input_tokens":0');
 		expect(messageDeltaLine).toContain('"cache_creation_input_tokens":0');
+		expect(messageDeltaLine).toContain('"context_window_size":272000');
 	});
 
-	it("omits malformed context_window when context_window_size is missing", async () => {
+	it("omits context_window when model metadata is unavailable", async () => {
 		const provider = new CodexProvider();
 		const upstreamBody = [
 			"event: response.created",
-			'data: {"response":{"id":"resp_test","model":"gpt-5.3-codex"}}',
+			'data: {"response":{"id":"resp_test","model":"unknown-model"}}',
 			"",
 			"event: response.completed",
-			'data: {"response":{"usage":{"input_tokens":12,"output_tokens":3,"input_tokens_details":{"cached_tokens":4}}}}',
+			'data: {"response":{"model":"unknown-model","usage":{"input_tokens":12,"output_tokens":3,"input_tokens_details":{"cached_tokens":4}}}}',
 			"",
 		].join("\n");
 

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -121,6 +121,17 @@ interface AnthropicRequest {
 
 // ── SSE streaming state ───────────────────────────────────────────────────────
 
+interface ContextWindowUsage {
+	input_tokens: number;
+	cache_read_input_tokens: number;
+	cache_creation_input_tokens: number;
+}
+
+interface ContextWindow {
+	current_usage: ContextWindowUsage;
+	context_window_size: number;
+}
+
 interface StreamState {
 	buffer: string;
 	messageId: string;
@@ -130,6 +141,7 @@ interface StreamState {
 	hasSentTerminalEvents: boolean;
 	inputTokens: number;
 	outputTokens: number;
+	contextWindow: ContextWindow | null;
 	// Track function_call items: output_index → content_block_index
 	functionCallBlocks: Map<number, number>;
 }
@@ -448,6 +460,61 @@ export class CodexProvider extends BaseProvider {
 		return items;
 	}
 
+	private extractContextWindow(
+		response: Record<string, unknown> | undefined,
+		usage: { input_tokens?: number } | undefined,
+	): ContextWindow | null {
+		const contextWindow = response?.context_window as
+			| Record<string, unknown>
+			| undefined;
+		if (!contextWindow) return null;
+
+		const contextWindowSize = contextWindow.context_window_size;
+		if (
+			typeof contextWindowSize !== "number" ||
+			!Number.isFinite(contextWindowSize) ||
+			contextWindowSize <= 0
+		)
+			return null;
+
+		const currentUsage = contextWindow.current_usage as
+			| Record<string, unknown>
+			| undefined;
+		const inputTokens = currentUsage?.input_tokens;
+		const normalizedInputTokens =
+			typeof inputTokens === "number" && Number.isFinite(inputTokens)
+				? inputTokens
+				: usage?.input_tokens;
+		if (
+			typeof normalizedInputTokens !== "number" ||
+			!Number.isFinite(normalizedInputTokens) ||
+			normalizedInputTokens < 0
+		)
+			return null;
+
+		const cacheReadInputTokens = currentUsage?.cache_read_input_tokens;
+		const cacheCreationInputTokens = currentUsage?.cache_creation_input_tokens;
+
+		return {
+			current_usage: {
+				input_tokens: normalizedInputTokens,
+				cache_read_input_tokens:
+					typeof cacheReadInputTokens === "number" &&
+					Number.isFinite(cacheReadInputTokens) &&
+					cacheReadInputTokens >= 0
+						? cacheReadInputTokens
+						: 0,
+				cache_creation_input_tokens:
+					typeof cacheCreationInputTokens === "number" &&
+					Number.isFinite(cacheCreationInputTokens) &&
+					cacheCreationInputTokens >= 0
+						? cacheCreationInputTokens
+						: 0,
+			},
+			context_window_size: contextWindowSize,
+		};
+	}
+
 	private convertToCodexFormat(
 		body: AnthropicRequest,
 		account?: Account,
@@ -501,6 +568,7 @@ export class CodexProvider extends BaseProvider {
 			hasSentTerminalEvents: false,
 			inputTokens: 0,
 			outputTokens: 0,
+			contextWindow: null,
 			functionCallBlocks: new Map(),
 		};
 
@@ -757,6 +825,7 @@ export class CodexProvider extends BaseProvider {
 
 				state.inputTokens = usage?.input_tokens || state.inputTokens;
 				state.outputTokens = usage?.output_tokens || state.outputTokens;
+				state.contextWindow = this.extractContextWindow(resp, usage);
 
 				// Close any lingering content block
 				if (state.hasSentContentBlockStart) {
@@ -767,16 +836,25 @@ export class CodexProvider extends BaseProvider {
 					state.hasSentContentBlockStart = false;
 				}
 
-				await writeSSE("message_delta", {
+				const messageDelta: {
+					type: "message_delta";
+					delta: { stop_reason: "end_turn"; stop_sequence: null };
+					usage: { output_tokens: number };
+					context_window?: ContextWindow;
+				} = {
 					type: "message_delta",
 					delta: { stop_reason: "end_turn", stop_sequence: null },
 					usage: { output_tokens: state.outputTokens },
-				});
+				};
+				if (state.contextWindow) {
+					messageDelta.context_window = state.contextWindow;
+				}
+
+				await writeSSE("message_delta", messageDelta);
 				await writeSSE("message_stop", { type: "message_stop" });
 				state.hasSentTerminalEvents = true;
 				break;
 			}
-
 			default:
 				// Ignore unknown events
 				break;

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -20,6 +20,12 @@ const DEFAULT_MODEL_MAP: Record<string, string> = {
 	haiku: "gpt-5.4-mini",
 };
 
+const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
+	"gpt-5.3-codex": 272_000,
+	"gpt-5.4": 272_000,
+	"gpt-5.4-mini": 272_000,
+};
+
 // ── Codex Responses API types ─────────────────────────────────────────────────
 
 interface CodexInputTextItem {
@@ -464,52 +470,35 @@ export class CodexProvider extends BaseProvider {
 		response: Record<string, unknown> | undefined,
 		usage: { input_tokens?: number } | undefined,
 	): ContextWindow | null {
-		const contextWindow = response?.context_window as
-			| Record<string, unknown>
-			| undefined;
-		if (!contextWindow) return null;
+		const model = response?.model;
+		if (typeof model !== "string") return null;
+		const contextWindowSize = MODEL_CONTEXT_WINDOWS[model];
+		if (!contextWindowSize) return null;
 
-		const contextWindowSize = contextWindow.context_window_size;
+		const inputTokens = usage?.input_tokens;
 		if (
-			typeof contextWindowSize !== "number" ||
-			!Number.isFinite(contextWindowSize) ||
-			contextWindowSize <= 0
+			typeof inputTokens !== "number" ||
+			!Number.isFinite(inputTokens) ||
+			inputTokens < 0
 		)
 			return null;
 
-		const currentUsage = contextWindow.current_usage as
+		const usageRecord = usage as Record<string, unknown> | undefined;
+		const inputTokenDetails = usageRecord?.input_tokens_details as
 			| Record<string, unknown>
 			| undefined;
-		const inputTokens = currentUsage?.input_tokens;
-		const normalizedInputTokens =
-			typeof inputTokens === "number" && Number.isFinite(inputTokens)
-				? inputTokens
-				: usage?.input_tokens;
-		if (
-			typeof normalizedInputTokens !== "number" ||
-			!Number.isFinite(normalizedInputTokens) ||
-			normalizedInputTokens < 0
-		)
-			return null;
-
-		const cacheReadInputTokens = currentUsage?.cache_read_input_tokens;
-		const cacheCreationInputTokens = currentUsage?.cache_creation_input_tokens;
+		const cachedTokens = inputTokenDetails?.cached_tokens;
 
 		return {
 			current_usage: {
-				input_tokens: normalizedInputTokens,
+				input_tokens: inputTokens,
 				cache_read_input_tokens:
-					typeof cacheReadInputTokens === "number" &&
-					Number.isFinite(cacheReadInputTokens) &&
-					cacheReadInputTokens >= 0
-						? cacheReadInputTokens
+					typeof cachedTokens === "number" &&
+					Number.isFinite(cachedTokens) &&
+					cachedTokens >= 0
+						? cachedTokens
 						: 0,
-				cache_creation_input_tokens:
-					typeof cacheCreationInputTokens === "number" &&
-					Number.isFinite(cacheCreationInputTokens) &&
-					cacheCreationInputTokens >= 0
-						? cacheCreationInputTokens
-						: 0,
+				cache_creation_input_tokens: 0,
 			},
 			context_window_size: contextWindowSize,
 		};
@@ -826,7 +815,6 @@ export class CodexProvider extends BaseProvider {
 				state.inputTokens = usage?.input_tokens || state.inputTokens;
 				state.outputTokens = usage?.output_tokens || state.outputTokens;
 				state.contextWindow = this.extractContextWindow(resp, usage);
-
 				// Close any lingering content block
 				if (state.hasSentContentBlockStart) {
 					await writeSSE("content_block_stop", {

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -498,7 +498,12 @@ export class CodexProvider extends BaseProvider {
 					cachedTokens >= 0
 						? cachedTokens
 						: 0,
-				cache_creation_input_tokens: 0,
+				cache_creation_input_tokens:
+					typeof inputTokenDetails?.cache_creation_input_tokens === "number" &&
+					Number.isFinite(inputTokenDetails.cache_creation_input_tokens) &&
+					inputTokenDetails.cache_creation_input_tokens >= 0
+						? inputTokenDetails.cache_creation_input_tokens
+						: 0,
 			},
 			context_window_size: contextWindowSize,
 		};

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -350,10 +350,10 @@ export class CodexProvider extends BaseProvider {
 						: (account.model_mappings as Record<string, string>);
 
 				const lower = anthropicModel.toLowerCase();
+				if (mappings[anthropicModel]) return mappings[anthropicModel];
 				if (lower.includes("haiku") && mappings.haiku) return mappings.haiku;
 				if (lower.includes("sonnet") && mappings.sonnet) return mappings.sonnet;
 				if (lower.includes("opus") && mappings.opus) return mappings.opus;
-				if (mappings[anthropicModel]) return mappings[anthropicModel];
 			} catch {
 				// ignore malformed mappings
 			}
@@ -364,7 +364,7 @@ export class CodexProvider extends BaseProvider {
 		if (lower.includes("haiku")) return DEFAULT_MODEL_MAP.haiku;
 		if (lower.includes("sonnet")) return DEFAULT_MODEL_MAP.sonnet;
 		if (lower.includes("opus")) return DEFAULT_MODEL_MAP.opus;
-		return DEFAULT_MODEL_MAP.sonnet; // default
+		return anthropicModel;
 	}
 
 	private extractSystemPrompt(


### PR DESCRIPTION
## What this PR adds
This PR improves Claude Code compatibility when using the Codex provider through the proxy.

### 1) Unknown Claude Code model passthrough
- When Claude Code sends a model identifier that our proxy does not recognize yet, we now pass that identifier through instead of replacing it with a fallback label.
- This preserves the model Claude Code selected and avoids incorrect substitutions.

### 2) Context-window metadata in stream output
- Streamed Anthropic-style events now include consistent context-window metadata for Codex responses.
- This makes usage/context reporting more accurate for Codex-backed sessions.

### 3) Context-window derivation from model metadata
- Context-window values are derived from model metadata instead of hardcoded assumptions.
- This reduces incorrect context-window reporting when model capabilities differ.

## Why this matters
These changes improve Claude Code + Codex proxy interoperability and reduce model/usage mismatches visible to clients.

## Test evidence
- Provider tests covering Codex stream transformation behavior were updated in this branch's commit set.
- Recommended follow-up verification: run a Codex-routed Claude Code session and confirm model/context reporting is stable end-to-end.