### PR TITLE
feat: add combined-quota tiles to Overview dashboard

### DIFF
--- a/packages/dashboard-web/src/components/OverviewTab.tsx
+++ b/packages/dashboard-web/src/components/OverviewTab.tsx
@@ -1,3 +1,4 @@
+import { registerUIRefresh } from "@better-ccflare/core";
 import {
 	formatCost,
 	formatNumber,
@@ -5,13 +6,23 @@ import {
 	formatTokensPerSecond,
 } from "@better-ccflare/ui-common";
 import { format } from "date-fns";
-import { Activity, CheckCircle, Clock, DollarSign, Zap } from "lucide-react";
-import React, { useCallback, useMemo, useState } from "react";
+import {
+	Activity,
+	BarChart3,
+	CheckCircle,
+	Clock,
+	DollarSign,
+	Gauge,
+	Zap,
+} from "lucide-react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { REFRESH_INTERVALS } from "../constants";
 import { useAccounts, useAnalytics, useStats } from "../hooks/queries";
+import { computePoolUsage } from "../lib/pool-usage";
 import { ChartsSection } from "./overview/ChartsSection";
 import { LoadingSkeleton } from "./overview/LoadingSkeleton";
 import { MetricCard } from "./overview/MetricCard";
+import { PoolMetricCard } from "./overview/PoolMetricCard";
 import { RateLimitInfo } from "./overview/RateLimitInfo";
 import { SystemStatus } from "./overview/SystemStatus";
 import { TimeRangeSelector } from "./overview/TimeRangeSelector";
@@ -28,6 +39,25 @@ export const OverviewTab = React.memo(() => {
 		"normal",
 	);
 	const { data: accounts, isLoading: accountsLoading } = useAccounts();
+
+	const [now, setNow] = useState(() => Date.now());
+	useEffect(() => {
+		return registerUIRefresh({
+			id: "pool-metric-card-update",
+			callback: () => setNow(Date.now()),
+			seconds: 30,
+			description: "Combined-quota tile refresh",
+		});
+	}, []);
+
+	const fiveHourPool = useMemo(
+		() => computePoolUsage(accounts ?? [], "five_hour", now),
+		[accounts, now],
+	);
+	const weeklyPool = useMemo(
+		() => computePoolUsage(accounts ?? [], "seven_day", now),
+		[accounts, now],
+	);
 
 	// Memoize percentage change calculation (must be at top level)
 	const pctChange = useCallback(
@@ -166,7 +196,7 @@ export const OverviewTab = React.memo(() => {
 			</div>
 
 			{/* Metrics Grid */}
-			<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-4">
+			<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 2xl:grid-cols-8 gap-4">
 				<MetricCard
 					title="Total Requests"
 					value={formatNumber(analytics?.totals.requests || 0)}
@@ -234,6 +264,18 @@ export const OverviewTab = React.memo(() => {
 					trend={trends.trendOutputSpeed}
 					trendPeriod={trendPeriod}
 					icon={Zap}
+				/>
+				<PoolMetricCard
+					title="5h Pool"
+					icon={Gauge}
+					result={fiveHourPool}
+					now={now}
+				/>
+				<PoolMetricCard
+					title="7d Pool"
+					icon={BarChart3}
+					result={weeklyPool}
+					now={now}
 				/>
 			</div>
 

--- a/packages/dashboard-web/src/components/OverviewTab.tsx
+++ b/packages/dashboard-web/src/components/OverviewTab.tsx
@@ -270,12 +270,14 @@ export const OverviewTab = React.memo(() => {
 					icon={Gauge}
 					result={fiveHourPool}
 					now={now}
+					window="five_hour"
 				/>
 				<PoolMetricCard
 					title="7d Pool"
 					icon={BarChart3}
 					result={weeklyPool}
 					now={now}
+					window="seven_day"
 				/>
 			</div>
 

--- a/packages/dashboard-web/src/components/OverviewTab.tsx
+++ b/packages/dashboard-web/src/components/OverviewTab.tsx
@@ -269,14 +269,12 @@ export const OverviewTab = React.memo(() => {
 					title="5h Pool"
 					icon={Gauge}
 					result={fiveHourPool}
-					now={now}
 					window="five_hour"
 				/>
 				<PoolMetricCard
 					title="7d Pool"
 					icon={BarChart3}
 					result={weeklyPool}
-					now={now}
 					window="seven_day"
 				/>
 			</div>

--- a/packages/dashboard-web/src/components/overview/PoolMetricCard.tsx
+++ b/packages/dashboard-web/src/components/overview/PoolMetricCard.tsx
@@ -13,7 +13,6 @@ interface PoolMetricCardProps {
 	title: string;
 	icon: React.ComponentType<{ className?: string }>;
 	result: PoolUsageResult;
-	now: number;
 	window: PoolWindow;
 }
 
@@ -69,37 +68,37 @@ function groupExcluded(
 	return groups;
 }
 
-function nextRefreshLabel(
+function nextQuotaTimeLabel(
+	earliestResetMs: number,
+	window: PoolWindow,
+): string {
+	const date = new Date(earliestResetMs);
+	return window === "seven_day"
+		? date.toLocaleString(undefined, {
+				month: "short",
+				day: "numeric",
+				hour: "2-digit",
+				minute: "2-digit",
+			})
+		: date.toLocaleTimeString(undefined, {
+				hour: "2-digit",
+				minute: "2-digit",
+			});
+}
+
+function nextQuotaLabel(
 	earliestResetMs: number,
 	accountName: string | null,
-	now: number,
 	window: PoolWindow,
 ): string {
 	const name = accountName ?? "unknown";
-	if (earliestResetMs <= now) {
-		return `${name} ready to refresh`;
-	}
-	const date = new Date(earliestResetMs);
-	const time =
-		window === "seven_day"
-			? date.toLocaleString(undefined, {
-					month: "short",
-					day: "numeric",
-					hour: "2-digit",
-					minute: "2-digit",
-				})
-			: date.toLocaleTimeString(undefined, {
-					hour: "2-digit",
-					minute: "2-digit",
-				});
-	return `${name} at ${time}`;
+	return `${name} at ${nextQuotaTimeLabel(earliestResetMs, window)}`;
 }
 
 export function PoolMetricCard({
 	title,
 	icon: Icon,
 	result,
-	now,
 	window,
 }: PoolMetricCardProps) {
 	const {
@@ -118,7 +117,10 @@ export function PoolMetricCard({
 	const showChip = eligibleTotal > 0;
 	const colorClass = headlineColor(average);
 	const headline = average != null ? formatPercentage(average, 0) : "—";
-	const showSubline = contributing.length > 0 || exhausted.length > 0;
+	const nextQuotaText =
+		earliestResetMs == null
+			? null
+			: `more quota at ${nextQuotaTimeLabel(earliestResetMs, window)}`;
 
 	const sortedContributing = contributing.slice().sort((a, b) => b.pct - a.pct);
 	const exhaustedGroups = groupExcluded(exhausted);
@@ -240,12 +242,11 @@ export function PoolMetricCard({
 				)}
 				{earliestResetMs != null && (
 					<div>
-						<div className="font-medium mb-1">Next refresh</div>
+						<div className="font-medium mb-1">More quota</div>
 						<div>
-							{nextRefreshLabel(
+							{nextQuotaLabel(
 								earliestResetMs,
 								earliestResetAccountName,
-								now,
 								window,
 							)}
 						</div>
@@ -265,9 +266,12 @@ export function PoolMetricCard({
 				<div className="space-y-1">
 					<p className="text-sm text-muted-foreground">{title}</p>
 					<p className={cn("text-2xl font-bold", colorClass)}>{headline}</p>
-					{showSubline && (
+					<p className="text-xs text-muted-foreground truncate">
+						capacity used
+					</p>
+					{nextQuotaText && (
 						<p className="text-xs text-muted-foreground truncate">
-							capacity used
+							{nextQuotaText}
 						</p>
 					)}
 				</div>

--- a/packages/dashboard-web/src/components/overview/PoolMetricCard.tsx
+++ b/packages/dashboard-web/src/components/overview/PoolMetricCard.tsx
@@ -22,6 +22,8 @@ const REASON_LABELS: Record<ExcludedReason, string> = {
 	rate_limited: "Rate-limited",
 	token_expired: "OAuth token expired",
 	usage_rate_limited: "Usage data unavailable (provider 429)",
+	five_hour_exhausted: "5h quota exhausted",
+	seven_day_exhausted: "7d quota exhausted",
 	no_usage_data: "No usage data yet",
 };
 
@@ -30,6 +32,8 @@ const REASON_ORDER: ExcludedReason[] = [
 	"rate_limited",
 	"token_expired",
 	"usage_rate_limited",
+	"five_hour_exhausted",
+	"seven_day_exhausted",
 	"no_usage_data",
 ];
 

--- a/packages/dashboard-web/src/components/overview/PoolMetricCard.tsx
+++ b/packages/dashboard-web/src/components/overview/PoolMetricCard.tsx
@@ -100,24 +100,28 @@ export function PoolMetricCard({
 }: PoolMetricCardProps) {
 	const {
 		average,
-		worst,
+		activeAverage,
 		contributing,
+		exhausted,
 		excluded,
 		fallback,
 		earliestResetMs,
 		earliestResetAccountName,
 	} = result;
 
-	const eligibleTotal = contributing.length + excluded.length;
+	const eligibleTotal =
+		contributing.length + exhausted.length + excluded.length;
 	const showChip = eligibleTotal > 0;
 	const colorClass = headlineColor(average);
 	const headline = average != null ? formatPercentage(average, 0) : "—";
-	const showSubline = contributing.length >= 2 && worst != null;
+	const showSubline = contributing.length > 0 || exhausted.length > 0;
 
 	const sortedContributing = contributing.slice().sort((a, b) => b.pct - a.pct);
+	const exhaustedGroups = groupExcluded(exhausted);
 	const excludedGroups = groupExcluded(excluded);
 
 	const hasContributing = contributing.length > 0;
+	const hasExhausted = exhausted.length > 0;
 	const hasExcluded = excluded.length > 0;
 	const hasFallback = fallback.length > 0;
 
@@ -129,12 +133,23 @@ export function PoolMetricCard({
 					className="flex items-center gap-1 text-xs text-muted-foreground cursor-help focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
 				>
 					<span className="tabular-nums">
-						({contributing.length}/{eligibleTotal})
+						({contributing.length}/{eligibleTotal} active)
 					</span>
 					<Info className="h-3 w-3" />
 				</button>
 			</PopoverTrigger>
 			<PopoverContent className="w-72 text-xs space-y-3">
+				<div>
+					<div className="font-medium mb-1">Pool usage</div>
+					<div className="text-muted-foreground">
+						Headline counts unavailable eligible accounts as 100% used.
+					</div>
+					{activeAverage != null && (
+						<div className="mt-1">
+							Active accounts average: {activeAverage.toFixed(0)}%
+						</div>
+					)}
+				</div>
 				{hasContributing && (
 					<div>
 						<div className="font-medium mb-1">
@@ -155,14 +170,37 @@ export function PoolMetricCard({
 						</ul>
 					</div>
 				)}
+				{hasExhausted && (
+					<div>
+						<div className="font-medium mb-1">
+							Unavailable ({exhausted.length})
+						</div>
+						<div className="space-y-2">
+							{exhaustedGroups.map(({ reason, items }) => (
+								<div key={reason}>
+									<div className="text-muted-foreground">
+										{REASON_LABELS[reason]} · counted as 100%
+									</div>
+									<ul className="ml-2 space-y-0.5">
+										{items.map((e) => (
+											<li key={e.name} className="truncate" title={e.name}>
+												{e.name}
+											</li>
+										))}
+									</ul>
+								</div>
+							))}
+						</div>
+					</div>
+				)}
 				{hasExcluded && (
 					<div>
-						<div className="font-medium mb-1">Excluded ({excluded.length})</div>
+						<div className="font-medium mb-1">Unknown ({excluded.length})</div>
 						<div className="space-y-2">
 							{excludedGroups.map(({ reason, items }) => (
 								<div key={reason}>
 									<div className="text-muted-foreground">
-										{REASON_LABELS[reason]}
+										{REASON_LABELS[reason]} · not counted
 									</div>
 									<ul className="ml-2 space-y-0.5">
 										{items.map((e) => (
@@ -223,12 +261,9 @@ export function PoolMetricCard({
 				<div className="space-y-1">
 					<p className="text-sm text-muted-foreground">{title}</p>
 					<p className={cn("text-2xl font-bold", colorClass)}>{headline}</p>
-					{showSubline && worst && (
-						<p
-							className="text-xs text-muted-foreground truncate"
-							title={worst.name}
-						>
-							worst: {worst.pct.toFixed(0)}% ({worst.name})
+					{showSubline && (
+						<p className="text-xs text-muted-foreground truncate">
+							capacity used
 						</p>
 					)}
 				</div>

--- a/packages/dashboard-web/src/components/overview/PoolMetricCard.tsx
+++ b/packages/dashboard-web/src/components/overview/PoolMetricCard.tsx
@@ -95,6 +95,29 @@ function nextQuotaLabel(
 	return `${name} at ${nextQuotaTimeLabel(earliestResetMs, window)}`;
 }
 
+function formatShortDuration(ms: number): string {
+	const totalMinutes = Math.max(0, Math.round(ms / 60000));
+	const hours = Math.floor(totalMinutes / 60);
+	const minutes = totalMinutes % 60;
+	if (hours > 0) return `${hours}h ${minutes}m`;
+	return `${minutes}m`;
+}
+
+function atRiskBadge(
+	willRunOutCount: number,
+	capacityCount: number,
+): { label: string | null; colorClass: string | null } {
+	if (willRunOutCount === 0 || capacityCount === 0) {
+		return { label: null, colorClass: null };
+	}
+	const colorClass =
+		willRunOutCount >= capacityCount ? "text-destructive" : "text-warning";
+	return {
+		label: `${willRunOutCount} of ${capacityCount} will run out`,
+		colorClass,
+	};
+}
+
 export function PoolMetricCard({
 	title,
 	icon: Icon,
@@ -110,10 +133,17 @@ export function PoolMetricCard({
 		fallback,
 		earliestResetMs,
 		earliestResetAccountName,
+		atRisk,
 	} = result;
 
 	const eligibleTotal =
 		contributing.length + exhausted.length + excluded.length;
+	const capacityCount = contributing.length + exhausted.length;
+	const willRunOutCount = atRisk.length + exhausted.length;
+	const { label: willRunOutText, colorClass: willRunOutColor } = atRiskBadge(
+		willRunOutCount,
+		capacityCount,
+	);
 	const showChip = eligibleTotal > 0;
 	const colorClass = headlineColor(average);
 	const headline = average != null ? formatPercentage(average, 0) : "—";
@@ -123,6 +153,9 @@ export function PoolMetricCard({
 			: `more quota at ${nextQuotaTimeLabel(earliestResetMs, window)}`;
 
 	const sortedContributing = contributing.slice().sort((a, b) => b.pct - a.pct);
+	const sortedAtRisk = atRisk
+		.slice()
+		.sort((a, b) => a.exhaustsAtMs - b.exhaustsAtMs);
 	const exhaustedGroups = groupExcluded(exhausted);
 	const excludedGroups = groupExcluded(excluded);
 
@@ -130,6 +163,7 @@ export function PoolMetricCard({
 	const hasExhausted = exhausted.length > 0;
 	const hasExcluded = excluded.length > 0;
 	const hasFallback = fallback.length > 0;
+	const hasAtRisk = atRisk.length > 0;
 
 	const triggerNode = showChip ? (
 		<Popover>
@@ -171,6 +205,29 @@ export function PoolMetricCard({
 										{c.name}
 									</span>
 									<span className="tabular-nums">{c.pct.toFixed(0)}%</span>
+								</li>
+							))}
+						</ul>
+					</div>
+				)}
+				{hasAtRisk && (
+					<div>
+						<div className="font-medium mb-1">At risk ({atRisk.length})</div>
+						<div className="text-muted-foreground mb-1">
+							Projected to exhaust before their window resets.
+						</div>
+						<ul className="space-y-0.5">
+							{sortedAtRisk.map((a) => (
+								<li
+									key={a.name}
+									className="flex items-center justify-between gap-2"
+								>
+									<span className="truncate" title={a.name}>
+										{a.name}
+									</span>
+									<span className="tabular-nums">
+										runs out in {formatShortDuration(a.timeToExhaustMs)}
+									</span>
 								</li>
 							))}
 						</ul>
@@ -272,6 +329,11 @@ export function PoolMetricCard({
 					{nextQuotaText && (
 						<p className="text-xs text-muted-foreground truncate">
 							{nextQuotaText}
+						</p>
+					)}
+					{willRunOutText && (
+						<p className={cn("text-xs truncate", willRunOutColor)}>
+							{willRunOutText}
 						</p>
 					)}
 				</div>

--- a/packages/dashboard-web/src/components/overview/PoolMetricCard.tsx
+++ b/packages/dashboard-web/src/components/overview/PoolMetricCard.tsx
@@ -1,6 +1,10 @@
 import { formatPercentage } from "@better-ccflare/ui-common";
 import { Info } from "lucide-react";
-import type { ExcludedReason, PoolUsageResult } from "../../lib/pool-usage";
+import type {
+	ExcludedReason,
+	PoolUsageResult,
+	PoolWindow,
+} from "../../lib/pool-usage";
 import { cn } from "../../lib/utils";
 import { Card, CardContent } from "../ui/card";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
@@ -10,6 +14,7 @@ interface PoolMetricCardProps {
 	icon: React.ComponentType<{ className?: string }>;
 	result: PoolUsageResult;
 	now: number;
+	window: PoolWindow;
 }
 
 const REASON_LABELS: Record<ExcludedReason, string> = {
@@ -64,15 +69,25 @@ function nextRefreshLabel(
 	earliestResetMs: number,
 	accountName: string | null,
 	now: number,
+	window: PoolWindow,
 ): string {
 	const name = accountName ?? "unknown";
 	if (earliestResetMs <= now) {
 		return `${name} ready to refresh`;
 	}
-	const time = new Date(earliestResetMs).toLocaleTimeString(undefined, {
-		hour: "2-digit",
-		minute: "2-digit",
-	});
+	const date = new Date(earliestResetMs);
+	const time =
+		window === "seven_day"
+			? date.toLocaleString(undefined, {
+					month: "short",
+					day: "numeric",
+					hour: "2-digit",
+					minute: "2-digit",
+				})
+			: date.toLocaleTimeString(undefined, {
+					hour: "2-digit",
+					minute: "2-digit",
+				});
 	return `${name} at ${time}`;
 }
 
@@ -81,6 +96,7 @@ export function PoolMetricCard({
 	icon: Icon,
 	result,
 	now,
+	window,
 }: PoolMetricCardProps) {
 	const {
 		average,
@@ -184,7 +200,12 @@ export function PoolMetricCard({
 					<div>
 						<div className="font-medium mb-1">Next refresh</div>
 						<div>
-							{nextRefreshLabel(earliestResetMs, earliestResetAccountName, now)}
+							{nextRefreshLabel(
+								earliestResetMs,
+								earliestResetAccountName,
+								now,
+								window,
+							)}
 						</div>
 					</div>
 				)}

--- a/packages/dashboard-web/src/components/overview/PoolMetricCard.tsx
+++ b/packages/dashboard-web/src/components/overview/PoolMetricCard.tsx
@@ -104,7 +104,6 @@ export function PoolMetricCard({
 	const hasContributing = contributing.length > 0;
 	const hasExcluded = excluded.length > 0;
 	const hasFallback = fallback.length > 0;
-	const hasNextRefresh = earliestResetMs != null;
 
 	const triggerNode = showChip ? (
 		<Popover>
@@ -181,7 +180,7 @@ export function PoolMetricCard({
 						</ul>
 					</div>
 				)}
-				{hasNextRefresh && (
+				{earliestResetMs != null && (
 					<div>
 						<div className="font-medium mb-1">Next refresh</div>
 						<div>

--- a/packages/dashboard-web/src/components/overview/PoolMetricCard.tsx
+++ b/packages/dashboard-web/src/components/overview/PoolMetricCard.tsx
@@ -1,0 +1,218 @@
+import { formatPercentage } from "@better-ccflare/ui-common";
+import { Info } from "lucide-react";
+import type { ExcludedReason, PoolUsageResult } from "../../lib/pool-usage";
+import { cn } from "../../lib/utils";
+import { Card, CardContent } from "../ui/card";
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
+
+interface PoolMetricCardProps {
+	title: string;
+	icon: React.ComponentType<{ className?: string }>;
+	result: PoolUsageResult;
+	now: number;
+}
+
+const REASON_LABELS: Record<ExcludedReason, string> = {
+	paused: "Paused",
+	rate_limited: "Rate-limited",
+	token_expired: "OAuth token expired",
+	usage_rate_limited: "Usage data unavailable (provider 429)",
+	no_usage_data: "No usage data yet",
+};
+
+const REASON_ORDER: ExcludedReason[] = [
+	"paused",
+	"rate_limited",
+	"token_expired",
+	"usage_rate_limited",
+	"no_usage_data",
+];
+
+function headlineColor(average: number | null): string | undefined {
+	if (average == null) return undefined;
+	if (average < 60) return "text-success";
+	if (average < 80) return "text-warning";
+	return "text-destructive";
+}
+
+function groupExcluded(
+	excluded: PoolUsageResult["excluded"],
+): Array<{ reason: ExcludedReason; items: PoolUsageResult["excluded"] }> {
+	const map = new Map<ExcludedReason, PoolUsageResult["excluded"]>();
+	for (const entry of excluded) {
+		const bucket = map.get(entry.reason);
+		if (bucket) {
+			bucket.push(entry);
+		} else {
+			map.set(entry.reason, [entry]);
+		}
+	}
+	const groups: Array<{
+		reason: ExcludedReason;
+		items: PoolUsageResult["excluded"];
+	}> = [];
+	for (const reason of REASON_ORDER) {
+		const items = map.get(reason);
+		if (items && items.length > 0) {
+			groups.push({ reason, items });
+		}
+	}
+	return groups;
+}
+
+function nextRefreshLabel(
+	earliestResetMs: number,
+	accountName: string | null,
+	now: number,
+): string {
+	const name = accountName ?? "unknown";
+	if (earliestResetMs <= now) {
+		return `${name} ready to refresh`;
+	}
+	const time = new Date(earliestResetMs).toLocaleTimeString(undefined, {
+		hour: "2-digit",
+		minute: "2-digit",
+	});
+	return `${name} at ${time}`;
+}
+
+export function PoolMetricCard({
+	title,
+	icon: Icon,
+	result,
+	now,
+}: PoolMetricCardProps) {
+	const {
+		average,
+		worst,
+		contributing,
+		excluded,
+		fallback,
+		earliestResetMs,
+		earliestResetAccountName,
+	} = result;
+
+	const eligibleTotal = contributing.length + excluded.length;
+	const showChip = eligibleTotal > 0;
+	const colorClass = headlineColor(average);
+	const headline = average != null ? formatPercentage(average, 0) : "—";
+	const showSubline = contributing.length >= 2 && worst != null;
+
+	const sortedContributing = contributing.slice().sort((a, b) => b.pct - a.pct);
+	const excludedGroups = groupExcluded(excluded);
+
+	const hasContributing = contributing.length > 0;
+	const hasExcluded = excluded.length > 0;
+	const hasFallback = fallback.length > 0;
+	const hasNextRefresh = earliestResetMs != null;
+
+	const triggerNode = showChip ? (
+		<Popover>
+			<PopoverTrigger asChild>
+				<button
+					type="button"
+					className="flex items-center gap-1 text-xs text-muted-foreground cursor-help focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+				>
+					<span className="tabular-nums">
+						({contributing.length}/{eligibleTotal})
+					</span>
+					<Info className="h-3 w-3" />
+				</button>
+			</PopoverTrigger>
+			<PopoverContent className="w-72 text-xs space-y-3">
+				{hasContributing && (
+					<div>
+						<div className="font-medium mb-1">
+							Contributing ({contributing.length})
+						</div>
+						<ul className="space-y-0.5">
+							{sortedContributing.map((c) => (
+								<li
+									key={c.name}
+									className="flex items-center justify-between gap-2"
+								>
+									<span className="truncate" title={c.name}>
+										{c.name}
+									</span>
+									<span className="tabular-nums">{c.pct.toFixed(0)}%</span>
+								</li>
+							))}
+						</ul>
+					</div>
+				)}
+				{hasExcluded && (
+					<div>
+						<div className="font-medium mb-1">Excluded ({excluded.length})</div>
+						<div className="space-y-2">
+							{excludedGroups.map(({ reason, items }) => (
+								<div key={reason}>
+									<div className="text-muted-foreground">
+										{REASON_LABELS[reason]}
+									</div>
+									<ul className="ml-2 space-y-0.5">
+										{items.map((e) => (
+											<li key={e.name} className="truncate" title={e.name}>
+												{e.name}
+											</li>
+										))}
+									</ul>
+								</div>
+							))}
+						</div>
+					</div>
+				)}
+				{hasFallback && (
+					<div>
+						<div className="font-medium mb-1">Fallback ({fallback.length})</div>
+						<div className="text-muted-foreground mb-1">
+							Pay-as-you-go capacity, not counted in this pool.
+						</div>
+						<ul className="space-y-0.5">
+							{fallback.map((f) => (
+								<li
+									key={f.name}
+									className="truncate"
+									title={`${f.name} (${f.provider})`}
+								>
+									{f.name}{" "}
+									<span className="text-muted-foreground">({f.provider})</span>
+								</li>
+							))}
+						</ul>
+					</div>
+				)}
+				{hasNextRefresh && (
+					<div>
+						<div className="font-medium mb-1">Next refresh</div>
+						<div>
+							{nextRefreshLabel(earliestResetMs, earliestResetAccountName, now)}
+						</div>
+					</div>
+				)}
+			</PopoverContent>
+		</Popover>
+	) : null;
+
+	return (
+		<Card>
+			<CardContent className="p-6">
+				<div className="flex items-center justify-between mb-4">
+					<Icon className="h-8 w-8 text-muted-foreground/20" />
+					{triggerNode}
+				</div>
+				<div className="space-y-1">
+					<p className="text-sm text-muted-foreground">{title}</p>
+					<p className={cn("text-2xl font-bold", colorClass)}>{headline}</p>
+					{showSubline && worst && (
+						<p
+							className="text-xs text-muted-foreground truncate"
+							title={worst.name}
+						>
+							worst: {worst.pct.toFixed(0)}% ({worst.name})
+						</p>
+					)}
+				</div>
+			</CardContent>
+		</Card>
+	);
+}

--- a/packages/dashboard-web/src/lib/__tests__/pool-usage.test.ts
+++ b/packages/dashboard-web/src/lib/__tests__/pool-usage.test.ts
@@ -273,24 +273,38 @@ describe("computePoolUsage", () => {
 
 		const result = computePoolUsage(accounts, "five_hour", NOW);
 		expect(result.contributing).toEqual([]);
-		expect(result.excluded).toEqual([{ name: "p", reason: "paused" }]);
+		expect(result.exhausted).toEqual([{ name: "p", reason: "paused" }]);
+		expect(result.excluded).toEqual([]);
+		expect(result.average).toBe(100);
 	});
 
-	it("rate_limited account (rateLimitedUntil > now) → excluded reason rate_limited", () => {
+	it("rate_limited account (rateLimitedUntil > now) counts as exhausted capacity", () => {
 		const accounts: AccountResponse[] = [
+			mkAccount({
+				name: "active",
+				provider: "anthropic",
+				usageData: {
+					five_hour: { utilization: 20, resets_at: null },
+					seven_day: { utilization: 20, resets_at: null },
+				} as never,
+			}),
 			mkAccount({
 				name: "rl",
 				provider: "anthropic",
 				rateLimitedUntil: NOW + 60_000,
 				usageData: {
-					five_hour: { utilization: 50, resets_at: null },
-					seven_day: { utilization: 50, resets_at: null },
+					five_hour: { utilization: 90, resets_at: null },
+					seven_day: { utilization: 90, resets_at: null },
 				} as never,
 			}),
 		];
 
 		const result = computePoolUsage(accounts, "five_hour", NOW);
-		expect(result.excluded).toEqual([{ name: "rl", reason: "rate_limited" }]);
+		expect(result.average).toBe(60);
+		expect(result.activeAverage).toBe(20);
+		expect(result.contributing).toHaveLength(1);
+		expect(result.exhausted).toEqual([{ name: "rl", reason: "rate_limited" }]);
+		expect(result.excluded).toEqual([]);
 	});
 
 	it("token_expired requires hasRefreshToken=true and parsed time < now", () => {
@@ -308,7 +322,9 @@ describe("computePoolUsage", () => {
 		];
 
 		const result = computePoolUsage(accounts, "five_hour", NOW);
-		expect(result.excluded).toEqual([{ name: "te", reason: "token_expired" }]);
+		expect(result.exhausted).toEqual([{ name: "te", reason: "token_expired" }]);
+		expect(result.excluded).toEqual([]);
+		expect(result.average).toBe(100);
 	});
 
 	it("usage_rate_limited when usageRateLimitedUntil > now AND no usageData", () => {
@@ -322,9 +338,11 @@ describe("computePoolUsage", () => {
 		];
 
 		const result = computePoolUsage(accounts, "five_hour", NOW);
-		expect(result.excluded).toEqual([
+		expect(result.exhausted).toEqual([
 			{ name: "url", reason: "usage_rate_limited" },
 		]);
+		expect(result.excluded).toEqual([]);
+		expect(result.average).toBe(100);
 	});
 
 	it("no_usage_data when eligible provider has usageData === null and is not rate-limited", () => {

--- a/packages/dashboard-web/src/lib/__tests__/pool-usage.test.ts
+++ b/packages/dashboard-web/src/lib/__tests__/pool-usage.test.ts
@@ -1,0 +1,472 @@
+import { describe, expect, it } from "bun:test";
+import type { AccountResponse } from "@better-ccflare/types";
+import {
+	computePoolUsage,
+	isAlibabaShape,
+	isAnthropicStyleShape,
+	isNanoGPTShape,
+	isZaiShape,
+	normalizeResetMs,
+} from "../pool-usage";
+
+const NOW = 1_700_000_000_000;
+
+function mkAccount(partial: Partial<AccountResponse>): AccountResponse {
+	return {
+		id: partial.id ?? "id",
+		name: partial.name ?? "acc",
+		provider: partial.provider ?? "anthropic",
+		requestCount: 0,
+		totalRequests: 0,
+		lastUsed: null,
+		created: new Date(NOW).toISOString(),
+		paused: false,
+		tokenStatus: "valid",
+		tokenExpiresAt: null,
+		rateLimitStatus: "OK",
+		rateLimitReset: null,
+		rateLimitRemaining: null,
+		rateLimitedUntil: null,
+		rateLimitedReason: null,
+		rateLimitedAt: null,
+		sessionInfo: "",
+		priority: 0,
+		autoFallbackEnabled: false,
+		autoRefreshEnabled: false,
+		autoPauseOnOverageEnabled: false,
+		peakHoursPauseEnabled: false,
+		customEndpoint: null,
+		modelMappings: null,
+		usageUtilization: null,
+		usageWindow: null,
+		usageData: null,
+		usageRateLimitedUntil: null,
+		usageThrottledUntil: null,
+		usageThrottledWindows: [],
+		hasRefreshToken: true,
+		crossRegionMode: null,
+		modelFallbacks: null,
+		billingType: null,
+		sessionStats: null,
+		...partial,
+	};
+}
+
+describe("normalizeResetMs", () => {
+	it("returns null for null/undefined", () => {
+		expect(normalizeResetMs(null)).toBeNull();
+		expect(normalizeResetMs(undefined)).toBeNull();
+	});
+
+	it("returns finite numbers as-is", () => {
+		expect(normalizeResetMs(1_700_000_000_000)).toBe(1_700_000_000_000);
+	});
+
+	it("returns null for non-finite numbers", () => {
+		expect(normalizeResetMs(Number.NaN)).toBeNull();
+		expect(normalizeResetMs(Number.POSITIVE_INFINITY)).toBeNull();
+	});
+
+	it("parses ISO strings", () => {
+		const iso = "2024-01-01T00:00:00.000Z";
+		expect(normalizeResetMs(iso)).toBe(Date.parse(iso));
+	});
+
+	it("returns null for unparseable strings", () => {
+		expect(normalizeResetMs("not-a-date")).toBeNull();
+	});
+});
+
+describe("shape detectors", () => {
+	it("isNanoGPTShape true for NanoGPT data", () => {
+		expect(
+			isNanoGPTShape({
+				active: true,
+				daily: { used: 0, remaining: 0, percentUsed: 0, resetAt: 0 },
+				monthly: { used: 0, remaining: 0, percentUsed: 0, resetAt: 0 },
+			} as never),
+		).toBe(true);
+	});
+
+	it("isAlibabaShape true for Alibaba data", () => {
+		expect(
+			isAlibabaShape({
+				five_hour: { percentUsed: 0, resetAt: 0 },
+				weekly: { percentUsed: 0, resetAt: 0 },
+			} as never),
+		).toBe(true);
+	});
+
+	it("isZaiShape true when tokens_limit present", () => {
+		expect(
+			isZaiShape({
+				tokens_limit: { percentage: 0, resetAt: 0 },
+			} as never),
+		).toBe(true);
+	});
+
+	it("isAnthropicStyleShape excludes alibaba/zai/nanogpt", () => {
+		expect(
+			isAnthropicStyleShape({
+				five_hour: { utilization: 0, resets_at: null },
+				seven_day: { utilization: 0, resets_at: null },
+			} as never),
+		).toBe(true);
+		expect(
+			isAnthropicStyleShape({
+				five_hour: { percentUsed: 0, resetAt: 0 },
+				weekly: { percentUsed: 0, resetAt: 0 },
+			} as never),
+		).toBe(false);
+	});
+});
+
+describe("computePoolUsage", () => {
+	it("returns empty for empty accounts", () => {
+		const result = computePoolUsage([], "five_hour", NOW);
+		expect(result.average).toBeNull();
+		expect(result.worst).toBeNull();
+		expect(result.contributing).toEqual([]);
+		expect(result.excluded).toEqual([]);
+		expect(result.fallback).toEqual([]);
+		expect(result.earliestResetMs).toBeNull();
+		expect(result.earliestResetAccountName).toBeNull();
+	});
+
+	it("averages Anthropic + Codex for 5h pool", () => {
+		const accounts: AccountResponse[] = [
+			mkAccount({
+				name: "anthro-a",
+				provider: "anthropic",
+				usageData: {
+					five_hour: { utilization: 40, resets_at: null },
+					seven_day: { utilization: 20, resets_at: null },
+				} as never,
+			}),
+			mkAccount({
+				name: "codex-b",
+				provider: "codex",
+				usageData: {
+					five_hour: { utilization: 60, resets_at: null },
+					seven_day: { utilization: 30, resets_at: null },
+				} as never,
+			}),
+		];
+
+		const five = computePoolUsage(accounts, "five_hour", NOW);
+		expect(five.average).toBe(50);
+		expect(five.worst).toEqual({ name: "codex-b", pct: 60 });
+		expect(five.contributing).toHaveLength(2);
+		expect(five.excluded).toEqual([]);
+		expect(five.fallback).toEqual([]);
+
+		const seven = computePoolUsage(accounts, "seven_day", NOW);
+		expect(seven.average).toBe(25);
+		expect(seven.worst).toEqual({ name: "codex-b", pct: 30 });
+	});
+
+	it("Alibaba contributes to both pools via percentUsed", () => {
+		const accounts: AccountResponse[] = [
+			mkAccount({
+				name: "alibaba",
+				provider: "alibaba-coding-plan",
+				usageData: {
+					five_hour: { percentUsed: 45, resetAt: NOW + 1_000_000 },
+					weekly: { percentUsed: 70, resetAt: NOW + 2_000_000 },
+					monthly: { percentUsed: 80, resetAt: NOW + 3_000_000 },
+				} as never,
+			}),
+		];
+
+		const five = computePoolUsage(accounts, "five_hour", NOW);
+		expect(five.contributing).toHaveLength(1);
+		expect(five.contributing[0].pct).toBe(45);
+		expect(five.contributing[0].resetMs).toBe(NOW + 1_000_000);
+
+		const seven = computePoolUsage(accounts, "seven_day", NOW);
+		expect(seven.contributing).toHaveLength(1);
+		expect(seven.contributing[0].pct).toBe(70);
+		expect(seven.contributing[0].resetMs).toBe(NOW + 2_000_000);
+	});
+
+	it("Zai contributes to 5h via tokens_limit.percentage but is fallback for 7d", () => {
+		const accounts: AccountResponse[] = [
+			mkAccount({
+				name: "zai-1",
+				provider: "zai",
+				hasRefreshToken: false,
+				usageData: {
+					tokens_limit: { percentage: 33, resetAt: NOW + 1000 },
+					time_limit: { percentage: 90, resetAt: NOW + 2000 },
+				} as never,
+			}),
+		];
+
+		const five = computePoolUsage(accounts, "five_hour", NOW);
+		expect(five.contributing).toHaveLength(1);
+		expect(five.contributing[0].pct).toBe(33);
+		expect(five.fallback).toEqual([]);
+
+		const seven = computePoolUsage(accounts, "seven_day", NOW);
+		expect(seven.contributing).toEqual([]);
+		expect(seven.fallback).toEqual([{ name: "zai-1", provider: "zai" }]);
+	});
+
+	it("claude-console-api goes to fallback for both pools", () => {
+		const accounts: AccountResponse[] = [
+			mkAccount({
+				name: "console",
+				provider: "claude-console-api",
+				hasRefreshToken: false,
+				usageData: null,
+			}),
+		];
+
+		const five = computePoolUsage(accounts, "five_hour", NOW);
+		expect(five.fallback).toEqual([
+			{ name: "console", provider: "claude-console-api" },
+		]);
+		expect(five.excluded).toEqual([]);
+		expect(five.contributing).toEqual([]);
+
+		const seven = computePoolUsage(accounts, "seven_day", NOW);
+		expect(seven.fallback).toEqual([
+			{ name: "console", provider: "claude-console-api" },
+		]);
+	});
+
+	it("Anthropic with seven_day.utilization null: contributing to 5h, no_usage_data for 7d", () => {
+		const accounts: AccountResponse[] = [
+			mkAccount({
+				name: "anthro",
+				provider: "anthropic",
+				usageData: {
+					five_hour: { utilization: 25, resets_at: null },
+					seven_day: { utilization: null, resets_at: null },
+				} as never,
+			}),
+		];
+
+		const five = computePoolUsage(accounts, "five_hour", NOW);
+		expect(five.contributing).toHaveLength(1);
+		expect(five.contributing[0].pct).toBe(25);
+
+		const seven = computePoolUsage(accounts, "seven_day", NOW);
+		expect(seven.contributing).toEqual([]);
+		expect(seven.excluded).toEqual([
+			{ name: "anthro", reason: "no_usage_data" },
+		]);
+	});
+
+	it("paused account → excluded reason paused", () => {
+		const accounts: AccountResponse[] = [
+			mkAccount({
+				name: "p",
+				provider: "anthropic",
+				paused: true,
+				usageData: {
+					five_hour: { utilization: 50, resets_at: null },
+					seven_day: { utilization: 50, resets_at: null },
+				} as never,
+			}),
+		];
+
+		const result = computePoolUsage(accounts, "five_hour", NOW);
+		expect(result.contributing).toEqual([]);
+		expect(result.excluded).toEqual([{ name: "p", reason: "paused" }]);
+	});
+
+	it("rate_limited account (rateLimitedUntil > now) → excluded reason rate_limited", () => {
+		const accounts: AccountResponse[] = [
+			mkAccount({
+				name: "rl",
+				provider: "anthropic",
+				rateLimitedUntil: NOW + 60_000,
+				usageData: {
+					five_hour: { utilization: 50, resets_at: null },
+					seven_day: { utilization: 50, resets_at: null },
+				} as never,
+			}),
+		];
+
+		const result = computePoolUsage(accounts, "five_hour", NOW);
+		expect(result.excluded).toEqual([{ name: "rl", reason: "rate_limited" }]);
+	});
+
+	it("token_expired requires hasRefreshToken=true and parsed time < now", () => {
+		const accounts: AccountResponse[] = [
+			mkAccount({
+				name: "te",
+				provider: "anthropic",
+				hasRefreshToken: true,
+				tokenExpiresAt: new Date(NOW - 60_000).toISOString(),
+				usageData: {
+					five_hour: { utilization: 50, resets_at: null },
+					seven_day: { utilization: 50, resets_at: null },
+				} as never,
+			}),
+		];
+
+		const result = computePoolUsage(accounts, "five_hour", NOW);
+		expect(result.excluded).toEqual([{ name: "te", reason: "token_expired" }]);
+	});
+
+	it("usage_rate_limited when usageRateLimitedUntil > now AND no usageData", () => {
+		const accounts: AccountResponse[] = [
+			mkAccount({
+				name: "url",
+				provider: "anthropic",
+				usageRateLimitedUntil: NOW + 60_000,
+				usageData: null,
+			}),
+		];
+
+		const result = computePoolUsage(accounts, "five_hour", NOW);
+		expect(result.excluded).toEqual([
+			{ name: "url", reason: "usage_rate_limited" },
+		]);
+	});
+
+	it("no_usage_data when eligible provider has usageData === null and is not rate-limited", () => {
+		const accounts: AccountResponse[] = [
+			mkAccount({
+				name: "nud",
+				provider: "anthropic",
+				usageData: null,
+			}),
+		];
+
+		const result = computePoolUsage(accounts, "five_hour", NOW);
+		expect(result.excluded).toEqual([{ name: "nud", reason: "no_usage_data" }]);
+	});
+
+	it("API-key provider (hasRefreshToken=false) with tokenStatus=expired is NOT token_expired excluded", () => {
+		const accounts: AccountResponse[] = [
+			mkAccount({
+				name: "api-key",
+				provider: "zai",
+				hasRefreshToken: false,
+				tokenStatus: "expired",
+				tokenExpiresAt: new Date(NOW - 60_000).toISOString(),
+				usageData: {
+					tokens_limit: { percentage: 22, resetAt: NOW + 1000 },
+				} as never,
+			}),
+		];
+
+		const result = computePoolUsage(accounts, "five_hour", NOW);
+		expect(result.excluded).toEqual([]);
+		expect(result.contributing).toHaveLength(1);
+		expect(result.contributing[0].pct).toBe(22);
+	});
+
+	it("earliestResetMs filters nulls and picks min; earliestResetAccountName matches", () => {
+		const accounts: AccountResponse[] = [
+			mkAccount({
+				name: "a",
+				provider: "anthropic",
+				usageData: {
+					five_hour: {
+						utilization: 10,
+						resets_at: new Date(NOW + 5_000_000).toISOString(),
+					},
+					seven_day: { utilization: 0, resets_at: null },
+				} as never,
+			}),
+			mkAccount({
+				name: "b",
+				provider: "anthropic",
+				usageData: {
+					five_hour: {
+						utilization: 20,
+						resets_at: new Date(NOW + 1_000_000).toISOString(),
+					},
+					seven_day: { utilization: 0, resets_at: null },
+				} as never,
+			}),
+			mkAccount({
+				name: "c",
+				provider: "anthropic",
+				usageData: {
+					five_hour: { utilization: 30, resets_at: null },
+					seven_day: { utilization: 0, resets_at: null },
+				} as never,
+			}),
+		];
+
+		const result = computePoolUsage(accounts, "five_hour", NOW);
+		expect(result.earliestResetMs).toBe(NOW + 1_000_000);
+		expect(result.earliestResetAccountName).toBe("b");
+	});
+
+	it("single contributing → returns worst (UI handles suppression)", () => {
+		const accounts: AccountResponse[] = [
+			mkAccount({
+				name: "solo",
+				provider: "anthropic",
+				usageData: {
+					five_hour: { utilization: 42, resets_at: null },
+					seven_day: { utilization: 0, resets_at: null },
+				} as never,
+			}),
+		];
+
+		const result = computePoolUsage(accounts, "five_hour", NOW);
+		expect(result.contributing).toHaveLength(1);
+		expect(result.worst).toEqual({ name: "solo", pct: 42 });
+	});
+
+	it("Anthropic with seven_day_opus/seven_day_sonnet populated: only seven_day counts", () => {
+		const accounts: AccountResponse[] = [
+			mkAccount({
+				name: "anthro",
+				provider: "anthropic",
+				usageData: {
+					five_hour: { utilization: 10, resets_at: null },
+					seven_day: { utilization: 50, resets_at: null },
+					seven_day_opus: { utilization: 90, resets_at: null },
+					seven_day_sonnet: { utilization: 99, resets_at: null },
+					seven_day_oauth_apps: { utilization: 88, resets_at: null },
+				} as never,
+			}),
+		];
+
+		const result = computePoolUsage(accounts, "seven_day", NOW);
+		expect(result.contributing).toHaveLength(1);
+		expect(result.contributing[0].pct).toBe(50);
+		expect(result.average).toBe(50);
+	});
+
+	it("three contributing accounts 30/60/87 → average 59, worst points at 87% account", () => {
+		const accounts: AccountResponse[] = [
+			mkAccount({
+				name: "low",
+				provider: "anthropic",
+				usageData: {
+					five_hour: { utilization: 30, resets_at: null },
+					seven_day: { utilization: 0, resets_at: null },
+				} as never,
+			}),
+			mkAccount({
+				name: "mid",
+				provider: "anthropic",
+				usageData: {
+					five_hour: { utilization: 60, resets_at: null },
+					seven_day: { utilization: 0, resets_at: null },
+				} as never,
+			}),
+			mkAccount({
+				name: "high",
+				provider: "anthropic",
+				usageData: {
+					five_hour: { utilization: 87, resets_at: null },
+					seven_day: { utilization: 0, resets_at: null },
+				} as never,
+			}),
+		];
+
+		const result = computePoolUsage(accounts, "five_hour", NOW);
+		expect(result.average).toBe(59);
+		expect(result.worst).toEqual({ name: "high", pct: 87 });
+	});
+});

--- a/packages/dashboard-web/src/lib/__tests__/pool-usage.test.ts
+++ b/packages/dashboard-web/src/lib/__tests__/pool-usage.test.ts
@@ -496,6 +496,142 @@ describe("computePoolUsage", () => {
 		expect(result.worst).toEqual({ name: "high", pct: 87 });
 	});
 
+	describe("atRisk projection", () => {
+		const FIVE_HOUR_MS = 5 * 60 * 60 * 1000;
+		const SEVEN_DAY_MS = 7 * 24 * 60 * 60 * 1000;
+
+		function mkAnthropicAt(
+			name: string,
+			pct: number,
+			resetMs: number | null,
+		): AccountResponse {
+			return mkAccount({
+				name,
+				provider: "anthropic",
+				usageData: {
+					five_hour: {
+						utilization: pct,
+						resets_at: resetMs == null ? null : new Date(resetMs).toISOString(),
+					},
+					seven_day: { utilization: 0, resets_at: null },
+				} as never,
+			});
+		}
+
+		it("flags account burning faster than linear pace as at-risk", () => {
+			// 4.5h elapsed of a 5h window, 90% used → time-to-exhaust 30m, remaining 30m
+			// Use 91% to push timeToExhaust strictly below remaining.
+			const elapsedMs = 4.5 * 60 * 60 * 1000;
+			const resetMs = NOW + (FIVE_HOUR_MS - elapsedMs);
+			const account = mkAnthropicAt("burner", 91, resetMs);
+
+			const result = computePoolUsage([account], "five_hour", NOW);
+
+			expect(result.atRisk).toHaveLength(1);
+			expect(result.atRisk[0].name).toBe("burner");
+			expect(result.atRisk[0].pct).toBe(91);
+			expect(result.atRisk[0].resetMs).toBe(resetMs);
+			expect(result.atRisk[0].remainingMs).toBe(FIVE_HOUR_MS - elapsedMs);
+			expect(result.atRisk[0].exhaustsAtMs).toBeGreaterThan(NOW);
+			expect(result.atRisk[0].exhaustsAtMs).toBeLessThan(resetMs);
+		});
+
+		it("does not flag account on linear pace boundary (timeToExhaust === remaining)", () => {
+			// 1h elapsed of 5h window, 20% used → on perfect linear pace; will exactly
+			// reach 100% at reset. timeToExhaustMs === remainingMs, not strictly less.
+			const elapsedMs = 1 * 60 * 60 * 1000;
+			const resetMs = NOW + (FIVE_HOUR_MS - elapsedMs);
+			const account = mkAnthropicAt("steady", 20, resetMs);
+
+			const result = computePoolUsage([account], "five_hour", NOW);
+
+			expect(result.atRisk).toEqual([]);
+		});
+
+		it("does not flag account strictly under linear pace", () => {
+			// 1h elapsed of 5h window, 10% used → timeToExhaust = 9h, remaining = 4h.
+			// Far under pace; should never appear in atRisk.
+			const elapsedMs = 1 * 60 * 60 * 1000;
+			const resetMs = NOW + (FIVE_HOUR_MS - elapsedMs);
+			const account = mkAnthropicAt("slow", 10, resetMs);
+
+			const result = computePoolUsage([account], "five_hour", NOW);
+
+			expect(result.contributing).toHaveLength(1);
+			expect(result.atRisk).toEqual([]);
+		});
+
+		it("skips contributing accounts with resetMs === null", () => {
+			const account = mkAnthropicAt("nullreset", 95, null);
+
+			const result = computePoolUsage([account], "five_hour", NOW);
+
+			expect(result.contributing).toHaveLength(1);
+			expect(result.atRisk).toEqual([]);
+		});
+
+		it("skips contributing accounts with 0% usage (no rate to project)", () => {
+			const elapsedMs = 1 * 60 * 60 * 1000;
+			const resetMs = NOW + (FIVE_HOUR_MS - elapsedMs);
+			const account = mkAnthropicAt("idle", 0, resetMs);
+
+			const result = computePoolUsage([account], "five_hour", NOW);
+
+			expect(result.atRisk).toEqual([]);
+		});
+
+		it("does not include exhausted accounts in atRisk (they are already in exhausted)", () => {
+			const elapsedMs = 4.5 * 60 * 60 * 1000;
+			const resetMs = NOW + (FIVE_HOUR_MS - elapsedMs);
+			const burner = mkAnthropicAt("burner", 95, resetMs);
+			const exhaustedAccount = mkAccount({
+				name: "exh",
+				provider: "anthropic",
+				usageData: {
+					five_hour: {
+						utilization: 100,
+						resets_at: new Date(NOW + 60_000).toISOString(),
+					},
+					seven_day: { utilization: 0, resets_at: null },
+				} as never,
+			});
+
+			const result = computePoolUsage(
+				[burner, exhaustedAccount],
+				"five_hour",
+				NOW,
+			);
+
+			expect(result.atRisk).toHaveLength(1);
+			expect(result.atRisk[0].name).toBe("burner");
+			expect(result.exhausted.map((e) => e.name)).toContain("exh");
+		});
+
+		it("projects 7d window correctly using SEVEN_DAY_MS", () => {
+			// 6 days elapsed of 7d window, 95% used → timeToExhaust ≈ 6d * 0.05/0.95 ≈ 7.6h
+			// remaining = 24h, so 7.6h < 24h → at risk.
+			const elapsedMs = 6 * 24 * 60 * 60 * 1000;
+			const resetMs = NOW + (SEVEN_DAY_MS - elapsedMs);
+			const account = mkAccount({
+				name: "weekly-burner",
+				provider: "anthropic",
+				usageData: {
+					five_hour: { utilization: 0, resets_at: null },
+					seven_day: {
+						utilization: 95,
+						resets_at: new Date(resetMs).toISOString(),
+					},
+				} as never,
+			});
+
+			const result = computePoolUsage([account], "seven_day", NOW);
+
+			expect(result.atRisk).toHaveLength(1);
+			expect(result.atRisk[0].name).toBe("weekly-burner");
+			expect(result.atRisk[0].resetMs).toBe(resetMs);
+		});
+	});
+
 	it("counts accounts exhausted in another quota window as unavailable 5h capacity", () => {
 		const accounts: AccountResponse[] = [
 			mkAccount({

--- a/packages/dashboard-web/src/lib/__tests__/pool-usage.test.ts
+++ b/packages/dashboard-web/src/lib/__tests__/pool-usage.test.ts
@@ -487,4 +487,65 @@ describe("computePoolUsage", () => {
 		expect(result.average).toBe(59);
 		expect(result.worst).toEqual({ name: "high", pct: 87 });
 	});
+
+	it("counts accounts exhausted in another quota window as unavailable 5h capacity", () => {
+		const accounts: AccountResponse[] = [
+			mkAccount({
+				name: "codex",
+				provider: "codex",
+				usageData: {
+					five_hour: { utilization: 28, resets_at: null },
+					seven_day: { utilization: 35, resets_at: null },
+				} as never,
+			}),
+			mkAccount({
+				name: "weekly-exhausted",
+				provider: "anthropic",
+				usageData: {
+					five_hour: { utilization: 31, resets_at: null },
+					seven_day: { utilization: 100, resets_at: null },
+				} as never,
+			}),
+			mkAccount({
+				name: "five-hour-exhausted",
+				provider: "anthropic",
+				usageData: {
+					five_hour: { utilization: 100, resets_at: null },
+					seven_day: { utilization: 30, resets_at: null },
+				} as never,
+			}),
+			mkAccount({
+				name: "both-exhausted",
+				provider: "anthropic",
+				usageData: {
+					five_hour: { utilization: 0, resets_at: null },
+					seven_day: { utilization: 100, resets_at: null },
+				} as never,
+			}),
+		];
+
+		const fiveHour = computePoolUsage(accounts, "five_hour", NOW);
+		expect(fiveHour.average).toBe(82);
+		expect(fiveHour.activeAverage).toBe(28);
+		expect(fiveHour.contributing).toEqual([
+			{ name: "codex", pct: 28, resetMs: null },
+		]);
+		expect(fiveHour.exhausted).toEqual([
+			{ name: "weekly-exhausted", reason: "seven_day_exhausted" },
+			{ name: "five-hour-exhausted", reason: "five_hour_exhausted" },
+			{ name: "both-exhausted", reason: "seven_day_exhausted" },
+		]);
+
+		const sevenDay = computePoolUsage(accounts, "seven_day", NOW);
+		expect(sevenDay.average).toBe(83.75);
+		expect(sevenDay.activeAverage).toBe(35);
+		expect(sevenDay.contributing).toEqual([
+			{ name: "codex", pct: 35, resetMs: null },
+		]);
+		expect(sevenDay.exhausted).toEqual([
+			{ name: "weekly-exhausted", reason: "seven_day_exhausted" },
+			{ name: "five-hour-exhausted", reason: "five_hour_exhausted" },
+			{ name: "both-exhausted", reason: "seven_day_exhausted" },
+		]);
+	});
 });

--- a/packages/dashboard-web/src/lib/__tests__/pool-usage.test.ts
+++ b/packages/dashboard-web/src/lib/__tests__/pool-usage.test.ts
@@ -254,7 +254,7 @@ describe("computePoolUsage", () => {
 		const seven = computePoolUsage(accounts, "seven_day", NOW);
 		expect(seven.contributing).toEqual([]);
 		expect(seven.excluded).toEqual([
-			{ name: "anthro", reason: "no_usage_data" },
+			{ name: "anthro", reason: "no_usage_data", resetMs: null },
 		]);
 	});
 
@@ -273,7 +273,9 @@ describe("computePoolUsage", () => {
 
 		const result = computePoolUsage(accounts, "five_hour", NOW);
 		expect(result.contributing).toEqual([]);
-		expect(result.exhausted).toEqual([{ name: "p", reason: "paused" }]);
+		expect(result.exhausted).toEqual([
+			{ name: "p", reason: "paused", resetMs: null },
+		]);
 		expect(result.excluded).toEqual([]);
 		expect(result.average).toBe(100);
 	});
@@ -303,7 +305,9 @@ describe("computePoolUsage", () => {
 		expect(result.average).toBe(60);
 		expect(result.activeAverage).toBe(20);
 		expect(result.contributing).toHaveLength(1);
-		expect(result.exhausted).toEqual([{ name: "rl", reason: "rate_limited" }]);
+		expect(result.exhausted).toEqual([
+			{ name: "rl", reason: "rate_limited", resetMs: NOW + 60_000 },
+		]);
 		expect(result.excluded).toEqual([]);
 	});
 
@@ -322,7 +326,9 @@ describe("computePoolUsage", () => {
 		];
 
 		const result = computePoolUsage(accounts, "five_hour", NOW);
-		expect(result.exhausted).toEqual([{ name: "te", reason: "token_expired" }]);
+		expect(result.exhausted).toEqual([
+			{ name: "te", reason: "token_expired", resetMs: null },
+		]);
 		expect(result.excluded).toEqual([]);
 		expect(result.average).toBe(100);
 	});
@@ -339,7 +345,7 @@ describe("computePoolUsage", () => {
 
 		const result = computePoolUsage(accounts, "five_hour", NOW);
 		expect(result.exhausted).toEqual([
-			{ name: "url", reason: "usage_rate_limited" },
+			{ name: "url", reason: "usage_rate_limited", resetMs: NOW + 60_000 },
 		]);
 		expect(result.excluded).toEqual([]);
 		expect(result.average).toBe(100);
@@ -355,7 +361,9 @@ describe("computePoolUsage", () => {
 		];
 
 		const result = computePoolUsage(accounts, "five_hour", NOW);
-		expect(result.excluded).toEqual([{ name: "nud", reason: "no_usage_data" }]);
+		expect(result.excluded).toEqual([
+			{ name: "nud", reason: "no_usage_data", resetMs: null },
+		]);
 	});
 
 	it("API-key provider (hasRefreshToken=false) with tokenStatus=expired is NOT token_expired excluded", () => {
@@ -503,14 +511,20 @@ describe("computePoolUsage", () => {
 				provider: "anthropic",
 				usageData: {
 					five_hour: { utilization: 31, resets_at: null },
-					seven_day: { utilization: 100, resets_at: null },
+					seven_day: {
+						utilization: 100,
+						resets_at: new Date(NOW + 5_000_000).toISOString(),
+					},
 				} as never,
 			}),
 			mkAccount({
 				name: "five-hour-exhausted",
 				provider: "anthropic",
 				usageData: {
-					five_hour: { utilization: 100, resets_at: null },
+					five_hour: {
+						utilization: 100,
+						resets_at: new Date(NOW + 1_000_000).toISOString(),
+					},
 					seven_day: { utilization: 30, resets_at: null },
 				} as never,
 			}),
@@ -531,10 +545,20 @@ describe("computePoolUsage", () => {
 			{ name: "codex", pct: 28, resetMs: null },
 		]);
 		expect(fiveHour.exhausted).toEqual([
-			{ name: "weekly-exhausted", reason: "seven_day_exhausted" },
-			{ name: "five-hour-exhausted", reason: "five_hour_exhausted" },
-			{ name: "both-exhausted", reason: "seven_day_exhausted" },
+			{
+				name: "weekly-exhausted",
+				reason: "seven_day_exhausted",
+				resetMs: NOW + 5_000_000,
+			},
+			{
+				name: "five-hour-exhausted",
+				reason: "five_hour_exhausted",
+				resetMs: NOW + 1_000_000,
+			},
+			{ name: "both-exhausted", reason: "seven_day_exhausted", resetMs: null },
 		]);
+		expect(fiveHour.earliestResetMs).toBe(NOW + 1_000_000);
+		expect(fiveHour.earliestResetAccountName).toBe("five-hour-exhausted");
 
 		const sevenDay = computePoolUsage(accounts, "seven_day", NOW);
 		expect(sevenDay.average).toBe(83.75);
@@ -543,9 +567,19 @@ describe("computePoolUsage", () => {
 			{ name: "codex", pct: 35, resetMs: null },
 		]);
 		expect(sevenDay.exhausted).toEqual([
-			{ name: "weekly-exhausted", reason: "seven_day_exhausted" },
-			{ name: "five-hour-exhausted", reason: "five_hour_exhausted" },
-			{ name: "both-exhausted", reason: "seven_day_exhausted" },
+			{
+				name: "weekly-exhausted",
+				reason: "seven_day_exhausted",
+				resetMs: NOW + 5_000_000,
+			},
+			{
+				name: "five-hour-exhausted",
+				reason: "five_hour_exhausted",
+				resetMs: NOW + 1_000_000,
+			},
+			{ name: "both-exhausted", reason: "seven_day_exhausted", resetMs: null },
 		]);
+		expect(sevenDay.earliestResetMs).toBe(NOW + 1_000_000);
+		expect(sevenDay.earliestResetAccountName).toBe("five-hour-exhausted");
 	});
 });

--- a/packages/dashboard-web/src/lib/pool-usage.ts
+++ b/packages/dashboard-web/src/lib/pool-usage.ts
@@ -1,0 +1,293 @@
+import type { AccountResponse, FullUsageData } from "@better-ccflare/types";
+
+export type PoolWindow = "five_hour" | "seven_day";
+
+export type ExcludedReason =
+	| "paused"
+	| "rate_limited"
+	| "token_expired"
+	| "usage_rate_limited"
+	| "no_usage_data";
+
+export interface PoolUsageContribution {
+	name: string;
+	pct: number;
+	resetMs: number | null;
+}
+
+export interface PoolUsageExclusion {
+	name: string;
+	reason: ExcludedReason;
+}
+
+export interface PoolUsageFallback {
+	name: string;
+	provider: string;
+}
+
+export interface PoolUsageResult {
+	average: number | null;
+	worst: { name: string; pct: number } | null;
+	contributing: PoolUsageContribution[];
+	excluded: PoolUsageExclusion[];
+	fallback: PoolUsageFallback[];
+	earliestResetMs: number | null;
+	earliestResetAccountName: string | null;
+}
+
+const FIVE_HOUR_ELIGIBLE_PROVIDERS: ReadonlySet<string> = new Set([
+	"anthropic",
+	"codex",
+	"alibaba-coding-plan",
+	"zai",
+]);
+
+const SEVEN_DAY_ELIGIBLE_PROVIDERS: ReadonlySet<string> = new Set([
+	"anthropic",
+	"codex",
+	"alibaba-coding-plan",
+]);
+
+export function normalizeResetMs(
+	value: string | number | null | undefined,
+): number | null {
+	if (value === null || value === undefined) return null;
+	if (typeof value === "number") {
+		return Number.isFinite(value) ? value : null;
+	}
+	if (typeof value === "string") {
+		const parsed = Date.parse(value);
+		return Number.isFinite(parsed) ? parsed : null;
+	}
+	return null;
+}
+
+export function isNanoGPTShape(
+	usageData: FullUsageData | null | undefined,
+): boolean {
+	return (
+		usageData != null &&
+		"active" in usageData &&
+		"daily" in usageData &&
+		"monthly" in usageData
+	);
+}
+
+export function isAlibabaShape(
+	usageData: FullUsageData | null | undefined,
+): boolean {
+	return usageData != null && "five_hour" in usageData && "weekly" in usageData;
+}
+
+export function isZaiShape(
+	usageData: FullUsageData | null | undefined,
+): boolean {
+	return (
+		usageData != null &&
+		("time_limit" in usageData || "tokens_limit" in usageData)
+	);
+}
+
+export function isAnthropicStyleShape(
+	usageData: FullUsageData | null | undefined,
+): boolean {
+	if (usageData == null) return false;
+	if (isNanoGPTShape(usageData)) return false;
+	if (isAlibabaShape(usageData)) return false;
+	if (isZaiShape(usageData)) return false;
+	return "five_hour" in usageData && "seven_day" in usageData;
+}
+
+interface ExtractedValue {
+	pct: number | null;
+	resetMs: number | null;
+}
+
+function extractFiveHour(usageData: FullUsageData): ExtractedValue | null {
+	if (isNanoGPTShape(usageData)) return null;
+	if (isAlibabaShape(usageData)) {
+		const data = usageData as {
+			five_hour: { percentUsed: number | null; resetAt: number | null };
+		};
+		return {
+			pct: data.five_hour?.percentUsed ?? null,
+			resetMs: normalizeResetMs(data.five_hour?.resetAt ?? null),
+		};
+	}
+	if (isZaiShape(usageData)) {
+		const data = usageData as {
+			tokens_limit?: {
+				percentage: number | null;
+				resetAt: number | null;
+			} | null;
+		};
+		const tokens = data.tokens_limit;
+		if (!tokens) {
+			return { pct: null, resetMs: null };
+		}
+		return {
+			pct: tokens.percentage ?? null,
+			resetMs: normalizeResetMs(tokens.resetAt ?? null),
+		};
+	}
+	if (isAnthropicStyleShape(usageData)) {
+		const data = usageData as {
+			five_hour?: { utilization: number | null; resets_at: string | null };
+		};
+		const five = data.five_hour;
+		if (!five) {
+			return { pct: null, resetMs: null };
+		}
+		return {
+			pct: five.utilization ?? null,
+			resetMs: normalizeResetMs(five.resets_at ?? null),
+		};
+	}
+	return null;
+}
+
+function extractSevenDay(usageData: FullUsageData): ExtractedValue | null {
+	if (isNanoGPTShape(usageData)) return null;
+	if (isAlibabaShape(usageData)) {
+		const data = usageData as {
+			weekly: { percentUsed: number | null; resetAt: number | null };
+		};
+		return {
+			pct: data.weekly?.percentUsed ?? null,
+			resetMs: normalizeResetMs(data.weekly?.resetAt ?? null),
+		};
+	}
+	if (isZaiShape(usageData)) {
+		return null;
+	}
+	if (isAnthropicStyleShape(usageData)) {
+		const data = usageData as {
+			seven_day?: { utilization: number | null; resets_at: string | null };
+		};
+		const seven = data.seven_day;
+		if (!seven) {
+			return { pct: null, resetMs: null };
+		}
+		return {
+			pct: seven.utilization ?? null,
+			resetMs: normalizeResetMs(seven.resets_at ?? null),
+		};
+	}
+	return null;
+}
+
+function eligibleProvidersFor(window: PoolWindow): ReadonlySet<string> {
+	return window === "five_hour"
+		? FIVE_HOUR_ELIGIBLE_PROVIDERS
+		: SEVEN_DAY_ELIGIBLE_PROVIDERS;
+}
+
+function classifyExclusion(
+	account: AccountResponse,
+	now: number,
+): ExcludedReason | null {
+	if (account.paused === true) return "paused";
+	if (account.rateLimitedUntil != null && account.rateLimitedUntil > now) {
+		return "rate_limited";
+	}
+	if (account.hasRefreshToken === true && account.tokenExpiresAt) {
+		const expiresMs = Date.parse(account.tokenExpiresAt);
+		if (Number.isFinite(expiresMs) && expiresMs < now) {
+			return "token_expired";
+		}
+	}
+	if (
+		account.usageRateLimitedUntil != null &&
+		account.usageRateLimitedUntil > now &&
+		!account.usageData
+	) {
+		return "usage_rate_limited";
+	}
+	return null;
+}
+
+export function computePoolUsage(
+	accounts: AccountResponse[],
+	window: PoolWindow,
+	now: number,
+): PoolUsageResult {
+	const contributing: PoolUsageContribution[] = [];
+	const excluded: PoolUsageExclusion[] = [];
+	const fallback: PoolUsageFallback[] = [];
+
+	const eligible = eligibleProvidersFor(window);
+
+	for (const account of accounts) {
+		if (!eligible.has(account.provider)) {
+			fallback.push({ name: account.name, provider: account.provider });
+			continue;
+		}
+
+		const exclusion = classifyExclusion(account, now);
+		if (exclusion) {
+			excluded.push({ name: account.name, reason: exclusion });
+			continue;
+		}
+
+		if (!account.usageData) {
+			excluded.push({ name: account.name, reason: "no_usage_data" });
+			continue;
+		}
+
+		const extracted =
+			window === "five_hour"
+				? extractFiveHour(account.usageData)
+				: extractSevenDay(account.usageData);
+
+		if (extracted === null) {
+			fallback.push({ name: account.name, provider: account.provider });
+			continue;
+		}
+
+		if (extracted.pct === null) {
+			excluded.push({ name: account.name, reason: "no_usage_data" });
+			continue;
+		}
+
+		contributing.push({
+			name: account.name,
+			pct: extracted.pct,
+			resetMs: extracted.resetMs,
+		});
+	}
+
+	const average =
+		contributing.length === 0
+			? null
+			: contributing.reduce((sum, c) => sum + c.pct, 0) / contributing.length;
+
+	let worst: { name: string; pct: number } | null = null;
+	for (const c of contributing) {
+		if (worst === null || c.pct > worst.pct) {
+			worst = { name: c.name, pct: c.pct };
+		}
+	}
+
+	const resetCandidates = contributing.filter(
+		(c): c is PoolUsageContribution & { resetMs: number } => c.resetMs != null,
+	);
+	const earliestResetMs =
+		resetCandidates.length === 0
+			? null
+			: Math.min(...resetCandidates.map((c) => c.resetMs));
+	const earliestResetAccountName =
+		earliestResetMs === null
+			? null
+			: (resetCandidates.find((c) => c.resetMs === earliestResetMs)?.name ??
+				null);
+
+	return {
+		average,
+		worst,
+		contributing,
+		excluded,
+		fallback,
+		earliestResetMs,
+		earliestResetAccountName,
+	};
+}

--- a/packages/dashboard-web/src/lib/pool-usage.ts
+++ b/packages/dashboard-web/src/lib/pool-usage.ts
@@ -27,8 +27,10 @@ export interface PoolUsageFallback {
 
 export interface PoolUsageResult {
 	average: number | null;
+	activeAverage: number | null;
 	worst: { name: string; pct: number } | null;
 	contributing: PoolUsageContribution[];
+	exhausted: PoolUsageExclusion[];
 	excluded: PoolUsageExclusion[];
 	fallback: PoolUsageFallback[];
 	earliestResetMs: number | null;
@@ -212,6 +214,7 @@ export function computePoolUsage(
 	now: number,
 ): PoolUsageResult {
 	const contributing: PoolUsageContribution[] = [];
+	const exhausted: PoolUsageExclusion[] = [];
 	const excluded: PoolUsageExclusion[] = [];
 	const fallback: PoolUsageFallback[] = [];
 
@@ -225,7 +228,7 @@ export function computePoolUsage(
 
 		const exclusion = classifyExclusion(account, now);
 		if (exclusion) {
-			excluded.push({ name: account.name, reason: exclusion });
+			exhausted.push({ name: account.name, reason: exclusion });
 			continue;
 		}
 
@@ -256,15 +259,27 @@ export function computePoolUsage(
 		});
 	}
 
-	const average =
+	const activeAverage =
 		contributing.length === 0
 			? null
 			: contributing.reduce((sum, c) => sum + c.pct, 0) / contributing.length;
+	const capacityCount = contributing.length + exhausted.length;
+	const average =
+		capacityCount === 0
+			? null
+			: (contributing.reduce((sum, c) => sum + c.pct, 0) +
+					exhausted.length * 100) /
+				capacityCount;
 
 	let worst: { name: string; pct: number } | null = null;
 	for (const c of contributing) {
 		if (worst === null || c.pct > worst.pct) {
 			worst = { name: c.name, pct: c.pct };
+		}
+	}
+	for (const e of exhausted) {
+		if (worst === null || 100 > worst.pct) {
+			worst = { name: e.name, pct: 100 };
 		}
 	}
 
@@ -283,8 +298,10 @@ export function computePoolUsage(
 
 	return {
 		average,
+		activeAverage,
 		worst,
 		contributing,
+		exhausted,
 		excluded,
 		fallback,
 		earliestResetMs,

--- a/packages/dashboard-web/src/lib/pool-usage.ts
+++ b/packages/dashboard-web/src/lib/pool-usage.ts
@@ -20,6 +20,7 @@ export interface PoolUsageContribution {
 export interface PoolUsageExclusion {
 	name: string;
 	reason: ExcludedReason;
+	resetMs: number | null;
 }
 
 export interface PoolUsageFallback {
@@ -189,15 +190,15 @@ function eligibleProvidersFor(window: PoolWindow): ReadonlySet<string> {
 function classifyExclusion(
 	account: AccountResponse,
 	now: number,
-): ExcludedReason | null {
-	if (account.paused === true) return "paused";
+): { reason: ExcludedReason; resetMs: number | null } | null {
+	if (account.paused === true) return { reason: "paused", resetMs: null };
 	if (account.rateLimitedUntil != null && account.rateLimitedUntil > now) {
-		return "rate_limited";
+		return { reason: "rate_limited", resetMs: account.rateLimitedUntil };
 	}
 	if (account.hasRefreshToken === true && account.tokenExpiresAt) {
 		const expiresMs = Date.parse(account.tokenExpiresAt);
 		if (Number.isFinite(expiresMs) && expiresMs < now) {
-			return "token_expired";
+			return { reason: "token_expired", resetMs: null };
 		}
 	}
 	if (
@@ -205,24 +206,27 @@ function classifyExclusion(
 		account.usageRateLimitedUntil > now &&
 		!account.usageData
 	) {
-		return "usage_rate_limited";
+		return {
+			reason: "usage_rate_limited",
+			resetMs: account.usageRateLimitedUntil,
+		};
 	}
 	return null;
 }
 
 function classifyQuotaExhaustion(
 	account: AccountResponse,
-): ExcludedReason | null {
+): { reason: ExcludedReason; resetMs: number | null } | null {
 	if (!account.usageData) return null;
 
 	const fiveHour = extractFiveHour(account.usageData);
 	if (fiveHour?.pct != null && fiveHour.pct >= 100) {
-		return "five_hour_exhausted";
+		return { reason: "five_hour_exhausted", resetMs: fiveHour.resetMs };
 	}
 
 	const sevenDay = extractSevenDay(account.usageData);
 	if (sevenDay?.pct != null && sevenDay.pct >= 100) {
-		return "seven_day_exhausted";
+		return { reason: "seven_day_exhausted", resetMs: sevenDay.resetMs };
 	}
 
 	return null;
@@ -249,12 +253,20 @@ export function computePoolUsage(
 		const exclusion =
 			classifyExclusion(account, now) ?? classifyQuotaExhaustion(account);
 		if (exclusion) {
-			exhausted.push({ name: account.name, reason: exclusion });
+			exhausted.push({
+				name: account.name,
+				reason: exclusion.reason,
+				resetMs: exclusion.resetMs,
+			});
 			continue;
 		}
 
 		if (!account.usageData) {
-			excluded.push({ name: account.name, reason: "no_usage_data" });
+			excluded.push({
+				name: account.name,
+				reason: "no_usage_data",
+				resetMs: null,
+			});
 			continue;
 		}
 
@@ -269,7 +281,11 @@ export function computePoolUsage(
 		}
 
 		if (extracted.pct === null) {
-			excluded.push({ name: account.name, reason: "no_usage_data" });
+			excluded.push({
+				name: account.name,
+				reason: "no_usage_data",
+				resetMs: extracted.resetMs,
+			});
 			continue;
 		}
 
@@ -304,8 +320,9 @@ export function computePoolUsage(
 		}
 	}
 
-	const resetCandidates = contributing.filter(
-		(c): c is PoolUsageContribution & { resetMs: number } => c.resetMs != null,
+	const resetCandidates = [...contributing, ...exhausted].filter(
+		(c): (PoolUsageContribution | PoolUsageExclusion) & { resetMs: number } =>
+			c.resetMs != null && c.resetMs > now,
 	);
 	const earliestResetMs =
 		resetCandidates.length === 0

--- a/packages/dashboard-web/src/lib/pool-usage.ts
+++ b/packages/dashboard-web/src/lib/pool-usage.ts
@@ -7,6 +7,8 @@ export type ExcludedReason =
 	| "rate_limited"
 	| "token_expired"
 	| "usage_rate_limited"
+	| "five_hour_exhausted"
+	| "seven_day_exhausted"
 	| "no_usage_data";
 
 export interface PoolUsageContribution {
@@ -208,6 +210,24 @@ function classifyExclusion(
 	return null;
 }
 
+function classifyQuotaExhaustion(
+	account: AccountResponse,
+): ExcludedReason | null {
+	if (!account.usageData) return null;
+
+	const fiveHour = extractFiveHour(account.usageData);
+	if (fiveHour?.pct != null && fiveHour.pct >= 100) {
+		return "five_hour_exhausted";
+	}
+
+	const sevenDay = extractSevenDay(account.usageData);
+	if (sevenDay?.pct != null && sevenDay.pct >= 100) {
+		return "seven_day_exhausted";
+	}
+
+	return null;
+}
+
 export function computePoolUsage(
 	accounts: AccountResponse[],
 	window: PoolWindow,
@@ -226,7 +246,8 @@ export function computePoolUsage(
 			continue;
 		}
 
-		const exclusion = classifyExclusion(account, now);
+		const exclusion =
+			classifyExclusion(account, now) ?? classifyQuotaExhaustion(account);
 		if (exclusion) {
 			exhausted.push({ name: account.name, reason: exclusion });
 			continue;

--- a/packages/dashboard-web/src/lib/pool-usage.ts
+++ b/packages/dashboard-web/src/lib/pool-usage.ts
@@ -1,3 +1,4 @@
+import { computeWindowStartMs } from "@better-ccflare/core";
 import type { AccountResponse, FullUsageData } from "@better-ccflare/types";
 
 export type PoolWindow = "five_hour" | "seven_day";
@@ -15,6 +16,14 @@ export interface PoolUsageContribution {
 	name: string;
 	pct: number;
 	resetMs: number | null;
+}
+
+export interface PoolUsageProjection
+	extends Omit<PoolUsageContribution, "resetMs"> {
+	resetMs: number;
+	exhaustsAtMs: number;
+	timeToExhaustMs: number;
+	remainingMs: number;
 }
 
 export interface PoolUsageExclusion {
@@ -38,6 +47,7 @@ export interface PoolUsageResult {
 	fallback: PoolUsageFallback[];
 	earliestResetMs: number | null;
 	earliestResetAccountName: string | null;
+	atRisk: PoolUsageProjection[];
 }
 
 const FIVE_HOUR_ELIGIBLE_PROVIDERS: ReadonlySet<string> = new Set([
@@ -334,6 +344,29 @@ export function computePoolUsage(
 			: (resetCandidates.find((c) => c.resetMs === earliestResetMs)?.name ??
 				null);
 
+	const atRisk: PoolUsageProjection[] = [];
+	for (const c of contributing) {
+		if (c.resetMs == null) continue;
+		const startMs = computeWindowStartMs(c.resetMs, window);
+		if (startMs == null) continue;
+		const elapsed = now - startMs;
+		const remainingMs = c.resetMs - now;
+		if (elapsed <= 0 || remainingMs <= 0) continue;
+		const f = c.pct / 100;
+		if (f <= 0 || f >= 1) continue;
+		const timeToExhaustMs = ((1 - f) / f) * elapsed;
+		if (timeToExhaustMs < remainingMs) {
+			atRisk.push({
+				name: c.name,
+				pct: c.pct,
+				resetMs: c.resetMs,
+				exhaustsAtMs: now + timeToExhaustMs,
+				timeToExhaustMs,
+				remainingMs,
+			});
+		}
+	}
+
 	return {
 		average,
 		activeAverage,
@@ -344,5 +377,6 @@ export function computePoolUsage(
 		fallback,
 		earliestResetMs,
 		earliestResetAccountName,
+		atRisk,
 	};
 }

--- a/packages/dashboard-web/src/lib/pool-usage.ts
+++ b/packages/dashboard-web/src/lib/pool-usage.ts
@@ -331,8 +331,11 @@ export function computePoolUsage(
 	}
 
 	const resetCandidates = [...contributing, ...exhausted].filter(
-		(c): (PoolUsageContribution | PoolUsageExclusion) & { resetMs: number } =>
-			c.resetMs != null && c.resetMs > now,
+		(
+			c,
+		): c is (PoolUsageContribution | PoolUsageExclusion) & {
+			resetMs: number;
+		} => c.resetMs != null && c.resetMs > now,
 	);
 	const earliestResetMs =
 		resetCandidates.length === 0


### PR DESCRIPTION
Two new MetricCard-shaped tiles ("5h Pool", "7d Pool") at the end of the Overview metric row aggregate per-account 5-hour and weekly utilization across all available accounts. Headline shows the average utilization across contributing accounts; a worst-account subline points at the most-exhausted account. A popover surfaces the per-account breakdown, excluded accounts grouped by reason (paused/rate-limited/token-expired/usage-rate-limited/no-data), the fallback (pay-as-you-go) accounts that aren't metered into this pool, and the next-resetting account.

Provider classification is hybrid: a provider-eligibility gate (anthropic OAuth, codex, alibaba-coding-plan, zai for 5h; same minus zai for weekly) plus shape detection on usageData mirroring RateLimitProgress so cached payloads under unexpected provider strings are still extracted correctly. NanoGPT daily/monthly is treated as fallback to avoid conflating monthly with weekly.

Implementation is pure frontend: data comes from the existing /api/accounts response via the already-polled useAccounts() hook (60s). A registerUIRefresh tick at 30s keeps the next-refresh time accurate between polls. No backend, no migration, no new endpoint.

Files:
- packages/dashboard-web/src/lib/pool-usage.ts (pure module: computePoolUsage, types, shape detection, normalizeResetMs)
- packages/dashboard-web/src/lib/__tests__/pool-usage.test.ts (25 tests covering provider eligibility, exclusion reasons, cross-pool cases, normalization)
- packages/dashboard-web/src/components/overview/PoolMetricCard.tsx (UI tile component)
- packages/dashboard-web/src/components/OverviewTab.tsx (wire-up: imports, ticking now state, two useMemo blocks, grid class change lg:grid-cols-6 -> lg:grid-cols-4 2xl:grid-cols-8, two tiles appended after Output Speed)

Closes the manual "open Account Management and check each account individually" workflow for tracking pool-wide quota usage.

<img width="544" height="202" alt="Screenshot from 2026-05-14 12-09-37" src="https://github.com/user-attachments/assets/5d5b28dd-a2ca-4a85-aebd-e260433f16ae" />
