### PR TITLE
feat: add LeastUsed load-balancing strategy

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -22,7 +22,25 @@ import {
 	initPayloadEncryption,
 } from "@better-ccflare/database";
 import { APIRouter, AuthService } from "@better-ccflare/http-api";
-import { SessionStrategy } from "@better-ccflare/load-balancer";
+import { LeastUsedStrategy, SessionStrategy } from "@better-ccflare/load-balancer";
+import { StrategyName, type LoadBalancingStrategy } from "@better-ccflare/types";
+
+/**
+ * Build a load-balancing strategy from its enum name. Add new strategies here
+ * as additional cases. Falls back to SessionStrategy on unknown values.
+ */
+function buildStrategy(
+	name: StrategyName,
+	sessionDurationMs: number,
+): LoadBalancingStrategy {
+	switch (name) {
+		case StrategyName.LeastUsed:
+			return new LeastUsedStrategy();
+		case StrategyName.Session:
+		default:
+			return new SessionStrategy(sessionDurationMs);
+	}
+}
 import { Logger } from "@better-ccflare/logger";
 import {
 	getProvider,
@@ -740,7 +758,11 @@ export default async function startServer(options?: {
 	};
 
 	// Now create the strategy with runtime config
-	const strategy = new SessionStrategy(runtimeConfig.sessionDurationMs);
+	const strategy = buildStrategy(
+		config.getStrategy(),
+		runtimeConfig.sessionDurationMs,
+	);
+	log.info(`Load-balancing strategy: ${config.getStrategy()}`);
 
 	const strategyStore: StrategyStore = Object.assign(dbOps, {
 		getAccountUtilization(accountId: string, provider: string): number | null {
@@ -825,14 +847,14 @@ export default async function startServer(options?: {
 	// Hot reload strategy configuration
 	config.on("change", ({ key }: { key: string }) => {
 		if (key === "lb_strategy") {
-			log.info(`Strategy configuration changed to: ${config.getStrategy()}`);
 			const newStrategyName = config.getStrategy();
-			// For now, only SessionStrategy is supported
-			if (newStrategyName === "session") {
-				const strategy = new SessionStrategy(runtimeConfig.sessionDurationMs);
-				strategy.initialize(strategyStore);
-				proxyContext.strategy = strategy;
-			}
+			log.info(`Strategy configuration changed to: ${newStrategyName}`);
+			const strategy = buildStrategy(
+				newStrategyName,
+				runtimeConfig.sessionDurationMs,
+			);
+			strategy.initialize(strategyStore);
+			proxyContext.strategy = strategy;
 		}
 		if (key === "store_payloads") {
 			sendWorkerConfigUpdate(config.getStorePayloads());

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -23,24 +23,6 @@ import {
 } from "@better-ccflare/database";
 import { APIRouter, AuthService } from "@better-ccflare/http-api";
 import { LeastUsedStrategy, SessionStrategy } from "@better-ccflare/load-balancer";
-import { StrategyName, type LoadBalancingStrategy } from "@better-ccflare/types";
-
-/**
- * Build a load-balancing strategy from its enum name. Add new strategies here
- * as additional cases. Falls back to SessionStrategy on unknown values.
- */
-function buildStrategy(
-	name: StrategyName,
-	sessionDurationMs: number,
-): LoadBalancingStrategy {
-	switch (name) {
-		case StrategyName.LeastUsed:
-			return new LeastUsedStrategy();
-		case StrategyName.Session:
-		default:
-			return new SessionStrategy(sessionDurationMs);
-	}
-}
 import { Logger } from "@better-ccflare/logger";
 import {
 	getProvider,
@@ -70,8 +52,29 @@ import {
 	terminateUsageWorker,
 } from "@better-ccflare/proxy";
 import { validatePathOrThrow } from "@better-ccflare/security";
-import type { Account, StrategyStore } from "@better-ccflare/types";
+import {
+	type Account,
+	type LoadBalancingStrategy,
+	StrategyName,
+	type StrategyStore,
+} from "@better-ccflare/types";
 import { serve } from "bun";
+
+/**
+ * Build a load-balancing strategy from its enum name. Add new strategies here
+ * as additional cases. Falls back to SessionStrategy on unknown values.
+ */
+function buildStrategy(
+	name: StrategyName,
+	sessionDurationMs: number,
+): LoadBalancingStrategy {
+	switch (name) {
+		case StrategyName.LeastUsed:
+			return new LeastUsedStrategy();
+		default:
+			return new SessionStrategy(sessionDurationMs);
+	}
+}
 
 // Import embedded dashboard assets (will be bundled in compiled binary)
 let embeddedDashboard: Record<

--- a/packages/load-balancer/src/index.ts
+++ b/packages/load-balancer/src/index.ts
@@ -1,1 +1,2 @@
 export { SessionStrategy } from "./strategies";
+export { LeastUsedStrategy } from "./strategies/least-used";

--- a/packages/load-balancer/src/index.ts
+++ b/packages/load-balancer/src/index.ts
@@ -1,2 +1,1 @@
-export { SessionStrategy } from "./strategies";
-export { LeastUsedStrategy } from "./strategies/least-used";
+export { LeastUsedStrategy, SessionStrategy } from "./strategies";

--- a/packages/load-balancer/src/strategies/__tests__/least-used-strategy.test.ts
+++ b/packages/load-balancer/src/strategies/__tests__/least-used-strategy.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { LeastUsedStrategy } from "@better-ccflare/load-balancer";
+import type {
+	Account,
+	RequestMeta,
+	StrategyStore,
+} from "@better-ccflare/types";
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "a",
+		name: "a",
+		provider: "anthropic",
+		api_key: null,
+		refresh_token: "r",
+		access_token: "t",
+		expires_at: Date.now() + 3_600_000,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: Date.now(),
+		rate_limited_until: null,
+		rate_limited_reason: null,
+		rate_limited_at: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		peak_hours_pause_enabled: false,
+		custom_endpoint: null,
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		billing_type: null,
+		pause_reason: null,
+		refresh_token_issued_at: null,
+		...overrides,
+	};
+}
+
+class MockStore implements StrategyStore {
+	resetCalls: Array<{ accountId: string; timestamp: number }> = [];
+	resumeCalls: string[] = [];
+	utilization: Map<string, number | null> = new Map();
+
+	resetAccountSession(accountId: string, timestamp: number): void {
+		this.resetCalls.push({ accountId, timestamp });
+	}
+	resumeAccount(accountId: string): void {
+		this.resumeCalls.push(accountId);
+	}
+	getAccountUtilization(accountId: string): number | null {
+		return this.utilization.has(accountId)
+			? (this.utilization.get(accountId) ?? null)
+			: null;
+	}
+	setUtil(accountId: string, value: number | null): void {
+		this.utilization.set(accountId, value);
+	}
+}
+
+const meta: RequestMeta = {
+	id: "req-1",
+	headers: new Headers(),
+	timestamp: Date.now(),
+} as unknown as RequestMeta;
+
+describe("LeastUsedStrategy", () => {
+	let store: MockStore;
+	let strategy: LeastUsedStrategy;
+
+	beforeEach(() => {
+		store = new MockStore();
+		strategy = new LeastUsedStrategy();
+		strategy.initialize(store);
+	});
+
+	it("returns [] when all accounts are unavailable", () => {
+		const accounts = [
+			makeAccount({ id: "p1", paused: true }),
+			makeAccount({
+				id: "rl1",
+				rate_limited_until: Date.now() + 60_000,
+			}),
+		];
+		expect(strategy.select(accounts, meta)).toEqual([]);
+	});
+
+	it("orders by priority ASC (lower number first)", () => {
+		const accounts = [
+			makeAccount({ id: "p2", priority: 2 }),
+			makeAccount({ id: "p0", priority: 0 }),
+			makeAccount({ id: "p1", priority: 1 }),
+		];
+		const ordered = strategy.select(accounts, meta);
+		expect(ordered.map((a) => a.id)).toEqual(["p0", "p1", "p2"]);
+	});
+
+	it("breaks priority ties by utilization ASC", () => {
+		store.setUtil("low", 10);
+		store.setUtil("med", 50);
+		store.setUtil("high", 90);
+		const accounts = [
+			makeAccount({ id: "high" }),
+			makeAccount({ id: "low" }),
+			makeAccount({ id: "med" }),
+		];
+		const ordered = strategy.select(accounts, meta);
+		expect(ordered.map((a) => a.id)).toEqual(["low", "med", "high"]);
+	});
+
+	it("treats null utilization as 0 (newly-added accounts win ties)", () => {
+		// 'fresh' has no utilization data; 'used' is at 30%.
+		store.setUtil("used", 30);
+		const accounts = [
+			makeAccount({ id: "used" }),
+			makeAccount({ id: "fresh" }),
+		];
+		const ordered = strategy.select(accounts, meta);
+		expect(ordered[0].id).toBe("fresh");
+	});
+
+	it("falls back to priority-only ordering when initialize() was not called", () => {
+		const noStoreStrategy = new LeastUsedStrategy();
+		const accounts = [
+			makeAccount({ id: "low", priority: 5 }),
+			makeAccount({ id: "high", priority: 0 }),
+		];
+		const ordered = noStoreStrategy.select(accounts, meta);
+		expect(ordered.map((a) => a.id)).toEqual(["high", "low"]);
+	});
+
+	it("rotates concurrent picks via the recency penalty", () => {
+		// Three equal accounts (priority 0, util 0) — without the recency
+		// penalty, every select() would pick the same first-in-array account.
+		// The penalty must shift the picked account to the back of subsequent
+		// selects within RECENT_PICK_WINDOW_MS.
+		const accounts = [
+			makeAccount({ id: "x" }),
+			makeAccount({ id: "y" }),
+			makeAccount({ id: "z" }),
+		];
+
+		const first = strategy.select(accounts, meta);
+		const second = strategy.select(accounts, meta);
+		const third = strategy.select(accounts, meta);
+
+		const firstPrimary = first[0].id;
+		const secondPrimary = second[0].id;
+		const thirdPrimary = third[0].id;
+
+		// Each consecutive primary must differ from the previous one.
+		expect(secondPrimary).not.toBe(firstPrimary);
+		expect(thirdPrimary).not.toBe(secondPrimary);
+		// Across three selects we should have hit at least 2 distinct accounts.
+		expect(new Set([firstPrimary, secondPrimary, thirdPrimary]).size).toBeGreaterThanOrEqual(2);
+	});
+
+	describe("auto-unpause", () => {
+		it("resumes overage-paused accounts whose rate_limit_reset has elapsed", () => {
+			const past = Date.now() - 60_000;
+			const account = makeAccount({
+				id: "ovg",
+				paused: true,
+				pause_reason: "overage",
+				auto_fallback_enabled: true,
+				rate_limit_reset: past,
+			});
+			const ordered = strategy.select([account], meta);
+			expect(account.paused).toBe(false);
+			expect(store.resumeCalls).toContain("ovg");
+			expect(ordered.map((a) => a.id)).toEqual(["ovg"]);
+		});
+
+		it("does NOT resume manually-paused accounts", () => {
+			const past = Date.now() - 60_000;
+			const account = makeAccount({
+				id: "manual",
+				paused: true,
+				pause_reason: "manual",
+				auto_fallback_enabled: true,
+				rate_limit_reset: past,
+			});
+			const ordered = strategy.select([account], meta);
+			expect(account.paused).toBe(true);
+			expect(store.resumeCalls).not.toContain("manual");
+			expect(ordered).toEqual([]);
+		});
+
+		it("does NOT resume accounts without auto_fallback_enabled", () => {
+			const past = Date.now() - 60_000;
+			const account = makeAccount({
+				id: "no-flag",
+				paused: true,
+				pause_reason: "overage",
+				auto_fallback_enabled: false,
+				rate_limit_reset: past,
+			});
+			strategy.select([account], meta);
+			expect(account.paused).toBe(true);
+			expect(store.resumeCalls).not.toContain("no-flag");
+		});
+
+		it("does NOT resume when rate_limit_reset is still in the future", () => {
+			const future = Date.now() + 60_000;
+			const account = makeAccount({
+				id: "future",
+				paused: true,
+				pause_reason: "overage",
+				auto_fallback_enabled: true,
+				rate_limit_reset: future,
+			});
+			strategy.select([account], meta);
+			expect(account.paused).toBe(true);
+			expect(store.resumeCalls).not.toContain("future");
+		});
+	});
+});

--- a/packages/load-balancer/src/strategies/index.ts
+++ b/packages/load-balancer/src/strategies/index.ts
@@ -11,6 +11,8 @@ import {
 	requiresSessionDurationTracking,
 } from "@better-ccflare/types";
 
+export { LeastUsedStrategy } from "./least-used";
+
 export class SessionStrategy implements LoadBalancingStrategy {
 	private sessionDurationMs: number;
 	private store: StrategyStore | null = null;

--- a/packages/load-balancer/src/strategies/least-used.ts
+++ b/packages/load-balancer/src/strategies/least-used.ts
@@ -1,10 +1,11 @@
 import { isAccountAvailable } from "@better-ccflare/core";
 import { Logger } from "@better-ccflare/logger";
-import type {
-	Account,
-	LoadBalancingStrategy,
-	RequestMeta,
-	StrategyStore,
+import {
+	type Account,
+	type LoadBalancingStrategy,
+	PROVIDER_NAMES,
+	type RequestMeta,
+	type StrategyStore,
 } from "@better-ccflare/types";
 
 /**
@@ -21,6 +22,9 @@ const RECENT_PICK_WINDOW_MS = 500;
  * utilization deltas (typically 0–95).
  */
 const RECENT_PICK_PENALTY = 100;
+
+/** 1-second buffer for clock-skew protection on rate_limit_reset comparisons. */
+const RATE_LIMIT_RESET_BUFFER_MS = 1000;
 
 /**
  * LeastUsedStrategy — picks the available account with the lowest effective
@@ -60,6 +64,12 @@ export class LeastUsedStrategy implements LoadBalancingStrategy {
 
 	select(accounts: Account[], _meta: RequestMeta): Account[] {
 		const now = Date.now();
+
+		// Auto-unpause eligible accounts whose upstream usage window has reset.
+		// Mirrors SessionStrategy's checkForAutoFallbackAccounts path so users
+		// who configured auto_fallback_enabled accounts get the same self-recovery
+		// behaviour regardless of which strategy they pick.
+		this.autoUnpauseElapsedAccounts(accounts, now);
 
 		const available = accounts.filter((a) => isAccountAvailable(a, now));
 		if (available.length === 0) return [];
@@ -102,5 +112,51 @@ export class LeastUsedStrategy implements LoadBalancingStrategy {
 		);
 
 		return sorted;
+	}
+
+	/**
+	 * Auto-unpause any account whose:
+	 *   - auto_fallback_enabled flag is set, AND
+	 *   - upstream rate_limit_reset window has elapsed, AND
+	 *   - pause_reason is one of the reasons we consider safe to auto-unpause
+	 *     ('overage' or 'rate_limit_window'; null is also treated as safe to
+	 *     match SessionStrategy's behavior on legacy rows).
+	 *
+	 * Mutates the in-memory account.paused flag to false on resume so the
+	 * subsequent isAccountAvailable check reflects the new state. Manual
+	 * pauses (pause_reason='manual' or 'failure_threshold') are not touched.
+	 */
+	private autoUnpauseElapsedAccounts(accounts: Account[], now: number): void {
+		if (!this.store?.resumeAccount) return;
+
+		for (const account of accounts) {
+			if (!account.paused) continue;
+			if (!account.auto_fallback_enabled) continue;
+
+			// Only providers with proactive rate-limit-reset headers are eligible
+			// (matches SessionStrategy.checkForAutoFallbackAccounts).
+			const supportsWindowReset =
+				account.provider === PROVIDER_NAMES.ANTHROPIC ||
+				account.provider === PROVIDER_NAMES.CODEX ||
+				account.provider === PROVIDER_NAMES.ZAI;
+			if (!supportsWindowReset) continue;
+
+			const windowReset =
+				account.rate_limit_reset != null &&
+				account.rate_limit_reset < now - RATE_LIMIT_RESET_BUFFER_MS;
+			if (!windowReset) continue;
+
+			// Only auto-unpause for safe reasons. Match SessionStrategy:
+			// null pause_reason is treated as legacy/safe.
+			const safeReasons = [null, "overage", "rate_limit_window"];
+			const pauseReason = account.pause_reason ?? null;
+			if (!safeReasons.includes(pauseReason as string | null)) continue;
+
+			this.log.info(
+				`Auto-unpausing ${account.name} (pause_reason=${pauseReason}) — usage window has reset`,
+			);
+			this.store.resumeAccount(account.id);
+			account.paused = false;
+		}
 	}
 }

--- a/packages/load-balancer/src/strategies/least-used.ts
+++ b/packages/load-balancer/src/strategies/least-used.ts
@@ -8,18 +8,42 @@ import type {
 } from "@better-ccflare/types";
 
 /**
- * LeastUsedStrategy — picks the available account with the lowest reported
- * utilization, falling back to priority as a tiebreaker.
+ * Window during which a freshly-picked account is deprioritized so
+ * concurrent bursts rotate through the pool instead of all picking
+ * the same lowest-utilization candidate.
+ */
+const RECENT_PICK_WINDOW_MS = 500;
+
+/**
+ * Score added to an account's effective utilization when it was picked
+ * within RECENT_PICK_WINDOW_MS. 100 = "treat as fully utilized" for
+ * tiebreak purposes — large enough to override realistic upstream
+ * utilization deltas (typically 0–95).
+ */
+const RECENT_PICK_PENALTY = 100;
+
+/**
+ * LeastUsedStrategy — picks the available account with the lowest effective
+ * utilization, where effective utilization = upstream utilization + a
+ * recency penalty for accounts picked in the last RECENT_PICK_WINDOW_MS.
+ *
+ * Without the recency penalty, N concurrent select() calls all evaluate
+ * the same utilization snapshot and all pick the same lowest-util account,
+ * funneling the burst into one upstream and triggering chained per-account
+ * rate-limits — the exact failure mode this strategy is meant to avoid.
+ * The penalty makes burst behavior approximately round-robin (each select
+ * sees the previous pick as "recent" and deprioritizes it) while still
+ * preferring the genuinely least-utilized account for sparse traffic.
  *
  * Trade-off vs SessionStrategy:
  *   - No prompt-cache stickiness: each request is routed independently of
- *     the previous one, so cross-request prompt caches on Anthropic are
- *     less effective.
+ *     the previous one, so cross-request prompt caches on the upstream
+ *     are less effective.
  *   - Better burst behavior: a sudden spike of N concurrent requests is
- *     spread across all healthy accounts in priority + utilization order
- *     rather than funneled into a single sticky account, reducing the
- *     probability of multiple accounts hitting per-account rate limits in
- *     near-simultaneity ("burst-cool" pool exhaustion).
+ *     spread across all healthy accounts rather than funneled into a
+ *     single sticky account, reducing the probability of multiple
+ *     accounts hitting per-account rate limits in near-simultaneity
+ *     ("burst-cool" pool exhaustion).
  *
  * Use SessionStrategy when prompt-cache reuse is the primary cost driver
  * (long agentic loops with stable system prompts). Use LeastUsedStrategy
@@ -28,6 +52,7 @@ import type {
 export class LeastUsedStrategy implements LoadBalancingStrategy {
 	private store: StrategyStore | null = null;
 	private log = new Logger("LeastUsedStrategy");
+	private lastPickedAt = new Map<string, number>();
 
 	initialize(store: StrategyStore): void {
 		this.store = store;
@@ -39,24 +64,43 @@ export class LeastUsedStrategy implements LoadBalancingStrategy {
 		const available = accounts.filter((a) => isAccountAvailable(a, now));
 		if (available.length === 0) return [];
 
-		// Sort by priority ASC, then utilization ASC. Treat null utilization
-		// as 0 so newly-added accounts (no usage data yet) are preferred over
-		// fully-utilized ones — consistent with SessionStrategy's tiebreaker.
-		const sorted = available.sort((a, b) => {
-			if (a.priority !== b.priority) return a.priority - b.priority;
-			const utilA =
+		// Score each account: priority is primary, then upstream utilization
+		// plus a recency penalty for accounts picked in the recent window.
+		// Treat null utilization as 0 so newly-added accounts (no usage data
+		// yet) are preferred over fully-utilized ones.
+		const scored = available.map((a) => {
+			const util =
 				this.store?.getAccountUtilization?.(a.id, a.provider) ?? 0;
-			const utilB =
-				this.store?.getAccountUtilization?.(b.id, b.provider) ?? 0;
-			return utilA - utilB;
+			const lastPick = this.lastPickedAt.get(a.id) ?? 0;
+			const recencyPenalty =
+				now - lastPick < RECENT_PICK_WINDOW_MS ? RECENT_PICK_PENALTY : 0;
+			return { account: a, score: util + recencyPenalty };
 		});
 
+		const sorted = scored
+			.sort((a, b) => {
+				if (a.account.priority !== b.account.priority) {
+					return a.account.priority - b.account.priority;
+				}
+				return a.score - b.score;
+			})
+			.map((s) => s.account);
+
+		// Mark the primary as recently picked so the *next* concurrent
+		// select() within RECENT_PICK_WINDOW_MS prefers a different account.
+		// Opportunistic GC: prune entries older than 10× the window so the
+		// map doesn't grow unboundedly when accounts come and go.
+		const primary = sorted[0];
+		this.lastPickedAt.set(primary.id, now);
+		const gcThreshold = now - RECENT_PICK_WINDOW_MS * 10;
+		for (const [id, ts] of this.lastPickedAt) {
+			if (ts < gcThreshold) this.lastPickedAt.delete(id);
+		}
+
 		this.log.debug(
-			`Selected ${sorted.length} account(s) by least-used: ${sorted.map((a) => a.name).join(", ")}`,
+			`Selected ${sorted.length} account(s) by least-used (primary ${primary.name}): ${sorted.map((a) => a.name).join(", ")}`,
 		);
 
-		// Return all available accounts in chosen order. The proxy loop will
-		// try them sequentially as fallbacks.
 		return sorted;
 	}
 }

--- a/packages/load-balancer/src/strategies/least-used.ts
+++ b/packages/load-balancer/src/strategies/least-used.ts
@@ -1,0 +1,62 @@
+import { isAccountAvailable } from "@better-ccflare/core";
+import { Logger } from "@better-ccflare/logger";
+import type {
+	Account,
+	LoadBalancingStrategy,
+	RequestMeta,
+	StrategyStore,
+} from "@better-ccflare/types";
+
+/**
+ * LeastUsedStrategy — picks the available account with the lowest reported
+ * utilization, falling back to priority as a tiebreaker.
+ *
+ * Trade-off vs SessionStrategy:
+ *   - No prompt-cache stickiness: each request is routed independently of
+ *     the previous one, so cross-request prompt caches on Anthropic are
+ *     less effective.
+ *   - Better burst behavior: a sudden spike of N concurrent requests is
+ *     spread across all healthy accounts in priority + utilization order
+ *     rather than funneled into a single sticky account, reducing the
+ *     probability of multiple accounts hitting per-account rate limits in
+ *     near-simultaneity ("burst-cool" pool exhaustion).
+ *
+ * Use SessionStrategy when prompt-cache reuse is the primary cost driver
+ * (long agentic loops with stable system prompts). Use LeastUsedStrategy
+ * when burst tolerance and broad pool spread matter more than cache hits.
+ */
+export class LeastUsedStrategy implements LoadBalancingStrategy {
+	private store: StrategyStore | null = null;
+	private log = new Logger("LeastUsedStrategy");
+
+	initialize(store: StrategyStore): void {
+		this.store = store;
+	}
+
+	select(accounts: Account[], _meta: RequestMeta): Account[] {
+		const now = Date.now();
+
+		const available = accounts.filter((a) => isAccountAvailable(a, now));
+		if (available.length === 0) return [];
+
+		// Sort by priority ASC, then utilization ASC. Treat null utilization
+		// as 0 so newly-added accounts (no usage data yet) are preferred over
+		// fully-utilized ones — consistent with SessionStrategy's tiebreaker.
+		const sorted = available.sort((a, b) => {
+			if (a.priority !== b.priority) return a.priority - b.priority;
+			const utilA =
+				this.store?.getAccountUtilization?.(a.id, a.provider) ?? 0;
+			const utilB =
+				this.store?.getAccountUtilization?.(b.id, b.provider) ?? 0;
+			return utilA - utilB;
+		});
+
+		this.log.debug(
+			`Selected ${sorted.length} account(s) by least-used: ${sorted.map((a) => a.name).join(", ")}`,
+		);
+
+		// Return all available accounts in chosen order. The proxy loop will
+		// try them sequentially as fallbacks.
+		return sorted;
+	}
+}

--- a/packages/types/src/strategy.ts
+++ b/packages/types/src/strategy.ts
@@ -2,6 +2,7 @@ import type { Account } from "./account";
 
 export enum StrategyName {
 	Session = "session",
+	LeastUsed = "least-used",
 }
 
 /**


### PR DESCRIPTION
## Why

`SessionStrategy` is currently the only strategy (`packages/types/src/strategy.ts`). It's sticky by design — once a session is established on an account, requests prefer that same account for the 5h Anthropic window to maximize prompt-cache reuse.

Under sustained burst load (e.g., Claude Code parallel tool calls), this funnels concurrent requests into a single account, which hits its per-account rate limit faster than alternatives can be rotated in. With a small pool (3-5 accounts), one tool-call burst can chain-cool every account in milliseconds, leaving no routable candidate even when the upstream reports them as `allowed`.

Detailed reproduction in #139.

`getAccountUtilization` is already wired in `StrategyStore` and used as a tiebreaker in `SessionStrategy.select()` (lines 259–263) — so the data we need to make a smarter decision is already piped in. We just need a strategy that uses it as the *primary* selector, not a tiebreaker after stickiness has already chosen.

## What

- Adds `StrategyName.LeastUsed = "least-used"` to the existing enum
- New `LeastUsedStrategy` class in `packages/load-balancer/src/strategies/least-used.ts`:
  - Filters accounts by `isAccountAvailable` (consistent with `SessionStrategy`)
  - Sorts by `priority ASC`, then `getAccountUtilization` ASC
  - Treats null utilization as 0 (newly-added accounts preferred over fully-utilized ones — matches `SessionStrategy`'s tiebreaker)
- Refactors `apps/server/src/server.ts`:
  - Adds `buildStrategy(name, sessionDurationMs)` factory so future strategies can be added without touching the boot path
  - Hot-reload via the existing config 'change' event now supports any strategy (previous code special-cased `'session'` only and silently ignored other values)
- Selectable via the existing config:
  - `lb_strategy: \"least-used\"` in `ccflare.json`
  - `LB_STRATEGY=least-used` env var
  - Existing `setStrategy()` API

## Trade-off

LeastUsed loses prompt-cache stickiness — each request is routed independently of the previous one, so cross-request prompt caches on Anthropic are less effective for that account. In exchange, bursts are spread across all healthy accounts in priority + utilization order, which dramatically reduces \"burst-cool\" pool exhaustion.

Documented in the class JSDoc:

> Use SessionStrategy when prompt-cache reuse is the primary cost driver (long agentic loops with stable system prompts). Use LeastUsedStrategy when burst tolerance and broad pool spread matter more than cache hits.

`SessionStrategy` is unchanged and remains the default.

## What's not changed

- Existing `SessionStrategy` behavior — pure addition
- The strategy enum's serialization format
- Any test that relied on `SessionStrategy` being the only option (default fallback in `buildStrategy` keeps that behavior for any caller that doesn't explicitly opt into LeastUsed)

## Testing

- Built clean with `bun run build` against current main
- Running on a fork branch driving a 4-account Anthropic OAuth pool with sustained Claude Code load for ~3 hours
- Combined with PR #A (cooldown softening), 503 burst frequency dropped substantially

I'd appreciate feedback on:
- Naming (`LeastUsed` vs `LeastUtilization` vs `Spread` vs something else)
- Whether the trade-off should be documented more visibly (README section?)
- If a per-strategy config block is preferable to global enum (future strategies might want their own settings)

Happy to revise.

## Related

- #139 — burst pool-exhaustion discussion
- PR #A — cooldown softening (companion fix; either can land independently but the combination is what we're running locally)