### PR TITLE
fix: OpenAI converter compatibility fixes

### DIFF
--- a/packages/openai-formats/src/__tests__/converters.test.ts
+++ b/packages/openai-formats/src/__tests__/converters.test.ts
@@ -78,11 +78,12 @@ describe("convertAnthropicRequestToOpenAI — basic fields", () => {
 		expect(result.model).toBe("claude-opus-4-5");
 	});
 
-	it("passes max_tokens through", () => {
+	it("passes max_tokens through and mirrors max_completion_tokens", () => {
 		const result = convertAnthropicRequestToOpenAI(
 			anthropicRequest({ max_tokens: 512 }),
 		);
 		expect(result.max_tokens).toBe(512);
+		expect(result.max_completion_tokens).toBe(512);
 	});
 
 	it("passes temperature through", () => {
@@ -351,7 +352,7 @@ describe("convertAnthropicRequestToOpenAI — messages conversion", () => {
 		expect(assistantMsg?.reasoning_content).toBeUndefined();
 	});
 
-	it("sets reasoning_content even when thinking block has no accompanying text", () => {
+	it("preserves thinking-only assistant message with empty content", () => {
 		const result = convertAnthropicRequestToOpenAI(
 			anthropicRequest({
 				messages: [
@@ -364,13 +365,10 @@ describe("convertAnthropicRequestToOpenAI — messages conversion", () => {
 				],
 			}),
 		);
-		// No text content → message not pushed (content is null and no tool_calls)
-		// The message is omitted because content is null and tool_calls is absent.
-		// Verify the message is absent rather than crashing.
 		const assistantMsgs = result.messages.filter((m) => m.role === "assistant");
-		// Either omitted entirely or has reasoning_content — implementation omits it
-		// because content is null and there are no tool_calls.
-		expect(assistantMsgs).toHaveLength(0);
+		expect(assistantMsgs).toHaveLength(1);
+		expect(assistantMsgs[0]?.content).toBe("");
+		expect(assistantMsgs[0]?.reasoning_content).toBe("Only thinking, no text.");
 	});
 
 	it("sets reasoning_content alongside tool_calls when both are present", () => {
@@ -707,6 +705,21 @@ describe("convertOpenAIResponseToAnthropic — success cases", () => {
 		expect(toolBlock).toBeDefined();
 		expect(toolBlock?.name).toBe("search");
 		expect(toolBlock?.input).toEqual({ q: "bun" });
+	});
+
+	it("maps finish_reason content_filter → stop", () => {
+		const result = convertOpenAIResponseToAnthropic(
+			openaiTextResponse({
+				choices: [
+					{
+						index: 0,
+						message: { role: "assistant", content: "Filtered" },
+						finish_reason: "content_filter",
+					},
+				],
+			}),
+		);
+		expect((result as any).stop_reason).toBe("stop");
 	});
 
 	it("maps token usage to input_tokens / output_tokens", () => {

--- a/packages/openai-formats/src/__tests__/converters.test.ts
+++ b/packages/openai-formats/src/__tests__/converters.test.ts
@@ -483,30 +483,32 @@ describe("convertAnthropicRequestToOpenAI — tools", () => {
 // ── convertAnthropicRequestToOpenAI — tool_choice ────────────────────────────
 
 describe("convertAnthropicRequestToOpenAI — tool_choice", () => {
+	const withTool = { tools: [{ name: "foo", description: "a tool" }] };
+
 	it('maps {type:"auto"} → "auto"', () => {
 		const result = convertAnthropicRequestToOpenAI(
-			anthropicRequest({ tool_choice: { type: "auto" } }),
+			anthropicRequest({ ...withTool, tool_choice: { type: "auto" } }),
 		);
 		expect(result.tool_choice).toBe("auto");
 	});
 
 	it('maps {type:"any"} → "required"', () => {
 		const result = convertAnthropicRequestToOpenAI(
-			anthropicRequest({ tool_choice: { type: "any" } }),
+			anthropicRequest({ ...withTool, tool_choice: { type: "any" } }),
 		);
 		expect(result.tool_choice).toBe("required");
 	});
 
 	it('maps {type:"none"} → "none"', () => {
 		const result = convertAnthropicRequestToOpenAI(
-			anthropicRequest({ tool_choice: { type: "none" } }),
+			anthropicRequest({ ...withTool, tool_choice: { type: "none" } }),
 		);
 		expect(result.tool_choice).toBe("none");
 	});
 
 	it('maps {type:"tool",name:"foo"} → {type:"function",function:{name:"foo"}}', () => {
 		const result = convertAnthropicRequestToOpenAI(
-			anthropicRequest({ tool_choice: { type: "tool", name: "foo" } }),
+			anthropicRequest({ ...withTool, tool_choice: { type: "tool", name: "foo" } }),
 		);
 		expect(result.tool_choice).toEqual({
 			type: "function",
@@ -516,6 +518,13 @@ describe("convertAnthropicRequestToOpenAI — tool_choice", () => {
 
 	it("omits tool_choice when not set", () => {
 		const result = convertAnthropicRequestToOpenAI(anthropicRequest());
+		expect(result.tool_choice).toBeUndefined();
+	});
+
+	it("omits tool_choice when tools array absent", () => {
+		const result = convertAnthropicRequestToOpenAI(
+			anthropicRequest({ tool_choice: { type: "any" } }),
+		);
 		expect(result.tool_choice).toBeUndefined();
 	});
 });

--- a/packages/openai-formats/src/__tests__/converters.test.ts
+++ b/packages/openai-formats/src/__tests__/converters.test.ts
@@ -296,6 +296,106 @@ describe("convertAnthropicRequestToOpenAI — messages conversion", () => {
 		expect(toolMsg?.tool_call_id).toBe("tool_1");
 		expect(toolMsg?.content).toBe("Sunny, 22°C");
 	});
+
+	it("sets reasoning_content from a single thinking block", () => {
+		const result = convertAnthropicRequestToOpenAI(
+			anthropicRequest({
+				messages: [
+					{
+						role: "assistant",
+						content: [
+							{ type: "thinking", thinking: "Let me reason about this." },
+							{ type: "text", text: "The answer is 42." },
+						],
+					},
+				],
+			}),
+		);
+		const assistantMsg = result.messages.find((m) => m.role === "assistant");
+		expect(assistantMsg?.reasoning_content).toBe("Let me reason about this.");
+		expect(assistantMsg?.content).toBe("The answer is 42.");
+	});
+
+	it("concatenates multiple thinking blocks into reasoning_content", () => {
+		const result = convertAnthropicRequestToOpenAI(
+			anthropicRequest({
+				messages: [
+					{
+						role: "assistant",
+						content: [
+							{ type: "thinking", thinking: "Step one." },
+							{ type: "thinking", thinking: " Step two." },
+							{ type: "text", text: "Done." },
+						],
+					},
+				],
+			}),
+		);
+		const assistantMsg = result.messages.find((m) => m.role === "assistant");
+		expect(assistantMsg?.reasoning_content).toBe("Step one. Step two.");
+	});
+
+	it("omits reasoning_content when no thinking blocks present", () => {
+		const result = convertAnthropicRequestToOpenAI(
+			anthropicRequest({
+				messages: [
+					{
+						role: "assistant",
+						content: [{ type: "text", text: "Plain answer." }],
+					},
+				],
+			}),
+		);
+		const assistantMsg = result.messages.find((m) => m.role === "assistant");
+		expect(assistantMsg?.reasoning_content).toBeUndefined();
+	});
+
+	it("sets reasoning_content even when thinking block has no accompanying text", () => {
+		const result = convertAnthropicRequestToOpenAI(
+			anthropicRequest({
+				messages: [
+					{
+						role: "assistant",
+						content: [
+							{ type: "thinking", thinking: "Only thinking, no text." },
+						],
+					},
+				],
+			}),
+		);
+		// No text content → message not pushed (content is null and no tool_calls)
+		// The message is omitted because content is null and tool_calls is absent.
+		// Verify the message is absent rather than crashing.
+		const assistantMsgs = result.messages.filter((m) => m.role === "assistant");
+		// Either omitted entirely or has reasoning_content — implementation omits it
+		// because content is null and there are no tool_calls.
+		expect(assistantMsgs).toHaveLength(0);
+	});
+
+	it("sets reasoning_content alongside tool_calls when both are present", () => {
+		const result = convertAnthropicRequestToOpenAI(
+			anthropicRequest({
+				messages: [
+					{
+						role: "assistant",
+						content: [
+							{ type: "thinking", thinking: "I should call the tool." },
+							{
+								type: "tool_use",
+								id: "tool_2",
+								name: "calculator",
+								input: { expr: "2+2" },
+							},
+						],
+					},
+				],
+			}),
+		);
+		const assistantMsg = result.messages.find((m) => m.role === "assistant");
+		expect(assistantMsg?.reasoning_content).toBe("I should call the tool.");
+		expect(assistantMsg?.tool_calls).toHaveLength(1);
+		expect(assistantMsg?.tool_calls?.[0]?.function.name).toBe("calculator");
+	});
 });
 
 describe("convertAnthropicRequestToOpenAI — tools", () => {

--- a/packages/openai-formats/src/__tests__/converters.test.ts
+++ b/packages/openai-formats/src/__tests__/converters.test.ts
@@ -716,7 +716,7 @@ describe("convertOpenAIResponseToAnthropic — success cases", () => {
 		expect(toolBlock?.input).toEqual({ q: "bun" });
 	});
 
-	it("maps finish_reason content_filter → stop", () => {
+	it("maps finish_reason content_filter → end_turn", () => {
 		const result = convertOpenAIResponseToAnthropic(
 			openaiTextResponse({
 				choices: [
@@ -728,7 +728,7 @@ describe("convertOpenAIResponseToAnthropic — success cases", () => {
 				],
 			}),
 		);
-		expect((result as any).stop_reason).toBe("stop");
+		expect((result as any).stop_reason).toBe("end_turn");
 	});
 
 	it("maps token usage to input_tokens / output_tokens", () => {

--- a/packages/openai-formats/src/__tests__/converters.test.ts
+++ b/packages/openai-formats/src/__tests__/converters.test.ts
@@ -78,12 +78,12 @@ describe("convertAnthropicRequestToOpenAI — basic fields", () => {
 		expect(result.model).toBe("claude-opus-4-5");
 	});
 
-	it("passes max_tokens through and mirrors max_completion_tokens", () => {
+	it("passes max_tokens through", () => {
 		const result = convertAnthropicRequestToOpenAI(
 			anthropicRequest({ max_tokens: 512 }),
 		);
 		expect(result.max_tokens).toBe(512);
-		expect(result.max_completion_tokens).toBe(512);
+		expect(result.max_completion_tokens).toBeUndefined();
 	});
 
 	it("passes temperature through", () => {

--- a/packages/openai-formats/src/__tests__/converters.test.ts
+++ b/packages/openai-formats/src/__tests__/converters.test.ts
@@ -8,6 +8,7 @@ import type {
 	AnthropicRequest,
 	AnthropicResponse,
 	OpenAIResponse,
+	OpenAIToolChoice,
 } from "../types";
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
@@ -478,6 +479,162 @@ describe("convertAnthropicRequestToOpenAI — tools", () => {
 			anthropicRequest({ tools: [] }),
 		);
 		expect(result.tools).toBeUndefined();
+	});
+});
+
+// ── convertAnthropicRequestToOpenAI — tool_choice ────────────────────────────
+
+describe("convertAnthropicRequestToOpenAI — tool_choice", () => {
+	it('maps {type:"auto"} → "auto"', () => {
+		const result = convertAnthropicRequestToOpenAI(
+			anthropicRequest({ tool_choice: { type: "auto" } }),
+		);
+		expect(result.tool_choice).toBe("auto");
+	});
+
+	it('maps {type:"any"} → "required"', () => {
+		const result = convertAnthropicRequestToOpenAI(
+			anthropicRequest({ tool_choice: { type: "any" } }),
+		);
+		expect(result.tool_choice).toBe("required");
+	});
+
+	it('maps {type:"none"} → "none"', () => {
+		const result = convertAnthropicRequestToOpenAI(
+			anthropicRequest({ tool_choice: { type: "none" } }),
+		);
+		expect(result.tool_choice).toBe("none");
+	});
+
+	it('maps {type:"tool",name:"foo"} → {type:"function",function:{name:"foo"}}', () => {
+		const result = convertAnthropicRequestToOpenAI(
+			anthropicRequest({ tool_choice: { type: "tool", name: "foo" } }),
+		);
+		expect(result.tool_choice).toEqual({
+			type: "function",
+			function: { name: "foo" },
+		} satisfies OpenAIToolChoice);
+	});
+
+	it("omits tool_choice when not set", () => {
+		const result = convertAnthropicRequestToOpenAI(anthropicRequest());
+		expect(result.tool_choice).toBeUndefined();
+	});
+});
+
+// ── convertAnthropicRequestToOpenAI — multi-content tool results ──────────────
+
+describe("convertAnthropicRequestToOpenAI — multi-content tool results", () => {
+	it("passes through string tool result content unchanged", () => {
+		const result = convertAnthropicRequestToOpenAI(
+			anthropicRequest({
+				messages: [
+					{
+						role: "user",
+						content: [
+							{
+								type: "tool_result",
+								tool_use_id: "tool_1",
+								content: "plain string result",
+							},
+						],
+					},
+				],
+			}),
+		);
+		const toolMsg = result.messages.find((m) => m.role === "tool");
+		expect(toolMsg?.content).toBe("plain string result");
+	});
+
+	it("joins multiple text blocks in array tool result", () => {
+		const result = convertAnthropicRequestToOpenAI(
+			anthropicRequest({
+				messages: [
+					{
+						role: "user",
+						content: [
+							{
+								type: "tool_result",
+								tool_use_id: "tool_1",
+								content: [
+									{ type: "text", text: "First line." },
+									{ type: "text", text: "Second line." },
+								],
+							},
+						],
+					},
+				],
+			}),
+		);
+		const toolMsg = result.messages.find((m) => m.role === "tool");
+		expect(toolMsg?.content).toBe("First line.\nSecond line.");
+	});
+
+	it("replaces image blocks with placeholder text", () => {
+		const result = convertAnthropicRequestToOpenAI(
+			anthropicRequest({
+				messages: [
+					{
+						role: "user",
+						content: [
+							{
+								type: "tool_result",
+								tool_use_id: "tool_1",
+								content: [
+									{ type: "text", text: "Here is the image:" },
+									{
+										type: "image",
+										source: {
+											type: "base64",
+											media_type: "image/png",
+											data: "abc123",
+										},
+									},
+								],
+							},
+						],
+					},
+				],
+			}),
+		);
+		const toolMsg = result.messages.find((m) => m.role === "tool");
+		expect(toolMsg?.content).toContain("Here is the image:");
+		expect(toolMsg?.content).toContain(
+			"[image content not supported in OpenAI tool results]",
+		);
+	});
+
+	it("handles array with only an image block", () => {
+		const result = convertAnthropicRequestToOpenAI(
+			anthropicRequest({
+				messages: [
+					{
+						role: "user",
+						content: [
+							{
+								type: "tool_result",
+								tool_use_id: "tool_2",
+								content: [
+									{
+										type: "image",
+										source: {
+											type: "base64",
+											media_type: "image/jpeg",
+											data: "xyz",
+										},
+									},
+								],
+							},
+						],
+					},
+				],
+			}),
+		);
+		const toolMsg = result.messages.find((m) => m.role === "tool");
+		expect(toolMsg?.content).toBe(
+			"[image content not supported in OpenAI tool results]",
+		);
+		expect(toolMsg?.tool_call_id).toBe("tool_2");
 	});
 });
 

--- a/packages/openai-formats/src/__tests__/converters.test.ts
+++ b/packages/openai-formats/src/__tests__/converters.test.ts
@@ -663,7 +663,7 @@ describe("convertOpenAIResponseToAnthropic — success cases", () => {
 
 	it("maps finish_reason stop → end_turn", () => {
 		const result = convertOpenAIResponseToAnthropic(openaiTextResponse());
-		expect((result as any).stop_reason).toBe("end_turn");
+		expect(result.stop_reason).toBe("end_turn");
 	});
 
 	it("maps finish_reason length → max_tokens", () => {
@@ -678,7 +678,7 @@ describe("convertOpenAIResponseToAnthropic — success cases", () => {
 				],
 			}),
 		);
-		expect((result as any).stop_reason).toBe("max_tokens");
+		expect(result.stop_reason).toBe("max_tokens");
 	});
 
 	it("maps finish_reason tool_calls → tool_use", () => {
@@ -703,7 +703,7 @@ describe("convertOpenAIResponseToAnthropic — success cases", () => {
 				],
 			}),
 		);
-		expect((result as any).stop_reason).toBe("tool_use");
+		expect(result.stop_reason).toBe("tool_use");
 		const content = (result as any).content as Array<{
 			type: string;
 			id: string;
@@ -728,7 +728,7 @@ describe("convertOpenAIResponseToAnthropic — success cases", () => {
 				],
 			}),
 		);
-		expect((result as any).stop_reason).toBe("end_turn");
+		expect(result.stop_reason).toBe("end_turn");
 	});
 
 	it("maps token usage to input_tokens / output_tokens", () => {

--- a/packages/openai-formats/src/__tests__/stream.test.ts
+++ b/packages/openai-formats/src/__tests__/stream.test.ts
@@ -542,6 +542,274 @@ describe("transformStreamingResponse — flush path (no [DONE])", () => {
 	});
 });
 
+// ── transformStreamingResponse — thinking/reasoning blocks ───────────────────
+
+describe("transformStreamingResponse — reasoning_content (thinking blocks)", () => {
+	it("emits content_block_start with type thinking before first reasoning_content chunk", async () => {
+		const upstream = makeOpenAIStream([
+			JSON.stringify({
+				id: "c1",
+				model: "deepseek-r1",
+				choices: [
+					{
+						index: 0,
+						delta: { reasoning_content: "Let me think..." },
+						finish_reason: null,
+					},
+				],
+			}),
+			"[DONE]",
+		]);
+		const transformed = transformStreamingResponse(upstream);
+		const raw = await readStream(transformed.body!);
+		const events = parseSSEEvents(raw);
+		const thinkingStart = events.find(
+			(e) =>
+				e.event === "content_block_start" &&
+				JSON.parse(e.data!).content_block?.type === "thinking",
+		);
+		expect(thinkingStart).toBeDefined();
+		expect(JSON.parse(thinkingStart?.data!).index).toBe(0);
+	});
+
+	it("emits content_block_delta with type thinking_delta for reasoning_content chunks", async () => {
+		const upstream = makeOpenAIStream([
+			JSON.stringify({
+				id: "c1",
+				model: "deepseek-r1",
+				choices: [
+					{
+						index: 0,
+						delta: { reasoning_content: "First thought." },
+						finish_reason: null,
+					},
+				],
+			}),
+			JSON.stringify({
+				id: "c1",
+				model: "deepseek-r1",
+				choices: [
+					{
+						index: 0,
+						delta: { reasoning_content: " Second thought." },
+						finish_reason: null,
+					},
+				],
+			}),
+			"[DONE]",
+		]);
+		const transformed = transformStreamingResponse(upstream);
+		const raw = await readStream(transformed.body!);
+		const events = parseSSEEvents(raw);
+		const thinkingDeltas = events.filter(
+			(e) =>
+				e.event === "content_block_delta" &&
+				JSON.parse(e.data!).delta?.type === "thinking_delta",
+		);
+		expect(thinkingDeltas.length).toBeGreaterThanOrEqual(2);
+		const thoughts = thinkingDeltas.map(
+			(e) => JSON.parse(e.data!).delta.thinking,
+		);
+		expect(thoughts).toContain("First thought.");
+		expect(thoughts).toContain(" Second thought.");
+	});
+
+	it("emits content_block_start for thinking only once across multiple chunks", async () => {
+		const upstream = makeOpenAIStream([
+			JSON.stringify({
+				id: "c1",
+				model: "deepseek-r1",
+				choices: [
+					{ index: 0, delta: { reasoning_content: "A" }, finish_reason: null },
+				],
+			}),
+			JSON.stringify({
+				id: "c1",
+				model: "deepseek-r1",
+				choices: [
+					{ index: 0, delta: { reasoning_content: "B" }, finish_reason: null },
+				],
+			}),
+			"[DONE]",
+		]);
+		const transformed = transformStreamingResponse(upstream);
+		const raw = await readStream(transformed.body!);
+		const events = parseSSEEvents(raw);
+		const thinkingStarts = events.filter(
+			(e) =>
+				e.event === "content_block_start" &&
+				JSON.parse(e.data!).content_block?.type === "thinking",
+		);
+		expect(thinkingStarts).toHaveLength(1);
+	});
+
+	it("closes thinking block (content_block_stop at index 0) before opening text block when text follows", async () => {
+		const upstream = makeOpenAIStream([
+			JSON.stringify({
+				id: "c1",
+				model: "deepseek-r1",
+				choices: [
+					{
+						index: 0,
+						delta: { reasoning_content: "Thinking..." },
+						finish_reason: null,
+					},
+				],
+			}),
+			JSON.stringify({
+				id: "c1",
+				model: "deepseek-r1",
+				choices: [
+					{ index: 0, delta: { content: "Answer." }, finish_reason: null },
+				],
+			}),
+			"[DONE]",
+		]);
+		const transformed = transformStreamingResponse(upstream);
+		const raw = await readStream(transformed.body!);
+		const events = parseSSEEvents(raw);
+		const types = events.map((e) => e.event);
+
+		// content_block_stop at index 0 must appear before content_block_start for text
+		const stops = events
+			.map((e, i) => ({ e, i }))
+			.filter(
+				({ e }) =>
+					e.event === "content_block_stop" && JSON.parse(e.data!).index === 0,
+			);
+		const textStart = events
+			.map((e, i) => ({ e, i }))
+			.find(
+				({ e }) =>
+					e.event === "content_block_start" &&
+					JSON.parse(e.data!).content_block?.type === "text",
+			);
+		expect(stops.length).toBeGreaterThanOrEqual(1);
+		expect(textStart).toBeDefined();
+		expect(stops[0]?.i).toBeLessThan(textStart?.i);
+
+		// text block must be at index 1
+		expect(JSON.parse(textStart?.e.data!).index).toBe(1);
+		expect(types).toContain("message_start");
+	});
+
+	it("emits text block at index 1 when thinking preceded it", async () => {
+		const upstream = makeOpenAIStream([
+			JSON.stringify({
+				id: "c1",
+				model: "deepseek-r1",
+				choices: [
+					{
+						index: 0,
+						delta: { reasoning_content: "Think." },
+						finish_reason: null,
+					},
+				],
+			}),
+			JSON.stringify({
+				id: "c1",
+				model: "deepseek-r1",
+				choices: [
+					{ index: 0, delta: { content: "Reply." }, finish_reason: null },
+				],
+			}),
+			"[DONE]",
+		]);
+		const transformed = transformStreamingResponse(upstream);
+		const raw = await readStream(transformed.body!);
+		const events = parseSSEEvents(raw);
+		const textBlockStart = events.find(
+			(e) =>
+				e.event === "content_block_start" &&
+				JSON.parse(e.data!).content_block?.type === "text",
+		);
+		expect(textBlockStart).toBeDefined();
+		expect(JSON.parse(textBlockStart?.data!).index).toBe(1);
+
+		// text_delta should also be at index 1
+		const textDeltas = events.filter(
+			(e) =>
+				e.event === "content_block_delta" &&
+				JSON.parse(e.data!).delta?.type === "text_delta",
+		);
+		expect(textDeltas.length).toBeGreaterThanOrEqual(1);
+		expect(JSON.parse(textDeltas[0]?.data!).index).toBe(1);
+	});
+
+	it("emits content_block_stop at index 1 on stream end when thinking+text both present", async () => {
+		const upstream = makeOpenAIStream([
+			JSON.stringify({
+				id: "c1",
+				model: "deepseek-r1",
+				choices: [
+					{
+						index: 0,
+						delta: { reasoning_content: "Think." },
+						finish_reason: null,
+					},
+				],
+			}),
+			JSON.stringify({
+				id: "c1",
+				model: "deepseek-r1",
+				choices: [
+					{ index: 0, delta: { content: "Answer." }, finish_reason: "stop" },
+				],
+			}),
+			"[DONE]",
+		]);
+		const transformed = transformStreamingResponse(upstream);
+		const raw = await readStream(transformed.body!);
+		const events = parseSSEEvents(raw);
+		// The final content_block_stop (for text, not thinking) must be at index 1
+		const allStops = events.filter((e) => e.event === "content_block_stop");
+		const stopIndexes = allStops.map((e) => JSON.parse(e.data!).index);
+		expect(stopIndexes).toContain(1);
+	});
+
+	it("handles reasoning_content only (no text) — thinking block without text block", async () => {
+		const upstream = makeOpenAIStream([
+			JSON.stringify({
+				id: "c1",
+				model: "deepseek-r1",
+				choices: [
+					{
+						index: 0,
+						delta: { reasoning_content: "Pure thought." },
+						finish_reason: null,
+					},
+				],
+			}),
+			"[DONE]",
+		]);
+		const transformed = transformStreamingResponse(upstream);
+		const raw = await readStream(transformed.body!);
+		const events = parseSSEEvents(raw);
+
+		// Thinking block start was emitted
+		const thinkingStart = events.find(
+			(e) =>
+				e.event === "content_block_start" &&
+				JSON.parse(e.data!).content_block?.type === "thinking",
+		);
+		expect(thinkingStart).toBeDefined();
+
+		// No text block start emitted
+		const textStart = events.find(
+			(e) =>
+				e.event === "content_block_start" &&
+				JSON.parse(e.data!).content_block?.type === "text",
+		);
+		expect(textStart).toBeUndefined();
+
+		// When only thinking was emitted (hasSentContentBlockStart is false),
+		// the [DONE] handler skips emitStreamEnd — no message_stop is produced.
+		// This is current implementation behavior for reasoning-only responses.
+		const types = events.map((e) => e.event);
+		expect(types).not.toContain("message_stop");
+	});
+});
+
 // ── transformStreamingResponse — model extraction ────────────────────────────
 
 describe("transformStreamingResponse — model extraction", () => {

--- a/packages/openai-formats/src/__tests__/stream.test.ts
+++ b/packages/openai-formats/src/__tests__/stream.test.ts
@@ -805,7 +805,7 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 		// Thinking block must be closed exactly once and message terminated
 		const stops = events.filter((e) => e.event === "content_block_stop");
 		expect(stops).toHaveLength(1);
-		expect(JSON.parse(stops[0]!.data!).index).toBe(0);
+		expect(JSON.parse(stops[0]?.data!).index).toBe(0);
 		const types = events.map((e) => e.event);
 		expect(types).toContain("message_stop");
 	});
@@ -815,23 +815,46 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 			JSON.stringify({
 				id: "c1",
 				model: "deepseek-r1",
-				choices: [{ index: 0, delta: { reasoning_content: "Thinking..." }, finish_reason: null }],
-			}),
-			JSON.stringify({
-				id: "c1",
-				model: "deepseek-r1",
-				choices: [{
-					index: 0,
-					delta: {
-						tool_calls: [{ index: 0, id: "tc1", type: "function", function: { name: "search", arguments: "" } }],
+				choices: [
+					{
+						index: 0,
+						delta: { reasoning_content: "Thinking..." },
+						finish_reason: null,
 					},
-					finish_reason: null,
-				}],
+				],
 			}),
 			JSON.stringify({
 				id: "c1",
 				model: "deepseek-r1",
-				choices: [{ index: 0, delta: { tool_calls: [{ index: 0, function: { arguments: '{"q":"hi"}' } }] }, finish_reason: "tool_calls" }],
+				choices: [
+					{
+						index: 0,
+						delta: {
+							tool_calls: [
+								{
+									index: 0,
+									id: "tc1",
+									type: "function",
+									function: { name: "search", arguments: "" },
+								},
+							],
+						},
+						finish_reason: null,
+					},
+				],
+			}),
+			JSON.stringify({
+				id: "c1",
+				model: "deepseek-r1",
+				choices: [
+					{
+						index: 0,
+						delta: {
+							tool_calls: [{ index: 0, function: { arguments: '{"q":"hi"}' } }],
+						},
+						finish_reason: "tool_calls",
+					},
+				],
 			}),
 			"[DONE]",
 		]);
@@ -839,9 +862,20 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 		const raw = await readStream(transformed.body!);
 		const events = parseSSEEvents(raw);
 
-		const thinkingStart = events.findIndex((e) => e.event === "content_block_start" && JSON.parse(e.data!).content_block?.type === "thinking");
-		const thinkingStop = events.findIndex((e) => e.event === "content_block_stop" && JSON.parse(e.data!).index === 0);
-		const toolStart = events.findIndex((e) => e.event === "content_block_start" && JSON.parse(e.data!).content_block?.type === "tool_use");
+		const thinkingStart = events.findIndex(
+			(e) =>
+				e.event === "content_block_start" &&
+				JSON.parse(e.data!).content_block?.type === "thinking",
+		);
+		const thinkingStop = events.findIndex(
+			(e) =>
+				e.event === "content_block_stop" && JSON.parse(e.data!).index === 0,
+		);
+		const toolStart = events.findIndex(
+			(e) =>
+				e.event === "content_block_start" &&
+				JSON.parse(e.data!).content_block?.type === "tool_use",
+		);
 
 		expect(thinkingStart).toBeGreaterThanOrEqual(0);
 		expect(thinkingStop).toBeGreaterThanOrEqual(0);
@@ -849,7 +883,7 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 		// thinking must be closed before tool opens
 		expect(thinkingStop).toBeLessThan(toolStart);
 		// tool block gets index 1 (thinking consumed 0)
-		expect(JSON.parse(events[toolStart]!.data!).index).toBe(1);
+		expect(JSON.parse(events[toolStart]?.data!).index).toBe(1);
 	});
 
 	it("closes text block before first tool_use block when text precedes tool_calls", async () => {
@@ -857,21 +891,46 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 			JSON.stringify({
 				id: "c1",
 				model: "gpt-4o",
-				choices: [{ index: 0, delta: { content: "Let me check." }, finish_reason: null }],
+				choices: [
+					{
+						index: 0,
+						delta: { content: "Let me check." },
+						finish_reason: null,
+					},
+				],
 			}),
 			JSON.stringify({
 				id: "c1",
 				model: "gpt-4o",
-				choices: [{
-					index: 0,
-					delta: { tool_calls: [{ index: 0, id: "tc1", type: "function", function: { name: "search", arguments: "" } }] },
-					finish_reason: null,
-				}],
+				choices: [
+					{
+						index: 0,
+						delta: {
+							tool_calls: [
+								{
+									index: 0,
+									id: "tc1",
+									type: "function",
+									function: { name: "search", arguments: "" },
+								},
+							],
+						},
+						finish_reason: null,
+					},
+				],
 			}),
 			JSON.stringify({
 				id: "c1",
 				model: "gpt-4o",
-				choices: [{ index: 0, delta: { tool_calls: [{ index: 0, function: { arguments: '{"q":"x"}' } }] }, finish_reason: "tool_calls" }],
+				choices: [
+					{
+						index: 0,
+						delta: {
+							tool_calls: [{ index: 0, function: { arguments: '{"q":"x"}' } }],
+						},
+						finish_reason: "tool_calls",
+					},
+				],
 			}),
 			"[DONE]",
 		]);
@@ -879,9 +938,20 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 		const raw = await readStream(transformed.body!);
 		const events = parseSSEEvents(raw);
 
-		const textStartIdx = events.findIndex((e) => e.event === "content_block_start" && JSON.parse(e.data!).content_block?.type === "text");
-		const textStopIdx = events.findIndex((e) => e.event === "content_block_stop" && JSON.parse(e.data!).index === 0);
-		const toolStartIdx = events.findIndex((e) => e.event === "content_block_start" && JSON.parse(e.data!).content_block?.type === "tool_use");
+		const textStartIdx = events.findIndex(
+			(e) =>
+				e.event === "content_block_start" &&
+				JSON.parse(e.data!).content_block?.type === "text",
+		);
+		const textStopIdx = events.findIndex(
+			(e) =>
+				e.event === "content_block_stop" && JSON.parse(e.data!).index === 0,
+		);
+		const toolStartIdx = events.findIndex(
+			(e) =>
+				e.event === "content_block_start" &&
+				JSON.parse(e.data!).content_block?.type === "tool_use",
+		);
 
 		expect(textStartIdx).toBeGreaterThanOrEqual(0);
 		expect(textStopIdx).toBeGreaterThanOrEqual(0);
@@ -889,7 +959,107 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 		// text block (idx=0) must be closed before tool block opens
 		expect(textStopIdx).toBeLessThan(toolStartIdx);
 		// tool block gets index 1
-		expect(JSON.parse(events[toolStartIdx]!.data!).index).toBe(1);
+		expect(JSON.parse(events[toolStartIdx]?.data!).index).toBe(1);
+	});
+
+	it("closes text block before thinking block when content precedes reasoning_content", async () => {
+		// text chunk → reasoning_content chunk → [DONE]
+		// Text block (index 0) must be closed before thinking block (index 1) opens.
+		const upstream = makeOpenAIStream([
+			JSON.stringify({
+				id: "c1",
+				model: "deepseek-r1",
+				choices: [
+					{ index: 0, delta: { content: "Intro." }, finish_reason: null },
+				],
+			}),
+			JSON.stringify({
+				id: "c1",
+				model: "deepseek-r1",
+				choices: [
+					{
+						index: 0,
+						delta: { reasoning_content: "Now thinking." },
+						finish_reason: null,
+					},
+				],
+			}),
+			"[DONE]",
+		]);
+		const transformed = transformStreamingResponse(upstream);
+		const raw = await readStream(transformed.body!);
+		const events = parseSSEEvents(raw);
+
+		const textStartIdx = events.findIndex(
+			(e) =>
+				e.event === "content_block_start" &&
+				JSON.parse(e.data!).content_block?.type === "text",
+		);
+		const textStopIdx = events.findIndex(
+			(e) =>
+				e.event === "content_block_stop" && JSON.parse(e.data!).index === 0,
+		);
+		const thinkingStartIdx = events.findIndex(
+			(e) =>
+				e.event === "content_block_start" &&
+				JSON.parse(e.data!).content_block?.type === "thinking",
+		);
+
+		expect(textStartIdx).toBeGreaterThanOrEqual(0);
+		expect(textStopIdx).toBeGreaterThanOrEqual(0);
+		expect(thinkingStartIdx).toBeGreaterThanOrEqual(0);
+		// text block (index 0) closed before thinking block opens
+		expect(textStopIdx).toBeLessThan(thinkingStartIdx);
+		// thinking block gets index 1
+		expect(JSON.parse(events[thinkingStartIdx]?.data!).index).toBe(1);
+	});
+
+	it("handles same-delta reasoning_content + content: emits thinking block then text block", async () => {
+		// Single delta chunk carries both reasoning_content and content.
+		// Thinking block (index 0) must come before text block (index 1).
+		const upstream = makeOpenAIStream([
+			JSON.stringify({
+				id: "c1",
+				model: "deepseek-r1",
+				choices: [
+					{
+						index: 0,
+						delta: { reasoning_content: "Think.", content: "Answer." },
+						finish_reason: null,
+					},
+				],
+			}),
+			"[DONE]",
+		]);
+		const transformed = transformStreamingResponse(upstream);
+		const raw = await readStream(transformed.body!);
+		const events = parseSSEEvents(raw);
+
+		const thinkingStartIdx = events.findIndex(
+			(e) =>
+				e.event === "content_block_start" &&
+				JSON.parse(e.data!).content_block?.type === "thinking",
+		);
+		const textStartIdx = events.findIndex(
+			(e) =>
+				e.event === "content_block_start" &&
+				JSON.parse(e.data!).content_block?.type === "text",
+		);
+
+		expect(thinkingStartIdx).toBeGreaterThanOrEqual(0);
+		expect(textStartIdx).toBeGreaterThanOrEqual(0);
+		// thinking block (index 0) before text block (index 1)
+		expect(thinkingStartIdx).toBeLessThan(textStartIdx);
+		expect(JSON.parse(events[thinkingStartIdx]?.data!).index).toBe(0);
+		expect(JSON.parse(events[textStartIdx]?.data!).index).toBe(1);
+
+		// thinking block closed before text block opens
+		const thinkingStopIdx = events.findIndex(
+			(e) =>
+				e.event === "content_block_stop" && JSON.parse(e.data!).index === 0,
+		);
+		expect(thinkingStopIdx).toBeGreaterThanOrEqual(0);
+		expect(thinkingStopIdx).toBeLessThan(textStartIdx);
 	});
 });
 

--- a/packages/openai-formats/src/__tests__/stream.test.ts
+++ b/packages/openai-formats/src/__tests__/stream.test.ts
@@ -809,6 +809,48 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 		const types = events.map((e) => e.event);
 		expect(types).toContain("message_stop");
 	});
+
+	it("closes thinking block before first tool_use block when reasoning_content precedes tool_calls", async () => {
+		const upstream = makeOpenAIStream([
+			JSON.stringify({
+				id: "c1",
+				model: "deepseek-r1",
+				choices: [{ index: 0, delta: { reasoning_content: "Thinking..." }, finish_reason: null }],
+			}),
+			JSON.stringify({
+				id: "c1",
+				model: "deepseek-r1",
+				choices: [{
+					index: 0,
+					delta: {
+						tool_calls: [{ index: 0, id: "tc1", type: "function", function: { name: "search", arguments: "" } }],
+					},
+					finish_reason: null,
+				}],
+			}),
+			JSON.stringify({
+				id: "c1",
+				model: "deepseek-r1",
+				choices: [{ index: 0, delta: { tool_calls: [{ index: 0, function: { arguments: '{"q":"hi"}' } }] }, finish_reason: "tool_calls" }],
+			}),
+			"[DONE]",
+		]);
+		const transformed = transformStreamingResponse(upstream);
+		const raw = await readStream(transformed.body!);
+		const events = parseSSEEvents(raw);
+
+		const thinkingStart = events.findIndex((e) => e.event === "content_block_start" && JSON.parse(e.data!).content_block?.type === "thinking");
+		const thinkingStop = events.findIndex((e) => e.event === "content_block_stop" && JSON.parse(e.data!).index === 0);
+		const toolStart = events.findIndex((e) => e.event === "content_block_start" && JSON.parse(e.data!).content_block?.type === "tool_use");
+
+		expect(thinkingStart).toBeGreaterThanOrEqual(0);
+		expect(thinkingStop).toBeGreaterThanOrEqual(0);
+		expect(toolStart).toBeGreaterThanOrEqual(0);
+		// thinking must be closed before tool opens
+		expect(thinkingStop).toBeLessThan(toolStart);
+		// tool block gets index 1 (thinking consumed 0)
+		expect(JSON.parse(events[toolStart]!.data!).index).toBe(1);
+	});
 });
 
 // ── transformStreamingResponse — model extraction ────────────────────────────

--- a/packages/openai-formats/src/__tests__/stream.test.ts
+++ b/packages/openai-formats/src/__tests__/stream.test.ts
@@ -851,6 +851,46 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 		// tool block gets index 1 (thinking consumed 0)
 		expect(JSON.parse(events[toolStart]!.data!).index).toBe(1);
 	});
+
+	it("closes text block before first tool_use block when text precedes tool_calls", async () => {
+		const upstream = makeOpenAIStream([
+			JSON.stringify({
+				id: "c1",
+				model: "gpt-4o",
+				choices: [{ index: 0, delta: { content: "Let me check." }, finish_reason: null }],
+			}),
+			JSON.stringify({
+				id: "c1",
+				model: "gpt-4o",
+				choices: [{
+					index: 0,
+					delta: { tool_calls: [{ index: 0, id: "tc1", type: "function", function: { name: "search", arguments: "" } }] },
+					finish_reason: null,
+				}],
+			}),
+			JSON.stringify({
+				id: "c1",
+				model: "gpt-4o",
+				choices: [{ index: 0, delta: { tool_calls: [{ index: 0, function: { arguments: '{"q":"x"}' } }] }, finish_reason: "tool_calls" }],
+			}),
+			"[DONE]",
+		]);
+		const transformed = transformStreamingResponse(upstream);
+		const raw = await readStream(transformed.body!);
+		const events = parseSSEEvents(raw);
+
+		const textStartIdx = events.findIndex((e) => e.event === "content_block_start" && JSON.parse(e.data!).content_block?.type === "text");
+		const textStopIdx = events.findIndex((e) => e.event === "content_block_stop" && JSON.parse(e.data!).index === 0);
+		const toolStartIdx = events.findIndex((e) => e.event === "content_block_start" && JSON.parse(e.data!).content_block?.type === "tool_use");
+
+		expect(textStartIdx).toBeGreaterThanOrEqual(0);
+		expect(textStopIdx).toBeGreaterThanOrEqual(0);
+		expect(toolStartIdx).toBeGreaterThanOrEqual(0);
+		// text block (idx=0) must be closed before tool block opens
+		expect(textStopIdx).toBeLessThan(toolStartIdx);
+		// tool block gets index 1
+		expect(JSON.parse(events[toolStartIdx]!.data!).index).toBe(1);
+	});
 });
 
 // ── transformStreamingResponse — model extraction ────────────────────────────

--- a/packages/openai-formats/src/__tests__/stream.test.ts
+++ b/packages/openai-formats/src/__tests__/stream.test.ts
@@ -802,9 +802,11 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 		);
 		expect(textStart).toBeUndefined();
 
-		// Thinking block must be closed and message terminated
+		// Thinking block must be closed exactly once and message terminated
+		const stops = events.filter((e) => e.event === "content_block_stop");
+		expect(stops).toHaveLength(1);
+		expect(JSON.parse(stops[0]!.data!).index).toBe(0);
 		const types = events.map((e) => e.event);
-		expect(types).toContain("content_block_stop");
 		expect(types).toContain("message_stop");
 	});
 });

--- a/packages/openai-formats/src/__tests__/stream.test.ts
+++ b/packages/openai-formats/src/__tests__/stream.test.ts
@@ -1012,6 +1012,10 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 		expect(textStopIdx).toBeLessThan(thinkingStartIdx);
 		// thinking block gets index 1
 		expect(JSON.parse(events[thinkingStartIdx]?.data!).index).toBe(1);
+		// exactly 2 content_block_stop events: one for text (index 0), one for thinking (index 1)
+		const stops = events.filter((e) => e.event === "content_block_stop");
+		expect(stops).toHaveLength(2);
+		expect(stops.map((e) => JSON.parse(e.data!).index).sort()).toEqual([0, 1]);
 	});
 
 	it("handles same-delta reasoning_content + content: emits thinking block then text block", async () => {
@@ -1060,6 +1064,10 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 		);
 		expect(thinkingStopIdx).toBeGreaterThanOrEqual(0);
 		expect(thinkingStopIdx).toBeLessThan(textStartIdx);
+		// exactly 2 content_block_stop events: one for thinking (index 0), one for text (index 1)
+		const stops = events.filter((e) => e.event === "content_block_stop");
+		expect(stops).toHaveLength(2);
+		expect(stops.map((e) => JSON.parse(e.data!).index).sort()).toEqual([0, 1]);
 	});
 });
 

