### PR TITLE
feat: add 2s TTL cache to /health endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ Automated release system uses commit prefixes for changelog:
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **better-ccflare** (8818 symbols, 15673 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **better-ccflare** (8828 symbols, 15696 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/packages/core/src/__tests__/ttl-cache.test.ts
+++ b/packages/core/src/__tests__/ttl-cache.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, beforeEach } from "bun:test";
+import { TtlCache } from "@better-ccflare/core";
+
+describe("TtlCache", () => {
+	let currentTime: number;
+	let now: () => number;
+
+	beforeEach(() => {
+		currentTime = 1000000;
+		now = () => currentTime;
+	});
+
+	it("returns undefined before set", () => {
+		const cache = new TtlCache(1000, now);
+		expect(cache.get()).toBeUndefined();
+	});
+
+	it("returns value after set within TTL", () => {
+		const cache = new TtlCache(1000, now);
+		cache.set("hello");
+		expect(cache.get()).toBe("hello");
+	});
+
+	it("returns undefined after TTL expires", () => {
+		const cache = new TtlCache(1000, now);
+		cache.set("hello");
+		currentTime = 1001001; // 1001ms later
+		expect(cache.get()).toBeUndefined();
+	});
+
+	it("respects custom TTL", () => {
+		const shortCache = new TtlCache(50, now);
+		shortCache.set(42);
+
+		currentTime = 1000040; // 40ms later — still valid
+		expect(shortCache.get()).toBe(42);
+
+		currentTime = 1000051; // 51ms later — expired
+		expect(shortCache.get()).toBeUndefined();
+	});
+
+	it("set() overwrites previous value", () => {
+		const cache = new TtlCache(1000, now);
+		cache.set("first");
+		expect(cache.get()).toBe("first");
+
+		cache.set("second");
+		expect(cache.get()).toBe("second");
+	});
+
+	it("clear() removes value", () => {
+		const cache = new TtlCache(1000, now);
+		cache.set("hello");
+		expect(cache.get()).toBe("hello");
+
+		cache.clear();
+		expect(cache.get()).toBeUndefined();
+	});
+
+	it("clear() resets staleness", () => {
+		const cache = new TtlCache(1000, now);
+		cache.set("hello");
+		expect(cache.isStale()).toBeFalse();
+
+		cache.clear();
+		expect(cache.isStale()).toBeTrue();
+	});
+
+	describe("size", () => {
+		it("returns 0 before set", () => {
+			const cache = new TtlCache(1000, now);
+			expect(cache.size).toBe(0);
+		});
+
+		it("returns 1 after set within TTL", () => {
+			const cache = new TtlCache(1000, now);
+			cache.set("hello");
+			expect(cache.size).toBe(1);
+		});
+
+		it("returns 0 after TTL expires", () => {
+			const cache = new TtlCache(1000, now);
+			cache.set("hello");
+			currentTime = 1001001;
+			expect(cache.size).toBe(0);
+		});
+
+		it("returns 0 after clear", () => {
+			const cache = new TtlCache(1000, now);
+			cache.set("hello");
+			cache.clear();
+			expect(cache.size).toBe(0);
+		});
+	});
+
+	describe("isStale", () => {
+		it("returns true before set", () => {
+			const cache = new TtlCache(1000, now);
+			expect(cache.isStale()).toBeTrue();
+		});
+
+		it("returns false after set within TTL", () => {
+			const cache = new TtlCache(1000, now);
+			cache.set("hello");
+			expect(cache.isStale()).toBeFalse();
+		});
+
+		it("returns true after TTL expires", () => {
+			const cache = new TtlCache(1000, now);
+			cache.set("hello");
+			currentTime = 1001001;
+			expect(cache.isStale()).toBeTrue();
+		});
+
+		it("returns true after clear", () => {
+			const cache = new TtlCache(1000, now);
+			cache.set("hello");
+			cache.clear();
+			expect(cache.isStale()).toBeTrue();
+		});
+	});
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -78,6 +78,7 @@ export {
 	FIXED_WINDOW_DURATION_MS,
 	type SupportedWindow,
 } from "./throttle-utils";
+export { TtlCache } from "./ttl-cache";
 export { levenshteinDistance } from "./utils";
 export {
 	patterns,

--- a/packages/core/src/ttl-cache.ts
+++ b/packages/core/src/ttl-cache.ts
@@ -1,0 +1,40 @@
+export class TtlCache<T> {
+	private ttlMs: number;
+	private value: T | undefined;
+	private timestamp: number = 0;
+	private now: () => number;
+
+	constructor(ttlMs: number, now?: () => number) {
+		this.ttlMs = ttlMs;
+		this.now = now ?? (() => Date.now());
+	}
+
+	set(value: T): void {
+		this.value = value;
+		this.timestamp = this.now();
+	}
+
+	get(): T | undefined {
+		if (this.value === undefined) return undefined;
+		if (this.now() - this.timestamp > this.ttlMs) {
+			this.clear();
+			return undefined;
+		}
+		return this.value;
+	}
+
+	isStale(): boolean {
+		return this.get() === undefined;
+	}
+
+	clear(): void {
+		this.value = undefined;
+		this.timestamp = 0;
+	}
+
+	get size(): number {
+		return this.value !== undefined && this.now() - this.timestamp <= this.ttlMs
+			? 1
+			: 0;
+	}
+}

--- a/packages/core/src/ttl-cache.ts
+++ b/packages/core/src/ttl-cache.ts
@@ -26,7 +26,8 @@ export class TtlCache<T> {
 	}
 
 	isStale(): boolean {
-		return this.get() === undefined;
+		if (!this.hasValue) return true;
+		return this.now() - this.timestamp > this.ttlMs;
 	}
 
 	clear(): void {

--- a/packages/core/src/ttl-cache.ts
+++ b/packages/core/src/ttl-cache.ts
@@ -2,6 +2,7 @@ export class TtlCache<T> {
 	private ttlMs: number;
 	private value: T | undefined;
 	private timestamp: number = 0;
+	private hasValue: boolean = false;
 	private now: () => number;
 
 	constructor(ttlMs: number, now?: () => number) {
@@ -11,11 +12,12 @@ export class TtlCache<T> {
 
 	set(value: T): void {
 		this.value = value;
+		this.hasValue = true;
 		this.timestamp = this.now();
 	}
 
 	get(): T | undefined {
-		if (this.value === undefined) return undefined;
+		if (!this.hasValue) return undefined;
 		if (this.now() - this.timestamp > this.ttlMs) {
 			this.clear();
 			return undefined;
@@ -29,12 +31,11 @@ export class TtlCache<T> {
 
 	clear(): void {
 		this.value = undefined;
+		this.hasValue = false;
 		this.timestamp = 0;
 	}
 
 	get size(): number {
-		return this.value !== undefined && this.now() - this.timestamp <= this.ttlMs
-			? 1
-			: 0;
+		return this.hasValue && this.now() - this.timestamp <= this.ttlMs ? 1 : 0;
 	}
 }

--- a/packages/database/src/migrations.test.ts
+++ b/packages/database/src/migrations.test.ts
@@ -1,8 +1,8 @@
 import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { ensureSchema, runMigrations } from "../src/migrations";
 
 describe("Database Migrations - Tier Column Removal", () => {

--- a/packages/http-api/src/handlers/__tests__/health-runtime.test.ts
+++ b/packages/http-api/src/handlers/__tests__/health-runtime.test.ts
@@ -502,3 +502,92 @@ describe("?detail=1 parameter", () => {
 		expect(body.accounts_detail).toBeUndefined();
 	});
 });
+
+describe("cache isolation between detail and non-detail", () => {
+	it("does not serve cached detail response to non-detail request", async () => {
+		let callCount = 0;
+		const db = {
+			getAllAccounts: async () => {
+				callCount++;
+				return [{ name: `acc-${callCount}`, paused: false, rate_limited_until: null }];
+			},
+		} as unknown as import("@better-ccflare/database").DatabaseOperations;
+
+		const config = {
+			getStrategy: () => "session",
+			getHealthDetailEnabled: () => true,
+		} as unknown as import("@better-ccflare/config").Config;
+
+		const handler = createHealthHandler(db, config);
+
+		// First request with detail=1
+		const detailResp = await handler(new URL("http://localhost/health?detail=1"));
+		const detailBody = (await detailResp.json()) as Record<string, any>;
+		expect(detailBody.accounts_detail).toBeDefined();
+		expect(detailBody.accounts_detail[0].name).toBe("acc-1");
+		expect(callCount).toBe(1);
+
+		// Second request without detail — should NOT hit the detail cache
+		const normalResp = await handler(new URL("http://localhost/health"));
+		const normalBody = (await normalResp.json()) as Record<string, unknown>;
+		expect(normalBody).not.toHaveProperty("accounts_detail");
+		expect(callCount).toBe(2);
+	});
+
+	it("does not serve cached non-detail response to detail request", async () => {
+		let callCount = 0;
+		const db = {
+			getAllAccounts: async () => {
+				callCount++;
+				return [{ name: `acc-${callCount}`, paused: false, rate_limited_until: null }];
+			},
+		} as unknown as import("@better-ccflare/database").DatabaseOperations;
+
+		const config = {
+			getStrategy: () => "session",
+			getHealthDetailEnabled: () => true,
+		} as unknown as import("@better-ccflare/config").Config;
+
+		const handler = createHealthHandler(db, config);
+
+		// First request without detail
+		const normalResp = await handler(new URL("http://localhost/health"));
+		const normalBody = (await normalResp.json()) as Record<string, unknown>;
+		expect(normalBody).not.toHaveProperty("accounts_detail");
+		expect(callCount).toBe(1);
+
+		// Second request with detail=1 — should NOT hit the non-detail cache
+		const detailResp = await handler(new URL("http://localhost/health?detail=1"));
+		const detailBody = (await detailResp.json()) as Record<string, any>;
+		expect(detailBody.accounts_detail).toBeDefined();
+		expect(callCount).toBe(2);
+	});
+
+	it("caches same-mode repeated requests (hits cache, no extra DB call)", async () => {
+		let callCount = 0;
+		const db = {
+			getAllAccounts: async () => {
+				callCount++;
+				return [{ name: `acc-${callCount}`, paused: false, rate_limited_until: null }];
+			},
+		} as unknown as import("@better-ccflare/database").DatabaseOperations;
+
+		const config = {
+			getStrategy: () => "session",
+			getHealthDetailEnabled: () => true,
+		} as unknown as import("@better-ccflare/config").Config;
+
+		const handler = createHealthHandler(db, config);
+
+		const resp1 = await handler(new URL("http://localhost/health"));
+		const body1 = (await resp1.json()) as Record<string, any>;
+		expect(body1.accounts_detail).toBeUndefined();
+		expect(callCount).toBe(1);
+
+		// Repeated non-detail request — should hit cache
+		const resp2 = await handler(new URL("http://localhost/health"));
+		const body2 = (await resp2.json()) as Record<string, any>;
+		expect(body2.accounts_detail).toBeUndefined();
+		expect(callCount).toBe(1); // no extra DB call
+	});
+});

--- a/packages/http-api/src/handlers/health.ts
+++ b/packages/http-api/src/handlers/health.ts
@@ -151,8 +151,7 @@ export function createHealthHandler(
 		}
 
 		// Support ?detail=1 for per-account details (requires HEALTH_DETAIL_ENABLED=true)
-		const detailParam = url.searchParams.get("detail");
-		if (detailParam === "1" && config.getHealthDetailEnabled()) {
+		if (withDetail) {
 			response.accounts_detail = accounts.map((a) => ({
 				name: a.name,
 				status: a.paused

--- a/packages/http-api/src/handlers/health.ts
+++ b/packages/http-api/src/handlers/health.ts
@@ -1,5 +1,5 @@
 import type { Config } from "@better-ccflare/config";
-import { isAccountAvailable } from "@better-ccflare/core";
+import { isAccountAvailable, TtlCache } from "@better-ccflare/core";
 import type { DatabaseOperations } from "@better-ccflare/database";
 import { jsonResponse } from "@better-ccflare/http-common";
 import type { Account } from "@better-ccflare/types";
@@ -82,7 +82,14 @@ export function createHealthHandler(
 	getUsageWorkerHealth?: UsageWorkerHealthFn,
 	getIntegrityStatus?: IntegrityStatusFn,
 ) {
+	const cache = new TtlCache<HealthResponse>(2000);
+
 	return async (url: URL): Promise<Response> => {
+		const cached = cache.get();
+		if (cached) {
+			return jsonResponse(cached, cached.status === "ok" ? 200 : 503);
+		}
+
 		const accounts = await dbOps.getAllAccounts();
 		const now = Date.now();
 		const pool = computePoolStatus(accounts, now);
@@ -165,6 +172,7 @@ export function createHealthHandler(
 		}
 
 		const httpStatus = status === "ok" ? 200 : 503;
+		cache.set(response);
 		return jsonResponse(response, httpStatus);
 	};
 }

--- a/packages/http-api/src/handlers/health.ts
+++ b/packages/http-api/src/handlers/health.ts
@@ -75,6 +75,10 @@ export function computeHealthStatus(
 	return "ok";
 }
 
+function toHttpStatus(status: HealthResponse["status"]): 200 | 503 {
+	return status === "ok" ? 200 : 503;
+}
+
 export function createHealthHandler(
 	dbOps: DatabaseOperations,
 	config: Config,
@@ -91,7 +95,7 @@ export function createHealthHandler(
 		const cache = withDetail ? detailCache : normalCache;
 		const cached = cache.get();
 		if (cached) {
-			return jsonResponse(cached, cached.status === "ok" ? 200 : 503);
+			return jsonResponse(cached, toHttpStatus(cached.status));
 		}
 
 		const accounts = await dbOps.getAllAccounts();
@@ -174,8 +178,7 @@ export function createHealthHandler(
 			}));
 		}
 
-		const httpStatus = status === "ok" ? 200 : 503;
 		cache.set(response);
-		return jsonResponse(response, httpStatus);
+		return jsonResponse(response, toHttpStatus(status));
 	};
 }

--- a/packages/http-api/src/handlers/health.ts
+++ b/packages/http-api/src/handlers/health.ts
@@ -82,9 +82,13 @@ export function createHealthHandler(
 	getUsageWorkerHealth?: UsageWorkerHealthFn,
 	getIntegrityStatus?: IntegrityStatusFn,
 ) {
-	const cache = new TtlCache<HealthResponse>(2000);
+	const normalCache = new TtlCache<HealthResponse>(2000);
+	const detailCache = new TtlCache<HealthResponse>(2000);
 
 	return async (url: URL): Promise<Response> => {
+		const withDetail =
+			url.searchParams.get("detail") === "1" && config.getHealthDetailEnabled();
+		const cache = withDetail ? detailCache : normalCache;
 		const cached = cache.get();
 		if (cached) {
 			return jsonResponse(cached, cached.status === "ok" ? 200 : 503);


### PR DESCRIPTION
## Summary
- Add `TtlCache<T>` reusable single-value TTL cache utility with injectable `now()` for testability
- Wire 2s TTL cache into `/health` handler — skips DB `getAllAccounts()` query for fresh requests
- Full test coverage for TTL cache (15 tests, 0 failures)

## Why
The `/health` endpoint is auth-exempt and calls `getAllAccounts()` on every request. No rate limiting exists. An attacker could hammer it to exhaust DB connections.

A 2s cache blocks rapid-fire requests while keeping staleness imperceptible for health monitoring (typical 5-30s polling intervals).

## Test plan
- [ ] `bun test packages/core/src/__tests__/ttl-cache.test.ts` — 15 tests pass
- [ ] `bun run typecheck` — clean
- [ ] Manual: `curl http://localhost:8081/health` twice rapidly — second hits cache

## Files
- `packages/core/src/ttl-cache.ts` — new generic TTL cache class
- `packages/core/src/__tests__/ttl-cache.test.ts` — test suite
- `packages/core/src/index.ts` — export
- `packages/http-api/src/handlers/health.ts` — cache integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)