### PR TITLE
fix: keepalive 429s should not cool accounts; shorten no-reset default

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -45,6 +45,17 @@ export const TIME_CONSTANTS = {
 	// Token expiration durations
 	API_KEY_TOKEN_EXPIRY_MS: 365 * 24 * 60 * 60 * 1000, // 1 year - for API keys that don't expire
 	GOOGLE_TOKEN_EXPIRY_MS: 60 * 60 * 1000, // 1 hour - Google Cloud access tokens
+
+	// Default cooldown applied when an upstream returns 429 *without* a
+	// reset hint (no `retry-after`, no rate-limit-reset header, no SSE
+	// reset frame, no usage-cache window reset). Treats the cooldown
+	// as a probe interval rather than a hard ban: the account is
+	// excluded for a short window, then the next request re-probes.
+	// Real upstream rate-limit replies ship a retry-after / reset
+	// header and use the precise value from the header — those flows
+	// are unaffected by this default.
+	// Override at runtime via CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS.
+	DEFAULT_RATE_LIMIT_NO_RESET_COOLDOWN_MS: 60 * 1000, // 60s
 } as const;
 
 // Buffer sizes (in bytes unless specified)

--- a/packages/http-api/src/handlers/accounts.ts
+++ b/packages/http-api/src/handlers/accounts.ts
@@ -44,7 +44,10 @@ const log = new Logger("AccountsHandler");
 
 const RATE_LIMIT_REASONS = new Set<RateLimitReason>([
 	"upstream_429_with_reset",
+	// Kept for backwards-compat with DB rows written by ccflare ≤ v3.5.x;
+	// new code emits `upstream_429_no_reset_probe_cooldown` instead.
 	"upstream_429_no_reset_default_5h",
+	"upstream_429_no_reset_probe_cooldown",
 	"model_fallback_429",
 	"all_models_exhausted_429",
 ]);

--- a/packages/proxy/src/handlers/__tests__/extract-cooldown-until.test.ts
+++ b/packages/proxy/src/handlers/__tests__/extract-cooldown-until.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "bun:test";
+import { TIME_CONSTANTS } from "@better-ccflare/core";
 import { extractCooldownUntil } from "../proxy-operations";
 
 const ACCOUNT_ID = "acct-test";
 const MIN_COOLDOWN_MS = 60 * 1000;
