### PR TITLE
fix: auto-retry without cache_control for strict OpenAI-compat providers

### DIFF
--- a/packages/openai-formats/src/converters.ts
+++ b/packages/openai-formats/src/converters.ts
@@ -32,6 +32,23 @@ export function safeParseJSON(jsonString: string): any {
 }
 
 /**
+ * Strip cache_control from all system message content blocks and user/assistant
+ * message content blocks in an already-converted OpenAI request body.
+ * Used for providers that reject unknown fields (e.g. GLM-5.1).
+ */
+export function stripCacheControlFromOpenAIRequest(body: OpenAIRequest): void {
+	for (const msg of body.messages) {
+		if (Array.isArray(msg.content)) {
+			for (const part of msg.content) {
+				if (typeof part === "object" && part !== null) {
+					delete (part as Record<string, unknown>).cache_control;
+				}
+			}
+		}
+	}
+}
+
+/**
  * Convert Anthropic request format to OpenAI format
  */
 export function convertAnthropicRequestToOpenAI(

--- a/packages/openai-formats/src/converters.ts
+++ b/packages/openai-formats/src/converters.ts
@@ -37,6 +37,7 @@ export function safeParseJSON(jsonString: string): any {
  * Used for providers that reject unknown fields (e.g. GLM-5.1).
  */
 export function stripCacheControlFromOpenAIRequest(body: OpenAIRequest): void {
+	if (!Array.isArray(body.messages)) return;
 	for (const msg of body.messages) {
 		if (Array.isArray(msg.content)) {
 			for (const part of msg.content) {

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -298,8 +298,6 @@ async function isCacheControlRejectionError(
 			typeof message === "string" &&
 			message.includes("cache_control") &&
 			(message.includes("Extra inputs are not permitted") ||
-				message.includes("not permitted") ||
-				message.includes("unexpected") ||
 				message.includes("unknown field"))
 		);
 	} catch {
@@ -640,6 +638,9 @@ export async function proxyWithAccount(
 		if (await isCacheControlRejectionError(rawResponse)) {
 			const rejectorKey = cacheControlRejectorKey(account.id, transformedModel);
 			if (!cacheControlRejectors.has(rejectorKey)) {
+				// Mark before retry so subsequent requests pre-strip without a round-trip.
+				// The current caller still receives the retried response (or the original
+				// 400 if the retry also fails).
 				cacheControlRejectors.add(rejectorKey);
 				log.info(
 					`Provider rejected cache_control for account=${account.name} model=${transformedModel}, retrying without it`,

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -300,8 +300,7 @@ async function isCacheControlRejectionError(
 			(message.includes("Extra inputs are not permitted") ||
 				message.includes("not permitted") ||
 				message.includes("unexpected") ||
-				message.includes("unknown field") ||
-				message.includes("invalid"))
+				message.includes("unknown field"))
 		);
 	} catch {
 		return false;
@@ -648,9 +647,7 @@ export async function proxyWithAccount(
 			}
 
 			try {
-				const retryBodyJson = JSON.parse(
-					await transformedRequest.clone().text(),
-				);
+				const retryBodyJson = JSON.parse(transformedBodyText);
 				stripCacheControlFromOpenAIRequest(retryBodyJson);
 				const retryRequest = new Request(transformedRequest.url, {
 					method: transformedRequest.method,

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -1,5 +1,6 @@
 import { getModelList, logError, ProviderError } from "@better-ccflare/core";
 import { Logger } from "@better-ccflare/logger";
+import { stripCacheControlFromOpenAIRequest } from "@better-ccflare/openai-formats";
 import { getProvider, usageCache } from "@better-ccflare/providers";
 import type {
 	Account,
@@ -268,6 +269,46 @@ async function isInvalidThinkingSignatureError(
 }
 
 /**
+ * In-memory set of (accountId, model) pairs known to reject cache_control.
+ * Populated on first 400 rejection; cleared on server restart (fast re-learn).
+ */
+const cacheControlRejectors = new Set<string>();
+
+function cacheControlRejectorKey(accountId: string, model: string): string {
+	return `${accountId}:${model}`;
+}
+
+/**
+ * Checks if a 400 response is caused by an upstream provider rejecting the
+ * cache_control field (e.g. GLM-5.1 strict OpenAI-compatible validation).
+ */
+async function isCacheControlRejectionError(
+	response: Response,
+): Promise<boolean> {
+	if (response.status !== 400) return false;
+
+	try {
+		const clone = response.clone();
+		const contentType = response.headers.get("content-type");
+		if (!contentType?.includes("application/json")) return false;
+
+		const json = await clone.json();
+		const message: string = json.error?.message ?? json.message ?? "";
+		return (
+			typeof message === "string" &&
+			message.includes("cache_control") &&
+			(message.includes("Extra inputs are not permitted") ||
+				message.includes("not permitted") ||
+				message.includes("unexpected") ||
+				message.includes("unknown field") ||
+				message.includes("invalid"))
+		);
+	} catch {
+		return false;
+	}
+}
+
+/**
  * Checks if a response error indicates the requested model is unavailable.
  * Covers Anthropic (not_found_error), OpenAI-compat (model_not_found),
  * generic messages, and Bedrock (ResourceNotFoundException).
@@ -514,9 +555,41 @@ export async function proxyWithAccount(
 
 		const providerRequest = new Request(targetUrl, requestInit);
 
-		const transformedRequest = provider.transformRequestBody
+		let transformedRequest = provider.transformRequestBody
 			? await provider.transformRequestBody(providerRequest, account)
 			: providerRequest;
+
+		// Pre-strip cache_control for (account, model) pairs known to reject it
+		const transformedBodyText = await transformedRequest.clone().text();
+		let transformedBodyJson: Record<string, unknown> | null = null;
+		try {
+			transformedBodyJson = JSON.parse(transformedBodyText);
+		} catch {
+			// ignore
+		}
+		const transformedModel =
+			(transformedBodyJson?.model as string | undefined) ?? "";
+		if (
+			transformedModel &&
+			cacheControlRejectors.has(
+				cacheControlRejectorKey(account.id, transformedModel),
+			) &&
+			transformedBodyJson
+		) {
+			stripCacheControlFromOpenAIRequest(
+				transformedBodyJson as unknown as Parameters<
+					typeof stripCacheControlFromOpenAIRequest
+				>[0],
+			);
+			transformedRequest = new Request(transformedRequest.url, {
+				method: transformedRequest.method,
+				headers: transformedRequest.headers,
+				body: JSON.stringify(transformedBodyJson),
+			});
+			log.debug(
+				`Pre-stripped cache_control for known rejector: account=${account.name} model=${transformedModel}`,
+			);
+		}
 
 		// Make the request (or unwrap a synthetic provider response)
 		let rawResponse = isSyntheticProviderResponse(transformedRequest)
@@ -560,6 +633,35 @@ export async function proxyWithAccount(
 				log.warn(
 					"Failed to filter thinking blocks or no changes made, proceeding with original error response",
 				);
+			}
+		}
+
+		// Retry without cache_control if provider rejected it (e.g. GLM-5.1 strict validation).
+		// Mark (accountId, model) so subsequent requests skip cache_control immediately.
+		if (await isCacheControlRejectionError(rawResponse)) {
+			const rejectorKey = cacheControlRejectorKey(account.id, transformedModel);
+			if (!cacheControlRejectors.has(rejectorKey)) {
+				cacheControlRejectors.add(rejectorKey);
+				log.info(
+					`Provider rejected cache_control for account=${account.name} model=${transformedModel}, retrying without it`,
+				);
+			}
+
+			try {
+				const retryBodyJson = JSON.parse(
+					await transformedRequest.clone().text(),
+				);
+				stripCacheControlFromOpenAIRequest(retryBodyJson);
+				const retryRequest = new Request(transformedRequest.url, {
+					method: transformedRequest.method,
+					headers: transformedRequest.headers,
+					body: JSON.stringify(retryBodyJson),
+				});
+				rawResponse = isSyntheticProviderResponse(retryRequest)
+					? materializeSyntheticResponse(retryRequest)
+					: await makeProxyRequest(retryRequest);
+			} catch (err) {
+				log.warn("Failed to retry without cache_control:", err);
 			}
 		}
 


### PR DESCRIPTION
## Summary

- GLM-5.1 (and similar strict OpenAI-compatible providers) reject requests containing `cache_control` on message content blocks with a 400 validation error
- DeepSeek and others silently ignore the unknown field, so stripping for all providers would break working setups
- Added automatic detect-and-retry: on first 400 rejection containing `cache_control` in the error, retry without it and mark `(accountId, model)` in an in-memory set for future requests

## How it works

1. First request to a strict model → 400 with `cache_control` validation error
2. Proxy detects the error, strips `cache_control` from all message content blocks, retries immediately
3. Marks `(accountId, model)` in `cacheControlRejectors` Set
4. All subsequent requests to that pair → `cache_control` pre-stripped before sending

**Zero config. Fully transparent to the client.** One extra round-trip on first request per (account, model) pair per server boot, then zero overhead.

## Test plan

- [x] GLM-5.1 via opencode-go-openai account: first request succeeds (was previously 400)
- [x] DeepSeek-v4 via same account: unaffected, still works
- [x] Second request to GLM-5.1: no extra latency (pre-stripped)
- [x] All 227 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)