### PR TITLE
fix: insert requests row on model-fallback 429 paths

### DIFF
--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -745,17 +745,17 @@ export async function proxyWithAccount(
 							`[ccflare] account=${account.name} cooldown_applied reason=${reason} until=${new Date(cooldownUntil).toISOString()}`,
 						);
 						account.rate_limited_until = cooldownUntil;
-						const _rt1 = Date.now() - requestMeta.timestamp;
+						const responseTime = Date.now() - requestMeta.timestamp;
 						ctx.asyncWriter.enqueue(() =>
 							ctx.dbOps.saveRequest(
-								requestMeta.id,
+								crypto.randomUUID(),
 								req.method,
 								url.pathname,
 								account.id,
 								429,
 								false,
 								reason,
-								_rt1,
+								responseTime,
 								failoverAttempts,
 								undefined,
 								requestMeta.agentUsed ?? undefined,
@@ -882,17 +882,17 @@ export async function proxyWithAccount(
 							`[ccflare] account=${account.name} cooldown_applied reason=${reason} until=${new Date(cooldownUntil).toISOString()}`,
 						);
 						account.rate_limited_until = cooldownUntil;
-						const _rt2 = Date.now() - requestMeta.timestamp;
+						const responseTime = Date.now() - requestMeta.timestamp;
 						ctx.asyncWriter.enqueue(() =>
 							ctx.dbOps.saveRequest(
-								requestMeta.id,
+								crypto.randomUUID(),
 								req.method,
 								url.pathname,
 								account.id,
 								429,
 								false,
 								reason,
-								_rt2,
+								responseTime,
 								failoverAttempts,
 								undefined,
 								requestMeta.agentUsed ?? undefined,

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -745,6 +745,27 @@ export async function proxyWithAccount(
 							`[ccflare] account=${account.name} cooldown_applied reason=${reason} until=${new Date(cooldownUntil).toISOString()}`,
 						);
 						account.rate_limited_until = cooldownUntil;
+						const _rt1 = Date.now() - requestMeta.timestamp;
+						ctx.asyncWriter.enqueue(() =>
+							ctx.dbOps.saveRequest(
+								requestMeta.id,
+								req.method,
+								url.pathname,
+								account.id,
+								429,
+								false,
+								reason,
+								_rt1,
+								failoverAttempts,
+								undefined,
+								requestMeta.agentUsed ?? undefined,
+								apiKeyId ?? undefined,
+								apiKeyName ?? undefined,
+								requestMeta.project ?? null,
+								undefined,
+								requestMeta.comboName ?? null,
+							),
+						);
 						ctx.asyncWriter.enqueue(() =>
 							ctx.dbOps.markAccountRateLimited(
 								account.id,
@@ -861,6 +882,27 @@ export async function proxyWithAccount(
 							`[ccflare] account=${account.name} cooldown_applied reason=${reason} until=${new Date(cooldownUntil).toISOString()}`,
 						);
 						account.rate_limited_until = cooldownUntil;
+						const _rt2 = Date.now() - requestMeta.timestamp;
+						ctx.asyncWriter.enqueue(() =>
+							ctx.dbOps.saveRequest(
+								requestMeta.id,
+								req.method,
+								url.pathname,
+								account.id,
+								429,
+								false,
+								reason,
+								_rt2,
+								failoverAttempts,
+								undefined,
+								requestMeta.agentUsed ?? undefined,
+								apiKeyId ?? undefined,
+								apiKeyName ?? undefined,
+								requestMeta.project ?? null,
+								undefined,
+								requestMeta.comboName ?? null,
+							),
+						);
 						ctx.asyncWriter.enqueue(() =>
 							ctx.dbOps.markAccountRateLimited(
 								account.id,


### PR DESCRIPTION
Closes #194

Inserts a requests row (status_code=429, account_used=<id>) at both model-fallback 429 sites in proxy-operations.ts before calling markAccountRateLimited, completing the audit trail for operators tracking which requests triggered cooldowns.

Skips insertion for keepalive probes (consistent with PR #196 keepalive guard pattern).