### PR TITLE
feat: add dashboard_auth_enabled toggle to bypass dashboard auth

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -636,7 +636,7 @@ export default async function startServer(options?: {
 	});
 
 	// Initialize AuthService for proxy authentication
-	const authService = new AuthService(dbOps);
+	const authService = new AuthService(dbOps, config);
 
 	// Run startup maintenance once (cleanup only) - fire and forget
 	runStartupMaintenance(config, dbOps).catch((err) => {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -62,6 +62,7 @@ export interface ConfigData {
 	usage_throttling_five_hour_enabled?: boolean;
 	usage_throttling_weekly_enabled?: boolean;
 	health_detail_enabled?: boolean;
+	dashboard_auth_enabled?: boolean;
 	// Database configuration
 	db_wal_mode?: boolean;
 	db_busy_timeout_ms?: number;
@@ -416,6 +417,16 @@ export class Config extends EventEmitter {
 		return false;
 	}
 
+	getDashboardAuthEnabled(): boolean {
+		const fromFile = this.data.dashboard_auth_enabled;
+		if (typeof fromFile === "boolean") return fromFile;
+		return true; // default: auth enabled when keys exist
+	}
+
+	setDashboardAuthEnabled(value: boolean): void {
+		this.set("dashboard_auth_enabled", value);
+	}
+
 	getAllSettings(): Record<string, string | number | boolean | undefined> {
 		// Include current strategy (which might come from env)
 		return {
@@ -432,6 +443,7 @@ export class Config extends EventEmitter {
 				this.getUsageThrottlingFiveHourEnabled(),
 			usage_throttling_weekly_enabled: this.getUsageThrottlingWeeklyEnabled(),
 			health_detail_enabled: this.getHealthDetailEnabled(),
+			dashboard_auth_enabled: this.getDashboardAuthEnabled(),
 		};
 	}
 

--- a/packages/dashboard-web/src/api.ts
+++ b/packages/dashboard-web/src/api.ts
@@ -1721,6 +1721,47 @@ class API extends HttpClient {
 		}
 	}
 
+	async getDashboardAuth(): Promise<{ enabled: boolean }> {
+		const startTime = Date.now();
+		const url = "/api/config/dashboard-auth";
+
+		this.logger.debug(`→ GET ${url}`);
+
+		try {
+			const response = await this.get<{ enabled: boolean }>(url);
+			const duration = Date.now() - startTime;
+			this.logger.debug(`← GET ${url} - 200 (${duration}ms)`);
+			return response;
+		} catch (error) {
+			const duration = Date.now() - startTime;
+			this.logger.error(`✗ GET ${url} - ERROR (${duration}ms)`, {
+				error: error instanceof Error ? error.message : String(error),
+				stack: error instanceof Error ? error.stack : undefined,
+			});
+			throw error;
+		}
+	}
+
+	async setDashboardAuth(enabled: boolean): Promise<void> {
+		const startTime = Date.now();
+		const url = "/api/config/dashboard-auth";
+
+		this.logger.debug(`→ POST ${url}`, { enabled });
+
+		try {
+			await this.post(url, { enabled });
+			const duration = Date.now() - startTime;
+			this.logger.debug(`← POST ${url} - 200 (${duration}ms)`);
+		} catch (error) {
+			const duration = Date.now() - startTime;
+			this.logger.error(`✗ POST ${url} - ERROR (${duration}ms)`, {
+				error: error instanceof Error ? error.message : String(error),
+				stack: error instanceof Error ? error.stack : undefined,
+			});
+			throw error;
+		}
+	}
+
 	async cleanupNow(): Promise<{
 		removedRequests: number;
 		removedPayloads: number;

--- a/packages/dashboard-web/src/components/SettingsTab.tsx
+++ b/packages/dashboard-web/src/components/SettingsTab.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { CacheKeepaliveCard } from "./overview/CacheKeepaliveCard";
+import { DashboardAuthCard } from "./overview/DashboardAuthCard";
 import { DataRetentionCard } from "./overview/DataRetentionCard";
 import { SystemCacheTtlCard } from "./overview/SystemCacheTtlCard";
 import { UsageThrottlingCard } from "./overview/UsageThrottlingCard";
@@ -9,6 +10,7 @@ export const SettingsTab = React.memo(() => {
 		<div className="space-y-6">
 			{/* Configuration Cards Grid */}
 			<div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+				<DashboardAuthCard />
 				<CacheKeepaliveCard />
 				<SystemCacheTtlCard />
 				<UsageThrottlingCard />

--- a/packages/dashboard-web/src/components/overview/DashboardAuthCard.tsx
+++ b/packages/dashboard-web/src/components/overview/DashboardAuthCard.tsx
@@ -1,0 +1,68 @@
+import { useDashboardAuth, useSetDashboardAuth } from "../../hooks/queries";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "../ui/card";
+import { Switch } from "../ui/switch";
+
+export function DashboardAuthCard() {
+	const { data, isLoading } = useDashboardAuth();
+	const setDashboardAuth = useSetDashboardAuth();
+
+	const enabled = data?.enabled ?? true;
+
+	return (
+		<Card className="card-hover">
+			<CardHeader>
+				<CardTitle>Dashboard API Authentication</CardTitle>
+				<CardDescription>
+					When enabled, the dashboard API requires a valid API key. When
+					disabled, all <code>/api/*</code> routes are accessible without
+					authentication. Proxy routes (<code>/v1/*</code>) and debug routes
+					always require authentication regardless of this setting.
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
+				<div className="space-y-3">
+					<div className="flex items-center gap-3">
+						<Switch
+							disabled={isLoading || setDashboardAuth.isPending}
+							checked={enabled}
+							onCheckedChange={(checked) => setDashboardAuth.mutate(checked)}
+						/>
+						<span className="text-sm text-muted-foreground">
+							{enabled ? "Authentication enabled" : "Authentication disabled"}
+						</span>
+					</div>
+					{!enabled && (
+						<div className="flex items-start gap-2 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20">
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								viewBox="0 0 20 20"
+								fill="currentColor"
+								className="h-4 w-4 text-amber-500 mt-0.5 shrink-0"
+								role="img"
+								aria-labelledby="dashboard-auth-warning-title"
+							>
+								<title id="dashboard-auth-warning-title">Warning</title>
+								<path
+									fillRule="evenodd"
+									d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z"
+									clipRule="evenodd"
+								/>
+							</svg>
+							<p className="text-xs text-amber-600 dark:text-amber-400">
+								Dashboard API authentication is disabled. Anyone with network
+								access to this server can read and modify configuration. Use
+								only on trusted networks.
+							</p>
+						</div>
+					)}
+				</div>
+			</CardContent>
+		</Card>
+	);
+}

--- a/packages/dashboard-web/src/components/overview/DashboardAuthCard.tsx
+++ b/packages/dashboard-web/src/components/overview/DashboardAuthCard.tsx
@@ -56,8 +56,10 @@ export function DashboardAuthCard() {
 							</svg>
 							<p className="text-xs text-amber-600 dark:text-amber-400">
 								Dashboard API authentication is disabled. Anyone with network
-								access to this server can read and modify configuration. Use
-								only on trusted networks.
+								access to this server can read and modify all dashboard data,
+								including account credentials, request history, logs, and
+								configuration. Proxy routes and debug endpoints remain
+								protected. Use only on fully trusted networks.
 							</p>
 						</div>
 					)}

--- a/packages/dashboard-web/src/hooks/queries.ts
+++ b/packages/dashboard-web/src/hooks/queries.ts
@@ -323,6 +323,23 @@ export const useSetUsageThrottling = () => {
 	});
 };
 
+export const useDashboardAuth = () => {
+	return useQuery({
+		queryKey: ["dashboard-auth"],
+		queryFn: () => api.getDashboardAuth(),
+	});
+};
+
+export const useSetDashboardAuth = () => {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (enabled: boolean) => api.setDashboardAuth(enabled),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["dashboard-auth"] });
+		},
+	});
+};
+
 export const useCleanupNow = () => {
 	return useMutation({
 		mutationFn: () => api.cleanupNow(),

--- a/packages/http-api/src/handlers/__tests__/config.test.ts
+++ b/packages/http-api/src/handlers/__tests__/config.test.ts
@@ -30,6 +30,8 @@ function makeConfig() {
 		getCacheKeepaliveTtlMinutes: () => 0,
 		setCacheKeepaliveTtlMinutes: mock(() => {}),
 		setSystemPromptCacheTtl1h: mock(() => {}),
+		getDashboardAuthEnabled: () => true,
+		setDashboardAuthEnabled: mock(() => {}),
 	} as unknown as import("@better-ccflare/config").Config;
 }
 
@@ -45,6 +47,7 @@ describe("createConfigHandlers", () => {
 
 		expect(body.usage_throttling_five_hour_enabled).toBe(true);
 		expect(body.usage_throttling_weekly_enabled).toBe(true);
+		expect(body.dashboard_auth_enabled).toBe(true);
 	});
 
 	it("updates usage throttling windows from POST body", async () => {

--- a/packages/http-api/src/handlers/config.ts
+++ b/packages/http-api/src/handlers/config.ts
@@ -47,6 +47,7 @@ export function createConfigHandlers(
 					config.getUsageThrottlingFiveHourEnabled(),
 				usage_throttling_weekly_enabled:
 					config.getUsageThrottlingWeeklyEnabled(),
+				dashboard_auth_enabled: config.getDashboardAuthEnabled(),
 			};
 			return jsonResponse(response);
 		},
@@ -226,6 +227,21 @@ export function createConfigHandlers(
 			}
 			config.setUsageThrottlingFiveHourEnabled(body.fiveHourEnabled);
 			config.setUsageThrottlingWeeklyEnabled(body.weeklyEnabled);
+			return new Response(null, { status: 204 });
+		},
+
+		getDashboardAuth: (): Response => {
+			return jsonResponse({
+				enabled: config.getDashboardAuthEnabled(),
+			});
+		},
+
+		setDashboardAuth: async (req: Request): Promise<Response> => {
+			const body = (await req.json()) as { enabled?: unknown };
+			if (typeof body.enabled !== "boolean") {
+				return errorResponse(BadRequest("Invalid 'enabled': must be boolean"));
+			}
+			config.setDashboardAuthEnabled(body.enabled);
 			return new Response(null, { status: 204 });
 		},
 	};

--- a/packages/http-api/src/router.ts
+++ b/packages/http-api/src/router.ts
@@ -124,7 +124,7 @@ export class APIRouter {
 	constructor(context: APIContext) {
 		this.context = context;
 		this.handlers = new Map();
-		this.authService = new AuthService(context.dbOps);
+		this.authService = new AuthService(context.dbOps, context.config);
 		this.qwenStatusHandler = createQwenDeviceFlowStatusHandler();
 		this.codexStatusHandler = createCodexDeviceFlowStatusHandler();
 		this.registerHandlers();
@@ -350,6 +350,12 @@ export class APIRouter {
 		);
 		this.handlers.set("POST:/api/config/usage-throttling", (req) =>
 			configHandlers.setUsageThrottling(req),
+		);
+		this.handlers.set("GET:/api/config/dashboard-auth", () =>
+			configHandlers.getDashboardAuth(),
+		);
+		this.handlers.set("POST:/api/config/dashboard-auth", (req) =>
+			configHandlers.setDashboardAuth(req),
 		);
 		this.handlers.set("POST:/api/maintenance/cleanup", () => cleanupHandler());
 		this.handlers.set("POST:/api/maintenance/compact", () => compactHandler());

--- a/packages/http-api/src/services/__tests__/auth-service-dashboard-auth.test.ts
+++ b/packages/http-api/src/services/__tests__/auth-service-dashboard-auth.test.ts
@@ -2,14 +2,16 @@
  * Tests for dashboard_auth_enabled bypass in AuthService.isPathExempt.
  *
  * Test cases:
- *   1. dashboard_auth_enabled=true  + keys exist + /api/stats:                NOT exempt (current behaviour preserved)
- *   2. dashboard_auth_enabled=false + keys exist + /api/stats:                IS exempt
- *   3. dashboard_auth_enabled=false + keys exist + /v1/messages:              NOT exempt (proxy still gated)
- *   4. dashboard_auth_enabled=false + keys exist + /api/debug/heap:           NOT exempt (debug carve-out)
- *   5. dashboard_auth_enabled=false + no keys   + /api/stats:                 IS exempt
- *   6. dashboard_auth_enabled=false + keys exist + /api/config/dashboard-auth POST: IS exempt
- *   7. dashboard_auth_enabled=false + no keys   + /api/api-keys POST:         IS exempt (first-key creation)
- *   8. dashboard_auth_enabled=false + keys exist + /api/api-keys POST:        NOT exempt (key management gated)
+ *   1.  dashboard_auth_enabled=true  + keys exist + /api/stats:                NOT exempt (current behaviour preserved)
+ *   2.  dashboard_auth_enabled=false + keys exist + /api/stats:                IS exempt
+ *   3.  dashboard_auth_enabled=false + keys exist + /v1/messages:              NOT exempt (proxy still gated)
+ *   4.  dashboard_auth_enabled=false + keys exist + /api/debug/heap:           NOT exempt (debug carve-out)
+ *   5.  dashboard_auth_enabled=false + no keys   + /api/stats:                 IS exempt
+ *   6.  dashboard_auth_enabled=false + keys exist + /api/config/dashboard-auth POST: NOT exempt (lockout protection — LAN adversary can't flip auth back on)
+ *   6b. dashboard_auth_enabled=false + keys exist + /api/config/dashboard-auth GET:  IS exempt  (UI reads toggle state)
+ *   6c. dashboard_auth_enabled=false + keys exist + /api-admin/foo:            NOT exempt (bypass requires /api/ slash prefix)
+ *   7.  dashboard_auth_enabled=false + no keys   + /api/api-keys POST:         IS exempt (first-key creation)
+ *   8.  dashboard_auth_enabled=false + keys exist + /api/api-keys POST:        NOT exempt (key management gated)
  */
 
 import { describe, expect, test } from "bun:test";
@@ -79,11 +81,23 @@ describe("AuthService.isPathExempt — dashboard_auth_enabled bypass", () => {
 			expect(await svc.isPathExempt("/api/stats", "GET")).toBe(true);
 		});
 
-		test("case 6: keys exist + /api/config/dashboard-auth POST IS exempt", async () => {
+		test("case 6: keys exist + /api/config/dashboard-auth POST is NOT exempt — lockout protection (LAN adversary can't flip auth back on)", async () => {
 			const svc = new AuthService(makeDbOps(true), makeConfig(false));
 			expect(await svc.isPathExempt("/api/config/dashboard-auth", "POST")).toBe(
+				false,
+			);
+		});
+
+		test("case 6b: keys exist + /api/config/dashboard-auth GET IS exempt — UI can always read toggle state", async () => {
+			const svc = new AuthService(makeDbOps(true), makeConfig(false));
+			expect(await svc.isPathExempt("/api/config/dashboard-auth", "GET")).toBe(
 				true,
 			);
+		});
+
+		test("case 6c: keys exist + /api-admin (no slash after 'api') is NOT exempt — bypass requires /api/ slash-prefix", async () => {
+			const svc = new AuthService(makeDbOps(true), makeConfig(false));
+			expect(await svc.isPathExempt("/api-admin/foo", "GET")).toBe(false);
 		});
 
 		test("case 7: no keys + /api/api-keys POST IS exempt (first-key creation)", async () => {

--- a/packages/http-api/src/services/__tests__/auth-service-dashboard-auth.test.ts
+++ b/packages/http-api/src/services/__tests__/auth-service-dashboard-auth.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for dashboard_auth_enabled bypass in AuthService.isPathExempt.
+ *
+ * Test cases:
+ *   1. dashboard_auth_enabled=true  + keys exist + /api/stats:                NOT exempt (current behaviour preserved)
+ *   2. dashboard_auth_enabled=false + keys exist + /api/stats:                IS exempt
+ *   3. dashboard_auth_enabled=false + keys exist + /v1/messages:              NOT exempt (proxy still gated)
+ *   4. dashboard_auth_enabled=false + keys exist + /api/debug/heap:           NOT exempt (debug carve-out)
+ *   5. dashboard_auth_enabled=false + no keys   + /api/stats:                 IS exempt
+ *   6. dashboard_auth_enabled=false + keys exist + /api/config/dashboard-auth POST: IS exempt
+ *   7. dashboard_auth_enabled=false + no keys   + /api/api-keys POST:         IS exempt (first-key creation)
+ *   8. dashboard_auth_enabled=false + keys exist + /api/api-keys POST:        NOT exempt (key management gated)
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { DatabaseOperations } from "@better-ccflare/database";
+import { AuthService } from "@better-ccflare/http-api";
+
+function makeDbOps(hasKeys: boolean): DatabaseOperations {
+	return {
+		countActiveApiKeys: async () => (hasKeys ? 1 : 0),
+		getActiveApiKeys: async () => [],
+		updateApiKeyUsage: () => {},
+	} as unknown as DatabaseOperations;
+}
+
+function makeConfig(dashboardAuthEnabled: boolean) {
+	return {
+		getDashboardAuthEnabled: () => dashboardAuthEnabled,
+	};
+}
+
+describe("AuthService.isPathExempt — dashboard_auth_enabled bypass", () => {
+	describe("default behaviour (dashboard_auth_enabled=true)", () => {
+		test("case 1: keys exist + /api/stats is NOT exempt", async () => {
+			const svc = new AuthService(makeDbOps(true), makeConfig(true));
+			expect(await svc.isPathExempt("/api/stats", "GET")).toBe(false);
+		});
+
+		test("no keys + /api/stats: isPathExempt still false (no-keys path is in authenticateRequest)", async () => {
+			const svc = new AuthService(makeDbOps(false), makeConfig(true));
+			expect(await svc.isPathExempt("/api/stats", "GET")).toBe(false);
+		});
+	});
+
+	describe("bypass active (dashboard_auth_enabled=false)", () => {
+		test("case 2: keys exist + /api/stats IS exempt", async () => {
+			const svc = new AuthService(makeDbOps(true), makeConfig(false));
+			expect(await svc.isPathExempt("/api/stats", "GET")).toBe(true);
+		});
+
+		test("case 3: keys exist + /v1/messages is NOT exempt (proxy still gated)", async () => {
+			const svc = new AuthService(makeDbOps(true), makeConfig(false));
+			expect(await svc.isPathExempt("/v1/messages", "POST")).toBe(false);
+		});
+
+		test("case 3b: keys exist + /messages/test is NOT exempt (proxy still gated)", async () => {
+			const svc = new AuthService(makeDbOps(true), makeConfig(false));
+			expect(await svc.isPathExempt("/messages/test", "POST")).toBe(false);
+		});
+
+		test("case 4: keys exist + /api/debug/heap is NOT exempt (debug carve-out)", async () => {
+			const svc = new AuthService(makeDbOps(true), makeConfig(false));
+			expect(await svc.isPathExempt("/api/debug/heap", "GET")).toBe(false);
+		});
+
+		test("case 4b: keys exist + /api/debug/snapshot is NOT exempt", async () => {
+			const svc = new AuthService(makeDbOps(true), makeConfig(false));
+			expect(await svc.isPathExempt("/api/debug/snapshot", "GET")).toBe(false);
+		});
+
+		test("case 4c: keys exist + /api/debugger (no slash) is NOT exempt — carve-out covers /api/debug prefix without trailing slash", async () => {
+			const svc = new AuthService(makeDbOps(true), makeConfig(false));
+			expect(await svc.isPathExempt("/api/debugger", "GET")).toBe(false);
+		});
+
+		test("case 5: no keys + /api/stats IS exempt (bypass fires unconditionally)", async () => {
+			const svc = new AuthService(makeDbOps(false), makeConfig(false));
+			expect(await svc.isPathExempt("/api/stats", "GET")).toBe(true);
+		});
+
+		test("case 6: keys exist + /api/config/dashboard-auth POST IS exempt", async () => {
+			const svc = new AuthService(makeDbOps(true), makeConfig(false));
+			expect(await svc.isPathExempt("/api/config/dashboard-auth", "POST")).toBe(
+				true,
+			);
+		});
+
+		test("case 7: no keys + /api/api-keys POST IS exempt (first-key creation)", async () => {
+			const svc = new AuthService(makeDbOps(false), makeConfig(false));
+			expect(await svc.isPathExempt("/api/api-keys", "POST")).toBe(true);
+		});
+
+		test("case 8: keys exist + /api/api-keys POST is NOT exempt (key management gated)", async () => {
+			const svc = new AuthService(makeDbOps(true), makeConfig(false));
+			expect(await svc.isPathExempt("/api/api-keys", "POST")).toBe(false);
+		});
+
+		test("case 8b: keys exist + /api/api-keys GET is NOT exempt", async () => {
+			const svc = new AuthService(makeDbOps(true), makeConfig(false));
+			expect(await svc.isPathExempt("/api/api-keys", "GET")).toBe(false);
+		});
+	});
+
+	describe("backward compat (no config arg)", () => {
+		test("new AuthService(dbOps) works; /api/stats still not exempt", async () => {
+			const svc = new AuthService(makeDbOps(true));
+			expect(await svc.isPathExempt("/api/stats", "GET")).toBe(false);
+		});
+	});
+});

--- a/packages/http-api/src/services/auth-service.ts
+++ b/packages/http-api/src/services/auth-service.ts
@@ -177,14 +177,26 @@ export class AuthService {
 			return false;
 		}
 
+		// Writes to the dashboard-auth toggle always require auth, even when
+		// the bypass is active. Without this, any host with network access
+		// could POST { enabled: true } to lock the legitimate owner out of
+		// the dashboard until they used an API key or edited the config
+		// file directly. GET stays bypassed below so the UI can render the
+		// toggle state.
+		if (path === "/api/config/dashboard-auth" && method === "POST") {
+			return false;
+		}
+
 		// Dashboard auth bypass: when explicitly disabled, /api/* (excluding
 		// /api/debug*) is open even when API keys exist. Proxy routes
 		// (/v1/*, /messages/*) and debug routes remain gated regardless.
 		// /api/api-keys is handled by the block above — this branch is
-		// unreachable for those paths.
+		// unreachable for those paths. The `/api/` slash is required so
+		// future routes under `/api-*` (e.g., `/api-admin`) don't get
+		// unintentionally bypassed.
 		if (
 			this.config?.getDashboardAuthEnabled() === false &&
-			path.startsWith("/api") &&
+			(path === "/api" || path.startsWith("/api/")) &&
 			!path.startsWith("/api/debug")
 		) {
 			return true;

--- a/packages/http-api/src/services/auth-service.ts
+++ b/packages/http-api/src/services/auth-service.ts
@@ -15,12 +15,22 @@ export interface AuthenticationResult {
 	error?: string;
 }
 
+/**
+ * Minimal config interface required by AuthService.
+ * Using a structural type avoids adding a package dependency on @better-ccflare/config.
+ */
+interface AuthServiceConfig {
+	getDashboardAuthEnabled(): boolean;
+}
+
 export class AuthService {
 	private crypto: NodeCryptoUtils;
 	private dbOps: DatabaseOperations;
+	private config: AuthServiceConfig | null;
 
-	constructor(dbOps: DatabaseOperations) {
+	constructor(dbOps: DatabaseOperations, config?: AuthServiceConfig) {
 		this.dbOps = dbOps;
+		this.config = config ?? null;
 		this.crypto = new NodeCryptoUtils();
 	}
 
@@ -165,6 +175,19 @@ export class AuthService {
 			}
 			// All other API key operations require authentication
 			return false;
+		}
+
+		// Dashboard auth bypass: when explicitly disabled, /api/* (excluding
+		// /api/debug*) is open even when API keys exist. Proxy routes
+		// (/v1/*, /messages/*) and debug routes remain gated regardless.
+		// /api/api-keys is handled by the block above — this branch is
+		// unreachable for those paths.
+		if (
+			this.config?.getDashboardAuthEnabled() === false &&
+			path.startsWith("/api") &&
+			!path.startsWith("/api/debug")
+		) {
+			return true;
 		}
 
 		// Proxy endpoints (/v1/*, /messages/*, etc.) require authentication if enabled

--- a/packages/types/src/stats.ts
+++ b/packages/types/src/stats.ts
@@ -174,6 +174,7 @@ export interface ConfigResponse {
 	system_prompt_cache_ttl_1h: boolean;
 	usage_throttling_five_hour_enabled: boolean;
 	usage_throttling_weekly_enabled: boolean;
+	dashboard_auth_enabled: boolean;
 }
 
 export interface StrategyUpdateRequest {


### PR DESCRIPTION
When dashboard_auth_enabled is set to false (via Settings UI), the /api/* routes become accessible without an API key even when active keys exist. Proxy routes (/v1/*, /messages/*) and debug routes (/api/debug*) remain gated regardless, so per-consumer stats tracking on the proxy keeps working and heap snapshots stay admin-only.

Default is true (backward compatible). Toggle is configured exclusively through the Settings tab; the toggle endpoint /api/config/dashboard-auth is exempt from auth when the bypass is on so the user can never lock themselves out of it.

Use case: local LAN deployments that use API keys for per-consumer request stats but don't want a key prompt on the dashboard UI.