### PR TITLE
fix: persist priority through OAuth account creation flow

### DIFF
--- a/packages/database/src/database-operations.ts
+++ b/packages/database/src/database-operations.ts
@@ -747,6 +747,7 @@ OAuth tokens will need to be re-authenticated.
 		verifier: string,
 		mode: "console" | "claude-oauth",
 		customEndpoint?: string,
+		priority: number = 0,
 		ttlMinutes = 10,
 	): Promise<void> {
 		await this.oauth.createSession(
@@ -755,6 +756,7 @@ OAuth tokens will need to be re-authenticated.
 			verifier,
 			mode,
 			customEndpoint,
+			priority,
 			ttlMinutes,
 		);
 	}
@@ -764,6 +766,7 @@ OAuth tokens will need to be re-authenticated.
 		verifier: string;
 		mode: "console" | "claude-oauth";
 		customEndpoint?: string;
+		priority: number;
 	} | null> {
 		return this.oauth.getSession(sessionId);
 	}

--- a/packages/database/src/migrations-pg.ts
+++ b/packages/database/src/migrations-pg.ts
@@ -142,6 +142,7 @@ export async function ensureSchemaPg(adapter: BunSqlAdapter): Promise<void> {
 			verifier TEXT NOT NULL,
 			mode TEXT NOT NULL,
 			custom_endpoint TEXT,
+			priority INTEGER NOT NULL DEFAULT 0,
 			created_at BIGINT NOT NULL,
 			expires_at BIGINT NOT NULL
 		)
@@ -375,6 +376,12 @@ export async function runMigrationsPg(adapter: BunSqlAdapter): Promise<void> {
 			table: "oauth_sessions",
 			column: "custom_endpoint",
 			definition: "ALTER TABLE oauth_sessions ADD COLUMN custom_endpoint TEXT",
+		},
+		{
+			table: "oauth_sessions",
+			column: "priority",
+			definition:
+				"ALTER TABLE oauth_sessions ADD COLUMN priority INTEGER NOT NULL DEFAULT 0",
 		},
 	];
 

--- a/packages/database/src/migrations.ts
+++ b/packages/database/src/migrations.ts
@@ -99,6 +99,8 @@ export function ensureSchema(db: Database): void {
 			account_name TEXT NOT NULL,
 			verifier TEXT NOT NULL,
 			mode TEXT NOT NULL,
+			custom_endpoint TEXT,
+			priority INTEGER NOT NULL DEFAULT 0,
 			created_at INTEGER NOT NULL,
 			expires_at INTEGER NOT NULL
 		)
