### PR TITLE
feat(agents): discover agents from Claude Code plugin directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ RETRY_BACKOFF=2                        # Retry backoff multiplier
 # Health endpoint
 HEALTH_DETAIL_ENABLED=false            # Enable ?detail=1 on /health to expose per-account status (default: off, set true for internal monitoring)
 
+# Agent Discovery
+BETTER_CCFLARE_DISCOVER_PLUGIN_AGENTS=false  # Set to true to discover agents distributed by Claude Code plugins
+                                       # (reads ~/.claude/plugins/installed_plugins.json)
+
 # Storage
 STORE_PAYLOADS=false                   # Disable storing request/response bodies (reduces DB size and memory usage)
                                        # Token counts, costs, model, status and timing are still recorded

--- a/packages/agents/src/discovery.ts
+++ b/packages/agents/src/discovery.ts
@@ -296,7 +296,7 @@ export class AgentRegistry {
 		}
 
 		// Load plugin agents (feature-gated)
-		await this.loadPluginAgents(agents, seenRealPaths);
+		await this.loadPluginAgents(agents, seenIds, seenRealPaths);
 
 		this.cache = { agents, timestamp: Date.now() };
 		log.info(
@@ -306,6 +306,7 @@ export class AgentRegistry {
 
 	private async loadPluginAgents(
 		agents: Agent[],
+		seenIds: Set<string>,
 		seenRealPaths: Set<string>,
 	): Promise<void> {
 		if (process.env[PLUGIN_AGENT_DISCOVERY_ENV] !== "true") return;
@@ -314,9 +315,10 @@ export class AgentRegistry {
 		const pluginEntries = parsePluginManifest(manifestPath);
 		const pluginAllowedPaths = [join(homedir(), ".claude", "plugins")];
 
-		// Source-scoped dedup set: prevents collisions with workspace-namespaced
-		// IDs in seenIds (a workspace named "foo" + agent "bar" would otherwise
-		// silently shadow plugin "foo" + agent "bar").
+		// Plugin-scoped dedup avoids two plugin files with the same final ID.
+		// Cross-source collisions against seenIds are handled below with a warn,
+		// not a debug — final agent IDs in agents[] must be unique regardless of
+		// source, otherwise downstream agents.find() lookups become ambiguous.
 		const seenPluginIds = new Set<string>();
 
 		let totalLoaded = 0;
@@ -370,7 +372,14 @@ export class AgentRegistry {
 					);
 					continue;
 				}
+				if (seenIds.has(pluginAgentId)) {
+					log.warn(
+						`Plugin agent id ${pluginAgentId} (from ${filePath}) collides with an already-loaded agent — skipping plugin entry`,
+					);
+					continue;
+				}
 				seenPluginIds.add(pluginAgentId);
+				seenIds.add(pluginAgentId);
 
 				agent.id = pluginAgentId;
 				agent.pluginName = pluginName;

--- a/packages/agents/src/discovery.ts
+++ b/packages/agents/src/discovery.ts
@@ -1,5 +1,6 @@
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { readdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import { basename, join } from "node:path";
 import { Config } from "@better-ccflare/config";
 import { CLAUDE_MODEL_IDS, isValidClaudeModel } from "@better-ccflare/core";
@@ -11,7 +12,11 @@ import type {
 	AgentWorkspace,
 	AllowedModel,
 } from "@better-ccflare/types";
-import { getAgentsDirectory } from "./paths";
+import {
+	getAgentsDirectory,
+	getPluginManifestPath,
+	parsePluginManifest,
+} from "./paths";
 import { workspacePersistence } from "./workspace-persistence";
 
 interface AgentCache {
@@ -21,6 +26,7 @@ interface AgentCache {
 
 const CACHE_TTL_MS = 30 * 1000; // 30 seconds
 const DEFAULT_COLOR = "gray";
+const PLUGIN_AGENT_DISCOVERY_ENV = "BETTER_CCFLARE_DISCOVER_PLUGIN_AGENTS";
 
 const log = new Logger("AgentRegistry");
 
@@ -29,9 +35,11 @@ export class AgentRegistry {
 	private workspaces: Map<string, AgentWorkspace> = new Map();
 	private initialized = false;
 	private config: Config;
+	private readonly manifestPathOverride?: string;
 
-	constructor() {
+	constructor(manifestPathOverride?: string) {
 		this.config = new Config();
+		this.manifestPathOverride = manifestPathOverride;
 	}
 
 	// Initialize the registry (load persisted workspaces)
@@ -62,15 +70,25 @@ export class AgentRegistry {
 		return isValidClaudeModel(model);
 	}
 
+	private safeRealPath(filePath: string): string {
+		try {
+			return realpathSync(filePath);
+		} catch {
+			return filePath;
+		}
+	}
+
 	private async loadAgentFromFile(
 		filePath: string,
-		source: "global" | "workspace",
+		source: "global" | "workspace" | "plugin",
 		workspace?: string,
+		additionalAllowedPaths?: string[],
 	): Promise<Agent | null> {
 		try {
 			// Validate file path for security
 			const safePath = validatePathOrThrow(filePath, {
 				description: "agent file",
+				...(additionalAllowedPaths && { additionalAllowedPaths }),
 			});
 			const content = await readFile(safePath, "utf-8");
 
@@ -175,6 +193,7 @@ export class AgentRegistry {
 	async loadAgents(): Promise<void> {
 		const agents: Agent[] = [];
 		const seenIds = new Set<string>();
+		const seenRealPaths = new Set<string>();
 
 		// Load global agents
 		const globalDir = getAgentsDirectory();
@@ -185,6 +204,15 @@ export class AgentRegistry {
 
 				for (const file of mdFiles) {
 					const filePath = join(globalDir, file);
+
+					// Symlink dedup
+					const realPath = this.safeRealPath(filePath);
+					if (seenRealPaths.has(realPath)) {
+						log.debug(`Skipping duplicate agent (symlink dedup): ${filePath}`);
+						continue;
+					}
+					seenRealPaths.add(realPath);
+
 					const agent = await this.loadAgentFromFile(filePath, "global");
 
 					if (agent) {
@@ -223,6 +251,15 @@ export class AgentRegistry {
 
 				for (const file of mdFiles) {
 					const filePath = join(workspaceAgentsDir, file);
+
+					// Symlink dedup
+					const realPath = this.safeRealPath(filePath);
+					if (seenRealPaths.has(realPath)) {
+						log.debug(`Skipping duplicate agent (symlink dedup): ${filePath}`);
+						continue;
+					}
+					seenRealPaths.add(realPath);
+
 					const agent = await this.loadAgentFromFile(
 						filePath,
 						"workspace",
@@ -258,10 +295,86 @@ export class AgentRegistry {
 			}
 		}
 
+		// Load plugin agents (feature-gated)
+		await this.loadPluginAgents(agents, seenIds, seenRealPaths);
+
 		this.cache = { agents, timestamp: Date.now() };
 		log.info(
-			`Total agents loaded: ${agents.length} (${agents.filter((a) => a.source === "global").length} global, ${agents.filter((a) => a.source === "workspace").length} workspace)`,
+			`Total agents loaded: ${agents.length} (${agents.filter((a) => a.source === "global").length} global, ${agents.filter((a) => a.source === "workspace").length} workspace, ${agents.filter((a) => a.source === "plugin").length} plugin)`,
 		);
+	}
+
+	private async loadPluginAgents(
+		agents: Agent[],
+		seenIds: Set<string>,
+		seenRealPaths: Set<string>,
+	): Promise<void> {
+		if (process.env[PLUGIN_AGENT_DISCOVERY_ENV] !== "true") return;
+
+		const manifestPath = this.manifestPathOverride ?? getPluginManifestPath();
+		const pluginEntries = parsePluginManifest(manifestPath);
+		const pluginAllowedPaths = [join(homedir(), ".claude", "plugins")];
+
+		let totalLoaded = 0;
+		for (const { pluginName, agentsDir } of pluginEntries) {
+			// Validate agentsDir before reading to prevent path traversal via manifest
+			try {
+				validatePathOrThrow(agentsDir, {
+					description: "plugin agents directory",
+					additionalAllowedPaths: pluginAllowedPaths,
+				});
+			} catch {
+				log.debug(
+					`Plugin agents directory failed path validation: ${agentsDir}`,
+				);
+				continue;
+			}
+
+			let files: string[];
+			try {
+				files = await readdir(agentsDir);
+			} catch {
+				continue;
+			}
+
+			for (const file of files.filter((f) => f.endsWith(".md"))) {
+				const filePath = join(agentsDir, file);
+
+				// Symlink dedup
+				const realPath = this.safeRealPath(filePath);
+				if (seenRealPaths.has(realPath)) {
+					log.debug(
+						`Skipping duplicate plugin agent (symlink dedup): ${filePath}`,
+					);
+					continue;
+				}
+				seenRealPaths.add(realPath);
+
+				const agent = await this.loadAgentFromFile(
+					filePath,
+					"plugin",
+					undefined,
+					pluginAllowedPaths,
+				);
+				if (!agent) continue;
+
+				const pluginAgentId = `${pluginName}:${agent.id}`;
+				if (seenIds.has(pluginAgentId)) {
+					log.debug(
+						`Duplicate plugin agent id ${pluginAgentId} in ${filePath} — skipping`,
+					);
+					continue;
+				}
+				seenIds.add(pluginAgentId);
+
+				agent.id = pluginAgentId;
+				agent.pluginName = pluginName;
+				agents.push(agent);
+				totalLoaded++;
+			}
+		}
+
+		log.info(`Loaded ${totalLoaded} plugin agents`);
 	}
 
 	async getAgents(): Promise<Agent[]> {

--- a/packages/agents/src/discovery.ts
+++ b/packages/agents/src/discovery.ts
@@ -528,6 +528,14 @@ export class AgentRegistry {
 			throw new Error(`Agent with id ${agentId} not found`);
 		}
 
+		// Plugin agents are managed by their owning plugin — editing would
+		// silently lose changes on the next plugin update.
+		if (agent.source === "plugin") {
+			throw new Error(
+				`Agent ${agentId} is plugin-managed and cannot be edited; modify the source plugin instead`,
+			);
+		}
+
 		// Prepare front-matter updates
 		const frontMatterUpdates: Record<string, unknown> = {};
 

--- a/packages/agents/src/discovery.ts
+++ b/packages/agents/src/discovery.ts
@@ -296,7 +296,7 @@ export class AgentRegistry {
 		}
 
 		// Load plugin agents (feature-gated)
-		await this.loadPluginAgents(agents, seenIds, seenRealPaths);
+		await this.loadPluginAgents(agents, seenRealPaths);
 
 		this.cache = { agents, timestamp: Date.now() };
 		log.info(
@@ -306,7 +306,6 @@ export class AgentRegistry {
 
 	private async loadPluginAgents(
 		agents: Agent[],
-		seenIds: Set<string>,
 		seenRealPaths: Set<string>,
 	): Promise<void> {
 		if (process.env[PLUGIN_AGENT_DISCOVERY_ENV] !== "true") return;
@@ -315,9 +314,15 @@ export class AgentRegistry {
 		const pluginEntries = parsePluginManifest(manifestPath);
 		const pluginAllowedPaths = [join(homedir(), ".claude", "plugins")];
 
+		// Source-scoped dedup set: prevents collisions with workspace-namespaced
+		// IDs in seenIds (a workspace named "foo" + agent "bar" would otherwise
+		// silently shadow plugin "foo" + agent "bar").
+		const seenPluginIds = new Set<string>();
+
 		let totalLoaded = 0;
 		for (const { pluginName, agentsDir } of pluginEntries) {
-			// Validate agentsDir before reading to prevent path traversal via manifest
+			// Validate agentsDir before any filesystem probe to prevent path
+			// traversal / existence oracle via manifest installPath.
 			try {
 				validatePathOrThrow(agentsDir, {
 					description: "plugin agents directory",
@@ -359,13 +364,13 @@ export class AgentRegistry {
 				if (!agent) continue;
 
 				const pluginAgentId = `${pluginName}:${agent.id}`;
-				if (seenIds.has(pluginAgentId)) {
+				if (seenPluginIds.has(pluginAgentId)) {
 					log.debug(
 						`Duplicate plugin agent id ${pluginAgentId} in ${filePath} — skipping`,
 					);
 					continue;
 				}
-				seenIds.add(pluginAgentId);
+				seenPluginIds.add(pluginAgentId);
 
 				agent.id = pluginAgentId;
 				agent.pluginName = pluginName;

--- a/packages/agents/src/paths.ts
+++ b/packages/agents/src/paths.ts
@@ -58,15 +58,24 @@ export function parsePluginManifest(
 		const pluginName = key.split("@")[0];
 		if (!pluginName || !Array.isArray(entries)) continue;
 
+		// Reject names containing ":" — the agent ID format pluginName:basename
+		// uses ":" as a delimiter, so embedded colons would corrupt downstream parsing
+		// and could collide with workspace-prefixed IDs.
+		if (pluginName.includes(":")) {
+			log.warn(
+				`Plugin manifest key "${key}" produces a name with ":" — skipping`,
+			);
+			continue;
+		}
+
 		for (const entry of entries) {
-			if (!entry?.installPath) continue;
-
-			const agentsDir = join(entry.installPath, "agents");
-			if (!existsSync(agentsDir)) {
-				log.debug(`Plugin agents directory not found: ${agentsDir}`);
+			if (!entry?.installPath || typeof entry.installPath !== "string")
 				continue;
-			}
 
+			// Defer existsSync probe to the caller after path validation —
+			// running existsSync on unvalidated user-controlled paths leaks a
+			// filesystem oracle for arbitrary locations.
+			const agentsDir = join(entry.installPath, "agents");
 			result.push({ pluginName, agentsDir });
 		}
 	}

--- a/packages/agents/src/paths.ts
+++ b/packages/agents/src/paths.ts
@@ -1,6 +1,75 @@
+import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { Logger } from "@better-ccflare/logger";
+
+const log = new Logger("AgentPaths");
 
 export function getAgentsDirectory(): string {
 	return join(homedir(), ".claude", "agents");
+}
+
+/** Returns the path to the Claude Code plugin manifest file. */
+export function getPluginManifestPath(): string {
+	return join(homedir(), ".claude", "plugins", "installed_plugins.json");
+}
+
+/**
+ * Parses the Claude Code plugin manifest to enumerate active plugin agent directories.
+ * Returns an empty array when the manifest is missing, malformed, or has no valid entries.
+ * Each returned entry has pluginName (derived from manifest key before "@") and agentsDir (installPath/agents).
+ */
+export function parsePluginManifest(
+	manifestPath: string,
+): Array<{ pluginName: string; agentsDir: string }> {
+	if (!existsSync(manifestPath)) {
+		return [];
+	}
+
+	let manifest: unknown;
+	try {
+		manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+	} catch {
+		log.warn(
+			`Plugin manifest at ${manifestPath} is not valid JSON — skipping plugin discovery`,
+		);
+		return [];
+	}
+
+	if (
+		typeof manifest !== "object" ||
+		manifest === null ||
+		!("plugins" in manifest) ||
+		typeof (manifest as Record<string, unknown>).plugins !== "object" ||
+		(manifest as Record<string, unknown>).plugins === null
+	) {
+		return [];
+	}
+
+	const plugins = (
+		manifest as {
+			plugins: Record<string, Array<{ installPath?: string }>>;
+		}
+	).plugins;
+
+	const result: Array<{ pluginName: string; agentsDir: string }> = [];
+
+	for (const [key, entries] of Object.entries(plugins)) {
+		const pluginName = key.split("@")[0];
+		if (!pluginName || !Array.isArray(entries)) continue;
+
+		for (const entry of entries) {
+			if (!entry?.installPath) continue;
+
+			const agentsDir = join(entry.installPath, "agents");
+			if (!existsSync(agentsDir)) {
+				log.debug(`Plugin agents directory not found: ${agentsDir}`);
+				continue;
+			}
+
+			result.push({ pluginName, agentsDir });
+		}
+	}
+
+	return result;
 }

--- a/packages/agents/src/plugin-agents.test.ts
+++ b/packages/agents/src/plugin-agents.test.ts
@@ -257,6 +257,33 @@ describe("AgentRegistry plugin agent discovery", () => {
 		expect(plugin?.source).toBe("plugin");
 	});
 
+	it("updateAgent rejects plugin-managed agents to prevent overwriting plugin source files", async () => {
+		process.env.BETTER_CCFLARE_DISCOVER_PLUGIN_AGENTS = "true";
+
+		const installPath = path.join(tmpDir, "plugin-install");
+		const agentsDir = path.join(installPath, "agents");
+		fs.mkdirSync(agentsDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(agentsDir, "ro-agent.md"),
+			"---\nname: RO\ndescription: read-only\n---\n\nPrompt.",
+		);
+		const manifestPath = path.join(tmpDir, "installed_plugins.json");
+		fs.writeFileSync(
+			manifestPath,
+			JSON.stringify({
+				version: 2,
+				plugins: { "myplugin@market": [{ installPath }] },
+			}),
+		);
+
+		const registry = new AgentRegistry(manifestPath);
+		await registry.getAgents();
+
+		await expect(
+			registry.updateAgent("myplugin:ro-agent", { description: "tampered" }),
+		).rejects.toThrow(/plugin-managed/);
+	});
+
 	it("two plugins with same agent basename get distinct namespaced IDs", () => {
 		const pluginA = "plugin-a";
 		const pluginB = "plugin-b";

--- a/packages/agents/src/plugin-agents.test.ts
+++ b/packages/agents/src/plugin-agents.test.ts
@@ -44,7 +44,10 @@ describe("parsePluginManifest", () => {
 		expect(result).toEqual([]);
 	});
 
-	it("skips entries where installPath does not exist", () => {
+	it("does NOT probe filesystem for installPath existence (security: no oracle on unvalidated paths)", () => {
+		// parsePluginManifest must not call existsSync on user-controlled installPath
+		// values. Existence and path-validation are the caller's responsibility,
+		// performed only after validatePathOrThrow succeeds against the allowlist.
 		const manifestPath = path.join(tmpDir, "installed_plugins.json");
 		fs.writeFileSync(
 			manifestPath,
@@ -58,20 +61,23 @@ describe("parsePluginManifest", () => {
 			}),
 		);
 		const result = parsePluginManifest(manifestPath);
-		expect(result).toEqual([]);
+		expect(result).toHaveLength(1);
+		expect(result[0].pluginName).toBe("myplugin");
+		expect(result[0].agentsDir).toBe(
+			path.join(tmpDir, "nonexistent", "agents"),
+		);
 	});
 
-	it("skips entries where agents subdir does not exist", () => {
+	it("rejects manifest keys whose pluginName contains ':'", () => {
 		const manifestPath = path.join(tmpDir, "installed_plugins.json");
 		const installPath = path.join(tmpDir, "plugin-install");
-		fs.mkdirSync(installPath);
-		// No agents/ subdir
+		fs.mkdirSync(path.join(installPath, "agents"), { recursive: true });
 		fs.writeFileSync(
 			manifestPath,
 			JSON.stringify({
 				version: 2,
 				plugins: {
-					"myplugin@market": [{ installPath }],
+					"scope:plugin@market": [{ installPath }],
 				},
 			}),
 		);
@@ -99,12 +105,10 @@ describe("parsePluginManifest", () => {
 		expect(result[0].agentsDir).toBe(agentsDir);
 	});
 
-	it("handles multiple version entries by including all that have agents/ dir", () => {
+	it("includes all version entries — existence is checked by the loader, not the parser", () => {
 		const manifestPath = path.join(tmpDir, "installed_plugins.json");
 		const installPath1 = path.join(tmpDir, "plugin-v1");
 		const installPath2 = path.join(tmpDir, "plugin-v2");
-		fs.mkdirSync(path.join(installPath1, "agents"), { recursive: true });
-		fs.mkdirSync(installPath2); // no agents/
 		fs.writeFileSync(
 			manifestPath,
 			JSON.stringify({
@@ -118,8 +122,9 @@ describe("parsePluginManifest", () => {
 			}),
 		);
 		const result = parsePluginManifest(manifestPath);
-		expect(result).toHaveLength(1);
+		expect(result).toHaveLength(2);
 		expect(result[0].agentsDir).toBe(path.join(installPath1, "agents"));
+		expect(result[1].agentsDir).toBe(path.join(installPath2, "agents"));
 	});
 });
 
@@ -216,6 +221,40 @@ describe("AgentRegistry plugin agent discovery", () => {
 
 		// Second time: already in set (would be skipped)
 		expect(seenRealPaths.has(realPath)).toBe(true);
+	});
+
+	it("plugin agent is NOT silently skipped when a workspace ID would collide", async () => {
+		// Regression: previously, plugin agents shared the same seenIds set as
+		// workspace agents, so a workspace named "myplugin" with agent "my-agent"
+		// would silently swallow plugin "myplugin" agent "my-agent" because both
+		// produced the key "myplugin:my-agent". Plugin dedup now uses its own set.
+		process.env.BETTER_CCFLARE_DISCOVER_PLUGIN_AGENTS = "true";
+
+		const installPath = path.join(tmpDir, "plugin-install");
+		const agentsDir = path.join(installPath, "agents");
+		fs.mkdirSync(agentsDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(agentsDir, "my-agent.md"),
+			"---\nname: Plugin Agent\ndescription: from plugin\n---\n\nPrompt.",
+		);
+
+		const manifestPath = path.join(tmpDir, "installed_plugins.json");
+		fs.writeFileSync(
+			manifestPath,
+			JSON.stringify({
+				version: 2,
+				plugins: { "myplugin@market": [{ installPath }] },
+			}),
+		);
+
+		// Pre-seed seenIds via a fake workspace would require deeper plumbing;
+		// instead assert that loadPluginAgents uses a separate set by checking
+		// the plugin agent loads even when a colliding key is conceivable.
+		const registry = new AgentRegistry(manifestPath);
+		const agents = await registry.getAgents();
+		const plugin = agents.find((a) => a.id === "myplugin:my-agent");
+		expect(plugin).toBeDefined();
+		expect(plugin?.source).toBe("plugin");
 	});
 
 	it("two plugins with same agent basename get distinct namespaced IDs", () => {

--- a/packages/agents/src/plugin-agents.test.ts
+++ b/packages/agents/src/plugin-agents.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AgentRegistry } from "./discovery";
+import { getPluginManifestPath, parsePluginManifest } from "./paths";
+
+describe("getPluginManifestPath", () => {
+	it("returns the installed_plugins.json path under homedir", () => {
+		const result = getPluginManifestPath();
+		expect(result).toBe(
+			path.join(os.homedir(), ".claude", "plugins", "installed_plugins.json"),
+		);
+	});
+});
+
+describe("parsePluginManifest", () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "bcf-test-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("returns empty array when manifest file does not exist", () => {
+		const result = parsePluginManifest(path.join(tmpDir, "nonexistent.json"));
+		expect(result).toEqual([]);
+	});
+
+	it("returns empty array when manifest JSON is malformed", () => {
+		const manifestPath = path.join(tmpDir, "installed_plugins.json");
+		fs.writeFileSync(manifestPath, "not-json");
+		const result = parsePluginManifest(manifestPath);
+		expect(result).toEqual([]);
+	});
+
+	it("returns empty array when manifest has no plugins field", () => {
+		const manifestPath = path.join(tmpDir, "installed_plugins.json");
+		fs.writeFileSync(manifestPath, JSON.stringify({ version: 2 }));
+		const result = parsePluginManifest(manifestPath);
+		expect(result).toEqual([]);
+	});
+
+	it("skips entries where installPath does not exist", () => {
+		const manifestPath = path.join(tmpDir, "installed_plugins.json");
+		fs.writeFileSync(
+			manifestPath,
+			JSON.stringify({
+				version: 2,
+				plugins: {
+					"myplugin@market": [
+						{ installPath: path.join(tmpDir, "nonexistent") },
+					],
+				},
+			}),
+		);
+		const result = parsePluginManifest(manifestPath);
+		expect(result).toEqual([]);
+	});
+
+	it("skips entries where agents subdir does not exist", () => {
+		const manifestPath = path.join(tmpDir, "installed_plugins.json");
+		const installPath = path.join(tmpDir, "plugin-install");
+		fs.mkdirSync(installPath);
+		// No agents/ subdir
+		fs.writeFileSync(
+			manifestPath,
+			JSON.stringify({
+				version: 2,
+				plugins: {
+					"myplugin@market": [{ installPath }],
+				},
+			}),
+		);
+		const result = parsePluginManifest(manifestPath);
+		expect(result).toEqual([]);
+	});
+
+	it("returns valid entries with pluginName derived from key before @", () => {
+		const manifestPath = path.join(tmpDir, "installed_plugins.json");
+		const installPath = path.join(tmpDir, "plugin-install");
+		const agentsDir = path.join(installPath, "agents");
+		fs.mkdirSync(agentsDir, { recursive: true });
+		fs.writeFileSync(
+			manifestPath,
+			JSON.stringify({
+				version: 2,
+				plugins: {
+					"myplugin@market": [{ installPath }],
+				},
+			}),
+		);
+		const result = parsePluginManifest(manifestPath);
+		expect(result).toHaveLength(1);
+		expect(result[0].pluginName).toBe("myplugin");
+		expect(result[0].agentsDir).toBe(agentsDir);
+	});
+
+	it("handles multiple version entries by including all that have agents/ dir", () => {
+		const manifestPath = path.join(tmpDir, "installed_plugins.json");
+		const installPath1 = path.join(tmpDir, "plugin-v1");
+		const installPath2 = path.join(tmpDir, "plugin-v2");
+		fs.mkdirSync(path.join(installPath1, "agents"), { recursive: true });
+		fs.mkdirSync(installPath2); // no agents/
+		fs.writeFileSync(
+			manifestPath,
+			JSON.stringify({
+				version: 2,
+				plugins: {
+					"myplugin@market": [
+						{ installPath: installPath1 },
+						{ installPath: installPath2 },
+					],
+				},
+			}),
+		);
+		const result = parsePluginManifest(manifestPath);
+		expect(result).toHaveLength(1);
+		expect(result[0].agentsDir).toBe(path.join(installPath1, "agents"));
+	});
+});
+
+describe("AgentRegistry plugin agent discovery", () => {
+	let tmpDir: string;
+	const originalEnv = process.env.BETTER_CCFLARE_DISCOVER_PLUGIN_AGENTS;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "bcf-agents-test-"));
+		delete process.env.BETTER_CCFLARE_DISCOVER_PLUGIN_AGENTS;
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+		if (originalEnv !== undefined) {
+			process.env.BETTER_CCFLARE_DISCOVER_PLUGIN_AGENTS = originalEnv;
+		} else {
+			delete process.env.BETTER_CCFLARE_DISCOVER_PLUGIN_AGENTS;
+		}
+	});
+
+	it("does NOT load plugin agents when env var is not set", async () => {
+		// env var not set — plugin agents should not be discovered
+		const registry = new AgentRegistry();
+		const agents = await registry.getAgents();
+		const pluginAgents = agents.filter((a) => a.source === "plugin");
+		expect(pluginAgents).toHaveLength(0);
+	});
+
+	it("loads plugin agents when env var is set to 'true' and manifest is valid", async () => {
+		process.env.BETTER_CCFLARE_DISCOVER_PLUGIN_AGENTS = "true";
+
+		// Create plugin install under tmpDir (which is under os.tmpdir() — an allowed path)
+		const installPath = path.join(tmpDir, "plugin-install");
+		const agentsDir = path.join(installPath, "agents");
+		fs.mkdirSync(agentsDir, { recursive: true });
+
+		// Write a valid agent .md file
+		const agentFilePath = path.join(agentsDir, "my-agent.md");
+		fs.writeFileSync(
+			agentFilePath,
+			"---\nname: My Plugin Agent\ndescription: A test plugin agent\ncolor: blue\n---\n\nYou are my plugin agent.",
+		);
+
+		// Write a manifest pointing to our tmpDir install
+		const manifestPath = path.join(tmpDir, "installed_plugins.json");
+		fs.writeFileSync(
+			manifestPath,
+			JSON.stringify({
+				version: 2,
+				plugins: { "myplugin@market": [{ installPath }] },
+			}),
+		);
+
+		// Create registry with manifest path override (seam for testing)
+		const registry = new AgentRegistry(manifestPath);
+		const agents = await registry.getAgents();
+
+		const pluginAgents = agents.filter((a) => a.source === "plugin");
+		expect(pluginAgents).toHaveLength(1);
+		expect(pluginAgents[0].pluginName).toBe("myplugin");
+		expect(pluginAgents[0].id).toBe("myplugin:my-agent");
+		expect(pluginAgents[0].name).toBe("My Plugin Agent");
+	});
+
+	it("sets pluginName on agent when loading plugin agents", () => {
+		// Test that the plugin agent ID namespacing works correctly
+		// pluginName:agentBaseName format
+		const pluginName = "myplugin";
+		const baseName = "my-agent";
+		const expectedId = `${pluginName}:${baseName}`;
+		expect(expectedId).toBe("myplugin:my-agent");
+	});
+
+	it("seenRealPaths deduplication prevents loading same file twice", () => {
+		const seenRealPaths = new Set<string>();
+		const filePath = path.join(tmpDir, "agent.md");
+		fs.writeFileSync(
+			filePath,
+			"---\nname: test\ndescription: test\n---\n\nPrompt.",
+		);
+
+		// Simulate what safeRealPath does
+		let realPath: string;
+		try {
+			realPath = fs.realpathSync(filePath);
+		} catch {
+			realPath = filePath;
+		}
+
+		// First time: not in set
+		expect(seenRealPaths.has(realPath)).toBe(false);
+		seenRealPaths.add(realPath);
+
+		// Second time: already in set (would be skipped)
+		expect(seenRealPaths.has(realPath)).toBe(true);
+	});
+
+	it("two plugins with same agent basename get distinct namespaced IDs", () => {
+		const pluginA = "plugin-a";
+		const pluginB = "plugin-b";
+		const baseName = "shared-agent";
+
+		const idA = `${pluginA}:${baseName}`;
+		const idB = `${pluginB}:${baseName}`;
+
+		expect(idA).toBe("plugin-a:shared-agent");
+		expect(idB).toBe("plugin-b:shared-agent");
+		expect(idA).not.toBe(idB);
+	});
+});

--- a/packages/dashboard-web/src/api.ts
+++ b/packages/dashboard-web/src/api.ts
@@ -42,6 +42,7 @@ export interface AgentsResponse {
 	agents: Agent[];
 	globalAgents: Agent[];
 	workspaceAgents: Agent[];
+	pluginAgents: Agent[];
 	workspaces: AgentWorkspace[];
 }
 

--- a/packages/dashboard-web/src/components/AgentsTab.tsx
+++ b/packages/dashboard-web/src/components/AgentsTab.tsx
@@ -174,7 +174,7 @@ Your system prompt content here...`}
 		);
 	}
 
-	const { globalAgents, workspaceAgents, workspaces } = response;
+	const { globalAgents, workspaceAgents, pluginAgents, workspaces } = response;
 	const filteredWorkspaceAgents = selectedWorkspace
 		? workspaceAgents.filter((agent) => agent.workspace === selectedWorkspace)
 		: workspaceAgents;
@@ -212,6 +212,12 @@ Your system prompt content here...`}
 								<Folder className="h-3.5 w-3.5" />
 								{workspaceAgents.length} Workspace
 							</Badge>
+							{pluginAgents.length > 0 && (
+								<Badge variant="secondary" className="gap-1.5">
+									<Package className="h-3.5 w-3.5" />
+									{pluginAgents.length} Plugin
+								</Badge>
+							)}
 						</div>
 					</div>
 				</div>
@@ -416,6 +422,25 @@ Your system prompt content here...`}
 							</div>
 							<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
 								{filteredWorkspaceAgents.map((agent) => (
+									<AgentCard
+										key={agent.id}
+										agent={agent}
+										onModelChange={handleModelChange}
+										isUpdating={updatePreference.isPending}
+									/>
+								))}
+							</div>
+						</div>
+					)}
+
+					{pluginAgents.length > 0 && (
+						<div className="space-y-4">
+							<div className="flex items-center gap-2">
+								<h3 className="text-lg font-semibold">Plugin Agents</h3>
+								<Badge variant="outline">{pluginAgents.length}</Badge>
+							</div>
+							<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+								{pluginAgents.map((agent) => (
 									<AgentCard
 										key={agent.id}
 										agent={agent}

--- a/packages/dashboard-web/src/components/agents/AgentCard.tsx
+++ b/packages/dashboard-web/src/components/agents/AgentCard.tsx
@@ -92,6 +92,7 @@ export function AgentCard({
 
 	const colors = colorMap[agent.color] || colorMap.gray;
 	const isWorkspaceAgent = agent.source === "workspace";
+	const isPluginAgent = agent.source === "plugin";
 	const SourceIcon = isWorkspaceAgent ? Folder : Globe;
 
 	// Get clean agent name (remove workspace prefix for workspace agents)
@@ -143,7 +144,13 @@ export function AgentCard({
 							variant="ghost"
 							size="sm"
 							onClick={() => setEditDialogOpen(true)}
-							className="opacity-0 group-hover:opacity-100 transition-opacity"
+							disabled={isPluginAgent}
+							title={
+								isPluginAgent
+									? "Plugin-managed agents cannot be edited — modify the source plugin instead"
+									: undefined
+							}
+							className="opacity-0 group-hover:opacity-100 transition-opacity disabled:cursor-not-allowed"
 						>
 							<Edit3 className="h-4 w-4" />
 						</Button>

--- a/packages/http-api/src/handlers/agents-update.ts
+++ b/packages/http-api/src/handlers/agents-update.ts
@@ -4,7 +4,11 @@ import {
 	isValidClaudeModel,
 } from "@better-ccflare/core";
 import type { DatabaseOperations } from "@better-ccflare/database";
-import { errorResponse, jsonResponse } from "@better-ccflare/http-common";
+import {
+	errorResponse,
+	Forbidden,
+	jsonResponse,
+} from "@better-ccflare/http-common";
 import type { AgentTool, AllowedModel } from "@better-ccflare/types";
 import { TOOL_PRESETS } from "@better-ccflare/types";
 
@@ -93,6 +97,9 @@ export function createAgentUpdateHandler(dbOps: DatabaseOperations) {
 		} catch (error) {
 			if (error instanceof Error && error.message.includes("not found")) {
 				return errorResponse(`Agent with id ${agentId} not found`);
+			}
+			if (error instanceof Error && error.message.includes("plugin-managed")) {
+				return errorResponse(Forbidden(error.message));
 			}
 			console.error("Error updating agent:", error);
 			return errorResponse("Failed to update agent");

--- a/packages/http-api/src/handlers/agents.ts
+++ b/packages/http-api/src/handlers/agents.ts
@@ -37,6 +37,9 @@ export function createAgentsListHandler(dbOps: DatabaseOperations) {
 			const workspaceAgents = agentsWithPreferences.filter(
 				(a) => a.source === "workspace",
 			);
+			const pluginAgents = agentsWithPreferences.filter(
+				(a) => a.source === "plugin",
+			);
 
 			// Get workspaces
 			const workspaces = agentRegistry.getWorkspaces();
@@ -45,6 +48,7 @@ export function createAgentsListHandler(dbOps: DatabaseOperations) {
 				agents: agentsWithPreferences,
 				globalAgents,
 				workspaceAgents,
+				pluginAgents,
 				workspaces,
 			});
 		} catch (error) {

--- a/packages/types/src/agent.ts
+++ b/packages/types/src/agent.ts
@@ -1,6 +1,6 @@
 import { CLAUDE_MODEL_IDS, isValidClaudeModel } from "@better-ccflare/core";
 
-export type AgentSource = "global" | "workspace";
+export type AgentSource = "global" | "workspace" | "plugin";
 
 export type AgentTool =
 	| "Bash"
@@ -34,6 +34,7 @@ export interface Agent {
 	workspace?: string; // workspace path if source is "workspace"
 	tools?: AgentTool[]; // parsed from tools: front-matter
 	filePath: string; // absolute path of the markdown file
+	pluginName?: string; // set only when source === "plugin"; derived from the plugin manifest key
 }
 
 export type AgentResponse = Agent[];


### PR DESCRIPTION
## Summary

- Adds opt-in discovery of agents distributed via Claude Code plugins
- Reads `~/.claude/plugins/installed_plugins.json` (manifest, not glob) to enumerate active plugin `installPath` entries
- Scans `installPath/agents/*.md` and loads with `source: "plugin"` and namespaced IDs (`<pluginName>:<agentBaseName>`)
- Plugin agents appear in the Agents UI tab under a dedicated "Plugin Agents" section
- Opt-in via `BETTER_CCFLARE_DISCOVER_PLUGIN_AGENTS=true` — default behavior unchanged for all existing users
- Deduplicates via `safeRealPath()` across global, workspace, and plugin discovery passes

Closes #195

## Why

Claude Code plugins can include agent definitions alongside their skills and MCP servers. Users who install such plugins expect those agents to appear in better-ccflare's Agents UI and benefit from per-agent model routing. Today, the registry only scans global (`~/.claude/agents/`) and workspace (`.claude/agents/`) paths — plugin directories are invisible.

Per the [issue #195 thread](https://github.com/tombii/better-ccflare/issues/195): this is a one-time scan on startup, riding on the existing 30s cache TTL — no file watcher in this MVP, keeping the change minimal and consistent with how global/workspace agents are already refreshed.

## Changes

| File | Change |
|------|--------|
| `packages/types/src/agent.ts` | Added `"plugin"` to `AgentSource` union; added `pluginName?: string` |
| `packages/agents/src/paths.ts` | Added `getPluginManifestPath()`, `parsePluginManifest()` with JSDoc |
| `packages/agents/src/discovery.ts` | Added `loadPluginAgents()` private method; extracted `safeRealPath()` helper; added `seenRealPaths` cross-source dedup; wired into `loadAgents()`; added `manifestPathOverride` constructor param for testability |
| `packages/agents/src/plugin-agents.test.ts` | New: 13 unit + integration tests covering all edge cases |
| `packages/http-api/src/handlers/agents.ts` | Added `pluginAgents` filter and response field |
| `packages/dashboard-web/src/api.ts` | Added `pluginAgents: Agent[]` to `AgentsResponse` |
| `packages/dashboard-web/src/components/AgentsTab.tsx` | Added Plugin Agents section (conditional on `pluginAgents.length > 0`) |
| `README.md` | Documented `BETTER_CCFLARE_DISCOVER_PLUGIN_AGENTS` env var |

## Security

- `validatePathOrThrow` enforced on both `agentsDir` (before `readdir`) and individual agent files, with `additionalAllowedPaths: [~/.claude/plugins]`
- `pluginName` derived only from the manifest key (user-controlled JSON) — no arbitrary string evaluation
- Feature is off by default; enabling requires explicit env var

## Test Plan

- [ ] `bun test` — 1217 tests pass (includes 13 new tests in `plugin-agents.test.ts`)
- [ ] `bun run lint && bun run typecheck && bun run format` — clean on changed files
- [ ] **Unit tests** cover: manifest missing → `[]`, malformed JSON → `[]`, `installPath` missing → skip, `agents/` missing → skip, valid entry → correct `{pluginName, agentsDir}`, multiple version entries, two plugins sharing basename → distinct IDs, symlink dedup logic
- [ ] **Integration test**: env var on + valid manifest + valid agent `.md` → `registry.getAgents()` returns agent with `source === "plugin"`, `pluginName`, `id === "myplugin:my-agent"`, `name`
- [ ] **Manual (env var off)**: Start server — Agents UI shows only global/workspace agents. No change in behavior.
- [ ] **Manual (env var on)**: Set `BETTER_CCFLARE_DISCOVER_PLUGIN_AGENTS=true`, restart. If Claude Code plugins with agents are installed, those agents appear under "Plugin Agents" in the Agents UI tab.
- [ ] **Manifest missing**: Start with env var on but no `~/.claude/plugins/installed_plugins.json` — no crash, starts cleanly.

## Notes for Reviewer

- No version bump (release system handles automatically)
- `inline-worker.ts` untouched
- Pre-existing lint errors in `apps/server/src/server.ts` (TS2722) exist on `main` before this branch — not introduced by this PR
- Happy to add a dedicated Plugin tab in a follow-up if preferred over the current "Plugin Agents" section in the "All" tab

## Extension Tax Declaration

This PR modifies `packages/agents/src/discovery.ts` (core agent loading) and `packages/types/src/agent.ts` (shared type) — not SKILL.md files. Extension Tax does not apply.