### PR TITLE
fix: AutoRefreshScheduler skips known-cooled accounts; tag synthetic probes

### DIFF
--- a/packages/proxy/src/auto-refresh-scheduler.ts
+++ b/packages/proxy/src/auto-refresh-scheduler.ts
@@ -143,6 +143,14 @@ export class AutoRefreshScheduler {
 						OR rate_limit_reset IS NULL
 						OR rate_limit_reset < (? - 24 * 60 * 60 * 1000)
 					)
+					-- Skip accounts that are still inside an active per-account cooldown.
+					-- ccflare already knows upstream will reject us until rate_limited_until,
+					-- so probing during that window is a guaranteed-fail call that wastes
+					-- quota, re-applies the same cooldown, and pollutes the request log
+					-- with synthetic 503s (issue #199, bug 1).
+					AND (
+						rate_limited_until IS NULL OR rate_limited_until <= ?
+					)
 					-- Exclude accounts that are paused for reasons other than overage (e.g. manually
 					-- paused zai/codex accounts, or accounts paused by the failure-threshold guard).
 					-- auto_pause_on_overage_enabled defaults to 0 for zai/codex, so a manually-paused
@@ -155,7 +163,7 @@ export class AutoRefreshScheduler {
 						AND COALESCE(auto_pause_on_overage_enabled, 0) = 0
 					)
 			`,
-				[now, now],
+				[now, now, now],
 			);
 
 			log.debug(
@@ -360,6 +368,13 @@ export class AutoRefreshScheduler {
 				"x-better-ccflare-account-id": account.id,
 				// CRITICAL: Bypass session tracking for auto-refresh messages
 				"x-better-ccflare-bypass-session": "true",
+				// Tag the request as a synthetic auto-refresh probe so downstream
+				// pipeline layers can distinguish it from real user traffic
+				// (cache-body-store skips staging for these, request logging
+				// and pool-exhausted 503 metrics filter them out — issue #199,
+				// bug 2). Mirrors the existing x-better-ccflare-keepalive
+				// pattern used by cache-keepalive-scheduler.ts.
+				"x-better-ccflare-auto-refresh": "true",
 			});
 
 			// Try sending with multiple models if needed

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -525,8 +525,15 @@ export async function proxyWithAccount(
 		// Headers are stored because Anthropic's prepareHeaders() copies incoming
 		// client headers (anthropic-version, anthropic-beta, x-stainless-*, etc.)
 		// and augments them — providers that build headers from scratch ignore them.
-		// Skip staging for internal keepalive replays to prevent infinite loop.
-		if (!req.headers.get("x-better-ccflare-keepalive")) {
+		// Skip staging for internal synthetic requests:
+		//   - keepalive replays — prevent infinite loop
+		//   - auto-refresh probes — same loop-prevention concern, plus these
+		//     hit known-cooled accounts and shouldn't pollute the staged-body cache
+		//     (issue #199, bug 2).
+		const isSyntheticInternal =
+			req.headers.get("x-better-ccflare-keepalive") === "true" ||
+			req.headers.get("x-better-ccflare-auto-refresh") === "true";
+		if (!isSyntheticInternal) {
 			cacheBodyStore.stageRequest(
 				requestMeta.id,
 				account.id,

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -530,9 +530,12 @@ export async function proxyWithAccount(
 		//   - auto-refresh probes — same loop-prevention concern, plus these
 		//     hit known-cooled accounts and shouldn't pollute the staged-body cache
 		//     (issue #199, bug 2).
+		// Both checks are truthy (not strict-equality) to preserve the original
+		// keepalive guard's behaviour: any non-empty header value triggers the
+		// skip, matching what `!req.headers.get(...)` returned before.
 		const isSyntheticInternal =
-			req.headers.get("x-better-ccflare-keepalive") === "true" ||
-			req.headers.get("x-better-ccflare-auto-refresh") === "true";
+			!!req.headers.get("x-better-ccflare-keepalive") ||
+			!!req.headers.get("x-better-ccflare-auto-refresh");
 		if (!isSyntheticInternal) {
 			cacheBodyStore.stageRequest(
 				requestMeta.id,

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -345,41 +345,51 @@ export async function handleProxy(
 
 		const poolExhaustedResponse = createPoolExhaustedResponse(allAccounts);
 
-		// Send error message to usage worker for request history logging
-		ctx.usageWorker.postMessage({
-			type: "start",
-			messageId: crypto.randomUUID(),
-			requestId: requestMeta.id,
-			accountId: null,
-			method: req.method,
-			path: url.pathname,
-			timestamp: requestMeta.timestamp,
-			requestHeaders: Object.fromEntries(req.headers.entries()),
-			requestBody: null,
-			project: project ?? null,
-			responseStatus: 503,
-			responseHeaders: Object.fromEntries(
-				poolExhaustedResponse.headers.entries(),
-			),
-			isStream: false,
-			providerName: ctx.provider.name,
-			accountBillingType: null,
-			accountAutoPauseOnOverageEnabled: 0,
-			accountName: null,
-			agentUsed: agentUsed || null,
-			comboName: null,
-			apiKeyId: apiKeyId || null,
-			apiKeyName: apiKeyName || null,
-			retryAttempt: 0,
-			failoverAttempts: 0,
-		});
+		// Skip request-log staging for synthetic auto-refresh probes that
+		// 503 because their target account is on a known cooldown. Logging
+		// these as user-facing 503s inflates the dashboard fail-rate without
+		// reflecting any real client impact (issue #199, bug 2). The keepalive
+		// scheduler already gets the equivalent treatment via its loop-prevention
+		// header path; this brings auto-refresh in line.
+		const isAutoRefreshProbe =
+			req.headers.get("x-better-ccflare-auto-refresh") === "true";
+		if (!isAutoRefreshProbe) {
+			// Send error message to usage worker for request history logging
+			ctx.usageWorker.postMessage({
+				type: "start",
+				messageId: crypto.randomUUID(),
+				requestId: requestMeta.id,
+				accountId: null,
+				method: req.method,
+				path: url.pathname,
+				timestamp: requestMeta.timestamp,
+				requestHeaders: Object.fromEntries(req.headers.entries()),
+				requestBody: null,
+				project: project ?? null,
+				responseStatus: 503,
+				responseHeaders: Object.fromEntries(
+					poolExhaustedResponse.headers.entries(),
+				),
+				isStream: false,
+				providerName: ctx.provider.name,
+				accountBillingType: null,
+				accountAutoPauseOnOverageEnabled: 0,
+				accountName: null,
+				agentUsed: agentUsed || null,
+				comboName: null,
+				apiKeyId: apiKeyId || null,
+				apiKeyName: apiKeyName || null,
+				retryAttempt: 0,
+				failoverAttempts: 0,
+			});
 
-		ctx.usageWorker.postMessage({
-			type: "end",
-			requestId: requestMeta.id,
-			success: false,
-			error: "pool_exhausted",
-		});
+			ctx.usageWorker.postMessage({
+				type: "end",
+				requestId: requestMeta.id,
+				success: false,
+				error: "pool_exhausted",
+			});
+		}
 
 		return poolExhaustedResponse;
 	}

--- a/packages/proxy/src/response-handler.ts
+++ b/packages/proxy/src/response-handler.ts
@@ -288,12 +288,14 @@ export async function forwardToClient(
 
 						if (value) {
 							lastChunkTime = Date.now();
-							const chunkMsg: ChunkMessage = {
-								type: "chunk",
-								requestId,
-								data: value,
-							};
-							safePostMessage(ctx.usageWorker, chunkMsg);
+							if (shouldProcessRequest) {
+								const chunkMsg: ChunkMessage = {
+									type: "chunk",
+									requestId,
+									data: value,
+								};
+								safePostMessage(ctx.usageWorker, chunkMsg);
+							}
 
 							// Mid-stream rate-limit detection. The sniffer
 							// fires exactly once; after that feed() is a no-op.
@@ -318,20 +320,24 @@ export async function forwardToClient(
 					}
 				}
 				// Finished without errors
-				const endMsg: EndMessage = {
-					type: "end",
-					requestId,
-					success: isExpectedResponse(path, analyticsResponse),
-				};
-				safePostMessage(ctx.usageWorker, endMsg);
+				if (shouldProcessRequest) {
+					const endMsg: EndMessage = {
+						type: "end",
+						requestId,
+						success: isExpectedResponse(path, analyticsResponse),
+					};
+					safePostMessage(ctx.usageWorker, endMsg);
+				}
 			} catch (err) {
-				const endMsg: EndMessage = {
-					type: "end",
-					requestId,
-					success: false,
-					error: (err as Error).message,
-				};
-				safePostMessage(ctx.usageWorker, endMsg);
+				if (shouldProcessRequest) {
+					const endMsg: EndMessage = {
+						type: "end",
+						requestId,
+						success: false,
+						error: (err as Error).message,
+					};
+					safePostMessage(ctx.usageWorker, endMsg);
+				}
 			}
 		})();
 
@@ -343,13 +349,15 @@ export async function forwardToClient(
 	 *  NON-STREAMING RESPONSES — read body in background, send END once
 	 *********************************************************************/
 	if (!response.body) {
-		const endMsg: EndMessage = {
-			type: "end",
-			requestId,
-			responseBody: null,
-			success: isExpectedResponse(path, response),
-		};
-		safePostMessage(ctx.usageWorker, endMsg);
+		if (shouldProcessRequest) {
+			const endMsg: EndMessage = {
+				type: "end",
+				requestId,
+				responseBody: null,
+				success: isExpectedResponse(path, response),
+			};
+			safePostMessage(ctx.usageWorker, endMsg);
+		}
 
 		return response;
 	}
@@ -394,22 +402,26 @@ export async function forwardToClient(
 				}
 				cappedBuf = Buffer.concat(chunks);
 			}
-			const endMsg: EndMessage = {
-				type: "end",
-				requestId,
-				responseBody:
-					cappedBuf.byteLength > 0 ? cappedBuf.toString("base64") : null,
-				success: isExpectedResponse(path, analyticsResponse),
-			};
-			safePostMessage(ctx.usageWorker, endMsg);
+			if (shouldProcessRequest) {
+				const endMsg: EndMessage = {
+					type: "end",
+					requestId,
+					responseBody:
+						cappedBuf.byteLength > 0 ? cappedBuf.toString("base64") : null,
+					success: isExpectedResponse(path, analyticsResponse),
+				};
+				safePostMessage(ctx.usageWorker, endMsg);
+			}
 		} catch (err) {
-			const endMsg: EndMessage = {
-				type: "end",
-				requestId,
-				success: false,
-				error: (err as Error).message,
-			};
-			safePostMessage(ctx.usageWorker, endMsg);
+			if (shouldProcessRequest) {
+				const endMsg: EndMessage = {
+					type: "end",
+					requestId,
+					success: false,
+					error: (err as Error).message,
+				};
+				safePostMessage(ctx.usageWorker, endMsg);
+			}
 		}
 	})();
 

--- a/packages/proxy/src/response-handler.ts
+++ b/packages/proxy/src/response-handler.ts
@@ -118,11 +118,20 @@ export async function forwardToClient(
 	const isStream = ctx.provider.isStreamingResponse?.(response) ?? false;
 	const shouldStorePayloads = ctx.config.getStorePayloads?.() ?? true;
 
-	// Filter out count_tokens requests for OpenAI-compatible providers from request logs and worker
-	const shouldProcessRequest = !(
-		ctx.provider.name === "openai-compatible" &&
-		path === "/v1/messages/count_tokens"
-	);
+	// Filter out:
+	//   - count_tokens requests on OpenAI-compatible providers (existing
+	//     filter — these aren't billable user traffic).
+	//   - synthetic auto-refresh probes (issue #199, bug 2). Logging these
+	//     pollutes the user-visible 503/200 metrics on the dashboard with
+	//     internal scheduler activity. Header set by AutoRefreshScheduler
+	//     mirrors the existing keepalive pattern.
+	const isAutoRefreshProbe =
+		requestHeaders.get("x-better-ccflare-auto-refresh") === "true";
+	const shouldProcessRequest =
+		!(
+			ctx.provider.name === "openai-compatible" &&
+			path === "/v1/messages/count_tokens"
+		) && !isAutoRefreshProbe;
 
 	// Send START message immediately if not filtered
 	if (shouldProcessRequest) {


### PR DESCRIPTION
Closes #199 (both bugs).

## Bug 1 — probe known-cooled accounts

The scheduler's WHERE clause already excludes manual-paused accounts and filters by `rate_limit_reset` (the upstream usage-window reset), but it does **not** check `rate_limited_until` — the locally-tracked per-account cooldown that ccflare itself sets on 429 responses. So an account with a future `rate_limited_until` kept getting probed every minute, every probe immediately 429'd, the same cooldown got re-applied, and the loop continued until the window naturally expired (up to 3 days for weekly caps).

**Fix:** add ` AND (rate_limited_until IS NULL OR rate_limited_until <= ?)` to the eligibility query. Same shape as the existing `rate_limit_reset` check.

## Bug 2 — synthetic probe traffic logged as user 503s

When auto-refresh probes failed with a pool-exhausted 503, the failure landed in the `requests` table indistinguishable from a real client 503, inflating dashboard fail-rate metrics by ~1 entry per minute per cooled account.

**Fix:** tag every probe with `x-better-ccflare-auto-refresh: true` (mirrors the existing `x-better-ccflare-keepalive` pattern from `cache-keepalive-scheduler.ts`), then filter on that header at three sites:

1. `proxy-operations.ts` cacheBodyStore staging — same loop-prevention reason as keepalive (refactored to a shared `isSyntheticInternal` flag)
2. `proxy.ts` pool-exhausted 503 `worker.postMessage` — skip request log write entirely for synthetic probes
3. `response-handler.ts` `forwardToClient` — short-circuits the START message via the existing `shouldProcessRequest` filter (extended to include the auto-refresh header alongside the existing count_tokens filter)

## Repro evidence (from the issue)

```
13:44:05  AutoRefresh probes val_qa
13:44:05  → upstream 429 with retry-after pointing at 13:59:59 UTC
13:44:05  WARN  cooldown_applied reason=model_fallback_429 until=2026-05-06T13:59:59Z
13:44:05  ERROR Auto-refresh message failed for account val_qa: 503 Service Unavailable
13:45:05  AutoRefresh probes val_qa  ← 60s later, same account, same outcome
13:45:05  → upstream 429 (same retry-after — Anthropic is honest about it)
13:45:05  WARN  cooldown_applied reason=model_fallback_429 until=2026-05-06T13:59:59Z
13:45:05  ERROR Auto-refresh message failed for account val_qa: 503 Service Unavailable
```

After this PR: the second probe never happens. The query's `rate_limited_until <= now` filter excludes val_qa from the eligibility set until at-or-after 13:59:59. The internal 503 also no longer reaches the request log even when it does fire (e.g., for an account whose cooldown expires mid-tick).

## Notes for reviewer

- I extended the loop-prevention filter via the per-request boundary check at `proxy-operations:528` — that's the one that mirrors the keepalive pattern. The strip-list at `cache-body-store.ts:84` (which controls which headers get persisted *with* cached bodies, not loop prevention) is unchanged. Happy to add the new header to that list too if you'd prefer the strip-list to enumerate all internal headers — but I didn't want to creep the diff.

- Three pre-existing tests in `response-processor.test.ts` fail on `upstream/main` (expect `default_5h` / 5h window) — those expectations look inconsistent with #196's reason rename and are presumably waiting on that merge. Untouched by this PR; the build is clean and the surrounding 108 tests pass.

- Header name `x-better-ccflare-auto-refresh` is intentional symmetry with `x-better-ccflare-keepalive`. Easy to grep, easy for operators to recognize when debugging.

## Could also follow up with

A small README/operator note about which headers are reserved for ccflare-internal use:
- `x-better-ccflare-account-id` (forced-account routing)
- `x-better-ccflare-bypass-session` (auto-refresh / keepalive)
- `x-better-ccflare-keepalive` (loop prevention for cache-keepalive)
- `x-better-ccflare-auto-refresh` (this PR)

Would help anyone running their own probes / ops scripts. Not in this PR's scope unless you want it added.