### PR TITLE
improve(dashboard): reorganize account row to prevent action button overflow

### DIFF
--- a/packages/dashboard-web/src/components/accounts/AccountListItem.tsx
+++ b/packages/dashboard-web/src/components/accounts/AccountListItem.tsx
@@ -5,6 +5,7 @@ import {
 	Globe,
 	Hash,
 	KeyRound,
+	MoreHorizontal,
 	Pause,
 	Play,
 	RefreshCw,
@@ -21,6 +22,13 @@ import {
 } from "../../utils/provider-utils";
 import { OAuthTokenStatusWithBoundary } from "../OAuthTokenStatus";
 import { Button } from "../ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
 import { Switch } from "../ui/switch";
 import { RateLimitProgress } from "./RateLimitProgress";
 
@@ -117,265 +125,29 @@ export function AccountListItem({
 	return (
 		<div
 			key={account.name}
-			className={`p-4 border rounded-lg transition-colors space-y-4 ${
+			className={`p-4 border rounded-lg transition-colors space-y-3 ${
 				isActive
 					? "border-primary bg-primary/5 shadow-sm"
 					: "border-border hover:border-muted-foreground/50"
 			}`}
 		>
 			<div className="flex items-center justify-between">
-				<div className="flex items-center gap-4">
-					<div>
-						<div className="flex items-center gap-2">
-							<p className="font-medium">{account.name}</p>
-							{isActive && (
-								<span className="px-2 py-0.5 text-xs font-medium bg-primary text-primary-foreground rounded-full">
-									Active
-								</span>
-							)}
-							<span className="px-2 py-0.5 text-xs font-medium bg-secondary text-secondary-foreground rounded-full">
-								Priority: {account.priority}
-							</span>
-							<OAuthTokenStatusWithBoundary
-								accountName={account.name}
-								hasRefreshToken={account.hasRefreshToken}
-							/>
-							{providerSupportsAutoFeatures(account.provider) && (
-								<>
-									<div className="flex items-center gap-2">
-										<span className="text-xs text-muted-foreground">
-											Auto-fallback:
-										</span>
-										<Switch
-											checked={account.autoFallbackEnabled}
-											onCheckedChange={() => onAutoFallbackToggle(account)}
-											title="Automatically switch back to this account from lower-priority ones when its rate limit resets. Requires multiple accounts with different priorities."
-										/>
-									</div>
-									<div className="flex items-center gap-2">
-										<span className="text-xs text-muted-foreground">
-											Auto-refresh:
-										</span>
-										<Switch
-											checked={account.autoRefreshEnabled}
-											onCheckedChange={() => onAutoRefreshToggle(account)}
-											title="Automatically sends a minimal message when the usage window resets to avoid cold-start latency. Does not affect OAuth token refreshing."
-										/>
-									</div>
-								</>
-							)}
-							{providerSupportsCustomBilling(account.provider) && (
-								<div className="flex items-center gap-2">
-									<span className="text-xs text-muted-foreground">
-										Plan billing:
-									</span>
-									<Switch
-										checked={account.billingType === "plan"}
-										onCheckedChange={() => onBillingTypeToggle(account)}
-										title="Toggle plan billing for this account"
-									/>
-								</div>
-							)}
-							{account.provider === "anthropic" &&
-								onAutoPauseOnOverageToggle && (
-									<div className="flex items-center gap-2">
-										<span className="text-xs text-muted-foreground">
-											Auto-pause on overage:
-										</span>
-										<Switch
-											checked={account.autoPauseOnOverageEnabled ?? false}
-											onCheckedChange={() =>
-												onAutoPauseOnOverageToggle(account)
-											}
-											title="Automatically pause account when overage usage is detected. Note: detection only happens when Anthropic API reports overage, so some overage usage may occur before pausing. Account resumes when usage window resets."
-										/>
-									</div>
-								)}
-							{account.provider === "zai" && onPeakHoursPauseToggle && (
-								<div className="flex items-center gap-2">
-									<span className="text-xs text-muted-foreground">
-										Peak hours pause:
-									</span>
-									<Switch
-										checked={account.peakHoursPauseEnabled ?? false}
-										onCheckedChange={() => onPeakHoursPauseToggle(account)}
-										title="Automatically pause this account during Zai peak hours (14:00–18:00 SGT)"
-									/>
-								</div>
-							)}
-						</div>
-						<div className="flex items-center gap-2">
-							<p className="text-sm text-muted-foreground">
-								{account.provider}
-							</p>
-							{account.provider === "bedrock" && bedrockProfile && (
-								<>
-									<span className="text-sm text-muted-foreground">•</span>
-									<p className="text-sm text-muted-foreground">
-										Profile: {bedrockProfile}
-									</p>
-									{bedrockRegion && (
-										<>
-											<span className="text-sm text-muted-foreground">•</span>
-											<div
-												className="flex items-center gap-1"
-												title={`Region: ${bedrockRegion}`}
-											>
-												<Globe className="h-3 w-3 text-muted-foreground" />
-												<p className="text-sm text-muted-foreground">
-													{bedrockRegion}
-												</p>
-											</div>
-										</>
-									)}
-									{bedrockCrossRegionMode && (
-										<>
-											<span className="text-sm text-muted-foreground">•</span>
-											<p
-												className="text-sm text-muted-foreground"
-												title="Cross-region inference mode"
-											>
-												{bedrockCrossRegionMode}
-											</p>
-										</>
-									)}
-								</>
-							)}
-						</div>
-					</div>
-					<div className="flex items-center gap-2">
-						{presenter.isRateLimited && (
-							<span title="Account is rate-limited - requests will be rejected until the limit resets">
-								<AlertCircle className="h-4 w-4 text-yellow-600" />
-							</span>
-						)}
-						<span className="text-sm">{presenter.requestCount} requests</span>
-						<span className="text-sm text-muted-foreground">
-							{presenter.sessionInfo}
+				<div className="flex items-center gap-2 min-w-0">
+					<p className="font-medium truncate">{account.name}</p>
+					{isActive && (
+						<span className="px-2 py-0.5 text-xs font-medium bg-primary text-primary-foreground rounded-full">
+							Active
 						</span>
-						{presenter.isPaused && (
-							<span className="text-sm text-muted-foreground">Paused</span>
-						)}
-						{!presenter.isPaused && presenter.rateLimitStatus !== "OK" && (
-							<span
-								className={`text-sm ${
-									presenter.rateLimitStatus
-										.toLowerCase()
-										.startsWith("allowed_warning")
-										? "text-amber-600"
-										: presenter.rateLimitStatus
-													.toLowerCase()
-													.startsWith("allowed")
-											? "text-green-600"
-											: "text-destructive"
-								}`}
-							>
-								{presenter.rateLimitStatus}
-							</span>
-						)}
-						{staleLockDetected && (
-							<span
-								className="text-sm text-amber-600"
-								title="Stale lock detected: usage data shows available capacity but account is still rate-limited"
-							>
-								Stale lock detected
-							</span>
-						)}
-						{isUsageThrottled && (
-							<span
-								className="text-sm text-amber-600"
-								title="Usage throttling is delaying requests for this account until pacing catches up"
-							>
-								Usage throttled
-							</span>
-						)}
-					</div>
+					)}
+					<span className="px-2 py-0.5 text-xs font-medium bg-secondary text-secondary-foreground rounded-full">
+						Priority: {account.priority}
+					</span>
+					<OAuthTokenStatusWithBoundary
+						accountName={account.name}
+						hasRefreshToken={account.hasRefreshToken}
+					/>
 				</div>
-				<div className="flex items-center gap-2">
-					<Button
-						variant="ghost"
-						size="sm"
-						onClick={() => onRename(account)}
-						title="Rename account"
-					>
-						<Edit2 className="h-4 w-4" />
-					</Button>
-					<Button
-						variant="ghost"
-						size="sm"
-						onClick={() => onPriorityChange(account)}
-						title="Change account priority"
-					>
-						<Zap className="h-4 w-4" />
-					</Button>
-					{onCustomEndpointChange && (
-						<Button
-							variant="ghost"
-							size="sm"
-							onClick={() => onCustomEndpointChange(account)}
-							title={
-								account.customEndpoint
-									? `Custom endpoint: ${account.customEndpoint}`
-									: "Set custom endpoint"
-							}
-						>
-							<Globe
-								className={`h-4 w-4 ${
-									account.customEndpoint ? "text-primary" : ""
-								}`}
-							/>
-						</Button>
-					)}
-					{onModelMappingsChange && (
-						<Button
-							variant="ghost"
-							size="sm"
-							onClick={() => onModelMappingsChange(account)}
-							title={
-								account.modelMappings
-									? `Model mappings configured (${Object.keys(account.modelMappings).length} mappings)`
-									: "Configure model mappings"
-							}
-						>
-							<Hash
-								className={`h-4 w-4 ${
-									account.modelMappings ? "text-primary" : ""
-								}`}
-							/>
-						</Button>
-					)}
-					{account.provider === "qwen" && onReauth && (
-						<Button
-							variant="ghost"
-							size="sm"
-							onClick={() => onReauth(account)}
-							title="Re-authenticate this Qwen account (preserves all metadata)"
-						>
-							<KeyRound className="h-4 w-4" />
-						</Button>
-					)}
-					{account.provider === "anthropic" &&
-						account.hasRefreshToken &&
-						onAnthropicReauth && (
-							<Button
-								variant="ghost"
-								size="sm"
-								onClick={() => onAnthropicReauth(account)}
-								title="Re-authenticate this Anthropic account (preserves all metadata)"
-							>
-								<KeyRound className="h-4 w-4" />
-							</Button>
-						)}
-					{account.provider === "codex" && onCodexReauth && (
-						<Button
-							variant="ghost"
-							size="sm"
-							onClick={() => onCodexReauth(account)}
-							title="Re-authenticate this Codex account (preserves all metadata)"
-						>
-							<KeyRound className="h-4 w-4" />
-						</Button>
-					)}
+				<div className="flex items-center gap-1 shrink-0">
 					{account.provider === "anthropic" && (
 						<Button
 							variant="ghost"
@@ -397,22 +169,6 @@ export function AccountListItem({
 							/>
 						</Button>
 					)}
-					{showForceReset && (
-						<Button
-							variant="outline"
-							size="sm"
-							className="h-8 gap-1 text-xs"
-							onClick={() => onForceResetRateLimit(account)}
-							title={
-								staleLockDetected
-									? "Reset stale rate limit lock (usage shows capacity available)"
-									: "Force clear rate limit state from database"
-							}
-						>
-							<RefreshCw className="h-3.5 w-3.5" />
-							Force Reset
-						</Button>
-					)}
 					<Button
 						variant="ghost"
 						size="sm"
@@ -425,6 +181,83 @@ export function AccountListItem({
 							<Pause className="h-4 w-4" />
 						)}
 					</Button>
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<Button variant="ghost" size="sm" title="More actions">
+								<MoreHorizontal className="h-4 w-4" />
+							</Button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="end">
+							<DropdownMenuItem onClick={() => onRename(account)}>
+								<Edit2 className="mr-2 h-4 w-4" />
+								Rename
+							</DropdownMenuItem>
+							<DropdownMenuItem onClick={() => onPriorityChange(account)}>
+								<Zap className="mr-2 h-4 w-4" />
+								Change Priority
+							</DropdownMenuItem>
+							{(onCustomEndpointChange || onModelMappingsChange) && (
+								<DropdownMenuSeparator />
+							)}
+							{onCustomEndpointChange && (
+								<DropdownMenuItem
+									onClick={() => onCustomEndpointChange(account)}
+								>
+									<Globe
+										className={`mr-2 h-4 w-4 ${account.customEndpoint ? "text-primary" : ""}`}
+									/>
+									Custom Endpoint
+									{account.customEndpoint && (
+										<span className="ml-auto text-xs text-muted-foreground">
+											set
+										</span>
+									)}
+								</DropdownMenuItem>
+							)}
+							{onModelMappingsChange && (
+								<DropdownMenuItem
+									onClick={() => onModelMappingsChange(account)}
+								>
+									<Hash
+										className={`mr-2 h-4 w-4 ${account.modelMappings ? "text-primary" : ""}`}
+									/>
+									Model Mappings
+									{account.modelMappings && (
+										<span className="ml-auto text-xs text-muted-foreground">
+											{Object.keys(account.modelMappings).length}
+										</span>
+									)}
+								</DropdownMenuItem>
+							)}
+							{((account.provider === "qwen" && onReauth) ||
+								(account.provider === "anthropic" &&
+									account.hasRefreshToken &&
+									onAnthropicReauth) ||
+								(account.provider === "codex" && onCodexReauth)) && (
+								<DropdownMenuSeparator />
+							)}
+							{account.provider === "qwen" && onReauth && (
+								<DropdownMenuItem onClick={() => onReauth(account)}>
+									<KeyRound className="mr-2 h-4 w-4" />
+									Re-authenticate
+								</DropdownMenuItem>
+							)}
+							{account.provider === "anthropic" &&
+								account.hasRefreshToken &&
+								onAnthropicReauth && (
+									<DropdownMenuItem onClick={() => onAnthropicReauth(account)}>
+										<KeyRound className="mr-2 h-4 w-4" />
+										Re-authenticate
+									</DropdownMenuItem>
+								)}
+							{account.provider === "codex" && onCodexReauth && (
+								<DropdownMenuItem onClick={() => onCodexReauth(account)}>
+									<KeyRound className="mr-2 h-4 w-4" />
+									Re-authenticate
+								</DropdownMenuItem>
+							)}
+						</DropdownMenuContent>
+					</DropdownMenu>
 					<Button
 						variant="ghost"
 						size="sm"
@@ -433,6 +266,161 @@ export function AccountListItem({
 						<Trash2 className="h-4 w-4" />
 					</Button>
 				</div>
+			</div>
+			{(providerSupportsAutoFeatures(account.provider) ||
+				providerSupportsCustomBilling(account.provider) ||
+				(account.provider === "anthropic" && onAutoPauseOnOverageToggle) ||
+				(account.provider === "zai" && onPeakHoursPauseToggle)) && (
+				<div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
+					{providerSupportsAutoFeatures(account.provider) && (
+						<>
+							<div className="flex items-center gap-2">
+								<span className="text-xs text-muted-foreground">
+									Auto-fallback:
+								</span>
+								<Switch
+									checked={account.autoFallbackEnabled}
+									onCheckedChange={() => onAutoFallbackToggle(account)}
+									title="Automatically switch back to this account from lower-priority ones when its rate limit resets. Requires multiple accounts with different priorities."
+								/>
+							</div>
+							<div className="flex items-center gap-2">
+								<span className="text-xs text-muted-foreground">
+									Auto-refresh:
+								</span>
+								<Switch
+									checked={account.autoRefreshEnabled}
+									onCheckedChange={() => onAutoRefreshToggle(account)}
+									title="Automatically sends a minimal message when the usage window resets to avoid cold-start latency. Does not affect OAuth token refreshing."
+								/>
+							</div>
+						</>
+					)}
+					{providerSupportsCustomBilling(account.provider) && (
+						<div className="flex items-center gap-2">
+							<span className="text-xs text-muted-foreground">
+								Plan billing:
+							</span>
+							<Switch
+								checked={account.billingType === "plan"}
+								onCheckedChange={() => onBillingTypeToggle(account)}
+								title="Toggle plan billing for this account"
+							/>
+						</div>
+					)}
+					{account.provider === "anthropic" && onAutoPauseOnOverageToggle && (
+						<div className="flex items-center gap-2">
+							<span className="text-xs text-muted-foreground">
+								Auto-pause on overage:
+							</span>
+							<Switch
+								checked={account.autoPauseOnOverageEnabled ?? false}
+								onCheckedChange={() => onAutoPauseOnOverageToggle(account)}
+								title="Automatically pause account when overage usage is detected. Note: detection only happens when Anthropic API reports overage, so some overage usage may occur before pausing. Account resumes when usage window resets."
+							/>
+						</div>
+					)}
+					{account.provider === "zai" && onPeakHoursPauseToggle && (
+						<div className="flex items-center gap-2">
+							<span className="text-xs text-muted-foreground">
+								Peak hours pause:
+							</span>
+							<Switch
+								checked={account.peakHoursPauseEnabled ?? false}
+								onCheckedChange={() => onPeakHoursPauseToggle(account)}
+								title="Automatically pause this account during Zai peak hours (14:00–18:00 SGT)"
+							/>
+						</div>
+					)}
+				</div>
+			)}
+			<div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
+				<span>{account.provider}</span>
+				{account.provider === "bedrock" && bedrockProfile && (
+					<>
+						<span>·</span>
+						<span>Profile: {bedrockProfile}</span>
+						{bedrockRegion && (
+							<>
+								<span>·</span>
+								<div
+									className="flex items-center gap-1"
+									title={`Region: ${bedrockRegion}`}
+								>
+									<Globe className="h-3 w-3" />
+									<span>{bedrockRegion}</span>
+								</div>
+							</>
+						)}
+						{bedrockCrossRegionMode && (
+							<>
+								<span>·</span>
+								<span title="Cross-region inference mode">
+									{bedrockCrossRegionMode}
+								</span>
+							</>
+						)}
+					</>
+				)}
+			</div>
+			<div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
+				{presenter.isRateLimited && (
+					<span title="Account is rate-limited - requests will be rejected until the limit resets">
+						<AlertCircle className="h-4 w-4 text-yellow-600" />
+					</span>
+				)}
+				<span>{presenter.requestCount} requests</span>
+				<span className="text-muted-foreground">{presenter.sessionInfo}</span>
+				{presenter.isPaused && (
+					<span className="text-muted-foreground">Paused</span>
+				)}
+				{!presenter.isPaused && presenter.rateLimitStatus !== "OK" && (
+					<span
+						className={
+							presenter.rateLimitStatus
+								.toLowerCase()
+								.startsWith("allowed_warning")
+								? "text-amber-600"
+								: presenter.rateLimitStatus.toLowerCase().startsWith("allowed")
+									? "text-green-600"
+									: "text-destructive"
+						}
+					>
+						{presenter.rateLimitStatus}
+					</span>
+				)}
+				{staleLockDetected && (
+					<span
+						className="text-amber-600"
+						title="Stale lock detected: usage data shows available capacity but account is still rate-limited"
+					>
+						Stale lock detected
+					</span>
+				)}
+				{isUsageThrottled && (
+					<span
+						className="text-amber-600"
+						title="Usage throttling is delaying requests for this account until pacing catches up"
+					>
+						Usage throttled
+					</span>
+				)}
+				{showForceReset && (
+					<Button
+						variant="outline"
+						size="sm"
+						className="h-7 gap-1 text-xs"
+						onClick={() => onForceResetRateLimit(account)}
+						title={
+							staleLockDetected
+								? "Reset stale rate limit lock (usage shows capacity available)"
+								: "Force clear rate limit state from database"
+						}
+					>
+						<RefreshCw className="h-3.5 w-3.5" />
+						Force Reset
+					</Button>
+				)}
 			</div>
 			{account.sessionStats && (
 				<div className="text-xs text-muted-foreground">

--- a/packages/dashboard-web/src/components/accounts/AccountListItem.tsx
+++ b/packages/dashboard-web/src/components/accounts/AccountListItem.tsx
@@ -108,6 +108,12 @@ export function AccountListItem({
 	const isUsageThrottled =
 		typeof account.usageThrottledUntil === "number" &&
 		account.usageThrottledUntil > Date.now();
+	const hasReauth =
+		(account.provider === "qwen" && !!onReauth) ||
+		(account.provider === "anthropic" &&
+			account.hasRefreshToken &&
+			!!onAnthropicReauth) ||
+		(account.provider === "codex" && !!onCodexReauth);
 
 	// Parse Bedrock profile and region from custom_endpoint
 	let bedrockProfile: string | null = null;
@@ -202,6 +208,11 @@ export function AccountListItem({
 							{onCustomEndpointChange && (
 								<DropdownMenuItem
 									onClick={() => onCustomEndpointChange(account)}
+									title={
+										account.customEndpoint
+											? `Custom endpoint: ${account.customEndpoint}`
+											: "Set custom endpoint"
+									}
 								>
 									<Globe
 										className={`mr-2 h-4 w-4 ${account.customEndpoint ? "text-primary" : ""}`}
@@ -217,6 +228,11 @@ export function AccountListItem({
 							{onModelMappingsChange && (
 								<DropdownMenuItem
 									onClick={() => onModelMappingsChange(account)}
+									title={
+										account.modelMappings
+											? `Model mappings configured (${Object.keys(account.modelMappings).length} mappings)`
+											: "Configure model mappings"
+									}
 								>
 									<Hash
 										className={`mr-2 h-4 w-4 ${account.modelMappings ? "text-primary" : ""}`}
@@ -229,15 +245,12 @@ export function AccountListItem({
 									)}
 								</DropdownMenuItem>
 							)}
-							{((account.provider === "qwen" && onReauth) ||
-								(account.provider === "anthropic" &&
-									account.hasRefreshToken &&
-									onAnthropicReauth) ||
-								(account.provider === "codex" && onCodexReauth)) && (
-								<DropdownMenuSeparator />
-							)}
+							{hasReauth && <DropdownMenuSeparator />}
 							{account.provider === "qwen" && onReauth && (
-								<DropdownMenuItem onClick={() => onReauth(account)}>
+								<DropdownMenuItem
+									onClick={() => onReauth(account)}
+									title="Re-authenticate this Qwen account (preserves all metadata)"
+								>
 									<KeyRound className="mr-2 h-4 w-4" />
 									Re-authenticate
 								</DropdownMenuItem>
@@ -245,13 +258,19 @@ export function AccountListItem({
 							{account.provider === "anthropic" &&
 								account.hasRefreshToken &&
 								onAnthropicReauth && (
-									<DropdownMenuItem onClick={() => onAnthropicReauth(account)}>
+									<DropdownMenuItem
+										onClick={() => onAnthropicReauth(account)}
+										title="Re-authenticate this Anthropic account (preserves all metadata)"
+									>
 										<KeyRound className="mr-2 h-4 w-4" />
 										Re-authenticate
 									</DropdownMenuItem>
 								)}
 							{account.provider === "codex" && onCodexReauth && (
-								<DropdownMenuItem onClick={() => onCodexReauth(account)}>
+								<DropdownMenuItem
+									onClick={() => onCodexReauth(account)}
+									title="Re-authenticate this Codex account (preserves all metadata)"
+								>
 									<KeyRound className="mr-2 h-4 w-4" />
 									Re-authenticate
 								</DropdownMenuItem>

--- a/packages/dashboard-web/src/components/ui/dropdown-menu.tsx
+++ b/packages/dashboard-web/src/components/ui/dropdown-menu.tsx
@@ -184,5 +184,7 @@ export {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 };


### PR DESCRIPTION
The per-account card on the Accounts tab previously packed everything above the `Session: …` line into a single horizontal flex row with no overflow handling. Everything was pretty cramped and cut-off or pushed off screen.

It's now multiple rows + actions in an overflow menu.

<img width="512"  alt="Screenshot from 2026-05-14 00-58-30" src="https://github.com/user-attachments/assets/620dcbd3-83d1-4e67-b5d9-f1da722f3444" />
<img width="512"  alt="Screenshot from 2026-05-14 00-58-20" src="https://github.com/user-attachments/assets/0517684b-0de0-4ad5-8e29-12a1129ddad7" />