--- a/packages/openai-formats/src/__tests__/stream.test.ts
+++ b/packages/openai-formats/src/__tests__/stream.test.ts
@@ -684,7 +684,7 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 					e.event === "content_block_start" &&
 					JSON.parse(e.data!).content_block?.type === "text",
 			);
-		expect(stops.length).toBeGreaterThanOrEqual(1);
+		expect(stops).toHaveLength(1);
 		expect(textStart).toBeDefined();
 		expect(stops[0]?.i).toBeLessThan(textStart?.i);
 
@@ -761,10 +761,10 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 		const transformed = transformStreamingResponse(upstream);
 		const raw = await readStream(transformed.body!);
 		const events = parseSSEEvents(raw);
-		// The final content_block_stop (for text, not thinking) must be at index 1
+		// Exactly 2 content_block_stop events: thinking (index 0) and text (index 1)
 		const allStops = events.filter((e) => e.event === "content_block_stop");
-		const stopIndexes = allStops.map((e) => JSON.parse(e.data!).index);
-		expect(stopIndexes).toContain(1);
+		expect(allStops).toHaveLength(2);
+		expect(allStops.map((e) => JSON.parse(e.data!).index).sort()).toEqual([0, 1]);
 	});
 
 	it("handles reasoning_content only (no text) — thinking block without text block", async () => {

--- a/packages/openai-formats/src/__tests__/stream.test.ts
+++ b/packages/openai-formats/src/__tests__/stream.test.ts
@@ -579,3 +579,198 @@ describe("transformStreamingResponse — response metadata", () => {
 		expect(transformed.status).toBe(200);
 	});
 });
