### PR TITLE
bugfix: effort-level compatibility and count_tokens support

### DIFF
--- a/packages/openai-formats/src/__tests__/converters.test.ts
+++ b/packages/openai-formats/src/__tests__/converters.test.ts
@@ -120,6 +120,18 @@ describe("convertAnthropicRequestToOpenAI — basic fields", () => {
 		expect(result.stream).toBe(false);
 		expect(result.stream_options).toBeUndefined();
 	});
+
+	it("passes through reasoning effort when provided", () => {
+		const result = convertAnthropicRequestToOpenAI(
+			anthropicRequest({ reasoning: { effort: "high" } }),
+		);
+		expect(result.reasoning).toEqual({ effort: "high" });
+	});
+
+	it("does not include reasoning when effort is absent", () => {
+		const result = convertAnthropicRequestToOpenAI(anthropicRequest());
+		expect(result.reasoning).toBeUndefined();
+	});
 });
 
 describe("convertAnthropicRequestToOpenAI — system message", () => {

--- a/packages/openai-formats/src/__tests__/converters.test.ts
+++ b/packages/openai-formats/src/__tests__/converters.test.ts
@@ -138,24 +138,25 @@ describe("convertAnthropicRequestToOpenAI — basic fields", () => {
 			convertAnthropicRequestToOpenAI(
 				anthropicRequest({ reasoning: { effort: "extreme" } }),
 			),
-		).toThrow("reasoning.effort must be one of: low, medium, high");
+		).toThrow(
+			"reasoning.effort must be one of: minimal, low, medium, high, xhigh, max",
+		);
 	});
 
