### PR TITLE
fix: surface update-check failure reason in dashboard tile

### DIFF
--- a/packages/dashboard-web/src/components/navigation.tsx
+++ b/packages/dashboard-web/src/components/navigation.tsx
@@ -1,3 +1,4 @@
+import { parseHttpError } from "@better-ccflare/errors";
 import {
 	Activity,
 	BarChart3,
@@ -251,10 +252,7 @@ export function Navigation({
 			]);
 
 			if (!response.ok) {
-				const errBody = await response
-					.json()
-					.catch(() => ({}) as { error?: string });
-				throw new Error(errBody.error || `HTTP ${response.status}`);
+				throw await parseHttpError(response);
 			}
 
 			const data = await response.json();

--- a/packages/dashboard-web/src/components/navigation.tsx
+++ b/packages/dashboard-web/src/components/navigation.tsx
@@ -63,6 +63,7 @@ export function Navigation({
 		"idle" | "checking" | "available" | "current" | "error"
 	>("idle");
 	const [latestVersion, setLatestVersion] = useState<string>("");
+	const [updateError, setUpdateError] = useState<string | null>(null);
 	const location = useLocation();
 	const isMountedRef = useRef(true);
 
@@ -242,11 +243,17 @@ export function Navigation({
 		}
 
 		setUpdateStatus("checking");
+		setUpdateError(null);
 		try {
 			const [response, packageInfo] = await Promise.all([
 				fetch("/api/version/check"),
 				detectPackageManager(),
 			]);
+
+			if (!response.ok) {
+				const errBody = await response.json().catch(() => ({}) as { error?: string });
+				throw new Error(errBody.error || `HTTP ${response.status}`);
+			}
 
 			const data = await response.json();
 			const latest = data.version;
@@ -289,6 +296,7 @@ export function Navigation({
 			if (!isMountedRef.current) return;
 
 			setUpdateStatus("error");
+			setUpdateError(error instanceof Error ? error.message : String(error));
 			console.error("❌ Failed to check for updates:", error);
 		}
 	}, []);
@@ -494,6 +502,11 @@ export function Navigation({
 							{updateStatus === "current" && (
 								<p className="mt-1 text-xs text-muted-foreground text-left">
 									Version {version.replace(/^v/, "")}
+								</p>
+							)}
+							{updateStatus === "error" && updateError && (
+								<p className="mt-1 text-xs text-destructive text-left break-words">
+									{updateError}
 								</p>
 							)}
 						</div>

--- a/packages/dashboard-web/src/components/navigation.tsx
+++ b/packages/dashboard-web/src/components/navigation.tsx
@@ -251,7 +251,9 @@ export function Navigation({
 			]);
 
 			if (!response.ok) {
-				const errBody = await response.json().catch(() => ({}) as { error?: string });
+				const errBody = await response
+					.json()
+					.catch(() => ({}) as { error?: string });
 				throw new Error(errBody.error || `HTTP ${response.status}`);
 			}
 

--- a/packages/http-api/src/handlers/version.ts
+++ b/packages/http-api/src/handlers/version.ts
@@ -1,8 +1,11 @@
+import { Logger } from "@better-ccflare/logger";
 import {
 	errorResponse,
 	InternalServerError,
 	jsonResponse,
 } from "../utils/http-error";
+
+const log = new Logger("VersionHandler");
 
 // Cache the npm registry response to avoid excessive requests
 interface VersionCacheEntry {
@@ -51,9 +54,10 @@ export function createVersionCheckHandler() {
 				cached: false,
 			});
 		} catch (error) {
-			console.error("Failed to check for updates from npm registry:", error);
+			log.error("Failed to check for updates from npm registry:", error);
+			const message = error instanceof Error ? error.message : String(error);
 			return errorResponse(
-				InternalServerError("Failed to check for updates from npm registry"),
+				InternalServerError(`Update check failed: ${message}`),
 			);
 		}
 	};


### PR DESCRIPTION
The "Check for Updates" tile previously rendered "Check Failed" with no
explanation when the version check broke, leaving users unable to
diagnose. The backend swallowed the underlying error into a generic 500
message and logged via console.error (which never reaches app.log), and
the frontend never read the response body's error field nor checked the
HTTP status.

- Backend: include the underlying error message in the InternalServerError
  body, and log via the structured Logger so failures appear in app.log.
- Frontend: check response.ok and parse the error field; store the message
  in component state; render it under "Check Failed" in the sidebar tile.