-const ONE_HOUR_MS = 60 * 60 * 1000;
+const PROBE_COOLDOWN_MS = TIME_CONSTANTS.DEFAULT_RATE_LIMIT_NO_RESET_COOLDOWN_MS;
 
 function makeResponse(headers: Record<string, string> = {}): Response {
 	return new Response(null, { status: 429, headers });
@@ -67,11 +68,13 @@ describe("extractCooldownUntil", () => {
 		expect(result).toBe(cacheReset);
 	});
 
-	it("falls back to 1-hour default when no headers and no cache", () => {
+	it("falls back to probe-cooldown default when no headers and no cache", () => {
 		const before = Date.now();
 		const result = extractCooldownUntil(makeResponse(), ACCOUNT_ID, noCache);
-		expect(result).toBeGreaterThanOrEqual(before + ONE_HOUR_MS);
-		expect(result).toBeLessThan(before + ONE_HOUR_MS + 5000);
+		// Floor is the larger of MIN_COOLDOWN_MS and the configured default.
+		const expected = Math.max(PROBE_COOLDOWN_MS, MIN_COOLDOWN_MS);
+		expect(result).toBeGreaterThanOrEqual(before + expected);
+		expect(result).toBeLessThan(before + expected + 5000);
 	});
 
 	it("clamps small retry-after to MIN_COOLDOWN_MS", () => {

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -1,4 +1,9 @@
-import { getModelList, logError, ProviderError } from "@better-ccflare/core";
+import {
+	getModelList,
+	logError,
+	ProviderError,
+	TIME_CONSTANTS,
+} from "@better-ccflare/core";
 import { Logger } from "@better-ccflare/logger";
 import { stripCacheControlFromOpenAIRequest } from "@better-ccflare/openai-formats";
 import { getProvider, usageCache } from "@better-ccflare/providers";
@@ -22,7 +27,13 @@ const log = new Logger("ProxyOperations");
  * should be marked rate-limited after model exhaustion. Priority:
  *   1. retry-after / x-ratelimit-reset response header (actual upstream backoff)
  *   2. getRateLimitedUntil — usage-window reset time if known
- *   3. 1-hour default as last resort
+ *   3. probe-cooldown default (TIME_CONSTANTS.DEFAULT_RATE_LIMIT_NO_RESET_COOLDOWN_MS,
+ *      60s by default, overridable via CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS) as
+ *      last resort. Was a 1-hour ban prior to v3.5.x — that locked accounts
+ *      out unnecessarily when upstream returned a transient 429 without a
+ *      reset hint, draining small pools to zero routable accounts on a
+ *      single burst. Aligns with the same default used in
+ *      response-processor.ts when 429s arrive without a reset header.
  *
  * The result is always clamped to at least 60 seconds in the future to avoid a
  * zero or negative value when a parsed timestamp is already in the past.
@@ -37,7 +48,13 @@ export function extractCooldownUntil(
 	getRateLimitedUntil: (accountId: string) => number | null,
 ): number {
 	const MIN_COOLDOWN_MS = 60 * 1000; // 60 seconds floor
-	const DEFAULT_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
+	// Use `||` (not `??`) so empty-string and non-numeric env values
+	// (Number("") === 0, Number("abc") === NaN) fall through to the
+	// default — `??` would coalesce the empty string to 0 and silently
+	// disable the cooldown entirely.
+	const DEFAULT_COOLDOWN_MS =
+		Number(process.env.CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS) ||
+		TIME_CONSTANTS.DEFAULT_RATE_LIMIT_NO_RESET_COOLDOWN_MS;
 	const now = Date.now();
 
 	// 1. Check retry-after / x-ratelimit-reset headers
@@ -699,6 +716,22 @@ export async function proxyWithAccount(
 					// accounts are available; only genuine model-not-found
 					// errors (404/400) warrant returning the upstream response.
 					if (rawResponse.status === 429) {
+						// Skip cooldown on synthetic cache-keepalive replays. The
+						// keepalive scheduler fires parallel requests to every
+						// cached account; a burst of 4+ simultaneous requests
+						// trips Anthropic's per-IP burst limit and 429s every
+						// account at the same instant. Applying real cooldowns
+						// here drains the pool to zero routable accounts even
+						// though no real user-facing rate limit was hit.
+						const isKeepalive =
+							req.headers.get("x-better-ccflare-keepalive") === "true";
+						if (isKeepalive) {
+							log.warn(
+								`Keepalive replay for ${account.name} got 429 — skipping cooldown (synthetic burst, not a real per-account rate limit)`,
+							);
+							return null;
+						}
+
 						log.warn(
 							`Account ${account.name} rate-limited (429), no model fallbacks — failing over to next account`,
 						);
@@ -808,19 +841,34 @@ export async function proxyWithAccount(
 				// Only fire for genuine rate-limit responses (429); model-not-found
 				// (404/400) is a configuration issue, not account exhaustion.
 				if (rawResponse.status === 429) {
-					const cooldownUntil = extractCooldownUntil(
-						rawResponse,
-						account.id,
-						usageCache.getRateLimitedUntil.bind(usageCache),
-					);
-					const reason: RateLimitReason = "all_models_exhausted_429";
-					log.warn(
-						`[ccflare] account=${account.name} cooldown_applied reason=${reason} until=${new Date(cooldownUntil).toISOString()}`,
-					);
-					account.rate_limited_until = cooldownUntil;
-					ctx.asyncWriter.enqueue(() =>
-						ctx.dbOps.markAccountRateLimited(account.id, cooldownUntil, reason),
-					);
+					// Same keepalive-skip as the no-fallback path above: synthetic
+					// keepalive bursts can trip Anthropic's per-IP limit even when
+					// individual accounts are healthy.
+					const isKeepalive =
+						req.headers.get("x-better-ccflare-keepalive") === "true";
+					if (isKeepalive) {
+						log.warn(
+							`Keepalive replay for ${account.name} got 429 (post-model-list) — skipping cooldown`,
+						);
+					} else {
+						const cooldownUntil = extractCooldownUntil(
+							rawResponse,
+							account.id,
+							usageCache.getRateLimitedUntil.bind(usageCache),
+						);
+						const reason: RateLimitReason = "all_models_exhausted_429";
+						log.warn(
+							`[ccflare] account=${account.name} cooldown_applied reason=${reason} until=${new Date(cooldownUntil).toISOString()}`,
+						);
+						account.rate_limited_until = cooldownUntil;
+						ctx.asyncWriter.enqueue(() =>
+							ctx.dbOps.markAccountRateLimited(
+								account.id,
+								cooldownUntil,
+								reason,
+							),
+						);
+					}
 				}
 				return null;
 			}

--- a/packages/proxy/src/handlers/response-processor.ts
+++ b/packages/proxy/src/handlers/response-processor.ts
@@ -1,4 +1,4 @@
-import { logError, RateLimitError } from "@better-ccflare/core";
+import { logError, RateLimitError, TIME_CONSTANTS } from "@better-ccflare/core";
 import { Logger } from "@better-ccflare/logger";
 import {
 	type Provider,
@@ -268,17 +268,40 @@ export async function processProxyResponse(
 	// (status 200 with an SSE `event: error` frame partway through the body)
 	// is handled separately by the streaming forwarder — see issue #114.
 	if (rateLimitInfo.isRateLimited) {
-		if (rateLimitInfo.resetTime) {
+		// Skip cooldown application on synthetic cache-keepalive replays. The
+		// keepalive scheduler fires parallel requests across every cached
+		// account simultaneously; bursts of 4+ concurrent requests can trip
+		// Anthropic's per-IP burst limit and 429 every account at the same
+		// instant. Treating those as real per-account rate limits drains the
+		// pool to zero routable accounts even though no user-visible quota
+		// was actually exhausted. Loop-prevention header set by
+		// cache-keepalive-scheduler.ts; only synthetic replays carry it.
+		const isKeepalive =
+			requestMeta?.headers?.get("x-better-ccflare-keepalive") === "true";
+		if (isKeepalive) {
+			log.warn(
+				`Keepalive replay for ${account.name} got 429 — skipping cooldown (synthetic burst, not a real per-account rate limit)`,
+			);
+		} else if (rateLimitInfo.resetTime) {
 			handleRateLimitResponse(account, rateLimitInfo, ctx);
 		} else {
-			// Mark as rate-limited even without reset time
+			// Mark as rate-limited even without reset time. Use a short
+			// probe-friendly cooldown (default 60s, override via
+			// CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS) instead of the previous
+			// 5h hard-ban: a reset-less 429 is more likely a transient than
+			// a real rate-limit window, and a 5h ban on every transient
+			// error chains pool exhaustion under burst load.
+			const cooldownMs =
+				Number(process.env.CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS) ||
+				TIME_CONSTANTS.DEFAULT_RATE_LIMIT_NO_RESET_COOLDOWN_MS;
 			log.warn(
-				`Account ${account.name} rate-limited but no reset time available`,
+				`Account ${account.name} rate-limited but no reset time available — applying ${cooldownMs}ms probe cooldown`,
 			);
-			const cooldownUntil = Date.now() + 5 * 60 * 60 * 1000;
+			const cooldownUntil = Date.now() + cooldownMs;
 			account.rate_limited_until = cooldownUntil;
 			ctx.asyncWriter.enqueue(() => {
-				const reason: RateLimitReason = "upstream_429_no_reset_default_5h";
+				const reason: RateLimitReason =
+					"upstream_429_no_reset_probe_cooldown";
 				log.warn(
 					`[ccflare] account=${account.name} cooldown_applied reason=${reason} until=${new Date(cooldownUntil).toISOString()}`,
 				);
@@ -287,7 +310,7 @@ export async function processProxyResponse(
 					cooldownUntil,
 					reason,
 				);
-			}); // Default to 5 hours — applies to any provider without reset headers
+			});
 		}
 		// Also update metadata for rate-limited responses
 		const bypassSession =

--- a/packages/proxy/src/response-handler.ts
+++ b/packages/proxy/src/response-handler.ts
@@ -17,9 +17,19 @@ type ResponseWithAnalyticsStream = Response & {
 
 // Default cooldown for rate-limit errors detected mid-stream. SSE error
 // frames don't carry reset headers (HTTP headers were sent before the
-// error occurred), so we fall back to the same 5h default that
-// response-processor.ts uses for headerless 429 responses.
-const MID_STREAM_RATE_LIMIT_COOLDOWN_MS = 5 * 60 * 60 * 1000;
+// error occurred), so we fall back to the same probe-friendly default
+// that response-processor.ts uses for headerless 429 responses.
+//
+// Read on every call (not module load) so a runtime change to the env
+// var is picked up without a server restart. Use `||` (not `??`) so an
+// empty-string env value (Number("") === 0) falls through to the default
+// instead of silently disabling the cooldown.
+function getMidStreamRateLimitCooldownMs(): number {
+	return (
+		Number(process.env.CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS) ||
+		TIME_CONSTANTS.DEFAULT_RATE_LIMIT_NO_RESET_COOLDOWN_MS
+	);
+}
 
 // Must match MAX_REQUEST_BODY_BYTES in post-processor.worker.ts.
 // Cap applied before postMessage to avoid multi-MB structured clones.
@@ -283,7 +293,7 @@ export async function forwardToClient(
 									account,
 									{
 										isRateLimited: true,
-										resetTime: Date.now() + MID_STREAM_RATE_LIMIT_COOLDOWN_MS,
+										resetTime: Date.now() + getMidStreamRateLimitCooldownMs(),
 									},
 									ctx,
 								);

--- a/packages/types/src/account.ts
+++ b/packages/types/src/account.ts
@@ -1,6 +1,11 @@
 export type RateLimitReason =
 	| "upstream_429_with_reset"
+	/** @deprecated written by ccflare ≤ v3.5.x when no-reset 429s used a 5h ban.
+	 *  v3.5.2+ emits `upstream_429_no_reset_probe_cooldown` for the same path
+	 *  with a configurable shorter default. Existing DB rows keep the old
+	 *  value for history. */
 	| "upstream_429_no_reset_default_5h"
+	| "upstream_429_no_reset_probe_cooldown"
 	| "model_fallback_429"
 	| "all_models_exhausted_429";
 


### PR DESCRIPTION
**Supersedes #192** (this PR includes everything #192 did, plus the keepalive-skip which is the actual root cause).

## Root cause (concrete trace)

`cache-keepalive-scheduler.ts` fires `Promise.allSettled` across every cached account every `(ttl − 1)` minutes:

```ts
await Promise.allSettled(
    accounts.map((accountId) => this.replayRequest(accountId)),
);
```

With 4 accounts that's 4 simultaneous synthetic requests to Anthropic. The keepalive header `x-better-ccflare-keepalive: true` is currently used only to skip cache staging in `cache-body-store.ts` — it is **not** inspected by the cooldown path. So when Anthropic 429s the burst (per-IP burst contention, not real per-account rate limit), every account gets cooled at the same instant via the `model_fallback_429` branch in `proxy-operations.ts` (no model_fallbacks configured → \"no fallbacks, fail over\" path that still writes `rate_limited_until`).

`extractCooldownUntil`'s last-resort default was 1 hour. Net: 4 accounts cooled at the same second, unusable for an hour, with `rate_limit_status` from Anthropic still showing `allowed` or `allowed_warning`.

The keepalive-tagged requests also bypass request-log staging (the loop-prevention header), so operators see **zero 429s in the request log** while every account is mysteriously cooled. Took some digging.

### Live evidence

```
DB after a single keepalive burst:
  rate_limited_at       07:17:04 UTC
  rate_limited_until    08:17:04 UTC      ← exactly +1h, priority-3 default
  rate_limited_reason   model_fallback_429
  rate_limit_status     allowed_warning / allowed   ← Anthropic still says OK

Request log same window:
  200 ann_qa  ×734
  503 NULL    ×39   (pool_exhausted)
  429         ×0    ← keepalive bypasses request logging
```

## Fix

1. **Skip cooldown application on keepalive replays** in `response-processor.ts` (pre-stream + no-reset paths) and `proxy-operations.ts` (both 429 sites: `model_fallback_429` and `all_models_exhausted_429`). A keepalive 429 carries no information about the account's real serving capacity — it's synthetic burst contention, not user-traffic exhaustion.

2. **Shorten `extractCooldownUntil`'s last-resort default** from a hardcoded 1-hour ban to `TIME_CONSTANTS.DEFAULT_RATE_LIMIT_NO_RESET_COOLDOWN_MS` (60s, overridable via `CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS`). Defends non-keepalive paths from the same exhaustion pattern.

3. **Apply the same softening to:**
   - `response-processor.ts` pre-stream 429 path (was 5h default)
   - `response-handler.ts` mid-stream SSE rate-limit path (was 5h default)
   Both now read the same constant via the same env override (with `||` instead of `??` so empty-string env values fall through cleanly to the default).

4. **Audit trail:** rename the RateLimitReason emitted on no-reset 429s from `upstream_429_no_reset_default_5h` (now misleading — actual cooldown is 60s) to `upstream_429_no_reset_probe_cooldown`. Old value kept in the type union and API allowlist for backwards-compat with existing DB rows.

## Files changed

| File | Change |
|---|---|
| `packages/core/src/constants.ts` | Add `DEFAULT_RATE_LIMIT_NO_RESET_COOLDOWN_MS = 60_000` |
| `packages/proxy/src/handlers/proxy-operations.ts` | Keepalive-skip on both 429 sites; switch `extractCooldownUntil` default to constant + env override |
| `packages/proxy/src/handlers/response-processor.ts` | Keepalive-skip on the rate-limit branch; switch 5h literal to the new constant |
| `packages/proxy/src/response-handler.ts` | Switch 5h mid-stream literal to per-call read of the new constant |
| `packages/types/src/account.ts` | Add `upstream_429_no_reset_probe_cooldown`, deprecate `_default_5h` |
| `packages/http-api/src/handlers/accounts.ts` | Allowlist both old + new reason strings |
| `packages/proxy/src/handlers/__tests__/extract-cooldown-until.test.ts` | Update 1-hour-default test to assert the new constant |

## Tests

8 passing — the existing test suite for `extractCooldownUntil` plus the rewritten 1-hour-default case. A keepalive-skip integration test would need a heavier setup (mock `asyncWriter` + `dbOps`) — happy to add if reviewers want.

## Could also stagger keepalives

A logical companion fix is to add jitter to the `Promise.allSettled` keepalive fan-out so they don't burst Anthropic in one millisecond. Holding off in this PR — the cooldown-skip alone solves the user-visible symptom and is more conservative than re-architecting the scheduler. Happy to follow up.

## Related

- Closes #178 (the spurious-cooldown / stuck-active-account symptom — root cause is the keepalive interaction, not the priority-2 Map fallback I theorized earlier)
- Supersedes #192 (cooldown-only narrow PR; this one includes those changes and the keepalive root-cause fix)