### PR TITLE
fix: refetch request payload in details modal when missing

### DIFF
--- a/packages/dashboard-web/src/api.ts
+++ b/packages/dashboard-web/src/api.ts
@@ -732,6 +732,27 @@ class API extends HttpClient {
 		}
 	}
 
+	async getRequestPayload(id: string): Promise<RequestPayload> {
+		const startTime = Date.now();
+		const url = `/api/requests/payload/${encodeURIComponent(id)}`;
+
+		this.logger.debug(`→ GET ${url}`);
+
+		try {
+			const response = await this.get<Omit<RequestPayload, "id">>(url);
+			const duration = Date.now() - startTime;
+			this.logger.debug(`← GET ${url} - 200 (${duration}ms)`);
+			return { id, ...response };
+		} catch (error) {
+			const duration = Date.now() - startTime;
+			this.logger.error(`✗ GET ${url} - ERROR (${duration}ms)`, {
+				error: error instanceof Error ? error.message : String(error),
+				stack: error instanceof Error ? error.stack : undefined,
+			});
+			throw error;
+		}
+	}
+
 	async getRequestsSummary(
 		limit: number = API_LIMITS.requestsSummary,
 	): Promise<RequestSummary[]> {

--- a/packages/dashboard-web/src/components/RequestDetailsModal.tsx
+++ b/packages/dashboard-web/src/components/RequestDetailsModal.tsx
@@ -4,8 +4,8 @@ import {
 	formatTokens,
 } from "@better-ccflare/ui-common";
 import { Eye } from "lucide-react";
-import { useState } from "react";
-import type { RequestPayload, RequestSummary } from "../api";
+import { useEffect, useState } from "react";
+import { api, type RequestPayload, type RequestSummary } from "../api";
 import { ConversationView } from "./ConversationView";
 import { CopyButton } from "./CopyButton";
 import { TokenUsageDisplay } from "./TokenUsageDisplay";
@@ -35,6 +35,30 @@ export function RequestDetailsModal({
 	onClose,
 }: RequestDetailsModalProps) {
 	const [beautifyMode, setBeautifyMode] = useState(true);
+	const [hydrated, setHydrated] = useState<RequestPayload | null>(null);
+	const [failedId, setFailedId] = useState<string | null>(null);
+
+	const effective: RequestPayload =
+		hydrated && hydrated.id === request.id ? hydrated : request;
+
+	const needsHydration =
+		isOpen && !effective.error && !effective.request && failedId !== request.id;
+
+	useEffect(() => {
+		if (!needsHydration) return;
+		let cancelled = false;
+		api
+			.getRequestPayload(request.id)
+			.then((payload) => {
+				if (!cancelled) setHydrated(payload);
+			})
+			.catch(() => {
+				if (!cancelled) setFailedId(request.id);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [needsHydration, request.id]);
 
 	const decodeBase64 = (str: string | null): string => {
 		if (!str) return "No data";
@@ -74,8 +98,8 @@ export function RequestDetailsModal({
 		return formatJson(decoded);
 	};
 
-	const _isError = request.error || !request.meta.success;
-	const statusCode = request.response?.status;
+	const _isError = effective.error || !request.meta.success;
+	const statusCode = effective.response?.status;
 
 	return (
 		<Dialog open={isOpen} onOpenChange={onClose}>
@@ -145,8 +169,8 @@ export function RequestDetailsModal({
 
 					<TabsContent value="conversation" className="mt-4 flex-1 min-h-0">
 						<ConversationView
-							requestBody={decodeBase64(request.request.body)}
-							responseBody={decodeBase64(request.response?.body || null)}
+							requestBody={decodeBase64(effective.request?.body ?? null)}
+							responseBody={decodeBase64(effective.response?.body || null)}
 						/>
 					</TabsContent>
 
@@ -154,37 +178,47 @@ export function RequestDetailsModal({
 						value="request"
 						className="mt-4 space-y-4 overflow-y-auto max-h-[60vh]"
 					>
-						<div>
-							<div className="flex items-center justify-between mb-2">
-								<h3 className="font-semibold">Headers</h3>
-								<CopyButton
-									variant="ghost"
-									size="sm"
-									getValue={() => formatHeaders(request.request.headers)}
-								>
-									Copy
-								</CopyButton>
-							</div>
-							<pre className="bg-muted p-4 rounded-lg overflow-x-auto text-sm font-mono">
-								{formatHeaders(request.request.headers)}
-							</pre>
-						</div>
-
-						{request.request.body && (
-							<div>
-								<div className="flex items-center justify-between mb-2">
-									<h3 className="font-semibold">Body</h3>
-									<CopyButton
-										variant="ghost"
-										size="sm"
-										getValue={() => formatBody(request.request.body)}
-									>
-										Copy
-									</CopyButton>
+						{effective.request ? (
+							<>
+								<div>
+									<div className="flex items-center justify-between mb-2">
+										<h3 className="font-semibold">Headers</h3>
+										<CopyButton
+											variant="ghost"
+											size="sm"
+											getValue={() => formatHeaders(effective.request.headers)}
+										>
+											Copy
+										</CopyButton>
+									</div>
+									<pre className="bg-muted p-4 rounded-lg overflow-x-auto text-sm font-mono">
+										{formatHeaders(effective.request.headers)}
+									</pre>
 								</div>
-								<pre className="bg-muted p-4 rounded-lg overflow-x-auto text-sm font-mono">
-									{formatBody(request.request.body)}
-								</pre>
+
+								{effective.request.body && (
+									<div>
+										<div className="flex items-center justify-between mb-2">
+											<h3 className="font-semibold">Body</h3>
+											<CopyButton
+												variant="ghost"
+												size="sm"
+												getValue={() => formatBody(effective.request.body)}
+											>
+												Copy
+											</CopyButton>
+										</div>
+										<pre className="bg-muted p-4 rounded-lg overflow-x-auto text-sm font-mono">
+											{formatBody(effective.request.body)}
+										</pre>
+									</div>
+								)}
+							</>
+						) : (
+							<div className="text-center text-muted-foreground py-8">
+								{needsHydration
+									? "Loading payload…"
+									: "No request data available"}
 							</div>
 						)}
 					</TabsContent>
@@ -193,7 +227,7 @@ export function RequestDetailsModal({
 						value="response"
 						className="mt-4 space-y-4 overflow-y-auto max-h-[60vh]"
 					>
-						{request.response ? (
+						{effective.response ? (
 							<>
 								<div>
 									<div className="flex items-center justify-between mb-2">
@@ -202,8 +236,8 @@ export function RequestDetailsModal({
 											variant="ghost"
 											size="sm"
 											getValue={() =>
-												request.response
-													? formatHeaders(request.response.headers)
+												effective.response
+													? formatHeaders(effective.response.headers)
 													: ""
 											}
 										>
@@ -211,11 +245,11 @@ export function RequestDetailsModal({
 										</CopyButton>
 									</div>
 									<pre className="bg-muted p-4 rounded-lg overflow-x-auto text-sm font-mono">
-										{formatHeaders(request.response.headers)}
+										{formatHeaders(effective.response.headers)}
 									</pre>
 								</div>
 
-								{request.response.body && (
+								{effective.response.body && (
 									<div>
 										<div className="flex items-center justify-between mb-2">
 											<h3 className="font-semibold">Body</h3>
@@ -223,8 +257,8 @@ export function RequestDetailsModal({
 												variant="ghost"
 												size="sm"
 												getValue={() =>
-													request.response
-														? formatBody(request.response.body)
+													effective.response
+														? formatBody(effective.response.body)
 														: ""
 												}
 											>
@@ -232,17 +266,17 @@ export function RequestDetailsModal({
 											</CopyButton>
 										</div>
 										<pre className="bg-muted p-4 rounded-lg overflow-x-auto text-sm font-mono">
-											{formatBody(request.response.body)}
+											{formatBody(effective.response.body)}
 										</pre>
 									</div>
 								)}
 							</>
 						) : (
 							<div className="text-center text-muted-foreground py-8">
-								{request.error ? (
+								{effective.error ? (
 									<>
 										<p className="text-destructive font-medium">
-											Error: {request.error}
+											Error: {effective.error}
 										</p>
 										<p className="mt-2">No response data available</p>
 									</>


### PR DESCRIPTION
## Summary

The request details modal sometimes opens with an empty body. Root cause: `/api/requests/detail` `LEFT JOIN`s `request_payloads`, and the async writer commits the payload row a beat after the parent `requests` row. During that gap the endpoint returns `{id, meta}` only, so the modal's `request.request` is undefined and the Conversation/Request tabs render empty.

## Changes

- `packages/dashboard-web/src/api.ts` — add `getRequestPayload(id)` calling the existing `/api/requests/payload/:id` endpoint.
- `packages/dashboard-web/src/components/RequestDetailsModal.tsx` — when `effective.request` is missing on open, hydrate via the new method and re-render with the result. Show `Loading payload…` while pending; on a 404 (payload truly absent — retention cleanup, storage disabled), record the failed id so the modal falls back to `No request data available` instead of looping on the loading state.

## Test plan

- [ ] Open dashboard at `/`, watch the Requests list.
- [ ] Click into the most recent request immediately after it appears (within ~1 s of the upstream response). Modal should briefly show `Loading payload…`, then render the body.
- [ ] Click into older requests — should render immediately (no flicker, no extra fetch).
- [ ] Open a request whose `request_payloads` row was vacuumed by retention cleanup. Modal should show `No request data available` rather than loading forever.
- [ ] Switch the Request tab and back — body should remain rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)