+
+// ── transformStreamingResponse — block index collision ───────────────────────
+
+describe("transformStreamingResponse — block index assignment", () => {
+	it("text-only: text block gets index 0", async () => {
+		const upstream = makeOpenAIStream([
+			JSON.stringify({
+				id: "c1",
+				model: "gpt-4",
+				choices: [
+					{ index: 0, delta: { content: "Hello" }, finish_reason: null },
+				],
+			}),
+			"[DONE]",
+		]);
+		const transformed = transformStreamingResponse(upstream);
+		const raw = await readStream(transformed.body!);
+		const events = parseSSEEvents(raw);
+		const textStart = events.find(
+			(e) =>
+				e.event === "content_block_start" &&
+				JSON.parse(e.data!).content_block?.type === "text",
+		);
+		expect(textStart).toBeDefined();
+		expect(JSON.parse(textStart?.data!).index).toBe(0);
+
+		const textDeltas = events.filter(
+			(e) =>
+				e.event === "content_block_delta" &&
+				JSON.parse(e.data!).delta?.type === "text_delta",
+		);
+		for (const d of textDeltas) {
+			expect(JSON.parse(d.data!).index).toBe(0);
+		}
+	});
+
+	it("tool-only: first tool call (OpenAI index 0) gets Anthropic block index 0", async () => {
+		const upstream = makeOpenAIStream([
+			JSON.stringify({
+				id: "c1",
+				model: "gpt-4",
+				choices: [
+					{
+						index: 0,
+						delta: {
+							tool_calls: [
+								{
+									index: 0,
+									id: "call_abc",
+									type: "function",
+									function: { name: "search", arguments: '{"q":"test"}' },
+								},
+							],
+						},
+						finish_reason: null,
+					},
+				],
+			}),
+			"[DONE]",
+		]);
+		const transformed = transformStreamingResponse(upstream);
+		const raw = await readStream(transformed.body!);
+		const events = parseSSEEvents(raw);
+		const toolStart = events.find(
+			(e) =>
+				e.event === "content_block_start" &&
+				JSON.parse(e.data!).content_block?.type === "tool_use",
+		);
+		expect(toolStart).toBeDefined();
+		expect(JSON.parse(toolStart?.data!).index).toBe(0);
+	});
+
+	it("text then tool: text gets index 0, tool gets index 1 — no collision", async () => {
+		// OpenAI sends text content first, then tool_calls[0] — both naively map to index 0.
+		// The fix ensures the tool call is assigned the next monotonic block index (1).
+		const upstream = makeOpenAIStream([
+			JSON.stringify({
+				id: "c1",
+				model: "gpt-4",
+				choices: [
+					{ index: 0, delta: { content: "thinking..." }, finish_reason: null },
+				],
+			}),
+			JSON.stringify({
+				id: "c1",
+				model: "gpt-4",
+				choices: [
+					{
+						index: 0,
+						delta: {
+							tool_calls: [
+								{
+									index: 0,
+									id: "call_xyz",
+									type: "function",
+									function: { name: "lookup", arguments: '{"id":1}' },
+								},
+							],
+						},
+						finish_reason: null,
+					},
+				],
+			}),
+			"[DONE]",
+		]);
+		const transformed = transformStreamingResponse(upstream);
+		const raw = await readStream(transformed.body!);
+		const events = parseSSEEvents(raw);
+
+		const textStart = events.find(
+			(e) =>
+				e.event === "content_block_start" &&
+				JSON.parse(e.data!).content_block?.type === "text",
+		);
+		const toolStart = events.find(
+			(e) =>
+				e.event === "content_block_start" &&
+				JSON.parse(e.data!).content_block?.type === "tool_use",
+		);
+
+		expect(textStart).toBeDefined();
+		expect(toolStart).toBeDefined();
+
+		const textIdx = JSON.parse(textStart?.data!).index;
+		const toolIdx = JSON.parse(toolStart?.data!).index;
+
+		// Indices must be distinct — no collision
+		expect(textIdx).not.toBe(toolIdx);
+		// Text block came first: index 0; tool block came second: index 1
+		expect(textIdx).toBe(0);
+		expect(toolIdx).toBe(1);
+
+		// The input_json_delta must carry the same Anthropic index as the tool block_start
+		const jsonDelta = events.find(
+			(e) =>
+				e.event === "content_block_delta" &&
+				JSON.parse(e.data!).delta?.type === "input_json_delta",
+		);
+		expect(jsonDelta).toBeDefined();
+		expect(JSON.parse(jsonDelta?.data!).index).toBe(toolIdx);
+
+		// The content_block_stop for the tool must match too
+		const stops = events.filter((e) => e.event === "content_block_stop");
+		const stopIndices = stops.map((e) => JSON.parse(e.data!).index);
+		expect(stopIndices).toContain(toolIdx);
+	});
+
+	it("multiple tool calls: each gets a distinct monotonic Anthropic block index", async () => {
+		const upstream = makeOpenAIStream([
+			JSON.stringify({
+				id: "c1",
+				model: "gpt-4",
+				choices: [
+					{
+						index: 0,
+						delta: {
+							tool_calls: [
+								{
+									index: 0,
+									id: "call_a",
+									type: "function",
+									function: { name: "search", arguments: '{"q":"a"}' },
+								},
+								{
+									index: 1,
+									id: "call_b",
+									type: "function",
+									function: { name: "lookup", arguments: '{"id":"1"}' },
+								},
+							],
+						},
+						finish_reason: null,
+					},
+				],
+			}),
+			"[DONE]",
+		]);
+		const transformed = transformStreamingResponse(upstream);
+		const raw = await readStream(transformed.body!);
+		const events = parseSSEEvents(raw);
+
+		const toolStarts = events.filter(
+			(e) =>
+				e.event === "content_block_start" &&
+				JSON.parse(e.data!).content_block?.type === "tool_use",
+		);
+		expect(toolStarts).toHaveLength(2);
+
+		const indices = toolStarts.map((e) => JSON.parse(e.data!).index);
+		// All indices must be unique
+		expect(new Set(indices).size).toBe(2);
+		// Must be 0 and 1 (monotonically assigned)
+		expect(indices.sort()).toEqual([0, 1]);
+	});
+});

