### PR TITLE
fix: shorten default cooldown when 429 lacks reset hint (5h → 60s)

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -45,6 +45,17 @@ export const TIME_CONSTANTS = {
 	// Token expiration durations
 	API_KEY_TOKEN_EXPIRY_MS: 365 * 24 * 60 * 60 * 1000, // 1 year - for API keys that don't expire
 	GOOGLE_TOKEN_EXPIRY_MS: 60 * 60 * 1000, // 1 hour - Google Cloud access tokens
+
+	// Default cooldown applied when an upstream returns 429 *without* a
+	// reset hint (no `retry-after`, no rate-limit-reset header, no SSE
+	// reset frame). Previously 5h — pessimistic and prone to taking healthy
+	// accounts out of rotation on transient errors. The new default treats
+	// reset-less 429s as a probe interval rather than a hard ban: the
+	// account is excluded for a short window, then the next request will
+	// re-probe. Real Anthropic rate limits ship a `retry-after` and use
+	// the precise value from the header — those flows are unaffected.
+	// Override at runtime via CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS.
+	DEFAULT_RATE_LIMIT_NO_RESET_COOLDOWN_MS: 60 * 1000, // 60s
 } as const;
 
 // Buffer sizes (in bytes unless specified)

--- a/packages/http-api/src/handlers/accounts.ts
+++ b/packages/http-api/src/handlers/accounts.ts
@@ -44,7 +44,10 @@ const log = new Logger("AccountsHandler");
 
 const RATE_LIMIT_REASONS = new Set<RateLimitReason>([
 	"upstream_429_with_reset",
+	// Kept for backwards-compat with DB rows written by ccflare ≤ v3.5.x;
+	// new code emits `upstream_429_no_reset_probe_cooldown` instead.
 	"upstream_429_no_reset_default_5h",
+	"upstream_429_no_reset_probe_cooldown",
 	"model_fallback_429",
 	"all_models_exhausted_429",
 ]);