@@ -343,6 +345,7 @@ export function runMigrations(db: Database, dbPath?: string): void {
 		!requestPayloadsColumnNames.includes("timestamp") ||
 		!apiKeysColumnNames.includes("role") ||
 		!initialOauthSessionsColumnNames.includes("custom_endpoint") ||
+		!initialOauthSessionsColumnNames.includes("priority") ||
 		finalAccountsColumnNames.includes("account_tier") ||
 		finalOAuthColumnNames.includes("tier");
 
@@ -649,6 +652,14 @@ export function runMigrations(db: Database, dbPath?: string): void {
 			log.info("Added custom_endpoint column to oauth_sessions table");
 		}
 
+		// Add priority column to oauth_sessions if it doesn't exist
+		if (!initialOauthSessionsColumnNames.includes("priority")) {
+			db.prepare(
+				"ALTER TABLE oauth_sessions ADD COLUMN priority INTEGER NOT NULL DEFAULT 0",
+			).run();
+			log.info("Added priority column to oauth_sessions table");
+		}
+
 		// Add model column if it doesn't exist
 		if (!requestsColumnNames.includes("model")) {
 			db.prepare("ALTER TABLE requests ADD COLUMN model TEXT").run();
@@ -858,7 +869,7 @@ export function runMigrations(db: Database, dbPath?: string): void {
 		if (finalOAuthColumnNames.includes("tier")) {
 			db.prepare(`
 			CREATE TABLE oauth_sessions_new AS
-			SELECT id, account_name, verifier, mode, created_at, expires_at, custom_endpoint
+			SELECT id, account_name, verifier, mode, created_at, expires_at, custom_endpoint, priority
 			FROM oauth_sessions
 		`).run();
 

--- a/packages/database/src/migrations.ts
+++ b/packages/database/src/migrations.ts
@@ -867,6 +867,8 @@ export function runMigrations(db: Database, dbPath?: string): void {
 
 		// Drop tier column from oauth_sessions table if it exists
 		if (finalOAuthColumnNames.includes("tier")) {
+			// Relies on the priority ADD COLUMN above having run earlier in this
+			// same transaction; do not reorder these blocks.
 			db.prepare(`
 			CREATE TABLE oauth_sessions_new AS
 			SELECT id, account_name, verifier, mode, created_at, expires_at, custom_endpoint, priority

--- a/packages/database/src/migrations.ts
+++ b/packages/database/src/migrations.ts
@@ -869,11 +869,29 @@ export function runMigrations(db: Database, dbPath?: string): void {
 		if (finalOAuthColumnNames.includes("tier")) {
 			// Relies on the priority ADD COLUMN above having run earlier in this
 			// same transaction; do not reorder these blocks.
+			//
+			// IMPORTANT: explicitly recreate the target schema with all constraints
+			// (PRIMARY KEY, NOT NULL, DEFAULT) — `CREATE TABLE ... AS SELECT ...`
+			// only copies column types, dropping every constraint. Keep this in
+			// sync with the oauth_sessions definition in ensureSchema().
 			db.prepare(`
-			CREATE TABLE oauth_sessions_new AS
-			SELECT id, account_name, verifier, mode, created_at, expires_at, custom_endpoint, priority
-			FROM oauth_sessions
-		`).run();
+				CREATE TABLE oauth_sessions_new (
+					id TEXT PRIMARY KEY,
+					account_name TEXT NOT NULL,
+					verifier TEXT NOT NULL,
+					mode TEXT NOT NULL,
+					custom_endpoint TEXT,
+					priority INTEGER NOT NULL DEFAULT 0,
+					created_at INTEGER NOT NULL,
+					expires_at INTEGER NOT NULL
+				)
+			`).run();
+
+			db.prepare(`
+				INSERT INTO oauth_sessions_new (id, account_name, verifier, mode, custom_endpoint, priority, created_at, expires_at)
+				SELECT id, account_name, verifier, mode, custom_endpoint, priority, created_at, expires_at
+				FROM oauth_sessions
+			`).run();
 
 			db.prepare(`DROP TABLE oauth_sessions`).run();
 			db.prepare(

--- a/packages/database/src/repositories/__tests__/oauth.repository.test.ts
+++ b/packages/database/src/repositories/__tests__/oauth.repository.test.ts
@@ -75,3 +75,60 @@ describe("OAuthRepository - priority round-trip", () => {
 		expect(session?.customEndpoint).toBe("https://example.com/api");
 	});
 });
+
+describe("oauth_sessions tier-drop migration preserves constraints", () => {
+	it("rebuilds the table with PRIMARY KEY, NOT NULL, and DEFAULT 0 constraints intact", () => {
+		// Bootstrap an in-memory DB that looks like a legacy install:
+		// modern schema + an extra `tier` column to trigger the tier-drop rebuild.
+		const db = new Database(":memory:");
+		try {
+			ensureSchema(db);
+			db.prepare(`ALTER TABLE oauth_sessions ADD COLUMN tier TEXT`).run();
+
+			// Run migrations — this should detect the `tier` column and rebuild
+			// oauth_sessions via the explicit CREATE TABLE + INSERT path.
+			runMigrations(db);
+
+			const columns = db
+				.prepare("PRAGMA table_info(oauth_sessions)")
+				.all() as Array<{
+				name: string;
+				notnull: number;
+				// biome-ignore lint/suspicious/noExplicitAny: dflt_value can be string|number|null
+				dflt_value: any;
+				pk: number;
+			}>;
+
+			const byName = new Map(columns.map((c) => [c.name, c]));
+
+			// tier is gone
+			expect(byName.has("tier")).toBe(false);
+
+			// id is the primary key
+			const idCol = byName.get("id");
+			expect(idCol).toBeDefined();
+			expect(idCol?.pk).toBe(1);
+
+			// priority is NOT NULL with default 0 (SQLite returns dflt_value as a string)
+			const priorityCol = byName.get("priority");
+			expect(priorityCol).toBeDefined();
+			expect(priorityCol?.notnull).toBe(1);
+			expect(Number(priorityCol?.dflt_value)).toBe(0);
+
+			// All other constraint-bearing columns are still NOT NULL
+			for (const colName of [
+				"account_name",
+				"verifier",
+				"mode",
+				"created_at",
+				"expires_at",
+			]) {
+				const col = byName.get(colName);
+				expect(col).toBeDefined();
+				expect(col?.notnull).toBe(1);
+			}
+		} finally {
+			db.close();
+		}
+	});
+});

--- a/packages/database/src/repositories/__tests__/oauth.repository.test.ts
+++ b/packages/database/src/repositories/__tests__/oauth.repository.test.ts
@@ -1,0 +1,77 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { BunSqlAdapter } from "../../adapters/bun-sql-adapter";
+import { ensureSchema, runMigrations } from "../../migrations";
+import { OAuthRepository } from "../oauth.repository";
+
+describe("OAuthRepository - priority round-trip", () => {
+	let db: Database;
+	let repo: OAuthRepository;
+
+	beforeEach(() => {
+		// Fresh in-memory SQLite DB with the full schema applied.
+		db = new Database(":memory:");
+		ensureSchema(db);
+		runMigrations(db);
+		repo = new OAuthRepository(new BunSqlAdapter(db));
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("persists and returns the priority value passed to createSession", async () => {
+		const sessionId = "11111111-1111-1111-1111-111111111111";
+
+		await repo.createSession(
+			sessionId,
+			"acct-priority-42",
+			"verifier-string",
+			"claude-oauth",
+			undefined, // customEndpoint
+			42, // priority
+			10, // ttlMinutes
+		);
+
+		const session = await repo.getSession(sessionId);
+		expect(session).not.toBeNull();
+		expect(session?.priority).toBe(42);
+		expect(session?.accountName).toBe("acct-priority-42");
+		expect(session?.mode).toBe("claude-oauth");
+	});
+
+	it("defaults priority to 0 when omitted on createSession", async () => {
+		const sessionId = "22222222-2222-2222-2222-222222222222";
+
+		// Omit both priority and ttlMinutes — both have defaults.
+		await repo.createSession(
+			sessionId,
+			"acct-default-priority",
+			"verifier-string",
+			"console",
+		);
+
+		const session = await repo.getSession(sessionId);
+		expect(session).not.toBeNull();
+		expect(session?.priority).toBe(0);
+	});
+
+	it("preserves a non-default priority alongside customEndpoint", async () => {
+		const sessionId = "33333333-3333-3333-3333-333333333333";
+
+		await repo.createSession(
+			sessionId,
+			"acct-with-endpoint",
+			"verifier-string",
+			"console",
+			"https://example.com/api",
+			75,
+			10,
+		);
+
+		const session = await repo.getSession(sessionId);
+		expect(session).not.toBeNull();
+		expect(session?.priority).toBe(75);
+		expect(session?.customEndpoint).toBe("https://example.com/api");
+	});
+});

--- a/packages/database/src/repositories/oauth.repository.ts
+++ b/packages/database/src/repositories/oauth.repository.ts
@@ -63,7 +63,7 @@ export class OAuthRepository extends BaseRepository<OAuthSession> {
 			verifier: row.verifier,
 			mode: row.mode,
 			customEndpoint: row.custom_endpoint || undefined,
-			priority: row.priority ?? 0,
+			priority: row.priority,
 		};
 	}
 

--- a/packages/database/src/repositories/oauth.repository.ts
+++ b/packages/database/src/repositories/oauth.repository.ts
@@ -5,6 +5,7 @@ export interface OAuthSession {
 	verifier: string;
 	mode: "console" | "claude-oauth";
 	customEndpoint?: string;
+	priority: number;
 }
 
 export class OAuthRepository extends BaseRepository<OAuthSession> {
@@ -14,6 +15,7 @@ export class OAuthRepository extends BaseRepository<OAuthSession> {
 		verifier: string,
 		mode: "console" | "claude-oauth",
 		customEndpoint?: string,
+		priority: number = 0,
 		ttlMinutes = 10,
 	): Promise<void> {
 		const now = Date.now();
@@ -21,8 +23,8 @@ export class OAuthRepository extends BaseRepository<OAuthSession> {
 
 		await this.run(
 			`
-			INSERT INTO oauth_sessions (id, account_name, verifier, mode, custom_endpoint, created_at, expires_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?)
+			INSERT INTO oauth_sessions (id, account_name, verifier, mode, custom_endpoint, priority, created_at, expires_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 		`,
 			[
 				sessionId,
@@ -30,6 +32,7 @@ export class OAuthRepository extends BaseRepository<OAuthSession> {
 				verifier,
 				mode,
 				customEndpoint || null,
+				priority,
 				now,
 				expiresAt,
 			],
@@ -42,10 +45,11 @@ export class OAuthRepository extends BaseRepository<OAuthSession> {
 			verifier: string;
 			mode: "console" | "claude-oauth";
 			custom_endpoint: string | null;
+			priority: number;
 			expires_at: number;
 		}>(
 			`
-			SELECT account_name, verifier, mode, custom_endpoint, expires_at
+			SELECT account_name, verifier, mode, custom_endpoint, priority, expires_at
 			FROM oauth_sessions
 			WHERE id = ? AND expires_at > ?
 		`,
@@ -59,6 +63,7 @@ export class OAuthRepository extends BaseRepository<OAuthSession> {
 			verifier: row.verifier,
 			mode: row.mode,
 			customEndpoint: row.custom_endpoint || undefined,
+			priority: row.priority ?? 0,
 		};
 	}
 

--- a/packages/http-api/src/handlers/oauth.ts
+++ b/packages/http-api/src/handlers/oauth.ts
@@ -618,8 +618,9 @@ export function createAnthropicReauthInitHandler(
 					account.name,
 					flowResult.pkce.verifier,
 					"claude-oauth",
-					undefined,
-					10,
+					undefined, // customEndpoint
+					0, // priority — reauth preserves existing account's priority via UPDATE, this is unused
+					10, // ttlMinutes
 				);
 
 				return jsonResponse({
@@ -809,6 +810,9 @@ export function createOAuthInitHandler(dbOps: DatabaseOperations) {
 				},
 			);
 
+			// Validate priority (0-100, defaults to 0)
+			const priority = validatePriority(body.priority ?? 0, "priority");
+
 			const config = new Config();
 			const oauthFlow = await createOAuthFlow(dbOps, config);
 
@@ -819,13 +823,15 @@ export function createOAuthInitHandler(dbOps: DatabaseOperations) {
 					mode,
 				});
 
-				// Store custom endpoint in session for later use
+				// Store custom endpoint and priority in session so the callback
+				// can forward them to oauthFlow.complete() when creating the account.
 				dbOps.createOAuthSession(
 					flowResult.sessionId,
 					name,
 					flowResult.pkce.verifier,
 					mode,
 					customEndpoint,
+					priority,
 					10, // 10 minute TTL
 				);
 
@@ -895,6 +901,7 @@ export function createOAuthCallbackHandler(dbOps: DatabaseOperations) {
 				verifier,
 				mode: savedMode,
 				customEndpoint: savedCustomEndpoint,
+				priority: savedPriority,
 			} = oauthSession;
 
 			try {
@@ -931,6 +938,7 @@ export function createOAuthCallbackHandler(dbOps: DatabaseOperations) {
 						sessionId,
 						code,
 						name,
+						priority: savedPriority,
 						customEndpoint: savedCustomEndpoint,
 					},
 					flowData,


### PR DESCRIPTION
The /api/oauth/init handler received the priority in the request body but never stored it in the oauth_sessions row, so /api/oauth/callback could not retrieve it and the new account always landed with priority 0.
Add a priority column to oauth_sessions and thread the value through init -> session -> callback -> oauthFlow.complete(). Non-OAuth providers were already correct.