### PR TITLE
improve: Recent Errors UI with context, dismissal, and details modal

### DIFF
--- a/packages/dashboard-web/src/api.ts
+++ b/packages/dashboard-web/src/api.ts
@@ -167,9 +167,13 @@ class API extends HttpClient {
 		}
 	}
 
-	async getStats(): Promise<Stats> {
+	async getStats(opts?: { errorsSinceHours?: number }): Promise<Stats> {
 		const startTime = Date.now();
-		const url = "/api/stats";
+		const hours = opts?.errorsSinceHours;
+		const url =
+			typeof hours === "number" && Number.isFinite(hours) && hours > 0
+				? `/api/stats?errorsSinceHours=${hours}`
+				: "/api/stats";
 
 		this.logger.debug(`→ GET ${url}`);
 

--- a/packages/dashboard-web/src/components/OverviewTab.tsx
+++ b/packages/dashboard-web/src/components/OverviewTab.tsx
@@ -20,7 +20,6 @@ export const OverviewTab = React.memo(() => {
 	// Fetch all data using React Query hooks
 	const { data: stats, isLoading: statsLoading } = useStats(
 		REFRESH_INTERVALS.default,
-		24,
 	);
 	const [timeRange, setTimeRange] = useState("24h");
 	const { data: analytics, isLoading: analyticsLoading } = useAnalytics(

--- a/packages/dashboard-web/src/components/OverviewTab.tsx
+++ b/packages/dashboard-web/src/components/OverviewTab.tsx
@@ -246,7 +246,7 @@ export const OverviewTab = React.memo(() => {
 				loading={loading}
 			/>
 
-			<SystemStatus recentErrors={stats?.recentErrors} />
+			<SystemStatus />
 
 			{accounts && <RateLimitInfo accounts={accounts} />}
 		</div>

--- a/packages/dashboard-web/src/components/OverviewTab.tsx
+++ b/packages/dashboard-web/src/components/OverviewTab.tsx
@@ -20,6 +20,7 @@ export const OverviewTab = React.memo(() => {
 	// Fetch all data using React Query hooks
 	const { data: stats, isLoading: statsLoading } = useStats(
 		REFRESH_INTERVALS.default,
+		24,
 	);
 	const [timeRange, setTimeRange] = useState("24h");
 	const { data: analytics, isLoading: analyticsLoading } = useAnalytics(

--- a/packages/dashboard-web/src/components/StatsTab.tsx
+++ b/packages/dashboard-web/src/components/StatsTab.tsx
@@ -1,5 +1,7 @@
+import type { RecentErrorGroup } from "@better-ccflare/types";
 import { formatPercentage } from "@better-ccflare/ui-common";
-import { RefreshCw } from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import { RefreshCw, XCircle } from "lucide-react";
 import { useResetStats, useStats } from "../hooks/queries";
 import { useApiError } from "../hooks/useApiError";
 import { Button } from "./ui/button";
@@ -128,14 +130,41 @@ export function StatsTab() {
 					</CardHeader>
 					<CardContent>
 						<div className="space-y-2">
-							{stats.recentErrors.map((error: string, i: number) => (
-								<div
-									key={`error-${i}-${error.substring(0, 10)}`}
-									className="text-sm p-2 bg-destructive/10 rounded-md"
-								>
-									<p className="text-destructive">{error}</p>
-								</div>
-							))}
+							{stats.recentErrors.map(
+								(error: RecentErrorGroup, i: number) => {
+									const accountLabel =
+										error.accountName ??
+										(error.accountId === null
+											? "Unauthenticated"
+											: "Deleted account");
+									return (
+										<div
+											key={`error-${i}-${error.latestRequestId}`}
+											className="text-sm p-2 bg-destructive/10 rounded-md flex items-start gap-2"
+										>
+											<XCircle className="h-4 w-4 text-destructive shrink-0 mt-0.5" />
+											<div className="flex-1 min-w-0">
+												<p className="text-destructive font-medium break-words">
+													{error.errorCode}
+													{error.occurrenceCount > 1 && (
+														<span className="ml-2 text-xs font-normal">
+															×{error.occurrenceCount}
+														</span>
+													)}
+												</p>
+												<p className="text-xs text-destructive/80 mt-0.5">
+													{accountLabel}
+													{" • "}
+													{formatDistanceToNow(
+														new Date(error.latestTimestamp),
+														{ addSuffix: true },
+													)}
+												</p>
+											</div>
+										</div>
+									);
+								},
+							)}
 						</div>
 					</CardContent>
 				</Card>

--- a/packages/dashboard-web/src/components/StatsTab.tsx
+++ b/packages/dashboard-web/src/components/StatsTab.tsx
@@ -126,45 +126,47 @@ export function StatsTab() {
 				<Card>
 					<CardHeader>
 						<CardTitle>Recent Errors</CardTitle>
-						<CardDescription>Last 10 errors from all accounts</CardDescription>
+						<CardDescription>
+							Most recent errors from all accounts
+						</CardDescription>
 					</CardHeader>
 					<CardContent>
 						<div className="space-y-2">
-							{stats.recentErrors.map(
-								(error: RecentErrorGroup, i: number) => {
-									const accountLabel =
-										error.accountName ??
-										(error.accountId === null
-											? "Unauthenticated"
-											: "Deleted account");
-									return (
-										<div
-											key={`error-${i}-${error.latestRequestId}`}
-											className="text-sm p-2 bg-destructive/10 rounded-md flex items-start gap-2"
-										>
-											<XCircle className="h-4 w-4 text-destructive shrink-0 mt-0.5" />
-											<div className="flex-1 min-w-0">
-												<p className="text-destructive font-medium break-words">
-													{error.errorCode}
-													{error.occurrenceCount > 1 && (
-														<span className="ml-2 text-xs font-normal">
-															×{error.occurrenceCount}
-														</span>
-													)}
-												</p>
-												<p className="text-xs text-destructive/80 mt-0.5">
-													{accountLabel}
-													{" • "}
-													{formatDistanceToNow(
-														new Date(error.latestTimestamp),
-														{ addSuffix: true },
-													)}
-												</p>
-											</div>
+							{stats.recentErrors.map((error: RecentErrorGroup, i: number) => {
+								const accountLabel =
+									error.accountName ??
+									(error.accountId === null
+										? "Unauthenticated"
+										: "Deleted account");
+								return (
+									<div
+										key={`error-${i}-${error.latestRequestId}`}
+										className="text-sm p-2 bg-destructive/10 rounded-md flex items-start gap-2"
+									>
+										<XCircle className="h-4 w-4 text-destructive shrink-0 mt-0.5" />
+										<div className="flex-1 min-w-0">
+											<p className="text-destructive font-medium break-words">
+												{error.errorCode}
+												{error.occurrenceCount > 1 && (
+													<span
+														className="ml-2 text-xs font-normal"
+														aria-label={`${error.occurrenceCount} occurrences`}
+													>
+														×{error.occurrenceCount}
+													</span>
+												)}
+											</p>
+											<p className="text-xs text-destructive/80 mt-0.5">
+												{accountLabel}
+												{" • "}
+												{formatDistanceToNow(new Date(error.latestTimestamp), {
+													addSuffix: true,
+												})}
+											</p>
 										</div>
-									);
-								},
-							)}
+									</div>
+								);
+							})}
 						</div>
 					</CardContent>
 				</Card>

--- a/packages/dashboard-web/src/components/StatsTab.tsx
+++ b/packages/dashboard-web/src/components/StatsTab.tsx
@@ -132,7 +132,7 @@ export function StatsTab() {
 					</CardHeader>
 					<CardContent>
 						<div className="space-y-2">
-							{stats.recentErrors.map((error: RecentErrorGroup, i: number) => {
+							{stats.recentErrors.map((error: RecentErrorGroup) => {
 								const accountLabel =
 									error.accountName ??
 									(error.accountId === null
@@ -140,7 +140,7 @@ export function StatsTab() {
 										: "Deleted account");
 								return (
 									<div
-										key={`error-${i}-${error.latestRequestId}`}
+										key={error.latestRequestId}
 										className="text-sm p-2 bg-destructive/10 rounded-md flex items-start gap-2"
 									>
 										<XCircle className="h-4 w-4 text-destructive shrink-0 mt-0.5" />
@@ -150,6 +150,7 @@ export function StatsTab() {
 												{error.occurrenceCount > 1 && (
 													<span
 														className="ml-2 text-xs font-normal"
+														role="img"
 														aria-label={`${error.occurrenceCount} occurrences`}
 													>
 														×{error.occurrenceCount}

--- a/packages/dashboard-web/src/components/overview/SystemStatus.tsx
+++ b/packages/dashboard-web/src/components/overview/SystemStatus.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle, XCircle } from "lucide-react";
+import { CheckCircle } from "lucide-react";
 import { Badge } from "../ui/badge";
 import {
 	Card,
@@ -7,12 +7,9 @@ import {
 	CardHeader,
 	CardTitle,
 } from "../ui/card";
+import { RecentErrorsCard } from "./system-status/RecentErrorsCard";
 
-interface SystemStatusProps {
-	recentErrors?: string[];
-}
-
-export function SystemStatus({ recentErrors }: SystemStatusProps) {
+export function SystemStatus() {
 	return (
 		<Card>
 			<CardHeader>
@@ -38,22 +35,7 @@ export function SystemStatus({ recentErrors }: SystemStatusProps) {
 						</Badge>
 					</div>
 
-					{recentErrors && recentErrors.length > 0 && (
-						<div className="space-y-2">
-							<h4 className="text-sm font-medium text-muted-foreground">
-								Recent Errors
-							</h4>
-							{recentErrors.slice(0, 3).map((error, i) => (
-								<div
-									key={`error-${error.substring(0, 20)}-${i}`}
-									className="flex items-start gap-2 p-3 rounded-lg bg-destructive/10"
-								>
-									<XCircle className="h-4 w-4 text-destructive mt-0.5" />
-									<p className="text-sm text-muted-foreground">{error}</p>
-								</div>
-							))}
-						</div>
-					)}
+					<RecentErrorsCard />
 				</div>
 			</CardContent>
 		</Card>

--- a/packages/dashboard-web/src/components/overview/system-status/ErrorDetailsModal.tsx
+++ b/packages/dashboard-web/src/components/overview/system-status/ErrorDetailsModal.tsx
@@ -150,9 +150,8 @@ export function ErrorDetailsModal({
 						<DialogFooter>
 							<Button
 								variant="outline"
-								disabled={error === null}
 								onClick={() => {
-									if (error) onDismiss(error);
+									onDismiss(error);
 									onClose();
 								}}
 							>

--- a/packages/dashboard-web/src/components/overview/system-status/ErrorDetailsModal.tsx
+++ b/packages/dashboard-web/src/components/overview/system-status/ErrorDetailsModal.tsx
@@ -1,0 +1,170 @@
+import type { RecentErrorGroup } from "@better-ccflare/types";
+import { formatTimestamp } from "@better-ccflare/ui-common";
+import { formatDistanceToNow } from "date-fns";
+import { AlertTriangle, XCircle } from "lucide-react";
+import type { ReactNode } from "react";
+import { Button } from "../../ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "../../ui/dialog";
+import { Separator } from "../../ui/separator";
+import { getErrorMeta } from "./errorCodeMeta";
+
+interface ErrorDetailsModalProps {
+	error: RecentErrorGroup | null;
+	onClose: () => void;
+	onDismiss: (group: RecentErrorGroup) => void;
+}
+
+function accountValue(error: RecentErrorGroup): string {
+	if (error.accountName)
+		return `${error.accountName} (ID: ${error.accountId ?? "unknown"})`;
+	if (error.accountId === null) return "Unauthenticated";
+	return `Deleted account (ID: ${error.accountId})`;
+}
+
+function recoveryValue(rateLimitedUntil: number): string {
+	if (rateLimitedUntil <= Date.now()) return "Recovered";
+	const remaining = formatDistanceToNow(new Date(rateLimitedUntil), {
+		addSuffix: false,
+	});
+	return `Recovering in ${remaining}`;
+}
+
+interface DetailRowProps {
+	label: string;
+	children: ReactNode;
+}
+
+function DetailRow({ label, children }: DetailRowProps) {
+	return (
+		<div>
+			<p className="text-xs text-muted-foreground uppercase tracking-wide">
+				{label}
+			</p>
+			<div className="text-sm mt-0.5">{children}</div>
+		</div>
+	);
+}
+
+export function ErrorDetailsModal({
+	error,
+	onClose,
+	onDismiss,
+}: ErrorDetailsModalProps) {
+	const open = error !== null;
+
+	const meta = error ? getErrorMeta(error.errorCode) : null;
+	const isWarning = meta?.severity === "warning";
+	const Icon = isWarning ? AlertTriangle : XCircle;
+	const iconColor = isWarning ? "text-warning" : "text-destructive";
+
+	return (
+		<Dialog
+			open={open}
+			onOpenChange={(next) => {
+				if (!next) onClose();
+			}}
+		>
+			<DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+				{error && meta && (
+					<>
+						<DialogHeader>
+							<DialogTitle className="flex items-center gap-2">
+								<Icon className={`h-5 w-5 ${iconColor}`} />
+								{meta.title}
+							</DialogTitle>
+							<DialogDescription>{meta.description}</DialogDescription>
+						</DialogHeader>
+
+						<div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+							<DetailRow label="Error code">
+								<code className="font-mono text-xs bg-muted px-1.5 py-0.5 rounded">
+									{error.errorCode}
+								</code>
+							</DetailRow>
+							<DetailRow label="Account">{accountValue(error)}</DetailRow>
+							{error.model && (
+								<DetailRow label="Model">{error.model}</DetailRow>
+							)}
+							{error.statusCode != null && (
+								<DetailRow label="HTTP status">{error.statusCode}</DetailRow>
+							)}
+							{error.path && (
+								<DetailRow label="Path">
+									<span className="font-mono text-xs break-all">
+										{error.path}
+									</span>
+								</DetailRow>
+							)}
+							<DetailRow label="Failover attempts">
+								{error.failoverAttempts}
+							</DetailRow>
+							<DetailRow label="First seen">
+								{formatDistanceToNow(new Date(error.firstTimestamp), {
+									addSuffix: true,
+								})}
+								<span className="text-muted-foreground">
+									{" · "}
+									{formatTimestamp(error.firstTimestamp)}
+								</span>
+							</DetailRow>
+							<DetailRow label="Last seen">
+								{formatDistanceToNow(new Date(error.latestTimestamp), {
+									addSuffix: true,
+								})}
+								<span className="text-muted-foreground">
+									{" · "}
+									{formatTimestamp(error.latestTimestamp)}
+								</span>
+							</DetailRow>
+							<DetailRow label="Occurrence count">
+								{error.occurrenceCount}
+							</DetailRow>
+							<DetailRow label="Latest request ID">
+								<code className="font-mono text-xs break-all">
+									{error.latestRequestId}
+								</code>
+							</DetailRow>
+							{error.rateLimitedUntil != null && (
+								<DetailRow label="Recovery">
+									{recoveryValue(error.rateLimitedUntil)}
+								</DetailRow>
+							)}
+						</div>
+
+						<Separator />
+
+						<div className="rounded-lg bg-muted/50 p-3 text-sm">
+							<p className="text-xs text-muted-foreground uppercase tracking-wide mb-1">
+								Suggestion
+							</p>
+							{meta.suggestion}
+						</div>
+
+						<DialogFooter>
+							<Button
+								variant="outline"
+								disabled={error === null}
+								onClick={() => {
+									if (error) onDismiss(error);
+									onClose();
+								}}
+							>
+								Dismiss
+							</Button>
+							<Button variant="default" onClick={onClose}>
+								Close
+							</Button>
+						</DialogFooter>
+					</>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/packages/dashboard-web/src/components/overview/system-status/RecentErrorRow.tsx
+++ b/packages/dashboard-web/src/components/overview/system-status/RecentErrorRow.tsx
@@ -35,9 +35,17 @@ export function RecentErrorRow({
 	const absoluteTime = formatTimestamp(error.latestTimestamp);
 
 	return (
-		<button
-			type="button"
+		// biome-ignore lint/a11y/useSemanticElements: a real <button> would nest the dismiss <Button>, which is invalid HTML and breaks stopPropagation
+		<div
+			role="button"
+			tabIndex={0}
 			onClick={onClick}
+			onKeyDown={(e) => {
+				if (e.key === "Enter" || e.key === " ") {
+					e.preventDefault();
+					onClick();
+				}
+			}}
 			className={`w-full text-left p-3 rounded-lg flex items-start gap-2 cursor-pointer transition-colors hover:bg-opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring ${bgClass}`}
 		>
 			<Icon className={`h-4 w-4 mt-0.5 shrink-0 ${iconColor}`} />
@@ -77,6 +85,6 @@ export function RecentErrorRow({
 					<X className="h-3.5 w-3.5" />
 				</Button>
 			</div>
-		</button>
+		</div>
 	);
 }

--- a/packages/dashboard-web/src/components/overview/system-status/RecentErrorRow.tsx
+++ b/packages/dashboard-web/src/components/overview/system-status/RecentErrorRow.tsx
@@ -1,0 +1,82 @@
+import type { RecentErrorGroup } from "@better-ccflare/types";
+import { formatTimestamp } from "@better-ccflare/ui-common";
+import { formatDistanceToNow } from "date-fns";
+import { AlertTriangle, X, XCircle } from "lucide-react";
+import { Badge } from "../../ui/badge";
+import { Button } from "../../ui/button";
+import { getErrorMeta } from "./errorCodeMeta";
+
+interface RecentErrorRowProps {
+	error: RecentErrorGroup;
+	onClick: () => void;
+	onDismiss: () => void;
+}
+
+function accountLabel(error: RecentErrorGroup): string {
+	if (error.accountName) return error.accountName;
+	if (error.accountId === null) return "Unauthenticated";
+	return "Deleted account";
+}
+
+export function RecentErrorRow({
+	error,
+	onClick,
+	onDismiss,
+}: RecentErrorRowProps) {
+	const meta = getErrorMeta(error.errorCode);
+	const isWarning = meta.severity === "warning";
+	const Icon = isWarning ? AlertTriangle : XCircle;
+	const bgClass = isWarning ? "bg-warning/10" : "bg-destructive/10";
+	const iconColor = isWarning ? "text-warning" : "text-destructive";
+
+	const relativeTime = formatDistanceToNow(new Date(error.latestTimestamp), {
+		addSuffix: true,
+	});
+	const absoluteTime = formatTimestamp(error.latestTimestamp);
+
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className={`w-full text-left p-3 rounded-lg flex items-start gap-2 cursor-pointer transition-colors hover:bg-opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring ${bgClass}`}
+		>
+			<Icon className={`h-4 w-4 mt-0.5 shrink-0 ${iconColor}`} />
+			<div className="flex-1 min-w-0">
+				<p className="text-sm font-medium truncate">{meta.title}</p>
+				<p className="text-xs text-muted-foreground truncate">
+					{accountLabel(error)}
+					{error.model ? ` · ${error.model}` : ""}
+					{error.statusCode != null ? ` · ${error.statusCode}` : ""}
+				</p>
+			</div>
+			<div className="flex items-center gap-2 shrink-0">
+				{error.occurrenceCount > 1 && (
+					<Badge
+						variant="secondary"
+						aria-label={`${error.occurrenceCount} occurrences`}
+					>
+						×{error.occurrenceCount}
+					</Badge>
+				)}
+				<span
+					className="text-xs text-muted-foreground whitespace-nowrap"
+					title={absoluteTime}
+				>
+					{relativeTime}
+				</span>
+				<Button
+					variant="ghost"
+					size="sm"
+					className="h-7 w-7 p-0"
+					aria-label="Dismiss error"
+					onClick={(e) => {
+						e.stopPropagation();
+						onDismiss();
+					}}
+				>
+					<X className="h-3.5 w-3.5" />
+				</Button>
+			</div>
+		</button>
+	);
+}

--- a/packages/dashboard-web/src/components/overview/system-status/RecentErrorsCard.tsx
+++ b/packages/dashboard-web/src/components/overview/system-status/RecentErrorsCard.tsx
@@ -17,7 +17,7 @@ const WINDOW_OPTIONS: Array<{ value: ErrorWindowKey; label: string }> = [
 	{ value: "1h", label: "Last hour" },
 	{ value: "24h", label: "Last 24 hours" },
 	{ value: "7d", label: "Last 7 days" },
-	{ value: "all", label: "All time" },
+	{ value: "all", label: "Last year" },
 ];
 
 export function RecentErrorsCard() {
@@ -28,7 +28,7 @@ export function RecentErrorsCard() {
 		null,
 	);
 
-	const recentErrors = data?.recentErrors as RecentErrorGroup[] | undefined;
+	const recentErrors = data?.recentErrors;
 	const visibleErrors = recentErrors?.filter((err) => !isDismissed(err)) ?? [];
 
 	if (isLoading && !data) return null;

--- a/packages/dashboard-web/src/components/overview/system-status/RecentErrorsCard.tsx
+++ b/packages/dashboard-web/src/components/overview/system-status/RecentErrorsCard.tsx
@@ -1,4 +1,4 @@
-import type { RecentErrorGroup } from "@better-ccflare/types";
+import { NO_ACCOUNT_ID, type RecentErrorGroup } from "@better-ccflare/types";
 import { useState } from "react";
 import { useStats } from "../../../hooks/queries";
 import {
@@ -60,7 +60,7 @@ export function RecentErrorsCard() {
 			<div className="space-y-2">
 				{visibleErrors.map((error) => (
 					<RecentErrorRow
-						key={`${error.accountId ?? "no_account"}:${error.errorCode}:${error.latestRequestId}`}
+						key={`${error.accountId ?? NO_ACCOUNT_ID}:${error.errorCode}:${error.latestRequestId}`}
 						error={error}
 						onClick={() => setSelectedError(error)}
 						onDismiss={() => dismiss(error)}

--- a/packages/dashboard-web/src/components/overview/system-status/RecentErrorsCard.tsx
+++ b/packages/dashboard-web/src/components/overview/system-status/RecentErrorsCard.tsx
@@ -1,0 +1,78 @@
+import type { RecentErrorGroup } from "@better-ccflare/types";
+import { useState } from "react";
+import { useStats } from "../../../hooks/queries";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "../../ui/select";
+import { ErrorDetailsModal } from "./ErrorDetailsModal";
+import { RecentErrorRow } from "./RecentErrorRow";
+import { useDismissedErrors } from "./useDismissedErrors";
+import { type ErrorWindowKey, useErrorWindow } from "./useErrorWindow";
+
+const WINDOW_OPTIONS: Array<{ value: ErrorWindowKey; label: string }> = [
+	{ value: "1h", label: "Last hour" },
+	{ value: "24h", label: "Last 24 hours" },
+	{ value: "7d", label: "Last 7 days" },
+	{ value: "all", label: "All time" },
+];
+
+export function RecentErrorsCard() {
+	const { windowKey, setWindowKey, windowHours } = useErrorWindow();
+	const { data, isLoading } = useStats(undefined, windowHours);
+	const { dismiss, isDismissed } = useDismissedErrors();
+	const [selectedError, setSelectedError] = useState<RecentErrorGroup | null>(
+		null,
+	);
+
+	const recentErrors = data?.recentErrors as RecentErrorGroup[] | undefined;
+	const visibleErrors = recentErrors?.filter((err) => !isDismissed(err)) ?? [];
+
+	if (isLoading && !data) return null;
+	if (visibleErrors.length === 0) return null;
+
+	return (
+		<div className="space-y-2">
+			<div className="flex items-center justify-between">
+				<h4 className="text-sm font-medium text-muted-foreground">
+					Recent Errors
+				</h4>
+				<Select
+					value={windowKey}
+					onValueChange={(v) => setWindowKey(v as ErrorWindowKey)}
+				>
+					<SelectTrigger className="w-[140px] h-8 text-xs">
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						{WINDOW_OPTIONS.map((option) => (
+							<SelectItem key={option.value} value={option.value}>
+								{option.label}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			</div>
+
+			<div className="space-y-2">
+				{visibleErrors.map((error) => (
+					<RecentErrorRow
+						key={`${error.accountId ?? "no_account"}:${error.errorCode}:${error.latestRequestId}`}
+						error={error}
+						onClick={() => setSelectedError(error)}
+						onDismiss={() => dismiss(error)}
+					/>
+				))}
+			</div>
+
+			<ErrorDetailsModal
+				error={selectedError}
+				onClose={() => setSelectedError(null)}
+				onDismiss={(group) => dismiss(group)}
+			/>
+		</div>
+	);
+}

--- a/packages/dashboard-web/src/components/overview/system-status/errorCodeMeta.ts
+++ b/packages/dashboard-web/src/components/overview/system-status/errorCodeMeta.ts
@@ -1,0 +1,60 @@
+import type { RateLimitReason } from "@better-ccflare/types";
+
+export type ErrorSeverity = "warning" | "error";
+
+export interface ErrorMeta {
+	title: string;
+	description: string;
+	suggestion: string;
+	severity: ErrorSeverity;
+}
+
+const KNOWN_ERROR_META: Record<RateLimitReason, ErrorMeta> = {
+	upstream_429_with_reset: {
+		title: "Provider rate limit",
+		description: "The upstream provider returned 429 with a known reset time.",
+		suggestion: "The account will recover automatically at the reset time.",
+		severity: "warning",
+	},
+	upstream_429_no_reset_probe_cooldown: {
+		title: "Provider rate limit (no reset)",
+		description:
+			"The upstream provider returned 429 without a reset header; entering probe cooldown.",
+		suggestion:
+			"Cooldown defaults to 60s (configurable via CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS).",
+		severity: "warning",
+	},
+	upstream_429_no_reset_default_5h: {
+		title: "Provider rate limit (legacy 5h ban)",
+		description:
+			"Legacy ban from ccflare ≤ v3.5.x. No longer emitted by current code.",
+		suggestion: "Historical record — no action needed.",
+		severity: "warning",
+	},
+	model_fallback_429: {
+		title: "Rate limited — no fallback models",
+		description:
+			"The account was rate-limited and has no fallback models configured.",
+		suggestion:
+			"Configure model fallbacks for this account to enable automatic retry.",
+		severity: "error",
+	},
+	all_models_exhausted_429: {
+		title: "All fallback models rate-limited",
+		description: "Every fallback model also returned 429.",
+		suggestion: "Wait for cooldown, or add more diverse fallback models.",
+		severity: "error",
+	},
+};
+
+export function getErrorMeta(code: string): ErrorMeta {
+	if (code in KNOWN_ERROR_META) {
+		return KNOWN_ERROR_META[code as RateLimitReason];
+	}
+	return {
+		title: code || "Unknown error",
+		description: "No additional context is available for this error code.",
+		suggestion: "Check the server logs or the original request for details.",
+		severity: "error",
+	};
+}

--- a/packages/dashboard-web/src/components/overview/system-status/errorCodeMeta.ts
+++ b/packages/dashboard-web/src/components/overview/system-status/errorCodeMeta.ts
@@ -21,7 +21,7 @@ const KNOWN_ERROR_META: Record<RateLimitReason, ErrorMeta> = {
 		description:
 			"The upstream provider returned 429 without a reset header; entering probe cooldown.",
 		suggestion:
-			"Cooldown defaults to 60s (configurable via CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS).",
+			"Cooldown defaults to 60s. Set `CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS` in your environment to change it.",
 		severity: "warning",
 	},
 	upstream_429_no_reset_default_5h: {

--- a/packages/dashboard-web/src/components/overview/system-status/useDismissedErrors.ts
+++ b/packages/dashboard-web/src/components/overview/system-status/useDismissedErrors.ts
@@ -42,9 +42,9 @@ export function useDismissedErrors() {
 	});
 
 	// Persist the (possibly pruned) initial state back to storage once on mount.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentionally runs only on mount to persist the pruned initial state
 	useEffect(() => {
 		writeToStorage(state);
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	const dismiss = useCallback((group: RecentErrorGroup) => {

--- a/packages/dashboard-web/src/components/overview/system-status/useDismissedErrors.ts
+++ b/packages/dashboard-web/src/components/overview/system-status/useDismissedErrors.ts
@@ -1,39 +1,11 @@
 import { NO_ACCOUNT_ID, type RecentErrorGroup } from "@better-ccflare/types";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 const STORAGE_KEY = "better-ccflare:dismissed-errors";
 const PRUNE_AFTER_MS = 30 * 24 * 60 * 60 * 1000;
 
 function keyFor(group: RecentErrorGroup): string {
 	return `${group.accountId ?? NO_ACCOUNT_ID}:${group.errorCode}`;
-}
-
-function readFromStorage(): Record<string, number> {
-	if (typeof window === "undefined") return {};
-	try {
-		const raw = window.localStorage.getItem(STORAGE_KEY);
-		if (!raw) return {};
-		const parsed = JSON.parse(raw);
-		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-			const cleaned: Record<string, number> = {};
-			const now = Date.now();
-			let pruned = false;
-			for (const [k, v] of Object.entries(parsed)) {
-				if (typeof v === "number" && v + PRUNE_AFTER_MS > now) {
-					cleaned[k] = v;
-				} else {
-					pruned = true;
-				}
-			}
-			if (pruned) {
-				writeToStorage(cleaned);
-			}
-			return cleaned;
-		}
-		return {};
-	} catch {
-		return {};
-	}
 }
 
 function writeToStorage(state: Record<string, number>) {
@@ -46,7 +18,34 @@ function writeToStorage(state: Record<string, number>) {
 }
 
 export function useDismissedErrors() {
-	const [state, setState] = useState<Record<string, number>>(readFromStorage);
+	const [state, setState] = useState<Record<string, number>>(() => {
+		// pure: read + prune in memory, return cleaned state. No writes.
+		if (typeof window === "undefined") return {};
+		try {
+			const raw = window.localStorage.getItem(STORAGE_KEY);
+			if (!raw) return {};
+			const parsed = JSON.parse(raw);
+			if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+				const now = Date.now();
+				const cleaned: Record<string, number> = {};
+				for (const [k, v] of Object.entries(parsed)) {
+					if (typeof v === "number" && v + PRUNE_AFTER_MS > now) {
+						cleaned[k] = v;
+					}
+				}
+				return cleaned;
+			}
+			return {};
+		} catch {
+			return {};
+		}
+	});
+
+	// Persist the (possibly pruned) initial state back to storage once on mount.
+	useEffect(() => {
+		writeToStorage(state);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 
 	const dismiss = useCallback((group: RecentErrorGroup) => {
 		setState((prev) => {

--- a/packages/dashboard-web/src/components/overview/system-status/useDismissedErrors.ts
+++ b/packages/dashboard-web/src/components/overview/system-status/useDismissedErrors.ts
@@ -1,0 +1,75 @@
+import { NO_ACCOUNT_ID, type RecentErrorGroup } from "@better-ccflare/types";
+import { useCallback, useState } from "react";
+
+const STORAGE_KEY = "better-ccflare:dismissed-errors";
+const PRUNE_AFTER_MS = 30 * 24 * 60 * 60 * 1000;
+
+function keyFor(group: RecentErrorGroup): string {
+	return `${group.accountId ?? NO_ACCOUNT_ID}:${group.errorCode}`;
+}
+
+function readFromStorage(): Record<string, number> {
+	if (typeof window === "undefined") return {};
+	try {
+		const raw = window.localStorage.getItem(STORAGE_KEY);
+		if (!raw) return {};
+		const parsed = JSON.parse(raw);
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			const cleaned: Record<string, number> = {};
+			const now = Date.now();
+			let pruned = false;
+			for (const [k, v] of Object.entries(parsed)) {
+				if (typeof v === "number" && v + PRUNE_AFTER_MS > now) {
+					cleaned[k] = v;
+				} else {
+					pruned = true;
+				}
+			}
+			if (pruned) {
+				writeToStorage(cleaned);
+			}
+			return cleaned;
+		}
+		return {};
+	} catch {
+		return {};
+	}
+}
+
+function writeToStorage(state: Record<string, number>) {
+	if (typeof window === "undefined") return;
+	try {
+		window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+	} catch {
+		// ignore — degrade to in-memory
+	}
+}
+
+export function useDismissedErrors() {
+	const [state, setState] = useState<Record<string, number>>(readFromStorage);
+
+	const dismiss = useCallback((group: RecentErrorGroup) => {
+		setState((prev) => {
+			const next = { ...prev, [keyFor(group)]: Date.now() };
+			writeToStorage(next);
+			return next;
+		});
+	}, []);
+
+	const isDismissed = useCallback(
+		(group: RecentErrorGroup) => {
+			const dismissedBefore = state[keyFor(group)];
+			return (
+				dismissedBefore != null && group.latestTimestamp <= dismissedBefore
+			);
+		},
+		[state],
+	);
+
+	const clearAll = useCallback(() => {
+		setState({});
+		writeToStorage({});
+	}, []);
+
+	return { dismiss, isDismissed, clearAll };
+}

--- a/packages/dashboard-web/src/components/overview/system-status/useErrorWindow.ts
+++ b/packages/dashboard-web/src/components/overview/system-status/useErrorWindow.ts
@@ -1,0 +1,44 @@
+import { useCallback, useState } from "react";
+
+export type ErrorWindowKey = "1h" | "24h" | "7d" | "all";
+
+const STORAGE_KEY = "better-ccflare:errors:window";
+const DEFAULT: ErrorWindowKey = "24h";
+const HOURS: Record<ErrorWindowKey, number> = {
+	"1h": 1,
+	"24h": 24,
+	"7d": 168,
+	all: 8760,
+};
+
+function readFromStorage(): ErrorWindowKey {
+	if (typeof window === "undefined") return DEFAULT;
+	try {
+		const raw = window.localStorage.getItem(STORAGE_KEY);
+		if (raw === "1h" || raw === "24h" || raw === "7d" || raw === "all") {
+			return raw;
+		}
+		return DEFAULT;
+	} catch {
+		return DEFAULT;
+	}
+}
+
+function writeToStorage(key: ErrorWindowKey) {
+	if (typeof window === "undefined") return;
+	try {
+		window.localStorage.setItem(STORAGE_KEY, key);
+	} catch {
+		// ignore
+	}
+}
+
+export function useErrorWindow() {
+	const [windowKey, setWindowKeyState] =
+		useState<ErrorWindowKey>(readFromStorage);
+	const setWindowKey = useCallback((k: ErrorWindowKey) => {
+		setWindowKeyState(k);
+		writeToStorage(k);
+	}, []);
+	return { windowKey, setWindowKey, windowHours: HOURS[windowKey] };
+}

--- a/packages/dashboard-web/src/hooks/queries.ts
+++ b/packages/dashboard-web/src/hooks/queries.ts
@@ -25,10 +25,13 @@ export const useAgents = () => {
 	});
 };
 
-export const useStats = (refetchInterval?: number) => {
+export const useStats = (
+	refetchInterval?: number,
+	errorsSinceHours?: number,
+) => {
 	return useQuery({
-		queryKey: queryKeys.stats(),
-		queryFn: () => api.getStats(),
+		queryKey: queryKeys.stats(errorsSinceHours),
+		queryFn: () => api.getStats({ errorsSinceHours }),
 		staleTime: 15000, // Consider data fresh for 15 seconds
 		refetchInterval: refetchInterval ?? 30000, // Default to 30 seconds instead of 10
 		refetchIntervalInBackground: false, // Don't refresh when tab is not focused

--- a/packages/dashboard-web/src/lib/query-keys.ts
+++ b/packages/dashboard-web/src/lib/query-keys.ts
@@ -2,7 +2,10 @@ export const queryKeys = {
 	all: ["better-ccflare"] as const,
 	accounts: () => [...queryKeys.all, "accounts"] as const,
 	agents: () => [...queryKeys.all, "agents"] as const,
-	stats: () => [...queryKeys.all, "stats"] as const,
+	stats: (errorsSinceHours?: number) =>
+		errorsSinceHours === undefined
+			? ([...queryKeys.all, "stats"] as const)
+			: ([...queryKeys.all, "stats", { errorsSinceHours }] as const),
 	analytics: (
 		timeRange?: string,
 		filters?: unknown,

--- a/packages/database/src/repositories/stats.repository.ts
+++ b/packages/database/src/repositories/stats.repository.ts
@@ -2,7 +2,11 @@
  * Consolidated stats repository to eliminate duplication between cli-commands and http-api
  */
 
-import type { RecentErrorGroup, SessionStats } from "@better-ccflare/types";
+import type {
+	RateLimitReason,
+	RecentErrorGroup,
+	SessionStats,
+} from "@better-ccflare/types";
 import { NO_ACCOUNT_ID } from "@better-ccflare/types";
 import type { BunSqlAdapter } from "../adapters/bun-sql-adapter";
 
@@ -246,11 +250,11 @@ export class StatsRepository {
 				SELECT r.id, r.timestamp, r.error_message, r.account_used, r.model,
 				       r.status_code, r.path, r.failover_attempts,
 				       ROW_NUMBER() OVER (
-				         PARTITION BY r.error_message, COALESCE(r.account_used, '${NO_ACCOUNT_ID}')
+				         PARTITION BY r.error_message, COALESCE(r.account_used, ?)
 				         ORDER BY r.timestamp DESC
 				       ) AS rn,
-				       COUNT(*)         OVER (PARTITION BY r.error_message, COALESCE(r.account_used, '${NO_ACCOUNT_ID}')) AS occurrence_count,
-				       MIN(r.timestamp) OVER (PARTITION BY r.error_message, COALESCE(r.account_used, '${NO_ACCOUNT_ID}')) AS first_seen
+				       COUNT(*)         OVER (PARTITION BY r.error_message, COALESCE(r.account_used, ?)) AS occurrence_count,
+				       MIN(r.timestamp) OVER (PARTITION BY r.error_message, COALESCE(r.account_used, ?)) AS first_seen
 				FROM requests r
 				WHERE r.error_message IS NOT NULL
 				  AND r.error_message != ''
@@ -276,12 +280,11 @@ export class StatsRepository {
 			WHERE ranked.rn = 1
 			ORDER BY ranked.timestamp DESC
 			LIMIT ?`,
-			[sinceMs, limit],
+			[NO_ACCOUNT_ID, NO_ACCOUNT_ID, NO_ACCOUNT_ID, sinceMs, limit],
 		);
 
 		return rows.map((row) => {
-			const accountId =
-				row.account_id == null ? null : String(row.account_id);
+			const accountId = row.account_id == null ? null : String(row.account_id);
 			const accountName =
 				row.account_name == null ? null : String(row.account_name);
 			const model = row.model == null ? null : String(row.model);
@@ -289,15 +292,13 @@ export class StatsRepository {
 			const statusCode =
 				row.status_code == null ? null : Number(row.status_code);
 			const rateLimitedUntil =
-				row.rate_limited_until == null
-					? null
-					: Number(row.rate_limited_until);
+				row.rate_limited_until == null ? null : Number(row.rate_limited_until);
 			const rateLimitedAt =
 				row.rate_limited_at == null ? null : Number(row.rate_limited_at);
 			const rateLimitedReason =
 				row.rate_limited_reason == null
 					? null
-					: (String(row.rate_limited_reason) as RecentErrorGroup["rateLimitedReason"]);
+					: (String(row.rate_limited_reason) as RateLimitReason);
 
 			return {
 				errorCode: String(row.error_code ?? ""),

--- a/packages/database/src/repositories/stats.repository.ts
+++ b/packages/database/src/repositories/stats.repository.ts
@@ -2,7 +2,7 @@
  * Consolidated stats repository to eliminate duplication between cli-commands and http-api
  */
 
-import type { SessionStats } from "@better-ccflare/types";
+import type { RecentErrorGroup, SessionStats } from "@better-ccflare/types";
 import { NO_ACCOUNT_ID } from "@better-ccflare/types";
 import type { BunSqlAdapter } from "../adapters/bun-sql-adapter";
 
@@ -213,21 +213,109 @@ export class StatsRepository {
 	}
 
 	/**
-	 * Get recent errors (already exists in request.repository, but adding for completeness)
+	 * Get recent error groups within a time window.
+	 *
+	 * Groups requests by (error_message, account_used) and returns one entry per
+	 * group with metadata sourced from the most recent occurrence plus aggregate
+	 * stats and the owning account's current rate-limit state.
+	 *
+	 * @param sinceMs - Only include requests after this timestamp (ms since epoch).
+	 * @param limit - Maximum number of groups to return.
 	 */
-	async getRecentErrors(limit = 10): Promise<string[]> {
-		const errors = await this.adapter.query<{ error_message: string }>(
-			`SELECT error_message, MAX(timestamp) as latest
-			FROM requests
-			WHERE error_message IS NOT NULL
-				AND error_message != ''
-			GROUP BY error_message
-			ORDER BY latest DESC
+	async getRecentErrorGroups(
+		sinceMs: number,
+		limit = 10,
+	): Promise<RecentErrorGroup[]> {
+		const rows = await this.adapter.query<{
+			latest_request_id: unknown;
+			latest_timestamp: unknown;
+			error_code: unknown;
+			account_id: unknown;
+			model: unknown;
+			status_code: unknown;
+			path: unknown;
+			failover_attempts: unknown;
+			occurrence_count: unknown;
+			first_seen: unknown;
+			account_name: unknown;
+			rate_limited_until: unknown;
+			rate_limited_reason: unknown;
+			rate_limited_at: unknown;
+		}>(
+			`WITH ranked AS (
+				SELECT r.id, r.timestamp, r.error_message, r.account_used, r.model,
+				       r.status_code, r.path, r.failover_attempts,
+				       ROW_NUMBER() OVER (
+				         PARTITION BY r.error_message, COALESCE(r.account_used, '${NO_ACCOUNT_ID}')
+				         ORDER BY r.timestamp DESC
+				       ) AS rn,
+				       COUNT(*)         OVER (PARTITION BY r.error_message, COALESCE(r.account_used, '${NO_ACCOUNT_ID}')) AS occurrence_count,
+				       MIN(r.timestamp) OVER (PARTITION BY r.error_message, COALESCE(r.account_used, '${NO_ACCOUNT_ID}')) AS first_seen
+				FROM requests r
+				WHERE r.error_message IS NOT NULL
+				  AND r.error_message != ''
+				  AND r.timestamp > ?
+			)
+			SELECT
+				ranked.id              AS latest_request_id,
+				ranked.timestamp       AS latest_timestamp,
+				ranked.error_message   AS error_code,
+				ranked.account_used    AS account_id,
+				ranked.model,
+				ranked.status_code,
+				ranked.path,
+				ranked.failover_attempts,
+				ranked.occurrence_count,
+				ranked.first_seen,
+				a.name                 AS account_name,
+				a.rate_limited_until   AS rate_limited_until,
+				a.rate_limited_reason  AS rate_limited_reason,
+				a.rate_limited_at      AS rate_limited_at
+			FROM ranked
+			LEFT JOIN accounts a ON a.id = ranked.account_used
+			WHERE ranked.rn = 1
+			ORDER BY ranked.timestamp DESC
 			LIMIT ?`,
-			[limit],
+			[sinceMs, limit],
 		);
 
-		return errors.map((e) => e.error_message);
+		return rows.map((row) => {
+			const accountId =
+				row.account_id == null ? null : String(row.account_id);
+			const accountName =
+				row.account_name == null ? null : String(row.account_name);
+			const model = row.model == null ? null : String(row.model);
+			const path = row.path == null ? null : String(row.path);
+			const statusCode =
+				row.status_code == null ? null : Number(row.status_code);
+			const rateLimitedUntil =
+				row.rate_limited_until == null
+					? null
+					: Number(row.rate_limited_until);
+			const rateLimitedAt =
+				row.rate_limited_at == null ? null : Number(row.rate_limited_at);
+			const rateLimitedReason =
+				row.rate_limited_reason == null
+					? null
+					: (String(row.rate_limited_reason) as RecentErrorGroup["rateLimitedReason"]);
+
+			return {
+				errorCode: String(row.error_code ?? ""),
+				accountId,
+				accountName,
+				occurrenceCount: Number(row.occurrence_count) || 0,
+				latestTimestamp: Number(row.latest_timestamp) || 0,
+				firstTimestamp: Number(row.first_seen) || 0,
+				latestRequestId: String(row.latest_request_id ?? ""),
+				model,
+				statusCode,
+				path,
+				failoverAttempts: Number(row.failover_attempts) || 0,
+				rateLimitedUntil,
+				rateLimitedReason,
+				rateLimitedAt,
+			};
+		});
 	}
 
 	/**

--- a/packages/http-api/src/handlers/stats.ts
+++ b/packages/http-api/src/handlers/stats.ts
@@ -16,7 +16,9 @@ export function createStatsHandler(dbOps: DatabaseOperations) {
 
 		// Parse optional ?errorsSinceHours=<n> query parameter
 		// (default: 24, max: 8760 hours = 365 days)
-		const errorsHoursRaw = Number(url.searchParams.get("errorsSinceHours") ?? 24);
+		const errorsHoursRaw = Number(
+			url.searchParams.get("errorsSinceHours") ?? 24,
+		);
 		const errorsHours =
 			Number.isFinite(errorsHoursRaw) && errorsHoursRaw > 0
 				? Math.min(errorsHoursRaw, 8760)

--- a/packages/http-api/src/handlers/stats.ts
+++ b/packages/http-api/src/handlers/stats.ts
@@ -38,8 +38,10 @@ export function createStatsHandler(dbOps: DatabaseOperations) {
 		const accountsWithStats = await statsRepository.getAccountStats(10, true);
 
 		// Get recent errors
-		const recentErrors =
-			await statsRepository.getRecentErrorGroups(errorsSinceMs);
+		const recentErrors = await statsRepository.getRecentErrorGroups(
+			errorsSinceMs,
+			50,
+		);
 
 		// Get top models
 		const topModels = await statsRepository.getTopModels();

--- a/packages/http-api/src/handlers/stats.ts
+++ b/packages/http-api/src/handlers/stats.ts
@@ -14,6 +14,15 @@ export function createStatsHandler(dbOps: DatabaseOperations) {
 			Number.isFinite(sinceRaw) && sinceRaw > 0 ? Math.min(sinceRaw, 365) : 30;
 		const sinceMs = Date.now() - sinceDays * 24 * 60 * 60 * 1000;
 
+		// Parse optional ?errorsSinceHours=<n> query parameter
+		// (default: 24, max: 8760 hours = 365 days)
+		const errorsHoursRaw = Number(url.searchParams.get("errorsSinceHours") ?? 24);
+		const errorsHours =
+			Number.isFinite(errorsHoursRaw) && errorsHoursRaw > 0
+				? Math.min(errorsHoursRaw, 8760)
+				: 24;
+		const errorsSinceMs = Date.now() - errorsHours * 60 * 60 * 1000;
+
 		// Get overall statistics using the consolidated repository
 		const stats = await statsRepository.getAggregatedStats(sinceMs);
 		const activeAccounts = await statsRepository.getActiveAccountCount();
@@ -27,7 +36,8 @@ export function createStatsHandler(dbOps: DatabaseOperations) {
 		const accountsWithStats = await statsRepository.getAccountStats(10, true);
 
 		// Get recent errors
-		const recentErrors = await statsRepository.getRecentErrors();
+		const recentErrors =
+			await statsRepository.getRecentErrorGroups(errorsSinceMs);
 
 		// Get top models
 		const topModels = await statsRepository.getTopModels();

--- a/packages/types/src/stats.ts
+++ b/packages/types/src/stats.ts
@@ -30,13 +30,30 @@ export interface StatsResponse {
 	avgTokensPerSecond: number | null;
 }
 
+export interface RecentErrorGroup {
+	errorCode: string; // raw value from requests.error_message
+	accountId: string | null; // null when unauthenticated
+	accountName: string | null; // null when account deleted
+	occurrenceCount: number;
+	latestTimestamp: number; // ms epoch
+	firstTimestamp: number; // ms epoch
+	latestRequestId: string;
+	model: string | null;
+	statusCode: number | null;
+	path: string | null;
+	failoverAttempts: number;
+	rateLimitedUntil: number | null; // from accounts table, ms epoch
+	rateLimitedReason: RateLimitReason | null;
+	rateLimitedAt: number | null;
+}
+
 export interface StatsWithAccounts extends Stats {
 	accounts: Array<{
 		name: string;
 		requestCount: number;
 		successRate: number;
 	}>;
-	recentErrors: string[];
+	recentErrors: RecentErrorGroup[];
 }
 
 // Analytics types


### PR DESCRIPTION
  - Replaces `getRecentErrors()` with `getRecentErrorGroups()` using a CTE + window functions; LEFT JOIN accounts. Returns a `RecentErrorGroup[]` with
  timestamp, account, model, status code, occurrence count, and recovery info. **No DB migration** — the existing `requests` table already has everything.
  - New API param `?errorsSinceHours=<n>` on `/api/stats` (default 24, clamped to `(0, 8760]`).
  - New `RecentErrorsCard` (under `packages/dashboard-web/src/components/overview/system-status/`) replaces the bare-error-code list. Clickable rows open an
   `ErrorDetailsModal` with full context + human-readable description + recovery info. Per‑(errorCode, accountId) dismissal persisted in localStorage.
  Time-window selector (1h / 24h / 7d / all) also persisted. `StatsTab` updated atomically to the new shape.