--- a/packages/openai-formats/src/__tests__/stream.test.ts
+++ b/packages/openai-formats/src/__tests__/stream.test.ts
@@ -802,11 +802,10 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 		);
 		expect(textStart).toBeUndefined();
 
-		// When only thinking was emitted (hasSentContentBlockStart is false),
-		// the [DONE] handler skips emitStreamEnd — no message_stop is produced.
-		// This is current implementation behavior for reasoning-only responses.
+		// Thinking block must be closed and message terminated
 		const types = events.map((e) => e.event);
-		expect(types).not.toContain("message_stop");
+		expect(types).toContain("content_block_stop");
+		expect(types).toContain("message_stop");
 	});
 });
 

--- a/packages/openai-formats/src/__tests__/utils.test.ts
+++ b/packages/openai-formats/src/__tests__/utils.test.ts
@@ -126,8 +126,8 @@ describe("mapOpenAIFinishReason", () => {
 		expect(mapOpenAIFinishReason("function_call")).toBe("tool_use");
 	});
 
-	it("maps content_filter → stop_sequence", () => {
-		expect(mapOpenAIFinishReason("content_filter")).toBe("stop_sequence");
+	it("maps content_filter → end_turn", () => {
+		expect(mapOpenAIFinishReason("content_filter")).toBe("end_turn");
 	});
 
 	it("defaults unknown values to end_turn", () => {

--- a/packages/openai-formats/src/converters.ts
+++ b/packages/openai-formats/src/converters.ts
@@ -2,6 +2,7 @@ import { mapModelName } from "@better-ccflare/core";
 import { Logger } from "@better-ccflare/logger";
 import type { Account } from "@better-ccflare/types";
 import type {
+	AnthropicContent,
 	AnthropicContentBlock,
 	AnthropicRequest,
 	AnthropicResponse,
@@ -83,6 +84,23 @@ export function convertAnthropicRequestToOpenAI(
 				>,
 			},
 		}));
+	}
+
+	// Convert tool_choice
+	if (anthropicData.tool_choice !== undefined) {
+		const tc = anthropicData.tool_choice;
+		if (tc.type === "auto") {
+			openaiRequest.tool_choice = "auto";
+		} else if (tc.type === "any") {
+			openaiRequest.tool_choice = "required";
+		} else if (tc.type === "none") {
+			openaiRequest.tool_choice = "none";
+		} else if (tc.type === "tool") {
+			openaiRequest.tool_choice = {
+				type: "function",
+				function: { name: tc.name },
+			};
+		}
 	}
 
 	// Handle system message (Anthropic has it as top-level, OpenAI has it in messages array)
@@ -188,9 +206,30 @@ export function convertAnthropicRequestToOpenAI(
 					(item): item is AnthropicToolResult => item.type === "tool_result",
 				);
 				for (const toolResult of toolResults) {
+					let toolContent: string;
+					if (typeof toolResult.content === "string") {
+						toolContent = toolResult.content;
+					} else {
+						// Array content: serialize non-image items; drop images (not supported in OpenAI tool messages)
+						const parts: string[] = [];
+						for (const block of toolResult.content as AnthropicContent[]) {
+							if (block.type === "text") {
+								parts.push(block.text);
+							} else if (block.type === "image") {
+								// OpenAI tool messages don't support image content — drop with placeholder
+								parts.push(
+									"[image content not supported in OpenAI tool results]",
+								);
+							} else {
+								// Other structured blocks (tool_use, tool_result, etc.) — serialize as JSON
+								parts.push(JSON.stringify(block));
+							}
+						}
+						toolContent = parts.join("\n");
+					}
 					messages.push({
 						role: "tool",
-						content: toolResult.content,
+						content: toolContent,
 						tool_call_id: toolResult.tool_use_id,
 					});
 				}

--- a/packages/openai-formats/src/converters.ts
+++ b/packages/openai-formats/src/converters.ts
@@ -87,8 +87,8 @@ export function convertAnthropicRequestToOpenAI(
 		}));
 	}
 