-	it("rejects efforts unsupported by the mapped target model", () => {
-		expect(() =>
-			convertAnthropicRequestToOpenAI(
-				anthropicRequest({
-					model: "claude-sonnet-4-6",
-					reasoning: { effort: "high" },
+	it("downgrades efforts unsupported by the mapped target model", () => {
+		const result = convertAnthropicRequestToOpenAI(
+			anthropicRequest({
+				model: "claude-sonnet-4-6",
+				reasoning: { effort: "xhigh" },
+			}),
+			{
+				name: "test",
+				model_mappings: JSON.stringify({
+					sonnet: "gpt-5.4-mini",
 				}),
-				{
-					name: "test",
-					model_mappings: JSON.stringify({
-						sonnet: "gpt-5.4-mini",
-					}),
-				} as any,
-			),
-		).toThrow("reasoning.effort 'high' is not supported for model gpt-5.4-mini");
+			} as any,
+		);
+		expect(result.reasoning).toEqual({ effort: "medium" });
 	});
 });
 

--- a/packages/openai-formats/src/__tests__/converters.test.ts
+++ b/packages/openai-formats/src/__tests__/converters.test.ts
@@ -132,6 +132,31 @@ describe("convertAnthropicRequestToOpenAI — basic fields", () => {
 		const result = convertAnthropicRequestToOpenAI(anthropicRequest());
 		expect(result.reasoning).toBeUndefined();
 	});
+
+	it("rejects unsupported reasoning effort values", () => {
+		expect(() =>
+			convertAnthropicRequestToOpenAI(
+				anthropicRequest({ reasoning: { effort: "extreme" } }),
+			),
+		).toThrow("reasoning.effort must be one of: low, medium, high");
+	});
+
+	it("rejects efforts unsupported by the mapped target model", () => {
+		expect(() =>
+			convertAnthropicRequestToOpenAI(
+				anthropicRequest({
+					model: "claude-sonnet-4-6",
+					reasoning: { effort: "high" },
+				}),
+				{
+					name: "test",
+					model_mappings: JSON.stringify({
+						sonnet: "gpt-5.4-mini",
+					}),
+				} as any,
+			),
+		).toThrow("reasoning.effort 'high' is not supported for model gpt-5.4-mini");
+	});
 });
 
 describe("convertAnthropicRequestToOpenAI — system message", () => {

--- a/packages/openai-formats/src/converters.ts
+++ b/packages/openai-formats/src/converters.ts
@@ -64,6 +64,9 @@ export function convertAnthropicRequestToOpenAI(
 			openaiRequest.stream_options = { include_usage: true };
 		}
 	}
+	if (anthropicData.reasoning?.effort !== undefined) {
+		openaiRequest.reasoning = { effort: anthropicData.reasoning.effort };
+	}
 
 	// Convert tools (only if non-empty — Qwen/DashScope rejects empty tools array)
 	if (

--- a/packages/openai-formats/src/converters.ts
+++ b/packages/openai-formats/src/converters.ts
@@ -13,6 +13,7 @@ import type {
 	OpenAIResponse,
 } from "./types";
 import { mapOpenAIFinishReason, removeUriFormat } from "./utils";
+import { validateReasoningEffort } from "./reasoning";
 
 const log = new Logger("openai-formats/converters");
 
@@ -64,8 +65,12 @@ export function convertAnthropicRequestToOpenAI(
 			openaiRequest.stream_options = { include_usage: true };
 		}
 	}
-	if (anthropicData.reasoning?.effort !== undefined) {
-		openaiRequest.reasoning = { effort: anthropicData.reasoning.effort };
+	const reasoningEffort = validateReasoningEffort(anthropicData.reasoning?.effort, {
+		sourceModel: anthropicData.model,
+		targetModel: mappedModel,
+	});
+	if (reasoningEffort !== undefined) {
+		openaiRequest.reasoning = { effort: reasoningEffort };
 	}
 
 	// Convert tools (only if non-empty — Qwen/DashScope rejects empty tools array)

--- a/packages/openai-formats/src/converters.ts
+++ b/packages/openai-formats/src/converters.ts
@@ -1,6 +1,7 @@
 import { mapModelName } from "@better-ccflare/core";
 import { Logger } from "@better-ccflare/logger";
 import type { Account } from "@better-ccflare/types";
+import { resolveReasoningEffort } from "./reasoning";
 import type {
 	AnthropicContentBlock,
 	AnthropicRequest,
@@ -13,7 +14,6 @@ import type {
 	OpenAIResponse,
 } from "./types";
 import { mapOpenAIFinishReason, removeUriFormat } from "./utils";
-import { validateReasoningEffort } from "./reasoning";
 
 const log = new Logger("openai-formats/converters");
 
@@ -65,12 +65,22 @@ export function convertAnthropicRequestToOpenAI(
 			openaiRequest.stream_options = { include_usage: true };
 		}
 	}
-	const reasoningEffort = validateReasoningEffort(anthropicData.reasoning?.effort, {
-		sourceModel: anthropicData.model,
-		targetModel: mappedModel,
-	});
-	if (reasoningEffort !== undefined) {
-		openaiRequest.reasoning = { effort: reasoningEffort };
+	const reasoningResolution = resolveReasoningEffort(
+		anthropicData.reasoning?.effort,
+		{
+			sourceModel: anthropicData.model,
+			targetModel: mappedModel,
+		},
+	);
+	if (reasoningResolution.downgrades.length > 0) {
+		for (const downgrade of reasoningResolution.downgrades) {
+			log.warn(
+				`Downgraded reasoning effort for model ${downgrade.model}: ${downgrade.from} -> ${downgrade.to}`,
+			);
+		}
+	}
+	if (reasoningResolution.effort !== undefined) {
+		openaiRequest.reasoning = { effort: reasoningResolution.effort };
 	}
 
 	// Convert tools (only if non-empty — Qwen/DashScope rejects empty tools array)

--- a/packages/openai-formats/src/index.ts
+++ b/packages/openai-formats/src/index.ts
@@ -1,5 +1,5 @@
 export * from "./converters";
+export * from "./reasoning";
 export * from "./stream";
 export * from "./types";
 export * from "./utils";
-export * from "./reasoning";

--- a/packages/openai-formats/src/index.ts
+++ b/packages/openai-formats/src/index.ts
@@ -2,3 +2,4 @@ export * from "./converters";
 export * from "./stream";
 export * from "./types";
 export * from "./utils";
+export * from "./reasoning";

--- a/packages/openai-formats/src/reasoning.test.ts
+++ b/packages/openai-formats/src/reasoning.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it } from "bun:test";
 import {
 	getSupportedReasoningEfforts,
+	resolveReasoningEffort,
 	validateReasoningEffort,
 } from "./reasoning";
 
@@ -16,15 +17,19 @@ describe("reasoning effort support", () => {
 			"low",
 			"medium",
 			"high",
+			"xhigh",
+			"max",
 		]);
 		expect(getSupportedReasoningEfforts("claude-haiku-4-5")).toEqual([
 			"low",
 			"medium",
 		]);
 		expect(getSupportedReasoningEfforts("gpt-5.3-codex")).toEqual([
+			"minimal",
 			"low",
 			"medium",
 			"high",
+			"xhigh",
 		]);
 		expect(getSupportedReasoningEfforts("gpt-5.4-mini")).toEqual([
 			"low",
@@ -34,11 +39,26 @@ describe("reasoning effort support", () => {
 
 	it("accepts valid reasoning effort for supported Claude and Codex models", () => {
 		expect(
-			validateReasoningEffort("high", {
+			validateReasoningEffort("xhigh", {
 				sourceModel: "claude-sonnet-4-6",
 				targetModel: "gpt-5.3-codex",
 			}),
-		).toBe("high");
+		).toBe("xhigh");
+	});
+
+	it("downgrades unsupported effort to nearest lower supported level", () => {
+		const resolved = resolveReasoningEffort("xhigh", {
+			sourceModel: "claude-sonnet-4-6",
+			targetModel: "gpt-5.4-mini",
+		});
+		expect(resolved.effort).toBe("medium");
+		expect(resolved.downgrades).toEqual([
+			{
+				model: "gpt-5.4-mini",
+				from: "xhigh",
+				to: "medium",
+			},
+		]);
 	});
 
 	it("rejects unsupported reasoning effort values", () => {
@@ -47,15 +67,17 @@ describe("reasoning effort support", () => {
 				sourceModel: "claude-sonnet-4-6",
 				targetModel: "gpt-5.3-codex",
 			}),
-		).toThrow("reasoning.effort must be one of: low, medium, high");
+		).toThrow(
+			"reasoning.effort must be one of: minimal, low, medium, high, xhigh, max",
+		);
 	});
 
-	it("rejects reasoning effort unsupported by the selected target model", () => {
+	it("rejects reasoning effort unsupported by unknown model", () => {
 		expect(() =>
 			validateReasoningEffort("high", {
 				sourceModel: "claude-sonnet-4-6",
-				targetModel: "gpt-5.4-mini",
+				targetModel: "unknown-model",
 			}),
-		).toThrow("reasoning.effort 'high' is not supported for model gpt-5.4-mini");
+		).toThrow("reasoning.effort is not supported for model unknown-model");
 	});
 });

--- a/packages/openai-formats/src/reasoning.test.ts
+++ b/packages/openai-formats/src/reasoning.test.ts
@@ -72,12 +72,12 @@ describe("reasoning effort support", () => {
 		);
 	});
 
-	it("rejects reasoning effort unsupported by unknown model", () => {
-		expect(() =>
+	it("passes through effort when target model is unknown", () => {
+		expect(
 			validateReasoningEffort("high", {
 				sourceModel: "claude-sonnet-4-6",
 				targetModel: "unknown-model",
 			}),
-		).toThrow("reasoning.effort is not supported for model unknown-model");
+		).toBe("high");
 	});
 });

--- a/packages/openai-formats/src/reasoning.test.ts
+++ b/packages/openai-formats/src/reasoning.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Gili Tzabari. All rights reserved.
+ *
+ * Licensed under the CAT Commercial License.
+ * See LICENSE.md in the project root for license terms.
+ */
+import { describe, expect, it } from "bun:test";
+import {
+	getSupportedReasoningEfforts,
+	validateReasoningEffort,
+} from "./reasoning";
+
+describe("reasoning effort support", () => {
+	it("exposes supported Claude and Codex effort matrices", () => {
+		expect(getSupportedReasoningEfforts("claude-sonnet-4-6")).toEqual([
+			"low",
+			"medium",
+			"high",
+		]);
+		expect(getSupportedReasoningEfforts("claude-haiku-4-5")).toEqual([
+			"low",
+			"medium",
+		]);
+		expect(getSupportedReasoningEfforts("gpt-5.3-codex")).toEqual([
+			"low",
+			"medium",
+			"high",
+		]);
+		expect(getSupportedReasoningEfforts("gpt-5.4-mini")).toEqual([
+			"low",
+			"medium",
+		]);
+	});
+
+	it("accepts valid reasoning effort for supported Claude and Codex models", () => {
+		expect(
+			validateReasoningEffort("high", {
+				sourceModel: "claude-sonnet-4-6",
+				targetModel: "gpt-5.3-codex",
+			}),
+		).toBe("high");
+	});
+
+	it("rejects unsupported reasoning effort values", () => {
+		expect(() =>
+			validateReasoningEffort("extreme", {
+				sourceModel: "claude-sonnet-4-6",
+				targetModel: "gpt-5.3-codex",
+			}),
+		).toThrow("reasoning.effort must be one of: low, medium, high");
+	});
+
+	it("rejects reasoning effort unsupported by the selected target model", () => {
+		expect(() =>
+			validateReasoningEffort("high", {
+				sourceModel: "claude-sonnet-4-6",
+				targetModel: "gpt-5.4-mini",
+			}),
+		).toThrow("reasoning.effort 'high' is not supported for model gpt-5.4-mini");
+	});
+});

--- a/packages/openai-formats/src/reasoning.ts
+++ b/packages/openai-formats/src/reasoning.ts
@@ -40,12 +40,8 @@ const TARGET_REASONING_EFFORTS: Record<string, readonly ReasoningEffort[]> = {
 	"gpt-5.4-mini": ["low", "medium"],
 };
 
-function normalizeModelName(model: string): string {
-	return model.toLowerCase().trim();
-}
-
 function normalizeTargetModelName(model: string): string {
-	return normalizeModelName(model).replace(/^.*\//, "");
+	return model.toLowerCase().trim().replace(/^.*\//, "");
 }
 
 export function getSupportedReasoningEfforts(

--- a/packages/openai-formats/src/reasoning.ts
+++ b/packages/openai-formats/src/reasoning.ts
@@ -4,20 +4,39 @@
  * Licensed under the CAT Commercial License.
  * See LICENSE.md in the project root for license terms.
  */
-import { ValidationError, getModelFamily } from "@better-ccflare/core";
+import { getModelFamily, ValidationError } from "@better-ccflare/core";
 
-export const REASONING_EFFORT_VALUES = ["low", "medium", "high"] as const;
+export const REASONING_EFFORT_VALUES = [
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+] as const;
 export type ReasoningEffort = (typeof REASONING_EFFORT_VALUES)[number];
 
-const CLAUDE_REASONING_EFFORTS: Record<"opus" | "sonnet" | "haiku", readonly ReasoningEffort[]> = {
-	opus: ["low", "medium", "high"],
-	sonnet: ["low", "medium", "high"],
+const EFFORT_RANK: Record<ReasoningEffort, number> = {
+	minimal: 0,
+	low: 1,
+	medium: 2,
+	high: 3,
+	xhigh: 4,
+	max: 5,
+};
+
+const CLAUDE_REASONING_EFFORTS: Record<
+	"opus" | "sonnet" | "haiku",
+	readonly ReasoningEffort[]
+> = {
+	opus: ["low", "medium", "high", "xhigh", "max"],
+	sonnet: ["low", "medium", "high", "xhigh", "max"],
 	haiku: ["low", "medium"],
 };
 
 const TARGET_REASONING_EFFORTS: Record<string, readonly ReasoningEffort[]> = {
-	"gpt-5": ["low", "medium", "high"],
-	"gpt-5.3-codex": ["low", "medium", "high"],
+	"gpt-5": ["minimal", "low", "medium", "high", "xhigh"],
+	"gpt-5.3-codex": ["minimal", "low", "medium", "high", "xhigh"],
 	"gpt-5.4-mini": ["low", "medium"],
 };
 
@@ -49,12 +68,21 @@ export function getSupportedReasoningEfforts(
 	return null;
 }
 
-export function validateReasoningEffort(
+export interface ReasoningEffortResolution {
+	effort: ReasoningEffort | undefined;
+	downgrades: Array<{
+		model: string;
+		from: ReasoningEffort;
+		to: ReasoningEffort;
+	}>;
+}
+
+export function resolveReasoningEffort(
 	effort: unknown,
 	models: { sourceModel?: string; targetModel?: string },
-): ReasoningEffort | undefined {
+): ReasoningEffortResolution {
 	if (effort === undefined) {
-		return undefined;
+		return { effort: undefined, downgrades: [] };
 	}
 
 	if (
@@ -68,6 +96,13 @@ export function validateReasoningEffort(
 		);
 	}
 
+	let resolvedEffort = effort as ReasoningEffort;
+	const downgrades: Array<{
+		model: string;
+		from: ReasoningEffort;
+		to: ReasoningEffort;
+	}> = [];
+
 	const supportedModels = [models.sourceModel, models.targetModel].filter(
 		(model): model is string => typeof model === "string" && model.length > 0,
 	);
@@ -78,18 +113,41 @@ export function validateReasoningEffort(
 			throw new ValidationError(
 				`reasoning.effort is not supported for model ${model}`,
 				"reasoning.effort",
-				effort,
+				resolvedEffort,
 			);
 		}
 
-		if (!supportedEfforts.includes(effort as ReasoningEffort)) {
+		if (supportedEfforts.includes(resolvedEffort)) {
+			continue;
+		}
+
+		const requestedRank = EFFORT_RANK[resolvedEffort];
+		const nearestLower = [...supportedEfforts]
+			.filter((candidate) => EFFORT_RANK[candidate] <= requestedRank)
+			.sort((a, b) => EFFORT_RANK[b] - EFFORT_RANK[a])[0];
+
+		if (!nearestLower) {
 			throw new ValidationError(
-				`reasoning.effort '${effort}' is not supported for model ${model}; allowed values: ${supportedEfforts.join(", ")}`,
+				`reasoning.effort '${resolvedEffort}' is not supported for model ${model}; allowed values: ${supportedEfforts.join(", ")}`,
 				"reasoning.effort",
-				effort,
+				resolvedEffort,
 			);
 		}
+
+		downgrades.push({
+			model,
+			from: resolvedEffort,
+			to: nearestLower,
+		});
+		resolvedEffort = nearestLower;
 	}
 
-	return effort as ReasoningEffort;
+	return { effort: resolvedEffort, downgrades };
+}
+
+export function validateReasoningEffort(
+	effort: unknown,
+	models: { sourceModel?: string; targetModel?: string },
+): ReasoningEffort | undefined {
+	return resolveReasoningEffort(effort, models).effort;
 }

--- a/packages/openai-formats/src/reasoning.ts
+++ b/packages/openai-formats/src/reasoning.ts
@@ -99,13 +99,20 @@ export function resolveReasoningEffort(
 		to: ReasoningEffort;
 	}> = [];
 
-	const supportedModels = [models.sourceModel, models.targetModel].filter(
-		(model): model is string => typeof model === "string" && model.length > 0,
+	const modelContexts = [
+		{ model: models.sourceModel, role: "source" as const },
+		{ model: models.targetModel, role: "target" as const },
+	].filter(
+		(context): context is { model: string; role: "source" | "target" } =>
+			typeof context.model === "string" && context.model.length > 0,
 	);
 
-	for (const model of supportedModels) {
+	for (const { model, role } of modelContexts) {
 		const supportedEfforts = getSupportedReasoningEfforts(model);
 		if (!supportedEfforts) {
+			if (role === "target") {
+				continue;
+			}
 			throw new ValidationError(
 				`reasoning.effort is not supported for model ${model}`,
 				"reasoning.effort",

--- a/packages/openai-formats/src/reasoning.ts
+++ b/packages/openai-formats/src/reasoning.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 Gili Tzabari. All rights reserved.
+ *
+ * Licensed under the CAT Commercial License.
+ * See LICENSE.md in the project root for license terms.
+ */
+import { ValidationError, getModelFamily } from "@better-ccflare/core";
+
+export const REASONING_EFFORT_VALUES = ["low", "medium", "high"] as const;
+export type ReasoningEffort = (typeof REASONING_EFFORT_VALUES)[number];
+
+const CLAUDE_REASONING_EFFORTS: Record<"opus" | "sonnet" | "haiku", readonly ReasoningEffort[]> = {
+	opus: ["low", "medium", "high"],
+	sonnet: ["low", "medium", "high"],
+	haiku: ["low", "medium"],
+};
+
+const TARGET_REASONING_EFFORTS: Record<string, readonly ReasoningEffort[]> = {
+	"gpt-5": ["low", "medium", "high"],
+	"gpt-5.3-codex": ["low", "medium", "high"],
+	"gpt-5.4-mini": ["low", "medium"],
+};
+
+function normalizeModelName(model: string): string {
+	return model.toLowerCase().trim();
+}
+
+function normalizeTargetModelName(model: string): string {
+	return normalizeModelName(model).replace(/^.*\//, "");
+}
+
+export function getSupportedReasoningEfforts(
+	model: string,
+): readonly ReasoningEffort[] | null {
+	const normalized = normalizeTargetModelName(model);
+	const family = getModelFamily(normalized);
+	if (family) {
+		return CLAUDE_REASONING_EFFORTS[family];
+	}
+
+	if (normalized in TARGET_REASONING_EFFORTS) {
+		return TARGET_REASONING_EFFORTS[normalized];
+	}
+
+	if (normalized.startsWith("gpt-5")) {
+		return TARGET_REASONING_EFFORTS["gpt-5"];
+	}
+
+	return null;
+}
+
+export function validateReasoningEffort(
+	effort: unknown,
+	models: { sourceModel?: string; targetModel?: string },
+): ReasoningEffort | undefined {
+	if (effort === undefined) {
+		return undefined;
+	}
+
+	if (
+		typeof effort !== "string" ||
+		!REASONING_EFFORT_VALUES.includes(effort as ReasoningEffort)
+	) {
+		throw new ValidationError(
+			`reasoning.effort must be one of: ${REASONING_EFFORT_VALUES.join(", ")}`,
+			"reasoning.effort",
+			effort,
+		);
+	}
+
+	const supportedModels = [models.sourceModel, models.targetModel].filter(
+		(model): model is string => typeof model === "string" && model.length > 0,
+	);
+
+	for (const model of supportedModels) {
+		const supportedEfforts = getSupportedReasoningEfforts(model);
+		if (!supportedEfforts) {
+			throw new ValidationError(
+				`reasoning.effort is not supported for model ${model}`,
+				"reasoning.effort",
+				effort,
+			);
+		}
+
+		if (!supportedEfforts.includes(effort as ReasoningEffort)) {
+			throw new ValidationError(
+				`reasoning.effort '${effort}' is not supported for model ${model}; allowed values: ${supportedEfforts.join(", ")}`,
+				"reasoning.effort",
+				effort,
+			);
+		}
+	}
+
+	return effort as ReasoningEffort;
+}

--- a/packages/openai-formats/src/types.ts
+++ b/packages/openai-formats/src/types.ts
@@ -42,6 +42,7 @@ export interface OpenAIRequest {
 	stream?: boolean;
 	stream_options?: { include_usage: boolean };
 	tools?: OpenAITool[];
+	reasoning?: { effort?: string };
 }
 
 export interface AnthropicToolUse {
@@ -95,6 +96,7 @@ export interface AnthropicRequest {
 	stop_sequences?: string[];
 	stream?: boolean;
 	tools?: AnthropicTool[];
+	reasoning?: { effort?: string };
 }
 
 export interface OpenAIUsage {

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -1,8 +1,20 @@
 import { describe, expect, it } from "bun:test";
 import { CodexProvider } from "./provider";
-import { parseCodexUsageHeaders } from "./usage";
+
+const sseBody = (lines: string[]) => `${lines.join("\n")}\n`;
+const eventLine = (name: string, data: unknown) => [
+	`event: ${name}`,
+	`data: ${typeof data === "string" ? data : JSON.stringify(data)}`,
+	"",
+];
 
 describe("CodexProvider request conversion", () => {
+	it("handles count_tokens path", () => {
+		const provider = new CodexProvider();
+		expect(provider.canHandle("/v1/messages")).toBeTrue();
+		expect(provider.canHandle("/v1/messages/count_tokens")).toBeTrue();
+	});
+
 	it("forwards Claude reasoning effort to Codex reasoning.effort", async () => {
 		const provider = new CodexProvider();
 		const request = new Request("https://example.com/v1/messages", {
@@ -22,6 +34,25 @@ describe("CodexProvider request conversion", () => {
 		expect(body.reasoning).toEqual({ effort: "high" });
 	});
 
+	it("forwards xhigh reasoning effort to Codex unchanged", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-5-sonnet-20241022",
+				max_tokens: 100,
+				reasoning: { effort: "xhigh" },
+				messages: [{ role: "user", content: "Hello" }],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request);
+		const body = await transformed.json();
+
+		expect(body.reasoning).toEqual({ effort: "xhigh" });
+	});
+
 	it("keeps default Codex reasoning effort when Claude effort is absent", async () => {
 		const provider = new CodexProvider();
 		const request = new Request("https://example.com/v1/messages", {
@@ -39,162 +70,495 @@ describe("CodexProvider request conversion", () => {
 
 		expect(body.reasoning).toEqual({ effort: "medium" });
 	});
+
+	it("rejects unsupported reasoning effort values", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-5-sonnet-20241022",
+				max_tokens: 100,
+				reasoning: { effort: "extreme" },
+				messages: [{ role: "user", content: "Hello" }],
+			}),
+		});
+
+		await expect(provider.transformRequestBody(request)).rejects.toThrow(
+			"reasoning.effort must be one of: minimal, low, medium, high, xhigh, max",
+		);
+	});
+
+	it("downgrades efforts unsupported by the mapped Codex model", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-5-sonnet-20241022",
+				max_tokens: 100,
+				reasoning: { effort: "high" },
+				messages: [{ role: "user", content: "Hello" }],
+			}),
+		});
+
+		const account = {
+			name: "test",
+			model_mappings: JSON.stringify({
+				sonnet: "gpt-5.4-mini",
+			}),
+		} as Parameters<CodexProvider["transformRequestBody"]>[1];
+
+		const transformed = await provider.transformRequestBody(request, account);
+		const body = await transformed.json();
+		expect(body.reasoning).toEqual({ effort: "medium" });
+	});
 });
 
 describe("CodexProvider.processResponse", () => {
-	it("transforms streaming responses even when Codex returns the wrong content-type", async () => {
+	it("buffers tool-call arguments and emits them once before content_block_stop", async () => {
 		const provider = new CodexProvider();
-		const upstreamBody = [
-			"event: response.created",
-			'data: {"response":{"id":"resp_test","model":"gpt-5.3-codex"}}',
-			"",
-			"event: response.output_item.added",
-			'data: {"item":{"type":"message"},"output_index":0}',
-			"",
-			"event: response.content_part.added",
-			'data: {"part":{"type":"output_text"}}',
-			"",
-			"event: response.output_text.delta",
-			'data: {"delta":"hello"}',
-			"",
-			"event: response.output_item.done",
-			'data: {"item":{"type":"message"}}',
-			"",
-			"event: response.completed",
-			'data: {"response":{"usage":{"input_tokens":1,"output_tokens":1}}}',
-			"",
-		].join("\n");
+		const upstreamBody = sseBody([
+			...eventLine("response.created", {
+				response: { id: "resp_test", model: "gpt-5.4" },
+			}),
+			...eventLine("response.output_item.added", {
+				item: { type: "function_call", call_id: "call_1", name: "search" },
+				output_index: 0,
+			}),
+			...eventLine("response.function_call_arguments.delta", {
+				delta: '{"query":"hel',
+				output_index: 0,
+			}),
+			...eventLine("response.function_call_arguments.delta", {
+				delta: 'lo"}',
+				output_index: 0,
+			}),
+			...eventLine("response.output_item.done", {
+				item: { type: "function_call", call_id: "call_1", name: "search" },
+				output_index: 0,
+			}),
+			...eventLine("response.completed", {
+				response: {
+					model: "gpt-5.4",
+					usage: { input_tokens: 1, output_tokens: 1 },
+				},
+			}),
+		]);
 
 		const response = new Response(upstreamBody, {
 			status: 200,
-			headers: { "content-type": "application/json" },
+			headers: { "content-type": "text/event-stream" },
 		});
 
 		const transformed = await provider.processResponse(response, null);
 		const transformedBody = await transformed.text();
 
-		expect(transformed.headers.get("content-type")).toBe("text/event-stream");
-		expect(transformedBody).toContain("event: message_start");
-		expect(transformedBody).toContain('"text":"hello"');
-		expect(transformedBody.match(/event: message_stop/g)?.length ?? 0).toBe(1);
-		expect(transformedBody.match(/event: message_delta/g)?.length ?? 0).toBe(1);
+		expect(
+			transformedBody.match(/event: content_block_delta/g)?.length ?? 0,
+		).toBe(1);
+		expect(transformedBody).toContain('"index":0');
+		expect(transformedBody).toContain(
+			'"partial_json":"{\\"query\\":\\"hello\\"}"',
+		);
+		const deltaPos = transformedBody.indexOf("event: content_block_delta");
+		const stopPos = transformedBody.indexOf("event: content_block_stop");
+		expect(deltaPos).toBeGreaterThanOrEqual(0);
+		expect(stopPos).toBeGreaterThan(deltaPos);
 	});
 
-	it("passes through non-streaming error responses", async () => {
+	it("uses the function_call block index rather than the current text block index", async () => {
 		const provider = new CodexProvider();
-		const response = new Response('{"error":"bad_request"}', {
-			status: 400,
+		const upstreamBody = sseBody([
+			...eventLine("response.created", {
+				response: { id: "resp_test", model: "gpt-5.4" },
+			}),
+			...eventLine("response.output_item.added", {
+				item: { type: "function_call", call_id: "call_1", name: "search" },
+				output_index: 0,
+			}),
+			...eventLine("response.output_item.added", {
+				item: { type: "message" },
+				output_index: 1,
+			}),
+			...eventLine("response.content_part.added", {
+				part: { type: "output_text" },
+			}),
+			...eventLine("response.output_text.delta", { delta: "hello" }),
+			...eventLine("response.function_call_arguments.delta", {
+				delta: '{"query":"hel',
+				output_index: 0,
+			}),
+			...eventLine("response.function_call_arguments.delta", {
+				delta: 'lo"}',
+				output_index: 0,
+			}),
+			...eventLine("response.output_item.done", {
+				item: { type: "function_call", call_id: "call_1", name: "search" },
+				output_index: 0,
+			}),
+			...eventLine("response.completed", {
+				response: {
+					model: "gpt-5.4",
+					usage: { input_tokens: 1, output_tokens: 1 },
+				},
+			}),
+		]);
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const transformedBody = await transformed.text();
+		const deltaLine = transformedBody
+			.split("\n")
+			.find(
+				(line) =>
+					line.includes('"type":"content_block_delta"') &&
+					line.includes('"input_json_delta"'),
+			);
+
+		expect(deltaLine).not.toBeUndefined();
+		expect(deltaLine).toContain('"index":0');
+		expect(deltaLine).toContain('"partial_json":"{\\"query\\":\\"hello\\"}"');
+	});
+
+	it("includes input_tokens when model metadata is unavailable", async () => {
+		const provider = new CodexProvider();
+		const upstreamBody = sseBody([
+			...eventLine("response.created", {
+				response: { id: "resp_test", model: "unknown-model" },
+			}),
+			...eventLine("response.completed", {
+				response: {
+					model: "unknown-model",
+					usage: {
+						input_tokens: 12,
+						output_tokens: 3,
+						input_tokens_details: { cached_tokens: 4 },
+					},
+				},
+			}),
+		]);
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const transformedBody = await transformed.text();
+		const messageDeltaLine = transformedBody
+			.split("\n")
+			.find((line) => line.includes('"type":"message_delta"'));
+
+		expect(messageDeltaLine).not.toBeUndefined();
+		expect(messageDeltaLine).not.toContain('"context_window"');
+		expect(messageDeltaLine).toContain('"usage":{');
+		expect(messageDeltaLine).toContain('"output_tokens":3');
+		expect(messageDeltaLine).toContain('"input_tokens":12');
+		expect(messageDeltaLine).toContain(
+			'"delta":{"stop_reason":"end_turn","stop_sequence":null,"usage":{',
+		);
+		expect(messageDeltaLine).toContain('"cache_read_input_tokens":4');
+	});
+
+	it("normalizes message_delta usage and delta defaults when missing", async () => {
+		const provider = new CodexProvider();
+		const upstreamBody = sseBody([
+			...eventLine("response.created", {
+				response: { id: "resp_test", model: "gpt-5.4" },
+			}),
+			...eventLine("response.completed", {
+				response: {
+					model: "gpt-5.4",
+					usage: { input_tokens: 5, output_tokens: 2 },
+				},
+			}),
+		]);
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const transformedBody = await transformed.text();
+		const messageDeltaLine = transformedBody
+			.split("\n")
+			.find((line) => line.includes('"type":"message_delta"'));
+
+		expect(messageDeltaLine).not.toBeUndefined();
+		const dataPrefix = "data: ";
+		expect(messageDeltaLine?.startsWith(dataPrefix)).toBeTrue();
+		const payload = JSON.parse(
+			(messageDeltaLine as string).slice(dataPrefix.length),
+		);
+		expect(payload.usage.input_tokens).toBe(5);
+		expect(payload.usage.output_tokens).toBe(2);
+		expect(payload.usage.cache_read_input_tokens).toBe(0);
+		expect(payload.usage.cache_creation_input_tokens).toBe(0);
+		expect(payload.delta.stop_reason).toBe("end_turn");
+		expect(payload.delta.stop_sequence).toBe(null);
+	});
+	it("successful JSON responses pass through unchanged", async () => {
+		const provider = new CodexProvider();
+		const body = JSON.stringify({
+			type: "message",
+			message: { role: "assistant", content: [] },
+		});
+		const response = new Response(body, {
+			status: 200,
 			headers: { "content-type": "application/json" },
 		});
 
-		const processed = await provider.processResponse(response, null);
-
-		expect(processed.status).toBe(400);
-		expect(await processed.text()).toBe('{"error":"bad_request"}');
-	});
-});
-
-describe("parseCodexUsageHeaders", () => {
-	it("normalizes primary and secondary codex quota headers", () => {
-		const headers = new Headers({
-			"x-codex-primary-used-percent": "11",
-			"x-codex-primary-window-minutes": "10080",
-			"x-codex-primary-reset-at": "1775000000",
-			"x-codex-secondary-used-percent": "4",
-			"x-codex-secondary-window-minutes": "300",
-			"x-codex-secondary-reset-at": "1774600000",
-		});
-
-		const usage = parseCodexUsageHeaders(headers);
-
-		expect(usage).not.toBeNull();
-		expect(usage?.five_hour).toEqual({
-			utilization: 4,
-			resets_at: new Date(1774600000 * 1000).toISOString(),
-		});
-		expect(usage?.seven_day).toEqual({
-			utilization: 11,
-			resets_at: new Date(1775000000 * 1000).toISOString(),
-		});
-	});
-
-	it("ignores empty secondary placeholders when primary is seven-day usage", () => {
-		const headers = new Headers({
-			"x-codex-primary-used-percent": "11",
-			"x-codex-primary-window-minutes": "10080",
-			"x-codex-primary-reset-at": "1775000000",
-			"x-codex-secondary-used-percent": "0",
-			"x-codex-secondary-window-minutes": "0",
-		});
-
-		const usage = parseCodexUsageHeaders(headers);
-
-		expect(usage).toEqual({
-			five_hour: {
-				utilization: 0,
-				resets_at: null,
-			},
-			seven_day: {
-				utilization: 11,
-				resets_at: new Date(1775000000 * 1000).toISOString(),
-			},
-		});
-	});
-
-	it("falls back to legacy reset headers when utilization headers are missing", () => {
-		const headers = new Headers({
-			"x-codex-5h-reset-at": "1774600000",
-			"x-codex-7d-reset-at": "1775000000",
-		});
-
-		const usage = parseCodexUsageHeaders(headers);
-
-		expect(usage).toEqual({
-			five_hour: {
-				utilization: 0,
-				resets_at: new Date(1774600000 * 1000).toISOString(),
-			},
-			seven_day: {
-				utilization: 0,
-				resets_at: new Date(1775000000 * 1000).toISOString(),
-			},
-		});
-	});
-
-	it("returns null when no Codex usage headers are present", () => {
-		expect(parseCodexUsageHeaders(new Headers())).toBeNull();
-	});
-
-	it("drops invalid reset timestamps instead of throwing", () => {
-		const headers = new Headers({
-			"x-codex-primary-used-percent": "12",
-			"x-codex-primary-window-minutes": "300",
-			"x-codex-primary-reset-at": "1e309",
-		});
-
-		expect(parseCodexUsageHeaders(headers)).toEqual({
-			five_hour: { utilization: 12, resets_at: null },
-			seven_day: { utilization: 0, resets_at: null },
-		});
-	});
-});
-
-describe("parseCodexUsageHeaders reset-after handling", () => {
-	it("uses the supplied base time for relative reset headers", () => {
-		const baseTimeMs = Date.UTC(2026, 2, 27, 16, 0, 0);
-		const headers = new Headers({
-			"x-codex-primary-used-percent": "12",
-			"x-codex-primary-window-minutes": "300",
-			"x-codex-primary-reset-after-seconds": "600",
-		});
-
-		const usage = parseCodexUsageHeaders(headers, {
-			baseTimeMs,
-			allowRelativeResetAfter: true,
-		});
-
-		expect(usage?.five_hour?.resets_at).toBe(
-			new Date(baseTimeMs + 600_000).toISOString(),
+		const transformed = await provider.processResponse(response, null);
+		expect(transformed.headers.get("content-type")).toContain(
+			"application/json",
 		);
+		expect(await transformed.text()).toBe(body);
+	});
+
+	it("returns Anthropic JSON for non-streaming requests when upstream returns SSE", async () => {
+		const provider = new CodexProvider();
+		const requestId = "req_non_stream_1";
+		const originalRequest = new Request("https://example.test/v1/messages", {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				"x-better-ccflare-request-id": requestId,
+			},
+			body: JSON.stringify({
+				model: "claude-sonnet-4-5",
+				max_tokens: 16,
+				stream: false,
+				messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+			}),
+		});
+		await provider.transformRequestBody(originalRequest);
+
+		const upstreamBody = sseBody([
+			...eventLine("response.created", {
+				response: { id: "resp_test", model: "gpt-5.4" },
+			}),
+			...eventLine("response.output_item.added", {
+				item: { type: "message" },
+				output_index: 0,
+			}),
+			...eventLine("response.content_part.added", {
+				part: { type: "output_text" },
+			}),
+			...eventLine("response.output_text.delta", { delta: "Hi" }),
+			...eventLine("response.completed", {
+				response: {
+					model: "gpt-5.4",
+					usage: { input_tokens: 7, output_tokens: 2 },
+				},
+			}),
+		]);
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: {
+				"content-type": "text/event-stream",
+				"x-better-ccflare-request-id": requestId,
+				"x-better-ccflare-request-stream": "false",
+			},
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		expect(transformed.headers.get("content-type")).toContain(
+			"application/json",
+		);
+		const payload = JSON.parse(await transformed.text()) as Record<
+			string,
+			unknown
+		>;
+		expect(payload.type).toBe("message");
+		expect(payload.role).toBe("assistant");
+		expect(payload.usage).toEqual({
+			input_tokens: 7,
+			output_tokens: 2,
+			cache_read_input_tokens: 0,
+			cache_creation_input_tokens: 0,
+		});
+	});
+
+	it("message_start from response.created includes normalized top-level and nested usage", async () => {
+		const provider = new CodexProvider();
+		const upstreamBody = sseBody([
+			...eventLine("response.created", {
+				response: { id: "resp_test", model: "gpt-5.4" },
+			}),
+			...eventLine("response.completed", {
+				response: {
+					model: "gpt-5.4",
+					usage: { input_tokens: 2, output_tokens: 1 },
+				},
+			}),
+		]);
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const transformedBody = await transformed.text();
+		const messageStartLine = transformedBody
+			.split("\n")
+			.find((line) => line.includes('"type":"message_start"'));
+
+		expect(messageStartLine).not.toBeUndefined();
+		const payload = JSON.parse(
+			(messageStartLine as string).slice("data: ".length),
+		);
+		expect(payload.usage).toEqual({
+			input_tokens: 0,
+			output_tokens: 0,
+			cache_read_input_tokens: 0,
+			cache_creation_input_tokens: 0,
+		});
+		expect(payload.message.usage).toEqual({
+			input_tokens: 0,
+			output_tokens: 0,
+			cache_read_input_tokens: 0,
+			cache_creation_input_tokens: 0,
+		});
+	});
+
+	it("fallback message_start includes top-level usage", async () => {
+		const provider = new CodexProvider();
+		const upstreamBody = sseBody([
+			...eventLine("response.output_item.added", {
+				item: { type: "message" },
+				output_index: 0,
+			}),
+			...eventLine("response.content_part.added", {
+				part: { type: "output_text" },
+			}),
+			...eventLine("response.output_text.delta", { delta: "hello" }),
+		]);
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const transformedBody = await transformed.text();
+		const messageStartLine = transformedBody
+			.split("\n")
+			.find((line) => line.includes('"type":"message_start"'));
+		const messageDeltaLine = transformedBody
+			.split("\n")
+			.find((line) => line.includes('"type":"message_delta"'));
+
+		expect(messageStartLine).not.toBeUndefined();
+		const payload = JSON.parse(
+			(messageStartLine as string).slice("data: ".length),
+		);
+		expect(payload.usage.input_tokens).toBe(0);
+		expect(payload.usage.output_tokens).toBe(0);
+		expect(payload.usage.cache_read_input_tokens).toBe(0);
+		expect(payload.usage.cache_creation_input_tokens).toBe(0);
+		expect(payload.message.usage.input_tokens).toBe(0);
+		expect(payload.message.usage.output_tokens).toBe(0);
+		expect(messageDeltaLine).not.toBeUndefined();
+		expect(messageDeltaLine).toContain('"usage":{');
+		expect(messageDeltaLine).toContain('"input_tokens":0');
+		expect(messageDeltaLine).toContain('"output_tokens":0');
+		expect(messageDeltaLine).toContain(
+			'"delta":{"stop_reason":"end_turn","stop_sequence":null,"usage":{',
+		);
+	});
+
+	it("includes cache_creation_input_tokens in synthesized context_window when present", async () => {
+		const provider = new CodexProvider();
+		const upstreamBody = sseBody([
+			...eventLine("response.created", {
+				response: { id: "resp_test", model: "gpt-5.4" },
+			}),
+			...eventLine("response.completed", {
+				response: {
+					model: "gpt-5.4",
+					usage: {
+						input_tokens: 42,
+						output_tokens: 7,
+						input_tokens_details: {
+							cached_tokens: 5,
+							cache_creation_input_tokens: 9,
+						},
+					},
+				},
+			}),
+		]);
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const transformedBody = await transformed.text();
+		const messageDeltaLine = transformedBody
+			.split("\n")
+			.find((line) => line.includes('"type":"message_delta"'));
+
+		expect(messageDeltaLine).not.toBeUndefined();
+		expect(messageDeltaLine).toContain('"cache_creation_input_tokens":9');
+		expect(messageDeltaLine).not.toContain('"context_window"');
+	});
+
+	it("treats successful missing-content-type SSE bodies as streams", async () => {
+		const provider = new CodexProvider();
+		const upstreamBody = sseBody([
+			...eventLine("response.created", {
+				response: { id: "resp_test", model: "gpt-5.4" },
+			}),
+			...eventLine("response.output_item.added", {
+				item: { type: "message" },
+				output_index: 0,
+			}),
+			...eventLine("response.content_part.added", {
+				part: { type: "output_text" },
+			}),
+			...eventLine("response.output_text.delta", { delta: "hello" }),
+			...eventLine("response.completed", {
+				response: {
+					model: "gpt-5.4",
+					usage: { input_tokens: 2, output_tokens: 1 },
+				},
+			}),
+		]);
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: {},
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		expect(transformed.headers.get("content-type")).toContain(
+			"text/event-stream",
+		);
+		const transformedBody = await transformed.text();
+		expect(transformedBody).toContain("event: message_start");
+		expect(transformedBody).toContain("event: message_delta");
+		expect(transformedBody).toContain(
+			'"usage":{"input_tokens":2,"output_tokens":1',
+		);
+	});
+
+	it("passes through successful missing-content-type unknown bodies", async () => {
+		const provider = new CodexProvider();
+		const response = new Response("ok", {
+			status: 200,
+			headers: {},
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		expect(transformed.headers.get("content-type")).toBeNull();
+		expect(await transformed.text()).toBe("ok");
 	});
 });

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -2,6 +2,45 @@ import { describe, expect, it } from "bun:test";
 import { CodexProvider } from "./provider";
 import { parseCodexUsageHeaders } from "./usage";
 
+describe("CodexProvider request conversion", () => {
+	it("forwards Claude reasoning effort to Codex reasoning.effort", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-5-sonnet-20241022",
+				max_tokens: 100,
+				reasoning: { effort: "high" },
+				messages: [{ role: "user", content: "Hello" }],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request);
+		const body = await transformed.json();
+
+		expect(body.reasoning).toEqual({ effort: "high" });
+	});
+
+	it("keeps default Codex reasoning effort when Claude effort is absent", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-5-sonnet-20241022",
+				max_tokens: 100,
+				messages: [{ role: "user", content: "Hello" }],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request);
+		const body = await transformed.json();
+
+		expect(body.reasoning).toEqual({ effort: "medium" });
+	});
+});
+
 describe("CodexProvider.processResponse", () => {
 	it("transforms streaming responses even when Codex returns the wrong content-type", async () => {
 		const provider = new CodexProvider();

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -377,12 +377,92 @@ describe("CodexProvider.processResponse", () => {
 		>;
 		expect(payload.type).toBe("message");
 		expect(payload.role).toBe("assistant");
+		expect(payload.content).toEqual([{ type: "text", text: "Hi" }]);
 		expect(payload.usage).toEqual({
 			input_tokens: 7,
 			output_tokens: 2,
 			cache_read_input_tokens: 0,
 			cache_creation_input_tokens: 0,
 		});
+	});
+
+	it("preserves tool_use content in non-streaming SSE->JSON conversion", async () => {
+		const provider = new CodexProvider();
+		const requestId = "req_non_stream_tool_1";
+		const originalRequest = new Request("https://example.test/v1/messages", {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				"x-better-ccflare-request-id": requestId,
+			},
+			body: JSON.stringify({
+				model: "claude-sonnet-4-5",
+				max_tokens: 16,
+				stream: false,
+				tools: [
+					{
+						name: "search",
+						description: "search",
+						input_schema: {
+							type: "object",
+							properties: { query: { type: "string" } },
+						},
+					},
+				],
+				messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+			}),
+		});
+		await provider.transformRequestBody(originalRequest);
+
+		const upstreamBody = sseBody([
+			...eventLine("response.created", {
+				response: { id: "resp_tool", model: "gpt-5.4" },
+			}),
+			...eventLine("response.output_item.added", {
+				item: { type: "function_call", call_id: "call_1", name: "search" },
+				output_index: 0,
+			}),
+			...eventLine("response.function_call_arguments.delta", {
+				delta: '{"query":"hel',
+				output_index: 0,
+			}),
+			...eventLine("response.function_call_arguments.delta", {
+				delta: 'lo"}',
+				output_index: 0,
+			}),
+			...eventLine("response.output_item.done", {
+				item: { type: "function_call", call_id: "call_1", name: "search" },
+				output_index: 0,
+			}),
+			...eventLine("response.completed", {
+				response: {
+					model: "gpt-5.4",
+					usage: { input_tokens: 9, output_tokens: 4 },
+				},
+			}),
+		]);
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: {
+				"content-type": "text/event-stream",
+				"x-better-ccflare-request-id": requestId,
+				"x-better-ccflare-request-stream": "false",
+			},
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const payload = JSON.parse(await transformed.text()) as Record<
+			string,
+			unknown
+		>;
+		expect(payload.content).toEqual([
+			{
+				type: "tool_use",
+				id: "call_1",
+				name: "search",
+				input: { query: "hello" },
+			},
+		]);
 	});
 
 	it("message_start from response.created includes normalized top-level and nested usage", async () => {

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -1,8 +1,8 @@
 import { ValidationError, validateEndpointUrl } from "@better-ccflare/core";
 import { sanitizeProxyHeaders } from "@better-ccflare/http-common";
 import { Logger } from "@better-ccflare/logger";
+import { resolveReasoningEffort } from "@better-ccflare/openai-formats";
 import type { Account } from "@better-ccflare/types";
-import { validateReasoningEffort } from "@better-ccflare/openai-formats";
 import { BaseProvider } from "../../base";
 import type { RateLimitInfo, TokenRefreshResult } from "../../types";
 
@@ -13,6 +13,25 @@ const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const DEFAULT_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses";
 const CODEX_VERSION = "0.125.0";
 const CODEX_USER_AGENT = `codex-cli/${CODEX_VERSION} (Windows 10.0.26100; x64)`;
+
+const _normalizeUsage = (value: unknown): Record<string, number> => {
+	const usage =
+		typeof value === "object" && value !== null
+			? (value as Record<string, unknown>)
+			: {};
+	const getNumber = (field: string) => {
+		const candidate = usage[field];
+		return typeof candidate === "number" && Number.isFinite(candidate)
+			? candidate
+			: 0;
+	};
+	return {
+		input_tokens: getNumber("input_tokens"),
+		output_tokens: getNumber("output_tokens"),
+		cache_read_input_tokens: getNumber("cache_read_input_tokens"),
+		cache_creation_input_tokens: getNumber("cache_creation_input_tokens"),
+	};
+};
 
 // Default model mapping: Anthropic model name prefixes → Codex model names
 const DEFAULT_MODEL_MAP: Record<string, string> = {
@@ -67,7 +86,7 @@ interface CodexTool {
 interface CodexRequest {
 	model: string;
 	input: (CodexMessage | CodexFunctionCallItem | CodexFunctionCallOutputItem)[];
-	stream: true;
+	stream: boolean;
 	store: false;
 	reasoning?: { effort: string };
 	instructions?: string;
@@ -117,10 +136,16 @@ interface AnthropicRequest {
 	system?: string | { type: string; text: string }[];
 	stream?: boolean;
 	tools?: AnthropicTool[];
+	reasoning?: { effort?: string };
 	[key: string]: unknown;
 }
 
 // ── SSE streaming state ───────────────────────────────────────────────────────
+
+interface FunctionCallBuffer {
+	contentBlockIndex: number;
+	arguments: string[];
+}
 
 interface StreamState {
 	buffer: string;
@@ -131,16 +156,16 @@ interface StreamState {
 	hasSentTerminalEvents: boolean;
 	inputTokens: number;
 	outputTokens: number;
-	// Track function_call items: output_index → content_block_index
-	functionCallBlocks: Map<number, number>;
+	// Track function_call items: output_index → buffered arguments and block index
+	functionCallBlocks: Map<number, FunctionCallBuffer>;
 }
 
 export class CodexProvider extends BaseProvider {
 	name = "codex";
+	private requestStreamById = new Map<string, boolean>();
 
 	canHandle(path: string): boolean {
-		// Codex only handles /v1/messages; reject token counting etc.
-		return path === "/v1/messages";
+		return path === "/v1/messages" || path === "/v1/messages/count_tokens";
 	}
 
 	async refreshToken(
@@ -258,10 +283,18 @@ export class CodexProvider extends BaseProvider {
 
 		try {
 			const body = (await request.json()) as AnthropicRequest;
+			const requestId = request.headers.get("x-better-ccflare-request-id");
+			if (requestId) {
+				this.requestStreamById.set(requestId, body.stream === true);
+			}
 			const codexBody = this.convertToCodexFormat(body, account);
 
 			const newHeaders = new Headers(request.headers);
 			newHeaders.set("content-type", "application/json");
+			newHeaders.set(
+				"x-better-ccflare-request-stream",
+				body.stream === true ? "true" : "false",
+			);
 			newHeaders.delete("content-length");
 
 			return new Request(request.url, {
@@ -283,21 +316,60 @@ export class CodexProvider extends BaseProvider {
 		_account: Account | null,
 	): Promise<Response> {
 		const contentType = response.headers.get("content-type");
+		const requestId = response.headers.get("x-better-ccflare-request-id");
+		const headerRequestedStream = response.headers.get(
+			"x-better-ccflare-request-stream",
+		);
+		const requestedStream =
+			headerRequestedStream === "true"
+				? true
+				: headerRequestedStream === "false"
+					? false
+					: requestId
+						? this.requestStreamById.get(requestId) === true
+						: true;
+		if (requestId) {
+			this.requestStreamById.delete(requestId);
+		}
 		const isEventStream = contentType?.includes("text/event-stream") ?? false;
-		const shouldForceStreamingTransform =
-			response.ok && response.body !== null && !isEventStream;
-
-		if (shouldForceStreamingTransform) {
-			log.warn(
-				`Codex returned a successful response with unexpected content-type ${contentType ?? "<missing>"}; attempting SSE transformation`,
-			);
+		if (isEventStream) {
+			if (requestedStream) {
+				return this.transformStreamingResponse(response);
+			}
+			return this.transformSseResponseToJson(response);
 		}
 
-		if (isEventStream || shouldForceStreamingTransform) {
-			return this.transformStreamingResponse(response);
+		if (response.ok && response.body !== null) {
+			const probeText = await response.text();
+			const trimmed = probeText.trimStart();
+			const isSseLike = trimmed.startsWith("event:");
+			const _isJsonLike = trimmed.startsWith("{") || trimmed.startsWith("[");
+
+			if (isSseLike) {
+				log.warn(
+					`Codex returned successful response without SSE content-type (${contentType ?? "<missing>"}); transforming as ${requestedStream ? "SSE" : "JSON"}`,
+				);
+				const headers = sanitizeProxyHeaders(response.headers);
+				headers.set("content-type", "text/event-stream");
+				const sseResponse = new Response(probeText, {
+					status: response.status,
+					statusText: response.statusText,
+					headers,
+				});
+				if (requestedStream) {
+					return this.transformStreamingResponse(sseResponse);
+				}
+				return this.transformSseResponseToJson(sseResponse);
+			}
+
+			const headers = sanitizeProxyHeaders(response.headers);
+			return new Response(probeText, {
+				status: response.status,
+				statusText: response.statusText,
+				headers,
+			});
 		}
 
-		// Non-streaming errors should pass through with sanitized headers so callers see the upstream failure body.
 		const headers = sanitizeProxyHeaders(response.headers);
 		return new Response(response.body, {
 			status: response.status,
@@ -354,10 +426,10 @@ export class CodexProvider extends BaseProvider {
 						: (account.model_mappings as Record<string, string>);
 
 				const lower = anthropicModel.toLowerCase();
+				if (mappings[anthropicModel]) return mappings[anthropicModel];
 				if (lower.includes("haiku") && mappings.haiku) return mappings.haiku;
 				if (lower.includes("sonnet") && mappings.sonnet) return mappings.sonnet;
 				if (lower.includes("opus") && mappings.opus) return mappings.opus;
-				if (mappings[anthropicModel]) return mappings[anthropicModel];
 			} catch {
 				// ignore malformed mappings
 			}
@@ -368,7 +440,7 @@ export class CodexProvider extends BaseProvider {
 		if (lower.includes("haiku")) return DEFAULT_MODEL_MAP.haiku;
 		if (lower.includes("sonnet")) return DEFAULT_MODEL_MAP.sonnet;
 		if (lower.includes("opus")) return DEFAULT_MODEL_MAP.opus;
-		return DEFAULT_MODEL_MAP.sonnet; // default
+		return anthropicModel;
 	}
 
 	private extractSystemPrompt(
@@ -479,17 +551,24 @@ export class CodexProvider extends BaseProvider {
 			}));
 		}
 
-		const reasoningEffort = validateReasoningEffort(body.reasoning?.effort, {
+		const reasoningResolution = resolveReasoningEffort(body.reasoning?.effort, {
 			sourceModel: body.model,
 			targetModel: model,
 		});
+		if (reasoningResolution.downgrades.length > 0) {
+			for (const downgrade of reasoningResolution.downgrades) {
+				log.warn(
+					`Downgraded reasoning effort for model ${downgrade.model}: ${downgrade.from} -> ${downgrade.to}`,
+				);
+			}
+		}
 
 		const codexRequest: CodexRequest = {
 			model,
 			input,
 			stream: true,
 			store: false,
-			reasoning: { effort: reasoningEffort || "medium" },
+			reasoning: { effort: reasoningResolution.effort || "medium" },
 		};
 
 		codexRequest.instructions = instructions || "You are a helpful assistant.";
@@ -498,6 +577,83 @@ export class CodexProvider extends BaseProvider {
 		}
 
 		return codexRequest;
+	}
+
+	private async transformSseResponseToJson(
+		response: Response,
+	): Promise<Response> {
+		const source = await this.transformStreamingResponse(response).text();
+		const lines = source.split("\n");
+		let messageStartPayload: Record<string, unknown> | null = null;
+		let messageDeltaPayload: Record<string, unknown> | null = null;
+		let text = "";
+		for (let i = 0; i < lines.length; i++) {
+			const line = lines[i];
+			if (!line.startsWith("event:")) continue;
+			const eventName = line.slice("event:".length).trim();
+			const dataLine = lines[i + 1];
+			if (!dataLine?.startsWith("data:")) continue;
+			let data: Record<string, unknown>;
+			try {
+				data = JSON.parse(dataLine.slice("data:".length).trim());
+			} catch {
+				continue;
+			}
+			if (eventName === "message_start") {
+				messageStartPayload = data;
+			} else if (eventName === "message_delta") {
+				messageDeltaPayload = data;
+			} else if (eventName === "content_block_delta") {
+				const delta = data.delta as Record<string, unknown> | undefined;
+				if (delta?.type === "text_delta" && typeof delta.text === "string") {
+					text += delta.text;
+				}
+			}
+		}
+		const startMessage =
+			(messageStartPayload?.message as Record<string, unknown> | undefined) ??
+			{};
+		const deltaUsage = _normalizeUsage(messageDeltaPayload?.usage);
+		const startUsage = _normalizeUsage(startMessage.usage);
+		const usage = {
+			input_tokens:
+				deltaUsage.input_tokens > 0
+					? deltaUsage.input_tokens
+					: startUsage.input_tokens,
+			output_tokens:
+				deltaUsage.output_tokens > 0
+					? deltaUsage.output_tokens
+					: startUsage.output_tokens,
+			cache_read_input_tokens:
+				deltaUsage.cache_read_input_tokens > 0
+					? deltaUsage.cache_read_input_tokens
+					: startUsage.cache_read_input_tokens,
+			cache_creation_input_tokens:
+				deltaUsage.cache_creation_input_tokens > 0
+					? deltaUsage.cache_creation_input_tokens
+					: startUsage.cache_creation_input_tokens,
+		};
+		const jsonPayload = {
+			id:
+				typeof startMessage.id === "string"
+					? startMessage.id
+					: `msg_${crypto.randomUUID().replace(/-/g, "").substring(0, 24)}`,
+			type: "message",
+			role: "assistant",
+			model:
+				typeof startMessage.model === "string" ? startMessage.model : "gpt-5.4",
+			content: [{ type: "text", text }],
+			stop_reason: "end_turn",
+			stop_sequence: null,
+			usage,
+		};
+		const headers = sanitizeProxyHeaders(response.headers);
+		headers.set("content-type", "application/json");
+		return new Response(JSON.stringify(jsonPayload), {
+			status: response.status,
+			statusText: response.statusText,
+			headers,
+		});
 	}
 
 	private transformStreamingResponse(response: Response): Response {
@@ -525,8 +681,97 @@ export class CodexProvider extends BaseProvider {
 		const decoder = new TextDecoder();
 
 		const writeSSE = async (event: string, data: unknown) => {
-			const line = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+			const payload =
+				typeof data === "object" && data !== null
+					? (data as Record<string, unknown>)
+					: null;
+			const normalizeUsage = (value: unknown): Record<string, number> => {
+				const usage =
+					typeof value === "object" && value !== null
+						? (value as Record<string, unknown>)
+						: {};
+				const getNumber = (field: string) => {
+					const candidate = usage[field];
+					return typeof candidate === "number" && Number.isFinite(candidate)
+						? candidate
+						: 0;
+				};
+				return {
+					input_tokens: getNumber("input_tokens"),
+					output_tokens: getNumber("output_tokens"),
+					cache_read_input_tokens: getNumber("cache_read_input_tokens"),
+					cache_creation_input_tokens: getNumber("cache_creation_input_tokens"),
+				};
+			};
+			if ((event === "message_start" || event === "message_delta") && payload) {
+				const normalizedUsage = normalizeUsage(payload.usage);
+				payload.usage = normalizedUsage;
+				if (event === "message_start") {
+					const message =
+						typeof payload.message === "object" && payload.message !== null
+							? (payload.message as Record<string, unknown>)
+							: {};
+					message.usage = normalizeUsage(message.usage ?? normalizedUsage);
+					payload.message = message;
+				} else {
+					const message = payload.message as
+						| Record<string, unknown>
+						| undefined;
+					if (message) {
+						message.usage = normalizeUsage(message.usage ?? normalizedUsage);
+					}
+				}
+			}
+			if (event === "message_delta" && payload) {
+				payload.usage = normalizeUsage(payload.usage);
+				const delta =
+					typeof payload.delta === "object" && payload.delta !== null
+						? (payload.delta as Record<string, unknown>)
+						: {};
+				if (!("stop_reason" in delta)) {
+					delta.stop_reason = "end_turn";
+				}
+				if (!("stop_sequence" in delta)) {
+					delta.stop_sequence = null;
+				}
+				if (!("usage" in delta)) {
+					delta.usage = payload.usage;
+				}
+				payload.delta = delta;
+			}
+			const line = `event: ${event}
+data: ${JSON.stringify(data)}
+
+`;
 			await writer.write(encoder.encode(line));
+		};
+		const ensureMessageStart = async () => {
+			if (state.hasSentMessageStart) return;
+			state.hasSentMessageStart = true;
+			await writeSSE("message_start", {
+				type: "message_start",
+				usage: {
+					input_tokens: 0,
+					output_tokens: 0,
+					cache_read_input_tokens: 0,
+					cache_creation_input_tokens: 0,
+				},
+				message: {
+					id: state.messageId,
+					type: "message",
+					role: "assistant",
+					content: [],
+					model: "gpt-5.4",
+					stop_reason: null,
+					stop_sequence: null,
+					usage: {
+						input_tokens: 0,
+						output_tokens: 0,
+						cache_read_input_tokens: 0,
+						cache_creation_input_tokens: 0,
+					},
+				},
+			});
 		};
 
 		const processEvents = async () => {
@@ -569,26 +814,18 @@ export class CodexProvider extends BaseProvider {
 							continue;
 						}
 
-						await this.handleCodexEvent(eventName, data, state, writeSSE);
+						await this.handleCodexEvent(
+							eventName,
+							data,
+							state,
+							writeSSE,
+							ensureMessageStart,
+						);
 					}
 				}
 
 				// Flush any remaining
-				if (!state.hasSentMessageStart) {
-					await writeSSE("message_start", {
-						type: "message_start",
-						message: {
-							id: state.messageId,
-							type: "message",
-							role: "assistant",
-							content: [],
-							model: "gpt-5.3-codex",
-							stop_reason: null,
-							stop_sequence: null,
-							usage: { input_tokens: 0, output_tokens: 0 },
-						},
-					});
-				}
+				await ensureMessageStart();
 
 				// Close any open content block
 				if (state.hasSentContentBlockStart) {
@@ -600,10 +837,20 @@ export class CodexProvider extends BaseProvider {
 
 				// Final message_delta + message_stop if upstream never sent response.completed
 				if (!state.hasSentTerminalEvents) {
+					const usage = {
+						input_tokens: state.inputTokens,
+						output_tokens: state.outputTokens,
+						cache_read_input_tokens: 0,
+						cache_creation_input_tokens: 0,
+					};
 					await writeSSE("message_delta", {
 						type: "message_delta",
-						delta: { stop_reason: "end_turn", stop_sequence: null },
-						usage: { output_tokens: state.outputTokens },
+						delta: {
+							stop_reason: "end_turn",
+							stop_sequence: null,
+							usage,
+						},
+						usage,
 					});
 					await writeSSE("message_stop", { type: "message_stop" });
 				}
@@ -628,32 +875,20 @@ export class CodexProvider extends BaseProvider {
 		data: Record<string, unknown>,
 		state: StreamState,
 		writeSSE: (event: string, data: unknown) => Promise<void>,
+		ensureMessageStart: () => Promise<void>,
 	): Promise<void> {
 		switch (eventName) {
 			case "response.created": {
 				const resp = data.response as Record<string, unknown> | undefined;
 				const respId = (resp?.id as string) || state.messageId;
-				const model = (resp?.model as string) || "gpt-5.3-codex";
+				const _model = (resp?.model as string) || "gpt-5.4";
 
 				state.messageId = respId;
-				state.hasSentMessageStart = true;
+				if (state.hasSentMessageStart) {
+					break;
+				}
 
-				await writeSSE("message_start", {
-					type: "message_start",
-					message: {
-						id: respId,
-						type: "message",
-						role: "assistant",
-						content: [],
-						model,
-						stop_reason: null,
-						stop_sequence: null,
-						usage: {
-							input_tokens: state.inputTokens,
-							output_tokens: 0,
-						},
-					},
-				});
+				await ensureMessageStart();
 				break;
 			}
 
@@ -666,34 +901,32 @@ export class CodexProvider extends BaseProvider {
 					// Text content block will start on content_part.added
 					// Nothing to emit yet
 				} else if (itemType === "function_call") {
-					// Start a tool_use content block
 					const callId = item?.call_id as string;
 					const name = item?.name as string;
-					const blockIdx = state.contentBlockIndex;
-
-					if (outputIndex !== undefined) {
-						state.functionCallBlocks.set(outputIndex, blockIdx);
-					}
 
 					if (state.hasSentContentBlockStart) {
 						await writeSSE("content_block_stop", {
 							type: "content_block_stop",
-							index: blockIdx,
+							index: state.contentBlockIndex,
 						});
 						state.contentBlockIndex++;
+						state.hasSentContentBlockStart = false;
 					}
 
+					const blockIdx = state.contentBlockIndex;
+					await ensureMessageStart();
 					await writeSSE("content_block_start", {
 						type: "content_block_start",
-						index: state.contentBlockIndex,
-						content_block: {
-							type: "tool_use",
-							id: callId,
-							name,
-							input: {},
-						},
+						index: blockIdx,
+						content_block: { type: "tool_use", id: callId, name, input: {} },
 					});
 					state.hasSentContentBlockStart = true;
+					if (outputIndex !== undefined) {
+						state.functionCallBlocks.set(outputIndex, {
+							contentBlockIndex: blockIdx,
+							arguments: [],
+						});
+					}
 				}
 				break;
 			}
@@ -703,6 +936,7 @@ export class CodexProvider extends BaseProvider {
 				const partType = part?.type as string | undefined;
 
 				if (partType === "output_text") {
+					await ensureMessageStart();
 					// Start a text content block
 					if (state.hasSentContentBlockStart) {
 						await writeSSE("content_block_stop", {
@@ -736,17 +970,53 @@ export class CodexProvider extends BaseProvider {
 
 			case "response.function_call_arguments.delta": {
 				const delta = data.delta as string | undefined;
-				if (delta) {
-					await writeSSE("content_block_delta", {
-						type: "content_block_delta",
-						index: state.contentBlockIndex,
-						delta: { type: "input_json_delta", partial_json: delta },
-					});
+				const outputIndex = data.output_index as number | undefined;
+				if (delta && outputIndex !== undefined) {
+					const buffer = state.functionCallBlocks.get(outputIndex);
+					if (buffer) {
+						buffer.arguments.push(delta);
+					}
 				}
 				break;
 			}
 
 			case "response.output_item.done": {
+				const item = data.item as Record<string, unknown> | undefined;
+				const itemType = item?.type as string | undefined;
+
+				if (itemType === "function_call") {
+					const outputIndex = data.output_index as number | undefined;
+					const buffer =
+						outputIndex !== undefined
+							? state.functionCallBlocks.get(outputIndex)
+							: undefined;
+					if (buffer) {
+						await writeSSE("content_block_delta", {
+							type: "content_block_delta",
+							index: buffer.contentBlockIndex,
+							delta: {
+								type: "input_json_delta",
+								partial_json: buffer.arguments.join(""),
+							},
+						});
+						await writeSSE("content_block_stop", {
+							type: "content_block_stop",
+							index: buffer.contentBlockIndex,
+						});
+						if (outputIndex !== undefined) {
+							state.functionCallBlocks.delete(outputIndex);
+						}
+						if (
+							state.hasSentContentBlockStart &&
+							state.contentBlockIndex === buffer.contentBlockIndex
+						) {
+							state.contentBlockIndex++;
+							state.hasSentContentBlockStart = false;
+						}
+					}
+					break;
+				}
+
 				if (state.hasSentContentBlockStart) {
 					await writeSSE("content_block_stop", {
 						type: "content_block_stop",
@@ -764,9 +1034,12 @@ export class CodexProvider extends BaseProvider {
 					| { input_tokens?: number; output_tokens?: number }
 					| undefined;
 
-				state.inputTokens = usage?.input_tokens || state.inputTokens;
-				state.outputTokens = usage?.output_tokens || state.outputTokens;
-
+				if (typeof usage?.input_tokens === "number") {
+					state.inputTokens = usage.input_tokens;
+				}
+				if (typeof usage?.output_tokens === "number") {
+					state.outputTokens = usage.output_tokens;
+				}
 				// Close any lingering content block
 				if (state.hasSentContentBlockStart) {
 					await writeSSE("content_block_stop", {
@@ -776,11 +1049,59 @@ export class CodexProvider extends BaseProvider {
 					state.hasSentContentBlockStart = false;
 				}
 
-				await writeSSE("message_delta", {
+				const messageDeltaUsage: {
+					input_tokens?: number;
+					output_tokens: number;
+					cache_read_input_tokens?: number;
+					cache_creation_input_tokens?: number;
+				} = { output_tokens: state.outputTokens };
+				messageDeltaUsage.input_tokens = state.inputTokens;
+				const usageRecord = usage as Record<string, unknown> | undefined;
+				const inputTokenDetails = usageRecord?.input_tokens_details as
+					| Record<string, unknown>
+					| undefined;
+				const cachedTokens = inputTokenDetails?.cached_tokens;
+				if (
+					typeof cachedTokens === "number" &&
+					Number.isFinite(cachedTokens) &&
+					cachedTokens >= 0
+				) {
+					messageDeltaUsage.cache_read_input_tokens = cachedTokens;
+				}
+				const cacheCreationTokens =
+					inputTokenDetails?.cache_creation_input_tokens;
+				if (
+					typeof cacheCreationTokens === "number" &&
+					Number.isFinite(cacheCreationTokens) &&
+					cacheCreationTokens >= 0
+				) {
+					messageDeltaUsage.cache_creation_input_tokens = cacheCreationTokens;
+				}
+				log.warn(
+					`Codex terminal response.completed messageId=${state.messageId} model=${String(resp?.model ?? "")} inputTokens=${state.inputTokens} outputTokens=${state.outputTokens}`,
+				);
+
+				const messageDelta: {
+					type: "message_delta";
+					delta: {
+						stop_reason: "end_turn";
+						stop_sequence: null;
+						usage: typeof messageDeltaUsage;
+					};
+					usage: typeof messageDeltaUsage;
+					message: { usage: typeof messageDeltaUsage };
+				} = {
 					type: "message_delta",
-					delta: { stop_reason: "end_turn", stop_sequence: null },
-					usage: { output_tokens: state.outputTokens },
-				});
+					delta: {
+						stop_reason: "end_turn",
+						stop_sequence: null,
+						usage: messageDeltaUsage,
+					},
+					usage: messageDeltaUsage,
+					message: { usage: messageDeltaUsage },
+				};
+
+				await writeSSE("message_delta", messageDelta);
 				await writeSSE("message_stop", { type: "message_stop" });
 				state.hasSentTerminalEvents = true;
 				break;

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -1,7 +1,8 @@
-import { validateEndpointUrl } from "@better-ccflare/core";
+import { ValidationError, validateEndpointUrl } from "@better-ccflare/core";
 import { sanitizeProxyHeaders } from "@better-ccflare/http-common";
 import { Logger } from "@better-ccflare/logger";
 import type { Account } from "@better-ccflare/types";
+import { validateReasoningEffort } from "@better-ccflare/openai-formats";
 import { BaseProvider } from "../../base";
 import type { RateLimitInfo, TokenRefreshResult } from "../../types";
 
@@ -269,6 +270,9 @@ export class CodexProvider extends BaseProvider {
 				body: JSON.stringify(codexBody),
 			});
 		} catch (error) {
+			if (error instanceof ValidationError) {
+				throw error;
+			}
 			log.error("Failed to transform request body to Codex format:", error);
 			return request;
 		}
@@ -475,12 +479,17 @@ export class CodexProvider extends BaseProvider {
 			}));
 		}
 
+		const reasoningEffort = validateReasoningEffort(body.reasoning?.effort, {
+			sourceModel: body.model,
+			targetModel: model,
+		});
+
 		const codexRequest: CodexRequest = {
 			model,
 			input,
 			stream: true,
 			store: false,
-			reasoning: { effort: body.reasoning?.effort || "medium" },
+			reasoning: { effort: reasoningEffort || "medium" },
 		};
 
 		codexRequest.instructions = instructions || "You are a helpful assistant.";

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -480,7 +480,7 @@ export class CodexProvider extends BaseProvider {
 			input,
 			stream: true,
 			store: false,
-			reasoning: { effort: "medium" },
+			reasoning: { effort: body.reasoning?.effort || "medium" },
 		};
 
 		codexRequest.instructions = instructions || "You are a helpful assistant.";

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -240,7 +240,7 @@ export class CodexProvider extends BaseProvider {
 			try {
 				return validateEndpointUrl(account.custom_endpoint, "custom_endpoint");
 			} catch (error) {
-				log.warn(
+				log.debug(
 					`Invalid custom endpoint for ${account.name}: ${account.custom_endpoint}. Using default.`,
 					error,
 				);
@@ -346,7 +346,7 @@ export class CodexProvider extends BaseProvider {
 			const _isJsonLike = trimmed.startsWith("{") || trimmed.startsWith("[");
 
 			if (isSseLike) {
-				log.warn(
+				log.debug(
 					`Codex returned successful response without SSE content-type (${contentType ?? "<missing>"}); transforming as ${requestedStream ? "SSE" : "JSON"}`,
 				);
 				const headers = sanitizeProxyHeaders(response.headers);
@@ -557,7 +557,7 @@ export class CodexProvider extends BaseProvider {
 		});
 		if (reasoningResolution.downgrades.length > 0) {
 			for (const downgrade of reasoningResolution.downgrades) {
-				log.warn(
+				log.debug(
 					`Downgraded reasoning effort for model ${downgrade.model}: ${downgrade.from} -> ${downgrade.to}`,
 				);
 			}
@@ -586,7 +586,12 @@ export class CodexProvider extends BaseProvider {
 		const lines = source.split("\n");
 		let messageStartPayload: Record<string, unknown> | null = null;
 		let messageDeltaPayload: Record<string, unknown> | null = null;
-		let text = "";
+		const content: Array<Record<string, unknown>> = [];
+		const textByIndex = new Map<number, string>();
+		const toolByIndex = new Map<
+			number,
+			{ id: string; name: string; partialJson: string }
+		>();
 		for (let i = 0; i < lines.length; i++) {
 			const line = lines[i];
 			if (!line.startsWith("event:")) continue;
@@ -601,14 +606,70 @@ export class CodexProvider extends BaseProvider {
 			}
 			if (eventName === "message_start") {
 				messageStartPayload = data;
-			} else if (eventName === "message_delta") {
+				continue;
+			}
+			if (eventName === "message_delta") {
 				messageDeltaPayload = data;
-			} else if (eventName === "content_block_delta") {
+				continue;
+			}
+			if (eventName === "content_block_delta") {
+				const index = typeof data.index === "number" ? data.index : -1;
 				const delta = data.delta as Record<string, unknown> | undefined;
-				if (delta?.type === "text_delta" && typeof delta.text === "string") {
-					text += delta.text;
+				if (index < 0 || !delta) continue;
+				if (delta.type === "text_delta" && typeof delta.text === "string") {
+					textByIndex.set(index, (textByIndex.get(index) ?? "") + delta.text);
+				} else if (
+					delta.type === "input_json_delta" &&
+					typeof delta.partial_json === "string"
+				) {
+					const existing = toolByIndex.get(index);
+					if (existing) {
+						existing.partialJson += delta.partial_json;
+					} else {
+						toolByIndex.set(index, {
+							id: "",
+							name: "",
+							partialJson: delta.partial_json,
+						});
+					}
+				}
+				continue;
+			}
+			if (eventName === "content_block_start") {
+				const index = typeof data.index === "number" ? data.index : -1;
+				const block = data.content_block as Record<string, unknown> | undefined;
+				if (index < 0 || !block) continue;
+				if (block.type === "tool_use") {
+					toolByIndex.set(index, {
+						id: typeof block.id === "string" ? block.id : "",
+						name: typeof block.name === "string" ? block.name : "",
+						partialJson: toolByIndex.get(index)?.partialJson ?? "",
+					});
 				}
 			}
+		}
+		for (const [_index, text] of [...textByIndex.entries()].sort(
+			(a, b) => a[0] - b[0],
+		)) {
+			content.push({ type: "text", text });
+		}
+		for (const [index, tool] of [...toolByIndex.entries()].sort(
+			(a, b) => a[0] - b[0],
+		)) {
+			let input: Record<string, unknown> = {};
+			if (tool.partialJson.trim().length > 0) {
+				try {
+					input = JSON.parse(tool.partialJson) as Record<string, unknown>;
+				} catch {
+					input = {};
+				}
+			}
+			content.push({
+				type: "tool_use",
+				id: tool.id || `call_${index}`,
+				name: tool.name,
+				input,
+			});
 		}
 		const startMessage =
 			(messageStartPayload?.message as Record<string, unknown> | undefined) ??
@@ -642,7 +703,7 @@ export class CodexProvider extends BaseProvider {
 			role: "assistant",
 			model:
 				typeof startMessage.model === "string" ? startMessage.model : "gpt-5.4",
-			content: [{ type: "text", text }],
+			content: content.length > 0 ? content : [{ type: "text", text: "" }],
 			stop_reason: "end_turn",
 			stop_sequence: null,
 			usage,
@@ -1077,7 +1138,7 @@ data: ${JSON.stringify(data)}
 				) {
 					messageDeltaUsage.cache_creation_input_tokens = cacheCreationTokens;
 				}
-				log.warn(
+				log.debug(
 					`Codex terminal response.completed messageId=${state.messageId} model=${String(resp?.model ?? "")} inputTokens=${state.inputTokens} outputTokens=${state.outputTokens}`,
 				);
 

--- a/packages/providers/src/providers/openai/__tests__/provider.test.ts
+++ b/packages/providers/src/providers/openai/__tests__/provider.test.ts
@@ -44,6 +44,7 @@ describe("OpenAICompatibleProvider", () => {
 	describe("canHandle", () => {
 		it("should handle all paths", () => {
 			expect(provider.canHandle("/v1/messages")).toBe(true);
+			expect(provider.canHandle("/v1/messages/count_tokens")).toBe(true);
 			expect(provider.canHandle("/v1/chat/completions")).toBe(true);
 			expect(provider.canHandle("/any/path")).toBe(true);
 		});

--- a/packages/providers/src/providers/openai/provider.ts
+++ b/packages/providers/src/providers/openai/provider.ts
@@ -1,4 +1,4 @@
-import { getEndpointUrl, validateEndpointUrl } from "@better-ccflare/core";
+import { ValidationError, getEndpointUrl, validateEndpointUrl } from "@better-ccflare/core";
 import { Logger } from "@better-ccflare/logger";
 import {
 	convertAnthropicPathToOpenAI,
@@ -202,6 +202,9 @@ export class OpenAICompatibleProvider extends BaseProvider {
 				body: JSON.stringify(openaiBody),
 			});
 		} catch (error) {
+			if (error instanceof ValidationError) {
+				throw error;
+			}
 			log.error(
 				"Failed to transform Anthropic request to OpenAI format:",
 				error,

--- a/packages/providers/src/providers/openai/provider.ts
+++ b/packages/providers/src/providers/openai/provider.ts
@@ -1,4 +1,8 @@
-import { ValidationError, getEndpointUrl, validateEndpointUrl } from "@better-ccflare/core";
+import {
+	getEndpointUrl,
+	ValidationError,
+	validateEndpointUrl,
+} from "@better-ccflare/core";
 import { Logger } from "@better-ccflare/logger";
 import {
 	convertAnthropicPathToOpenAI,
@@ -17,12 +21,7 @@ const log = new Logger("OpenAICompatibleProvider");
 export class OpenAICompatibleProvider extends BaseProvider {
 	name = "openai-compatible";
 
-	canHandle(path: string): boolean {
-		// Reject Anthropic-specific endpoints that don't exist in OpenAI API
-		if (path === "/v1/messages/count_tokens") {
-			return false;
-		}
-		// Handle all other paths for OpenAI-compatible providers
+	canHandle(_path: string): boolean {
 		return true;
 	}
 

--- a/packages/proxy/src/handlers/__tests__/request-handler.test.ts
+++ b/packages/proxy/src/handlers/__tests__/request-handler.test.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Gili Tzabari. All rights reserved.
+ *
+ * Licensed under the CAT Commercial License.
+ * See LICENSE.md in the project root for license terms.
+ */
+import { describe, expect, it } from "bun:test";
+import { CodexProvider, OpenAICompatibleProvider } from "@better-ccflare/providers";
+import { validateProviderPath } from "../request-handler";
+
+describe("validateProviderPath", () => {
+	it("accepts count_tokens for OpenAI-compatible provider", () => {
+		expect(() =>
+			validateProviderPath(
+				new OpenAICompatibleProvider(),
+				"/v1/messages/count_tokens",
+			),
+		).not.toThrow();
+	});
+
+	it("accepts count_tokens for Codex provider", () => {
+		expect(() =>
+			validateProviderPath(new CodexProvider(), "/v1/messages/count_tokens"),
+		).not.toThrow();
+	});
+});

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -10,6 +10,24 @@ import { handleProxyError, processProxyResponse } from "./response-processor";
 import { getValidAccessToken } from "./token-manager";
 
 const log = new Logger("ProxyOperations");
+const CONTENT_TYPE_TRACE_ENABLED = process.env.CODEX_SSE_TRACE === "1";
+
+function traceContentType(
+	phase: "upstream-received" | "provider-exit",
+	response: Response,
+	providerName: string,
+	requestId: string,
+	account?: Account,
+): void {
+	if (!CONTENT_TYPE_TRACE_ENABLED) {
+		return;
+	}
+	const contentType = response.headers.get("content-type") ?? "<missing>";
+	const accountId = account?.id ?? "<missing>";
+	log.info(
+		`[content-type-trace] phase=${phase} status=${response.status} contentType=${contentType} provider=${providerName} requestId=${requestId} accountId=${accountId}`,
+	);
+}
 
 /**
  * Determines the absolute epoch timestamp (ms since epoch) until which an account
@@ -510,6 +528,14 @@ export async function proxyWithAccount(
 			: await makeProxyRequest(transformedRequest);
 
 		// Check if this is a Claude provider and we got an invalid thinking signature error
+		traceContentType(
+			"upstream-received",
+			rawResponse,
+			provider.name,
+			requestMeta.id,
+			account,
+		);
+
 		const isClaudeProvider =
 			provider.name === "anthropic" || account.provider === "claude-oauth";
 		if (
@@ -709,13 +735,44 @@ export async function proxyWithAccount(
 		}
 
 		// Process response (transform format, sanitize headers, etc.) using account-specific provider
+		const responseHeaders = new Headers(rawResponse.headers);
+		responseHeaders.set("x-better-ccflare-request-id", requestMeta.id);
+		const internalRequestStream = transformedRequest.headers.get(
+			"x-better-ccflare-request-stream",
+		);
+		if (internalRequestStream === "true" || internalRequestStream === "false") {
+			responseHeaders.set(
+				"x-better-ccflare-request-stream",
+				internalRequestStream,
+			);
+		}
+		const taggedRawResponse = new Response(rawResponse.body, {
+			status: rawResponse.status,
+			statusText: rawResponse.statusText,
+			headers: responseHeaders,
+		});
 		const response = await provider.processResponse(
-			rawResponse,
+			taggedRawResponse,
 			account,
 			req.headers,
 		);
 
+		if (process.env.CODEX_SSE_TRACE === "1") {
+			const contentType = response.headers.get("content-type") ?? "<missing>";
+			log.info(
+				`[proxy-lifecycle] requestId=${requestMeta.id} path=${url.pathname} provider=${provider.name} status=${response.status} contentType=${contentType} isStreamGuess=${provider.isStreamingResponse?.(response) ?? false} phase=post-provider`,
+			);
+		}
+
 		// Failover to next account on upstream 401 — credentials are invalid/expired
+		traceContentType(
+			"provider-exit",
+			response,
+			provider.name,
+			requestMeta.id,
+			account,
+		);
+
 		if (response.status === 401) {
 			log.warn(
 				`Authentication failed (401) for account ${account.name}, failing over to next account`,


### PR DESCRIPTION
## What this PR adds
This PR introduces two compatibility fixes for OpenAI-compatible/Codex routes.

### 1) Reasoning effort compatibility layer
- Forwards reasoning effort from Claude-style requests.
- Validates effort values against source/target model support.
- Adds downgrade mapping when requested effort is unsupported by the target model:
  - choose the same level when supported;
  - otherwise choose the nearest lower supported level;
  - log the downgrade so operators can see exactly what was applied.

### 2) `/v1/messages/count_tokens` provider-path support
- Removes early provider-path rejection for `count_tokens` on OpenAI-compatible and Codex routes.
- Adds a proxy-level regression test to prevent reintroducing the `Provider cannot handle path: /v1/messages/count_tokens` failure.

## Why this matters
- Prevents avoidable request failures when effort labels differ across model families.
- Preserves useful behavior via deterministic downgrades instead of hard rejection when a lower effort is valid.
- Fixes a concrete proxy compatibility gap for `count_tokens` requests.

## Test evidence
- `bun test packages/openai-formats/src/reasoning.test.ts packages/openai-formats/src/__tests__/converters.test.ts packages/providers/src/providers/codex/provider.test.ts packages/providers/src/providers/openai/__tests__/provider.test.ts`
- `bun test packages/proxy/src/handlers/__tests__/request-handler.test.ts`
- `bun run typecheck`