### PR TITLE
fix: exempt /api/version/check from authentication

### DIFF
--- a/__tests__/api-auth.test.ts
+++ b/__tests__/api-auth.test.ts
@@ -189,6 +189,32 @@ describe("API Authentication", () => {
 			expect(await authService.isPathExempt("/api/oauth/init", "POST")).toBe(true);
 		});
 
+		test("should exempt /api/version/check from authentication", async () => {
+			// Version check returns only the latest npm-published version (public data).
+			// The sidebar tile fires this on dashboard load with no API key in headers,
+			// so it must be reachable even when auth is enabled.
+			expect(authService.isStaticPathExempt("/api/version/check")).toBe(true);
+			expect(await authService.isPathExempt("/api/version/check", "GET")).toBe(true);
+		});
+
+		test("should allow /api/version/check without API key when auth is enabled", async () => {
+			// Reproduces the user-visible bug: with at least one API key configured,
+			// fetch("/api/version/check") from the dashboard returned 401 because the
+			// path was treated as a normal /api/* route requiring auth.
+			await generateApiKey(dbOps, "version-check-test-key", "admin");
+			expect(await authService.isAuthenticationEnabled()).toBe(true);
+
+			const request = new Request("http://localhost:8080/api/version/check");
+			const result = await authService.authenticateRequest(
+				request,
+				"/api/version/check",
+				"GET",
+			);
+
+			expect(result.isAuthenticated).toBe(true);
+			expect(result.error).toBeUndefined();
+		});
+
 		test("should exempt static assets from authentication", async () => {
 			expect(await authService.isPathExempt("/chunk-abc123.js", "GET")).toBe(true);
 			expect(await authService.isPathExempt("/chunk-abc123.css", "GET")).toBe(true);

--- a/packages/http-api/src/services/auth-service.ts
+++ b/packages/http-api/src/services/auth-service.ts
@@ -133,6 +133,13 @@ export class AuthService {
 			return true;
 		}
 
+		// Version check returns only the latest npm-published version. The
+		// dashboard's sidebar tile fires this on load with no API key in
+		// headers, so it must be reachable whether or not auth is enabled.
+		if (path === "/api/version/check") {
+			return true;
+		}
+
 		// All other paths are dashboard routes (client-side routing) or static assets
 		// These should be exempt to allow serving the dashboard HTML and assets
 		// This matches the server logic that serves index.html for non-API routes


### PR DESCRIPTION
The dashboard's "Check for Updates" sidebar tile calls fetch("/api/version/check") on load with no API key in headers. The router's auth middleware requires authentication for all /api/* paths except statically exempt ones (/health, /api/oauth/*). When at least one API key is configured (auth enabled), the version check returned 401 "API key required" and the tile rendered "Check Failed".

The handler only proxies the latest version from the public npm registry — no instance-specific data is exposed. Treat it like /health and exempt it from auth so the tile works regardless of auth state.

The endpoint has a 1-hour server-side cache, so exposing it does not create a DoS vector against npm.