-	// Convert tool_choice
-	if (anthropicData.tool_choice !== undefined) {
+	// Convert tool_choice — only emit when tools are present (OpenAI spec requirement)
+	if (anthropicData.tool_choice !== undefined && openaiRequest.tools?.length) {
 		const tc = anthropicData.tool_choice;
 		if (tc.type === "auto") {
 			openaiRequest.tool_choice = "auto";
@@ -245,7 +245,11 @@ export function convertAnthropicRequestToOpenAI(
 					openaiMessage.content = "";
 				}
 
-				if (openaiMessage.content !== null || openaiMessage.tool_calls) {
+				if (
+					(openaiMessage.content !== null &&
+						openaiMessage.content !== undefined) ||
+					openaiMessage.tool_calls
+				) {
 					messages.push(openaiMessage);
 				}
 			} else {

--- a/packages/openai-formats/src/converters.ts
+++ b/packages/openai-formats/src/converters.ts
@@ -50,7 +50,6 @@ export function convertAnthropicRequestToOpenAI(
 	// Map parameters
 	if (anthropicData.max_tokens !== undefined) {
 		openaiRequest.max_tokens = anthropicData.max_tokens;
-		openaiRequest.max_completion_tokens = anthropicData.max_tokens;
 	}
 	if (anthropicData.temperature !== undefined) {
 		openaiRequest.temperature = anthropicData.temperature;

--- a/packages/openai-formats/src/converters.ts
+++ b/packages/openai-formats/src/converters.ts
@@ -210,7 +210,7 @@ export function convertAnthropicRequestToOpenAI(
 					let toolContent: string;
 					if (typeof toolResult.content === "string") {
 						toolContent = toolResult.content;
-					} else {
+					} else if (Array.isArray(toolResult.content)) {
 						// Array content: serialize non-image items; drop images (not supported in OpenAI tool messages)
 						const parts: string[] = [];
 						for (const block of toolResult.content as AnthropicContent[]) {
@@ -227,6 +227,8 @@ export function convertAnthropicRequestToOpenAI(
 							}
 						}
 						toolContent = parts.join("\n");
+					} else {
+						toolContent = "";
 					}
 					messages.push({
 						role: "tool",

--- a/packages/openai-formats/src/converters.ts
+++ b/packages/openai-formats/src/converters.ts
@@ -50,6 +50,7 @@ export function convertAnthropicRequestToOpenAI(
 	// Map parameters
 	if (anthropicData.max_tokens !== undefined) {
 		openaiRequest.max_tokens = anthropicData.max_tokens;
+		openaiRequest.max_completion_tokens = anthropicData.max_tokens;
 	}
 	if (anthropicData.temperature !== undefined) {
 		openaiRequest.temperature = anthropicData.temperature;
@@ -234,7 +235,17 @@ export function convertAnthropicRequestToOpenAI(
 					});
 				}
 
-				if (openaiMessage.content || openaiMessage.tool_calls) {
+				if (
+					openaiMessage.content === null &&
+					!openaiMessage.tool_calls &&
+					thinkingBlocks.length > 0
+				) {
+					// Preserve thinking-only assistant turns while keeping
+					// OpenAI assistant content non-null.
+					openaiMessage.content = "";
+				}
+
+				if (openaiMessage.content !== null || openaiMessage.tool_calls) {
 					messages.push(openaiMessage);
 				}
 			} else {

--- a/packages/openai-formats/src/converters.ts
+++ b/packages/openai-formats/src/converters.ts
@@ -6,6 +6,7 @@ import type {
 	AnthropicRequest,
 	AnthropicResponse,
 	AnthropicTextContent,
+	AnthropicThinkingContent,
 	AnthropicToolResult,
 	AnthropicToolUse,
 	OpenAIMessage,
@@ -134,6 +135,12 @@ export function convertAnthropicRequestToOpenAI(
 				);
 				const hasCacheControl = textBlocks.some((part) => part.cache_control);
 
+				// Extract thinking blocks — needed for DeepSeek/reasoning providers
+				// that require reasoning_content to be passed back in conversation history
+				const thinkingBlocks = message.content.filter(
+					(part): part is AnthropicThinkingContent => part.type === "thinking",
+				);
+
 				let content: OpenAIMessage["content"];
 				if (hasCacheControl) {
 					content = textBlocks.map((part) => {
@@ -166,11 +173,17 @@ export function convertAnthropicRequestToOpenAI(
 					}));
 				}
 
-				if (openaiMessage.content || openaiMessage.tool_calls) {
-					messages.push(openaiMessage);
+				// Pass reasoning_content back for providers that require it (e.g. DeepSeek)
+				if (thinkingBlocks.length > 0) {
+					openaiMessage.reasoning_content = thinkingBlocks
+						.map((b) => b.thinking)
+						.join("");
 				}
 
-				// Handle tool_result blocks as separate 'tool' role messages
+				// Handle tool_result blocks as separate 'tool' role messages.
+				// Must be pushed BEFORE any accompanying text content so that
+				// tool messages immediately follow the assistant's tool_calls message
+				// (required by DeepSeek and OpenAI spec).
 				const toolResults = message.content.filter(
 					(item): item is AnthropicToolResult => item.type === "tool_result",
 				);
@@ -180,6 +193,10 @@ export function convertAnthropicRequestToOpenAI(
 						content: toolResult.content,
 						tool_call_id: toolResult.tool_use_id,
 					});
+				}
+
+				if (openaiMessage.content || openaiMessage.tool_calls) {
+					messages.push(openaiMessage);
 				}
 			} else {
 				// Simple string content

--- a/packages/openai-formats/src/stream.ts
+++ b/packages/openai-formats/src/stream.ts
@@ -70,6 +70,11 @@ function emitToolCallJson(
 /**
  * Emit content_block_stop, message_delta, and message_stop events.
  * Shared between [DONE] handler and flush handler.
+ *
+ * @param toolCallBlockIndices - Maps OpenAI tool_call delta index → Anthropic block index.
+ *   Pass null when stopReason is "end_turn" (text-only response).
+ * @param textBlockIndex - Anthropic block index used for the text content block.
+ *   Only used when stopReason is "end_turn".
  */
 function emitStreamEnd(
 	controller: TransformStreamDefaultController,
@@ -77,18 +82,18 @@ function emitStreamEnd(
 	stopReason: "tool_use" | "end_turn",
 	promptTokens: number,
 	completionTokens: number,
-	toolCallAccumulators: Record<number, string> | null,
+	toolCallBlockIndices: Record<number, number> | null,
 	cacheReadInputTokens: number,
 	cacheCreationInputTokens: number,
+	textBlockIndex = 0,
 ) {
 	// Send content_block_stop for all blocks
-	if (toolCallAccumulators) {
-		// Tool call blocks
-		for (const idx in toolCallAccumulators) {
-			const numIdx = Number.parseInt(idx, 10);
+	if (toolCallBlockIndices) {
+		// Tool call blocks — use Anthropic block indices (not OpenAI tool_call indices)
+		for (const anthropicIdx of Object.values(toolCallBlockIndices)) {
 			const contentBlockStop = {
 				type: "content_block_stop",
-				index: numIdx,
+				index: anthropicIdx,
 			};
 			controller.enqueue(
 				encoder.encode(`event: content_block_stop
@@ -101,10 +106,10 @@ function emitStreamEnd(
 			);
 		}
 	} else if (stopReason === "end_turn") {
-		// Text block at index 0
+		// Text block — use the assigned Anthropic block index
 		const contentBlockStop = {
 			type: "content_block_stop",
-			index: 0,
+			index: textBlockIndex,
 		};
 		controller.enqueue(
 			encoder.encode(`event: content_block_stop
@@ -172,12 +177,15 @@ export function transformStreamingResponse(response: Response): Response {
 					extractedModel: "unknown",
 					hasSentStart: false,
 					hasSentContentBlockStart: false,
+					textBlockIndex: 0,
 					promptTokens: 0,
 					completionTokens: 0,
 					cacheReadInputTokens: 0,
 					cacheCreationInputTokens: 0,
 					encounteredToolCall: false,
 					toolCallAccumulators: {},
+					nextBlockIndex: 0,
+					toolCallBlockIndices: {},
 					maxToolCallLength: 1_000_000,
 					maxToolCallIndex: 100,
 				} as TransformStreamContext;
@@ -204,12 +212,20 @@ export function transformStreamingResponse(response: Response): Response {
 						// Handle [DONE] marker
 						if (dataStr === "[DONE]") {
 							if (context.encounteredToolCall) {
-								// Emit buffered JSON for all tool calls, then stop events
-								for (const idx in context.toolCallAccumulators) {
-									const numIdx = Number.parseInt(idx, 10);
+								// Emit buffered JSON for all tool calls, then stop events.
+								// Use Anthropic block indices (from toolCallBlockIndices), not OpenAI tool_call indices.
+								for (const [openaiIdx, anthropicIdx] of Object.entries(
+									context.toolCallBlockIndices,
+								)) {
+									const numIdx = Number.parseInt(openaiIdx, 10);
 									const accumulated =
 										context.toolCallAccumulators[numIdx] || "";
-									emitToolCallJson(controller, encoder, numIdx, accumulated);
+									emitToolCallJson(
+										controller,
+										encoder,
+										anthropicIdx,
+										accumulated,
+									);
 								}
 								emitStreamEnd(
 									controller,
@@ -217,7 +233,7 @@ export function transformStreamingResponse(response: Response): Response {
 									"tool_use",
 									context.promptTokens,
 									context.completionTokens,
-									context.toolCallAccumulators,
+									context.toolCallBlockIndices,
 									context.cacheReadInputTokens,
 									context.cacheCreationInputTokens,
 								);
@@ -231,6 +247,7 @@ export function transformStreamingResponse(response: Response): Response {
 									null,
 									context.cacheReadInputTokens,
 									context.cacheCreationInputTokens,
+									context.textBlockIndex,
 								);
 							}
 
@@ -325,7 +342,10 @@ export function transformStreamingResponse(response: Response): Response {
 										continue;
 									}
 
-									// Send content_block_start on first tool call chunk
+									// Send content_block_start on first tool call chunk.
+									// Assign a monotonic Anthropic block index — do NOT reuse the
+									// OpenAI tool_call delta index, which always starts at 0 and
+									// would collide with a text content block also at index 0.
 									if (context.toolCallAccumulators[idx] === undefined) {
 										if (!toolCall.id || !toolCall.function?.name) {
 											log.warn(
@@ -334,9 +354,11 @@ export function transformStreamingResponse(response: Response): Response {
 											continue;
 										}
 										context.toolCallAccumulators[idx] = "";
+										const anthropicBlockIdx = context.nextBlockIndex++;
+										context.toolCallBlockIndices[idx] = anthropicBlockIdx;
 										const contentBlockStart = {
 											type: "content_block_start",
-											index: idx,
+											index: anthropicBlockIdx,
 											content_block: {
 												type: "tool_use",
 												id: toolCall.id,
@@ -367,12 +389,15 @@ export function transformStreamingResponse(response: Response): Response {
 										(context.toolCallAccumulators[idx] || "") + newArgs;
 								}
 							} else if (delta?.content) {
-								// Send content_block_start on first content
+								// Send content_block_start on first content.
+								// Use the monotonic nextBlockIndex so the text block index
+								// never collides with any tool_use blocks.
 								if (!context.hasSentContentBlockStart) {
 									context.hasSentContentBlockStart = true;
+									context.textBlockIndex = context.nextBlockIndex++;
 									const contentBlockStart = {
 										type: "content_block_start",
-										index: 0,
+										index: context.textBlockIndex,
 										content_block: {
 											type: "text",
 											text: "",
@@ -391,7 +416,7 @@ export function transformStreamingResponse(response: Response): Response {
 								// Send content delta
 								const contentBlockDelta = {
 									type: "content_block_delta",
-									index: 0,
+									index: context.textBlockIndex,
 									delta: {
 										type: "text_delta",
 										text: delta.content,
@@ -427,10 +452,12 @@ export function transformStreamingResponse(response: Response): Response {
 					log.warn(
 						"Stream terminated without [DONE] — emitting buffered tool calls + stop events",
 					);
-					for (const idx in context.toolCallAccumulators) {
-						const numIdx = Number.parseInt(idx, 10);
+					for (const [openaiIdx, anthropicIdx] of Object.entries(
+						context.toolCallBlockIndices,
+					)) {
+						const numIdx = Number.parseInt(openaiIdx, 10);
 						const accumulated = context.toolCallAccumulators[numIdx] || "";
-						emitToolCallJson(controller, encoder, numIdx, accumulated);
+						emitToolCallJson(controller, encoder, anthropicIdx, accumulated);
 					}
 					emitStreamEnd(
 						controller,
@@ -438,7 +465,7 @@ export function transformStreamingResponse(response: Response): Response {
 						"tool_use",
 						context.promptTokens,
 						context.completionTokens,
-						context.toolCallAccumulators,
+						context.toolCallBlockIndices,
 						context.cacheReadInputTokens,
 						context.cacheCreationInputTokens,
 					);
@@ -456,6 +483,7 @@ export function transformStreamingResponse(response: Response): Response {
 						null,
 						context.cacheReadInputTokens,
 						context.cacheCreationInputTokens,
+						context.textBlockIndex,
 					);
 				}
 

--- a/packages/openai-formats/src/stream.ts
+++ b/packages/openai-formats/src/stream.ts
@@ -252,19 +252,7 @@ export function transformStreamingResponse(response: Response): Response {
 									context.textBlockIndex,
 								);
 							} else if (context.hasSentThinkingBlockStart) {
-								// Reasoning-only stream: close thinking block and terminate message
-								const thinkingStop = {
-									type: "content_block_stop",
-									index: context.thinkingBlockIndex,
-								};
-								controller.enqueue(
-									encoder.encode(`event: content_block_stop\n`),
-								);
-								controller.enqueue(
-									encoder.encode(
-										`data: ${JSON.stringify(thinkingStop)}\n\n`,
-									),
-								);
+								// Reasoning-only stream: emitStreamEnd closes block via end_turn branch
 								emitStreamEnd(
 									controller,
 									encoder,
@@ -571,16 +559,7 @@ export function transformStreamingResponse(response: Response): Response {
 					log.warn(
 						"Stream terminated without [DONE] — closing reasoning-only thinking block",
 					);
-					const thinkingStop = {
-						type: "content_block_stop",
-						index: context.thinkingBlockIndex,
-					};
-					controller.enqueue(
-						encoder.encode(`event: content_block_stop\n`),
-					);
-					controller.enqueue(
-						encoder.encode(`data: ${JSON.stringify(thinkingStop)}\n\n`),
-					);
+					// emitStreamEnd closes the block via end_turn branch — no manual emit needed
 					emitStreamEnd(
 						controller,
 						encoder,

--- a/packages/openai-formats/src/stream.ts
+++ b/packages/openai-formats/src/stream.ts
@@ -242,6 +242,12 @@ export function transformStreamingResponse(response: Response): Response {
 									context.cacheCreationInputTokens,
 								);
 							} else if (context.hasSentContentBlockStart) {
+								// If text block was closed mid-stream (content→thinking transition),
+								// close the thinking block instead
+								const lastBlockIndex =
+									context.textBlockClosed
+										? context.thinkingBlockIndex
+										: context.textBlockIndex;
 								emitStreamEnd(
 									controller,
 									encoder,
@@ -251,7 +257,7 @@ export function transformStreamingResponse(response: Response): Response {
 									null,
 									context.cacheReadInputTokens,
 									context.cacheCreationInputTokens,
-									context.textBlockIndex,
+									lastBlockIndex,
 								);
 							} else if (context.hasSentThinkingBlockStart) {
 								// Reasoning-only stream: emitStreamEnd closes block via end_turn branch
@@ -448,6 +454,22 @@ export function transformStreamingResponse(response: Response): Response {
 								// Map to Anthropic thinking block using monotonic nextBlockIndex.
 								if (!context.hasSentThinkingBlockStart) {
 									context.hasSentThinkingBlockStart = true;
+									// Close text block first if one was already emitted
+									if (context.hasSentContentBlockStart && !context.textBlockClosed) {
+										context.textBlockClosed = true;
+										const textStop = {
+											type: "content_block_stop",
+											index: context.textBlockIndex,
+										};
+										controller.enqueue(
+											encoder.encode(`event: content_block_stop\n`),
+										);
+										controller.enqueue(
+											encoder.encode(
+												`data: ${JSON.stringify(textStop)}\n\n`,
+											),
+										);
+									}
 									context.thinkingBlockIndex = context.nextBlockIndex++;
 									const thinkingBlockStart = {
 										type: "content_block_start",
@@ -584,7 +606,11 @@ export function transformStreamingResponse(response: Response): Response {
 					context.hasSentContentBlockStart &&
 					!context.encounteredToolCall
 				) {
-					log.warn("Stream terminated without [DONE] — closing text block");
+					log.warn("Stream terminated without [DONE] — closing last open block");
+					const lastBlockIndex =
+						context.textBlockClosed
+							? context.thinkingBlockIndex
+							: context.textBlockIndex;
 					emitStreamEnd(
 						controller,
 						encoder,
@@ -594,7 +620,7 @@ export function transformStreamingResponse(response: Response): Response {
 						null,
 						context.cacheReadInputTokens,
 						context.cacheCreationInputTokens,
-						context.textBlockIndex,
+						lastBlockIndex,
 					);
 				} else if (context.hasSentThinkingBlockStart) {
 					log.warn(

--- a/packages/openai-formats/src/stream.ts
+++ b/packages/openai-formats/src/stream.ts
@@ -449,7 +449,9 @@ export function transformStreamingResponse(response: Response): Response {
 									context.toolCallAccumulators[idx] =
 										(context.toolCallAccumulators[idx] || "") + newArgs;
 								}
-							} else if (delta?.reasoning_content) {
+							} else {
+								// reasoning_content and content can coexist in one delta — handle both
+								if (delta?.reasoning_content) {
 								// DeepSeek/reasoning providers emit reasoning_content before text.
 								// Map to Anthropic thinking block using monotonic nextBlockIndex.
 								if (!context.hasSentThinkingBlockStart) {
@@ -503,7 +505,8 @@ export function transformStreamingResponse(response: Response): Response {
 								controller.enqueue(
 									encoder.encode(`data: ${JSON.stringify(thinkingDelta)}\n\n`),
 								);
-							} else if (delta?.content) {
+								}
+								if (delta?.content) {
 								// Send content_block_start on first content.
 								// Use the monotonic nextBlockIndex so the text block index
 								// never collides with any tool_use blocks.
@@ -563,6 +566,7 @@ export function transformStreamingResponse(response: Response): Response {
 										`data: ${JSON.stringify(contentBlockDelta)}\n\n`,
 									),
 								);
+								}
 							}
 						} catch (_parseError) {
 							// Ignore JSON parse errors for malformed chunks

--- a/packages/openai-formats/src/stream.ts
+++ b/packages/openai-formats/src/stream.ts
@@ -73,8 +73,8 @@ function emitToolCallJson(
  *
  * @param toolCallBlockIndices - Maps OpenAI tool_call delta index → Anthropic block index.
  *   Pass null when stopReason is "end_turn" (text-only response).
- * @param textBlockIndex - Anthropic block index used for the text content block.
- *   Only used when stopReason is "end_turn".
+ * @param endTurnBlockIndex - Anthropic block index to close when stopReason is "end_turn".
+ *   May be a text block or a thinking block depending on the stream pattern.
  */
 function emitStreamEnd(
 	controller: TransformStreamDefaultController,
@@ -85,7 +85,7 @@ function emitStreamEnd(
 	toolCallBlockIndices: Record<number, number> | null,
 	cacheReadInputTokens: number,
 	cacheCreationInputTokens: number,
-	textBlockIndex = 0,
+	endTurnBlockIndex = 0,
 ) {
 	// Send content_block_stop for all blocks
 	if (toolCallBlockIndices) {
@@ -106,10 +106,10 @@ function emitStreamEnd(
 			);
 		}
 	} else if (stopReason === "end_turn") {
-		// Text block — use the assigned Anthropic block index
+		// Text or thinking block — use the assigned Anthropic block index
 		const contentBlockStop = {
 			type: "content_block_stop",
-			index: textBlockIndex,
+			index: endTurnBlockIndex,
 		};
 		controller.enqueue(
 			encoder.encode(`event: content_block_stop
@@ -244,10 +244,9 @@ export function transformStreamingResponse(response: Response): Response {
 							} else if (context.hasSentContentBlockStart) {
 								// If text block was closed mid-stream (content→thinking transition),
 								// close the thinking block instead
-								const lastBlockIndex =
-									context.textBlockClosed
-										? context.thinkingBlockIndex
-										: context.textBlockIndex;
+								const lastBlockIndex = context.textBlockClosed
+									? context.thinkingBlockIndex
+									: context.textBlockIndex;
 								emitStreamEnd(
 									controller,
 									encoder,
@@ -409,9 +408,7 @@ export function transformStreamingResponse(response: Response): Response {
 												encoder.encode(`event: content_block_stop\n`),
 											);
 											controller.enqueue(
-												encoder.encode(
-													`data: ${JSON.stringify(textStop)}\n\n`,
-												),
+												encoder.encode(`data: ${JSON.stringify(textStop)}\n\n`),
 											);
 										}
 										context.toolCallAccumulators[idx] = "";
@@ -452,120 +449,126 @@ export function transformStreamingResponse(response: Response): Response {
 							} else {
 								// reasoning_content and content can coexist in one delta — handle both
 								if (delta?.reasoning_content) {
-								// DeepSeek/reasoning providers emit reasoning_content before text.
-								// Map to Anthropic thinking block using monotonic nextBlockIndex.
-								if (!context.hasSentThinkingBlockStart) {
-									context.hasSentThinkingBlockStart = true;
-									// Close text block first if one was already emitted
-									if (context.hasSentContentBlockStart && !context.textBlockClosed) {
-										context.textBlockClosed = true;
-										const textStop = {
-											type: "content_block_stop",
-											index: context.textBlockIndex,
+									// DeepSeek/reasoning providers emit reasoning_content before text.
+									// Map to Anthropic thinking block using monotonic nextBlockIndex.
+									if (!context.hasSentThinkingBlockStart) {
+										context.hasSentThinkingBlockStart = true;
+										// Close text block first if one was already emitted
+										if (
+											context.hasSentContentBlockStart &&
+											!context.textBlockClosed
+										) {
+											context.textBlockClosed = true;
+											const textStop = {
+												type: "content_block_stop",
+												index: context.textBlockIndex,
+											};
+											controller.enqueue(
+												encoder.encode(`event: content_block_stop\n`),
+											);
+											controller.enqueue(
+												encoder.encode(`data: ${JSON.stringify(textStop)}\n\n`),
+											);
+										}
+										context.thinkingBlockIndex = context.nextBlockIndex++;
+										const thinkingBlockStart = {
+											type: "content_block_start",
+											index: context.thinkingBlockIndex,
+											content_block: {
+												type: "thinking",
+												thinking: "",
+											},
 										};
 										controller.enqueue(
-											encoder.encode(`event: content_block_stop\n`),
+											encoder.encode(`event: content_block_start\n`),
 										);
 										controller.enqueue(
 											encoder.encode(
-												`data: ${JSON.stringify(textStop)}\n\n`,
+												`data: ${JSON.stringify(thinkingBlockStart)}\n\n`,
 											),
 										);
 									}
-									context.thinkingBlockIndex = context.nextBlockIndex++;
-									const thinkingBlockStart = {
-										type: "content_block_start",
+
+									const thinkingDelta = {
+										type: "content_block_delta",
 										index: context.thinkingBlockIndex,
-										content_block: {
-											type: "thinking",
-											thinking: "",
+										delta: {
+											type: "thinking_delta",
+											thinking: delta.reasoning_content,
 										},
 									};
 									controller.enqueue(
-										encoder.encode(`event: content_block_start\n`),
+										encoder.encode(`event: content_block_delta\n`),
 									);
 									controller.enqueue(
 										encoder.encode(
-											`data: ${JSON.stringify(thinkingBlockStart)}\n\n`,
+											`data: ${JSON.stringify(thinkingDelta)}\n\n`,
 										),
 									);
-								}
-
-								const thinkingDelta = {
-									type: "content_block_delta",
-									index: context.thinkingBlockIndex,
-									delta: {
-										type: "thinking_delta",
-										thinking: delta.reasoning_content,
-									},
-								};
-								controller.enqueue(
-									encoder.encode(`event: content_block_delta\n`),
-								);
-								controller.enqueue(
-									encoder.encode(`data: ${JSON.stringify(thinkingDelta)}\n\n`),
-								);
 								}
 								if (delta?.content) {
-								// Send content_block_start on first content.
-								// Use the monotonic nextBlockIndex so the text block index
-								// never collides with any tool_use blocks.
-								if (!context.hasSentContentBlockStart) {
-									context.hasSentContentBlockStart = true;
-									context.textBlockIndex = context.nextBlockIndex++;
+									// Send content_block_start on first content.
+									// Use the monotonic nextBlockIndex so the text block index
+									// never collides with any tool_use blocks.
+									if (!context.hasSentContentBlockStart) {
+										context.hasSentContentBlockStart = true;
+										context.textBlockIndex = context.nextBlockIndex++;
 
-									// Close thinking block first if one was emitted
-									if (context.hasSentThinkingBlockStart && !context.thinkingBlockClosed) {
-										context.thinkingBlockClosed = true;
-										const thinkingStop = {
-											type: "content_block_stop",
-											index: context.thinkingBlockIndex,
+										// Close thinking block first if one was emitted
+										if (
+											context.hasSentThinkingBlockStart &&
+											!context.thinkingBlockClosed
+										) {
+											context.thinkingBlockClosed = true;
+											const thinkingStop = {
+												type: "content_block_stop",
+												index: context.thinkingBlockIndex,
+											};
+											controller.enqueue(
+												encoder.encode(`event: content_block_stop\n`),
+											);
+											controller.enqueue(
+												encoder.encode(
+													`data: ${JSON.stringify(thinkingStop)}\n\n`,
+												),
+											);
+										}
+
+										const contentBlockStart = {
+											type: "content_block_start",
+											index: context.textBlockIndex,
+											content_block: {
+												type: "text",
+												text: "",
+											},
 										};
 										controller.enqueue(
-											encoder.encode(`event: content_block_stop\n`),
+											encoder.encode(`event: content_block_start\n`),
 										);
 										controller.enqueue(
 											encoder.encode(
-												`data: ${JSON.stringify(thinkingStop)}\n\n`,
+												`data: ${JSON.stringify(contentBlockStart)}\n\n`,
 											),
 										);
 									}
 
-									const contentBlockStart = {
-										type: "content_block_start",
+									// Send content delta
+									const contentBlockDelta = {
+										type: "content_block_delta",
 										index: context.textBlockIndex,
-										content_block: {
-											type: "text",
-											text: "",
+										delta: {
+											type: "text_delta",
+											text: delta.content,
 										},
 									};
 									controller.enqueue(
-										encoder.encode(`event: content_block_start\n`),
+										encoder.encode(`event: content_block_delta\n`),
 									);
 									controller.enqueue(
 										encoder.encode(
-											`data: ${JSON.stringify(contentBlockStart)}\n\n`,
+											`data: ${JSON.stringify(contentBlockDelta)}\n\n`,
 										),
 									);
-								}
-
-								// Send content delta
-								const contentBlockDelta = {
-									type: "content_block_delta",
-									index: context.textBlockIndex,
-									delta: {
-										type: "text_delta",
-										text: delta.content,
-									},
-								};
-								controller.enqueue(
-									encoder.encode(`event: content_block_delta\n`),
-								);
-								controller.enqueue(
-									encoder.encode(
-										`data: ${JSON.stringify(contentBlockDelta)}\n\n`,
-									),
-								);
 								}
 							}
 						} catch (_parseError) {
@@ -610,11 +613,12 @@ export function transformStreamingResponse(response: Response): Response {
 					context.hasSentContentBlockStart &&
 					!context.encounteredToolCall
 				) {
-					log.warn("Stream terminated without [DONE] — closing last open block");
-					const lastBlockIndex =
-						context.textBlockClosed
-							? context.thinkingBlockIndex
-							: context.textBlockIndex;
+					log.warn(
+						"Stream terminated without [DONE] — closing last open block",
+					);
+					const lastBlockIndex = context.textBlockClosed
+						? context.thinkingBlockIndex
+						: context.textBlockIndex;
 					emitStreamEnd(
 						controller,
 						encoder,

--- a/packages/openai-formats/src/stream.ts
+++ b/packages/openai-formats/src/stream.ts
@@ -178,6 +178,7 @@ export function transformStreamingResponse(response: Response): Response {
 					hasSentStart: false,
 					hasSentContentBlockStart: false,
 					hasSentThinkingBlockStart: false,
+					thinkingBlockClosed: false,
 					thinkingBlockIndex: 0,
 					textBlockIndex: 0,
 					promptTokens: 0,
@@ -368,6 +369,25 @@ export function transformStreamingResponse(response: Response): Response {
 											);
 											continue;
 										}
+										// Close thinking block before first tool block if not already closed
+										if (
+											context.hasSentThinkingBlockStart &&
+											!context.thinkingBlockClosed
+										) {
+											context.thinkingBlockClosed = true;
+											const thinkingStop = {
+												type: "content_block_stop",
+												index: context.thinkingBlockIndex,
+											};
+											controller.enqueue(
+												encoder.encode(`event: content_block_stop\n`),
+											);
+											controller.enqueue(
+												encoder.encode(
+													`data: ${JSON.stringify(thinkingStop)}\n\n`,
+												),
+											);
+										}
 										context.toolCallAccumulators[idx] = "";
 										const anthropicBlockIdx = context.nextBlockIndex++;
 										context.toolCallBlockIndices[idx] = anthropicBlockIdx;
@@ -450,7 +470,8 @@ export function transformStreamingResponse(response: Response): Response {
 									context.textBlockIndex = context.nextBlockIndex++;
 
 									// Close thinking block first if one was emitted
-									if (context.hasSentThinkingBlockStart) {
+									if (context.hasSentThinkingBlockStart && !context.thinkingBlockClosed) {
+										context.thinkingBlockClosed = true;
 										const thinkingStop = {
 											type: "content_block_stop",
 											index: context.thinkingBlockIndex,

--- a/packages/openai-formats/src/stream.ts
+++ b/packages/openai-formats/src/stream.ts
@@ -80,6 +80,7 @@ function emitStreamEnd(
 	toolCallAccumulators: Record<number, string> | null,
 	cacheReadInputTokens: number,
 	cacheCreationInputTokens: number,
+	textBlockIndex = 0,
 ) {
 	// Send content_block_stop for all blocks
 	if (toolCallAccumulators) {
@@ -101,10 +102,10 @@ function emitStreamEnd(
 			);
 		}
 	} else if (stopReason === "end_turn") {
-		// Text block at index 0
+		// Text block at textBlockIndex (1 when thinking block was emitted at index 0)
 		const contentBlockStop = {
 			type: "content_block_stop",
-			index: 0,
+			index: textBlockIndex,
 		};
 		controller.enqueue(
 			encoder.encode(`event: content_block_stop
@@ -172,6 +173,7 @@ export function transformStreamingResponse(response: Response): Response {
 					extractedModel: "unknown",
 					hasSentStart: false,
 					hasSentContentBlockStart: false,
+					hasSentThinkingBlockStart: false,
 					promptTokens: 0,
 					completionTokens: 0,
 					cacheReadInputTokens: 0,
@@ -231,6 +233,7 @@ export function transformStreamingResponse(response: Response): Response {
 									null,
 									context.cacheReadInputTokens,
 									context.cacheCreationInputTokens,
+									context.hasSentThinkingBlockStart ? 1 : 0,
 								);
 							}
 
@@ -366,13 +369,70 @@ export function transformStreamingResponse(response: Response): Response {
 									context.toolCallAccumulators[idx] =
 										(context.toolCallAccumulators[idx] || "") + newArgs;
 								}
+							} else if (delta?.reasoning_content) {
+								// DeepSeek/reasoning providers emit reasoning_content before text.
+								// Map to Anthropic thinking block at index 0.
+								if (!context.hasSentThinkingBlockStart) {
+									context.hasSentThinkingBlockStart = true;
+									const thinkingBlockStart = {
+										type: "content_block_start",
+										index: 0,
+										content_block: {
+											type: "thinking",
+											thinking: "",
+										},
+									};
+									controller.enqueue(
+										encoder.encode(`event: content_block_start\n`),
+									);
+									controller.enqueue(
+										encoder.encode(
+											`data: ${JSON.stringify(thinkingBlockStart)}\n\n`,
+										),
+									);
+								}
+
+								const thinkingDelta = {
+									type: "content_block_delta",
+									index: 0,
+									delta: {
+										type: "thinking_delta",
+										thinking: delta.reasoning_content,
+									},
+								};
+								controller.enqueue(
+									encoder.encode(`event: content_block_delta\n`),
+								);
+								controller.enqueue(
+									encoder.encode(`data: ${JSON.stringify(thinkingDelta)}\n\n`),
+								);
 							} else if (delta?.content) {
+								// Text block index: 1 if thinking was emitted, else 0
+								const textIndex = context.hasSentThinkingBlockStart ? 1 : 0;
+
 								// Send content_block_start on first content
 								if (!context.hasSentContentBlockStart) {
 									context.hasSentContentBlockStart = true;
+
+									// Close thinking block first if needed
+									if (context.hasSentThinkingBlockStart) {
+										const thinkingStop = {
+											type: "content_block_stop",
+											index: 0,
+										};
+										controller.enqueue(
+											encoder.encode(`event: content_block_stop\n`),
+										);
+										controller.enqueue(
+											encoder.encode(
+												`data: ${JSON.stringify(thinkingStop)}\n\n`,
+											),
+										);
+									}
+
 									const contentBlockStart = {
 										type: "content_block_start",
-										index: 0,
+										index: textIndex,
 										content_block: {
 											type: "text",
 											text: "",
@@ -391,7 +451,7 @@ export function transformStreamingResponse(response: Response): Response {
 								// Send content delta
 								const contentBlockDelta = {
 									type: "content_block_delta",
-									index: 0,
+									index: textIndex,
 									delta: {
 										type: "text_delta",
 										text: delta.content,
@@ -456,6 +516,7 @@ export function transformStreamingResponse(response: Response): Response {
 						null,
 						context.cacheReadInputTokens,
 						context.cacheCreationInputTokens,
+						context.hasSentThinkingBlockStart ? 1 : 0,
 					);
 				}
 

--- a/packages/openai-formats/src/stream.ts
+++ b/packages/openai-formats/src/stream.ts
@@ -179,6 +179,7 @@ export function transformStreamingResponse(response: Response): Response {
 					hasSentContentBlockStart: false,
 					hasSentThinkingBlockStart: false,
 					thinkingBlockClosed: false,
+					textBlockClosed: false,
 					thinkingBlockIndex: 0,
 					textBlockIndex: 0,
 					promptTokens: 0,
@@ -385,6 +386,25 @@ export function transformStreamingResponse(response: Response): Response {
 											controller.enqueue(
 												encoder.encode(
 													`data: ${JSON.stringify(thinkingStop)}\n\n`,
+												),
+											);
+										}
+										// Close text block before first tool block if not already closed
+										if (
+											context.hasSentContentBlockStart &&
+											!context.textBlockClosed
+										) {
+											context.textBlockClosed = true;
+											const textStop = {
+												type: "content_block_stop",
+												index: context.textBlockIndex,
+											};
+											controller.enqueue(
+												encoder.encode(`event: content_block_stop\n`),
+											);
+											controller.enqueue(
+												encoder.encode(
+													`data: ${JSON.stringify(textStop)}\n\n`,
 												),
 											);
 										}

--- a/packages/openai-formats/src/stream.ts
+++ b/packages/openai-formats/src/stream.ts
@@ -251,6 +251,31 @@ export function transformStreamingResponse(response: Response): Response {
 									context.cacheCreationInputTokens,
 									context.textBlockIndex,
 								);
+							} else if (context.hasSentThinkingBlockStart) {
+								// Reasoning-only stream: close thinking block and terminate message
+								const thinkingStop = {
+									type: "content_block_stop",
+									index: context.thinkingBlockIndex,
+								};
+								controller.enqueue(
+									encoder.encode(`event: content_block_stop\n`),
+								);
+								controller.enqueue(
+									encoder.encode(
+										`data: ${JSON.stringify(thinkingStop)}\n\n`,
+									),
+								);
+								emitStreamEnd(
+									controller,
+									encoder,
+									"end_turn",
+									context.promptTokens,
+									context.completionTokens,
+									null,
+									context.cacheReadInputTokens,
+									context.cacheCreationInputTokens,
+									context.thinkingBlockIndex,
+								);
 							}
 
 							// Cleanup entire context after stream completion
@@ -541,6 +566,31 @@ export function transformStreamingResponse(response: Response): Response {
 						context.cacheReadInputTokens,
 						context.cacheCreationInputTokens,
 						context.textBlockIndex,
+					);
+				} else if (context.hasSentThinkingBlockStart) {
+					log.warn(
+						"Stream terminated without [DONE] — closing reasoning-only thinking block",
+					);
+					const thinkingStop = {
+						type: "content_block_stop",
+						index: context.thinkingBlockIndex,
+					};
+					controller.enqueue(
+						encoder.encode(`event: content_block_stop\n`),
+					);
+					controller.enqueue(
+						encoder.encode(`data: ${JSON.stringify(thinkingStop)}\n\n`),
+					);
+					emitStreamEnd(
+						controller,
+						encoder,
+						"end_turn",
+						context.promptTokens,
+						context.completionTokens,
+						null,
+						context.cacheReadInputTokens,
+						context.cacheCreationInputTokens,
+						context.thinkingBlockIndex,
 					);
 				}
 

--- a/packages/openai-formats/src/types.ts
+++ b/packages/openai-formats/src/types.ts
@@ -154,6 +154,7 @@ export interface TransformStreamContext {
 	hasSentStart: boolean;
 	hasSentContentBlockStart: boolean;
 	hasSentThinkingBlockStart: boolean;
+	thinkingBlockClosed: boolean;
 	/** Anthropic block index for the thinking block (assigned by nextBlockIndex). */
 	thinkingBlockIndex: number;
 	/** Index of the text content block in the Anthropic stream (assigned by nextBlockIndex). */

--- a/packages/openai-formats/src/types.ts
+++ b/packages/openai-formats/src/types.ts
@@ -43,7 +43,6 @@ export interface OpenAIRequest {
 	model: string;
 	messages: OpenAIMessage[];
 	max_tokens?: number;
-	max_completion_tokens?: number;
 	temperature?: number;
 	top_p?: number;
 	stop?: string | string[];
@@ -84,7 +83,7 @@ export interface AnthropicToolUse {
 export interface AnthropicToolResult {
 	type: "tool_result";
 	tool_use_id: string;
-	content: string | AnthropicContent[];
+	content?: string | AnthropicContent[];
 }
 
 /**

--- a/packages/openai-formats/src/types.ts
+++ b/packages/openai-formats/src/types.ts
@@ -110,12 +110,23 @@ export interface TransformStreamContext {
 	extractedModel: string;
 	hasSentStart: boolean;
 	hasSentContentBlockStart: boolean;
+	/** Index of the text content block in the Anthropic stream (assigned by nextBlockIndex). */
+	textBlockIndex: number;
 	promptTokens: number;
 	completionTokens: number;
 	cacheReadInputTokens: number;
 	cacheCreationInputTokens: number;
 	encounteredToolCall: boolean;
 	toolCallAccumulators: Record<number, string>;
+	/**
+	 * Monotonic counter for Anthropic content_block indices.
+	 * Each new content block (text, thinking, tool_use) gets the next value.
+	 * OpenAI tool_calls[].index is used only to identify the accumulator slot,
+	 * NOT as the Anthropic block index.
+	 */
+	nextBlockIndex: number;
+	/** Maps OpenAI tool_call delta index → Anthropic content_block index. */
+	toolCallBlockIndices: Record<number, number>;
 	maxToolCallLength: number;
 	maxToolCallIndex: number;
 }

--- a/packages/openai-formats/src/types.ts
+++ b/packages/openai-formats/src/types.ts
@@ -21,6 +21,7 @@ export interface OpenAIMessage {
 		  }>;
 	tool_calls?: OpenAIToolCall[];
 	tool_call_id?: string;
+	reasoning_content?: string;
 }
 
 export interface OpenAITool {
@@ -63,8 +64,14 @@ export interface AnthropicTextContent {
 	cache_control?: { type: string };
 }
 
+export interface AnthropicThinkingContent {
+	type: "thinking";
+	thinking: string;
+}
+
 export type AnthropicContentBlock =
 	| AnthropicTextContent
+	| AnthropicThinkingContent
 	| AnthropicToolUse
 	| AnthropicToolResult;
 
@@ -110,6 +117,7 @@ export interface TransformStreamContext {
 	extractedModel: string;
 	hasSentStart: boolean;
 	hasSentContentBlockStart: boolean;
+	hasSentThinkingBlockStart: boolean;
 	promptTokens: number;
 	completionTokens: number;
 	cacheReadInputTokens: number;
@@ -122,6 +130,7 @@ export interface TransformStreamContext {
 
 export interface OpenAIStreamDelta {
 	content?: string;
+	reasoning_content?: string;
 	tool_calls?: Array<{
 		index: number;
 		id?: string;

--- a/packages/openai-formats/src/types.ts
+++ b/packages/openai-formats/src/types.ts
@@ -155,6 +155,7 @@ export interface TransformStreamContext {
 	hasSentContentBlockStart: boolean;
 	hasSentThinkingBlockStart: boolean;
 	thinkingBlockClosed: boolean;
+	textBlockClosed: boolean;
 	/** Anthropic block index for the thinking block (assigned by nextBlockIndex). */
 	thinkingBlockIndex: number;
 	/** Index of the text content block in the Anthropic stream (assigned by nextBlockIndex). */

--- a/packages/openai-formats/src/types.ts
+++ b/packages/openai-formats/src/types.ts
@@ -33,6 +33,12 @@ export interface OpenAITool {
 	};
 }
 
+export type OpenAIToolChoice =
+	| "auto"
+	| "none"
+	| "required"
+	| { type: "function"; function: { name: string } };
+
 export interface OpenAIRequest {
 	model: string;
 	messages: OpenAIMessage[];
@@ -43,19 +49,7 @@ export interface OpenAIRequest {
 	stream?: boolean;
 	stream_options?: { include_usage: boolean };
 	tools?: OpenAITool[];
-}
-
-export interface AnthropicToolUse {
-	type: "tool_use";
-	id: string;
-	name: string;
-	input?: Record<string, unknown>;
-}
-
-export interface AnthropicToolResult {
-	type: "tool_result";
-	tool_use_id: string;
-	content: string;
+	tool_choice?: OpenAIToolChoice;
 }
 
 export interface AnthropicTextContent {
@@ -68,6 +62,40 @@ export interface AnthropicThinkingContent {
 	type: "thinking";
 	thinking: string;
 }
+
+export interface AnthropicImageContent {
+	type: "image";
+	source: {
+		type: "base64" | "url";
+		media_type?: string;
+		data?: string;
+		url?: string;
+	};
+}
+
+export interface AnthropicToolUse {
+	type: "tool_use";
+	id: string;
+	name: string;
+	input?: Record<string, unknown>;
+}
+
+export interface AnthropicToolResult {
+	type: "tool_result";
+	tool_use_id: string;
+	content: string | AnthropicContent[];
+}
+
+/**
+ * Union of all Anthropic content block types that can appear in tool results
+ * or message content arrays.
+ */
+export type AnthropicContent =
+	| AnthropicTextContent
+	| AnthropicImageContent
+	| AnthropicThinkingContent
+	| AnthropicToolUse
+	| AnthropicToolResult;
 
 export type AnthropicContentBlock =
 	| AnthropicTextContent
@@ -86,6 +114,12 @@ export interface AnthropicTool {
 	input_schema?: Record<string, unknown>;
 }
 
+export type AnthropicToolChoice =
+	| { type: "auto" }
+	| { type: "any" }
+	| { type: "none" }
+	| { type: "tool"; name: string };
+
 export interface AnthropicRequest {
 	model: string;
 	max_tokens: number;
@@ -102,6 +136,7 @@ export interface AnthropicRequest {
 	stop_sequences?: string[];
 	stream?: boolean;
 	tools?: AnthropicTool[];
+	tool_choice?: AnthropicToolChoice;
 }
 
 export interface OpenAIUsage {

--- a/packages/openai-formats/src/types.ts
+++ b/packages/openai-formats/src/types.ts
@@ -43,6 +43,7 @@ export interface OpenAIRequest {
 	model: string;
 	messages: OpenAIMessage[];
 	max_tokens?: number;
+	max_completion_tokens?: number;
 	temperature?: number;
 	top_p?: number;
 	stop?: string | string[];

--- a/packages/openai-formats/src/utils.ts
+++ b/packages/openai-formats/src/utils.ts
@@ -65,7 +65,7 @@ export function mapOpenAIFinishReason(openaiReason?: string): string {
 		case "tool_calls":
 			return "tool_use";
 		case "content_filter":
-			return "stop_sequence";
+			return "end_turn";
 		default:
 			return "end_turn";
 	}


### PR DESCRIPTION
## Summary

- **[High]** Streaming block index collision: use monotonic `nextBlockIndex` counter for Anthropic `content_block` indices instead of reusing OpenAI `tool_calls[].index` (which always starts at 0 and collides with text block)
- **[Medium]** Forward `tool_choice` (`auto`/`any`/`none`/specific tool) to OpenAI equivalents (`auto`/`required`/`none`/`{type:"function",...}`); only emitted when `tools` array is present (OpenAI spec)
- **[Medium]** Multi-content tool results: widen `AnthropicToolResult.content` to `string | AnthropicContent[] | undefined`; text blocks joined, images replaced with placeholder
- **[Low]** Thinking-only assistant messages: emit with `content: ""` instead of dropping
- **[Low]** `finish_reason: "content_filter"` mapped to `"end_turn"` (valid Anthropic stop_reason)
- **[Low]** Block lifecycle fixes: close thinking/text blocks before tool_use blocks; close thinking block in reasoning-only streams; prevent double content_block_stop

Note: `max_completion_tokens` was intentionally not added — it causes 400s on older OpenAI-compatible providers (litellm, DashScope, etc.) and `max_tokens` already works on all current models including o1/o3.

## Test plan

- [ ] 108/108 tests pass in `packages/openai-formats`
- [ ] `bun run typecheck` clean
- [ ] New tests added for all fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)