--- a/packages/proxy/src/handlers/response-processor.ts
+++ b/packages/proxy/src/handlers/response-processor.ts
@@ -1,4 +1,4 @@
-import { logError, RateLimitError } from "@better-ccflare/core";
+import { logError, RateLimitError, TIME_CONSTANTS } from "@better-ccflare/core";
 import { Logger } from "@better-ccflare/logger";
 import {
 	type Provider,
@@ -271,11 +271,20 @@ export async function processProxyResponse(
 		if (rateLimitInfo.resetTime) {
 			handleRateLimitResponse(account, rateLimitInfo, ctx);
 		} else {
-			// Mark as rate-limited even without reset time
-			log.warn(
-				`Account ${account.name} rate-limited but no reset time available`,
+			// Mark as rate-limited even without reset time. Use a short
+			// probe-friendly cooldown (default 60s, override via
+			// CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS) instead of the previous
+			// 5h hard-ban: a reset-less 429 is more likely a transient than
+			// a real rate-limit window, and a 5h ban on every transient
+			// error chains pool exhaustion under burst load.
+			const cooldownMs = Number(
+				process.env.CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS ??
+					TIME_CONSTANTS.DEFAULT_RATE_LIMIT_NO_RESET_COOLDOWN_MS,
 			);
-			const cooldownUntil = Date.now() + 5 * 60 * 60 * 1000;
+			log.warn(
+				`Account ${account.name} rate-limited but no reset time available — applying ${cooldownMs}ms probe cooldown`,
+			);
+			const cooldownUntil = Date.now() + cooldownMs;
 			account.rate_limited_until = cooldownUntil;
 			ctx.asyncWriter.enqueue(() => {
 				const reason: RateLimitReason = "upstream_429_no_reset_default_5h";
@@ -287,7 +296,7 @@ export async function processProxyResponse(
 					cooldownUntil,
 					reason,
 				);
-			}); // Default to 5 hours — applies to any provider without reset headers
+			});
 		}
 		// Also update metadata for rate-limited responses
 		const bypassSession =

--- a/packages/proxy/src/handlers/response-processor.ts
+++ b/packages/proxy/src/handlers/response-processor.ts
@@ -277,10 +277,13 @@ export async function processProxyResponse(
 			// 5h hard-ban: a reset-less 429 is more likely a transient than
 			// a real rate-limit window, and a 5h ban on every transient
 			// error chains pool exhaustion under burst load.
-			const cooldownMs = Number(
-				process.env.CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS ??
-					TIME_CONSTANTS.DEFAULT_RATE_LIMIT_NO_RESET_COOLDOWN_MS,
-			);
+			// Use `||` (not `??`) so an empty-string or non-numeric env
+			// var (Number("") === 0, Number("abc") === NaN) falls through
+			// to the default. With `??` the empty string would coalesce
+			// to 0 and silently disable the cooldown entirely.
+			const cooldownMs =
+				Number(process.env.CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS) ||
+				TIME_CONSTANTS.DEFAULT_RATE_LIMIT_NO_RESET_COOLDOWN_MS;
 			log.warn(
 				`Account ${account.name} rate-limited but no reset time available — applying ${cooldownMs}ms probe cooldown`,
 			);

--- a/packages/proxy/src/handlers/response-processor.ts
+++ b/packages/proxy/src/handlers/response-processor.ts
@@ -287,7 +287,8 @@ export async function processProxyResponse(
 			const cooldownUntil = Date.now() + cooldownMs;
 			account.rate_limited_until = cooldownUntil;
 			ctx.asyncWriter.enqueue(() => {
-				const reason: RateLimitReason = "upstream_429_no_reset_default_5h";
+				const reason: RateLimitReason =
+					"upstream_429_no_reset_probe_cooldown";
 				log.warn(
 					`[ccflare] account=${account.name} cooldown_applied reason=${reason} until=${new Date(cooldownUntil).toISOString()}`,
 				);

--- a/packages/proxy/src/response-handler.ts
+++ b/packages/proxy/src/response-handler.ts
@@ -28,9 +28,14 @@ type ResponseWithAnalyticsStream = Response & {
 // var is picked up without a server restart, matching the per-call read
 // in response-processor.ts.
 function getMidStreamRateLimitCooldownMs(): number {
-	return Number(
-		process.env.CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS ??
-			TIME_CONSTANTS.DEFAULT_RATE_LIMIT_NO_RESET_COOLDOWN_MS,
+	// Use `||` (not `??`) so empty-string and non-numeric env values
+	// (Number("") === 0, Number("abc") === NaN) fall through to the
+	// default — `??` would coalesce the empty string to 0 and silently
+	// disable the cooldown entirely. Symmetric with the per-call read
+	// in response-processor.ts.
+	return (
+		Number(process.env.CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS) ||
+		TIME_CONSTANTS.DEFAULT_RATE_LIMIT_NO_RESET_COOLDOWN_MS
 	);
 }
 

--- a/packages/proxy/src/response-handler.ts
+++ b/packages/proxy/src/response-handler.ts
@@ -23,10 +23,16 @@ type ResponseWithAnalyticsStream = Response & {
 // override via CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS). Previously 5h —
 // changed to a probe interval to avoid chaining pool exhaustion when a
 // transient SSE error trips the cooldown.
-const MID_STREAM_RATE_LIMIT_COOLDOWN_MS = Number(
-	process.env.CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS ??
-		TIME_CONSTANTS.DEFAULT_RATE_LIMIT_NO_RESET_COOLDOWN_MS,
-);
+//
+// Read on every call (not at module load) so a runtime change to the env
+// var is picked up without a server restart, matching the per-call read
+// in response-processor.ts.
+function getMidStreamRateLimitCooldownMs(): number {
+	return Number(
+		process.env.CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS ??
+			TIME_CONSTANTS.DEFAULT_RATE_LIMIT_NO_RESET_COOLDOWN_MS,
+	);
+}
 
 // Must match MAX_REQUEST_BODY_BYTES in post-processor.worker.ts.
 // Cap applied before postMessage to avoid multi-MB structured clones.
@@ -290,7 +296,7 @@ export async function forwardToClient(
 									account,
 									{
 										isRateLimited: true,
-										resetTime: Date.now() + MID_STREAM_RATE_LIMIT_COOLDOWN_MS,
+										resetTime: Date.now() + getMidStreamRateLimitCooldownMs(),
 									},
 									ctx,
 								);

--- a/packages/proxy/src/response-handler.ts
+++ b/packages/proxy/src/response-handler.ts
@@ -17,9 +17,16 @@ type ResponseWithAnalyticsStream = Response & {
 
 // Default cooldown for rate-limit errors detected mid-stream. SSE error
 // frames don't carry reset headers (HTTP headers were sent before the
-// error occurred), so we fall back to the same 5h default that
-// response-processor.ts uses for headerless 429 responses.
-const MID_STREAM_RATE_LIMIT_COOLDOWN_MS = 5 * 60 * 60 * 1000;
+// error occurred), so we fall back to the same probe-friendly default
+// that response-processor.ts uses for headerless 429 responses
+// (TIME_CONSTANTS.DEFAULT_RATE_LIMIT_NO_RESET_COOLDOWN_MS, default 60s,
+// override via CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS). Previously 5h —
+// changed to a probe interval to avoid chaining pool exhaustion when a
+// transient SSE error trips the cooldown.
+const MID_STREAM_RATE_LIMIT_COOLDOWN_MS = Number(
+	process.env.CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS ??
+		TIME_CONSTANTS.DEFAULT_RATE_LIMIT_NO_RESET_COOLDOWN_MS,
+);
 
 // Must match MAX_REQUEST_BODY_BYTES in post-processor.worker.ts.
 // Cap applied before postMessage to avoid multi-MB structured clones.

--- a/packages/types/src/account.ts
+++ b/packages/types/src/account.ts
@@ -1,6 +1,10 @@
 export type RateLimitReason =
 	| "upstream_429_with_reset"
+	/** @deprecated written by ccflare ≤ v3.5.x when no-reset 429s used a 5h ban.
+	 *  v3.5.2+ emits `upstream_429_no_reset_probe_cooldown` for the same path
+	 *  with a 60s default. Existing DB rows keep the old value for history. */
 	| "upstream_429_no_reset_default_5h"
+	| "upstream_429_no_reset_probe_cooldown"
 	| "model_fallback_429"
 	| "all_models_exhausted_429";
 


### PR DESCRIPTION
## Why

When upstream returns a 429 *without* a `retry-after` header, rate-limit-reset header, or SSE reset frame, ccflare currently bans the account for **5 hours**:

- `packages/proxy/src/handlers/response-processor.ts:278` — pre-stream 429 without reset
- `packages/proxy/src/response-handler.ts:22` — mid-stream rate-limit detected via SSE error frame

That default is pessimistic — a reset-less 429 is more often a transient (network blip, brief upstream backpressure) than a real rate-limit window — and chains pool exhaustion under burst load: multiple accounts can be cooled in milliseconds, leaving no routable candidate even when the upstream itself reports them as `allowed`.

We hit this repeatedly on a small (4-account) Anthropic OAuth pool driving a Claude Code agentic workload. Detail in #139.

## What

- Adds `TIME_CONSTANTS.DEFAULT_RATE_LIMIT_NO_RESET_COOLDOWN_MS = 60_000` (60 seconds)
- Replaces both 5h literals with that constant
- Operators can override at runtime via `CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS` (matches the existing pattern used for `CF_STREAM_TOTAL_TIMEOUT_MS` etc.)

A 60s cooldown is a probe interval rather than a hard ban: the account is excluded for the next minute, and the request after that re-probes. If the upstream is genuinely rate-limited, the next 429 will re-cool it (and the retry-after header path handles it correctly). If it was transient, traffic resumes fast.

## What's not changed

- `handleRateLimitResponse` in `response-processor.ts:19` (precise `retry-after` / `rate-limit-reset` cooldown) — that's the 99% path and it already uses the exact header value
- Any provider-specific cooldown logic (Zai's body-parsed reset, Codex usage windows, etc.)

Just the "we don't know how long, so guess" path.

## Testing

- Existing tests pass (no test relied on the 5h literal as such)
- Built clean with `bun run build` against current main
- Running on a fork branch in production-ish workload for ~3 hours; 503 burst frequency dropped substantially

Defaults are conservative — happy to tune the 60s literal up if reviewers prefer (e.g., 5 min). The point is "not 5 hours."

## Related

- #139 (long discussion of the burst-503 symptom, this is half the fix; PR #B will add a `LeastUsed` strategy that's the other half)