### PR TITLE
Unify Codex model mapping path

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -775,7 +775,7 @@ export default async function startServer(options?: {
 		},
 	});
 
-	strategy.initialize(strategyStore);
+	strategy.initialize?.(strategyStore);
 
 	// Start usage worker eagerly (before first request)
 	startUsageWorker();
@@ -856,7 +856,7 @@ export default async function startServer(options?: {
 				newStrategyName,
 				runtimeConfig.sessionDurationMs,
 			);
-			strategy.initialize(strategyStore);
+			strategy.initialize?.(strategyStore);
 			proxyContext.strategy = strategy;
 		}
 		if (key === "store_payloads") {

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -823,6 +823,27 @@ describe("CodexProvider.transformRequestBody", () => {
 		expect(body.model).toBe("gpt-5.3-codex");
 	});
 
+	it("uses default Codex mapping for families missing from account mappings", async () => {
+		const provider = new CodexProvider();
+		const account = {
+			model_mappings: JSON.stringify({ sonnet: "gpt-5.3-codex" }),
+		} as Parameters<typeof provider.transformRequestBody>[1];
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-haiku",
+				max_tokens: 10,
+				messages: [{ role: "user", content: "hello" }],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request, account);
+		const body = await transformed.json();
+
+		expect(body.model).toBe("gpt-5.4-mini");
+	});
+
 	it("passes through unknown model names unchanged", async () => {
 		const provider = new CodexProvider();
 		const request = new Request("https://example.com/v1/messages", {

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -779,6 +779,50 @@ describe("CodexProvider.transformRequestBody", () => {
 		expect(body.model).toBe("gpt-5.3-codex");
 	});
 
+	it("uses account sonnet mapping for sonnet-family models", async () => {
+		const provider = new CodexProvider();
+		const account = {
+			model_mappings: JSON.stringify({ sonnet: "gpt-5.3-codex" }),
+		} as Parameters<typeof provider.transformRequestBody>[1];
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-7-sonnet",
+				max_tokens: 10,
+				messages: [{ role: "user", content: "hello" }],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request, account);
+		const body = await transformed.json();
+
+		expect(body.model).toBe("gpt-5.3-codex");
+	});
+
+	it("uses first model when account mapping value is an ordered array", async () => {
+		const provider = new CodexProvider();
+		const account = {
+			model_mappings: JSON.stringify({
+				sonnet: ["gpt-5.3-codex", "gpt-5.4"],
+			}),
+		} as Parameters<typeof provider.transformRequestBody>[1];
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-7-sonnet",
+				max_tokens: 10,
+				messages: [{ role: "user", content: "hello" }],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request, account);
+		const body = await transformed.json();
+
+		expect(body.model).toBe("gpt-5.3-codex");
+	});
+
 	it("passes through unknown model names unchanged", async () => {
 		const provider = new CodexProvider();
 		const request = new Request("https://example.com/v1/messages", {

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -1,4 +1,9 @@
-import { ValidationError, validateEndpointUrl } from "@better-ccflare/core";
+import {
+	ValidationError,
+	getModelList,
+	mapModelName,
+	validateEndpointUrl,
+} from "@better-ccflare/core";
 import { sanitizeProxyHeaders } from "@better-ccflare/http-common";
 import { Logger } from "@better-ccflare/logger";
 import { resolveReasoningEffort } from "@better-ccflare/openai-formats";
@@ -470,25 +475,14 @@ export class CodexProvider extends BaseProvider {
 	// ── Private helpers ──────────────────────────────────────────────────────
 
 	private mapModel(anthropicModel: string, account?: Account): string {
-		// Account-level overrides take priority
-		if (account?.model_mappings) {
-			try {
-				const mappings =
-					typeof account.model_mappings === "string"
-						? (JSON.parse(account.model_mappings) as Record<string, string>)
-						: (account.model_mappings as Record<string, string>);
-
-				const lower = anthropicModel.toLowerCase();
-				if (mappings[anthropicModel]) return mappings[anthropicModel];
-				if (lower.includes("haiku") && mappings.haiku) return mappings.haiku;
-				if (lower.includes("sonnet") && mappings.sonnet) return mappings.sonnet;
-				if (lower.includes("opus") && mappings.opus) return mappings.opus;
-			} catch {
-				// ignore malformed mappings
+		if (account) {
+			const mapped = mapModelName(anthropicModel, account);
+			const hasSharedMappings = getModelList(anthropicModel, account) !== null;
+			if (hasSharedMappings) {
+				return mapped;
 			}
 		}
 
-		// Default mapping by model family
 		const lower = anthropicModel.toLowerCase();
 		if (lower.includes("haiku")) return DEFAULT_MODEL_MAP.haiku;
 		if (lower.includes("sonnet")) return DEFAULT_MODEL_MAP.sonnet;

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -1,7 +1,6 @@
 import {
-	ValidationError,
-	getModelList,
 	mapModelName,
+	ValidationError,
 	validateEndpointUrl,
 } from "@better-ccflare/core";
 import { sanitizeProxyHeaders } from "@better-ccflare/http-common";
@@ -477,8 +476,7 @@ export class CodexProvider extends BaseProvider {
 	private mapModel(anthropicModel: string, account?: Account): string {
 		if (account) {
 			const mapped = mapModelName(anthropicModel, account);
-			const hasSharedMappings = getModelList(anthropicModel, account) !== null;
-			if (hasSharedMappings) {
+			if (mapped !== anthropicModel) {
 				return mapped;
 			}
 		}


### PR DESCRIPTION
## Summary
- Reuse the shared model mapping helper in the Codex provider so account mappings behave consistently.
- Fix Sonnet mappings to honor the configured provider model, including ordered-array mappings.
- Add targeted tests for explicit Sonnet mappings and array-based mappings.
- Guard optional strategy initialization in the server so `bun run typecheck` passes.

## Root cause
Codex had a private `mapModel()` implementation instead of using the shared `mapModelName()` path. That private path returned `mappings.sonnet` directly. String mappings such as `"sonnet": "gpt-5.3-codex"` worked, but ordered-array mappings such as `"sonnet": ["gpt-5.3-codex", "gpt-5.4"]` caused Codex to send the entire array as the upstream `model` value instead of selecting the first entry.

Using the shared mapping helper fixes this and also restores the shared model-mapping diagnostic logging behavior for Codex.

## Validation
- `bun test packages/providers/src/providers/codex/provider.test.ts`
- `bun run typecheck` ✅
- `bun run lint` *(still fails on unrelated pre-existing diagnostics and rewrites many files when run with `--unsafe`)*

## Notes
- The lint script in this repo is currently not usable as a clean gate for this PR because it rewrites unrelated files before failing on existing diagnostics.
- Fixes https://github.com/tombii/better-ccflare/issues/202