### PR TITLE
fix: drain HTTP and remove SIGTERM race so in-flight requests survive restart

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1323,10 +1323,29 @@ Available endpoints:
 	};
 }
 
+// Max wall-clock time between SIGTERM and process exit. Long enough to let
+// most in-flight streaming responses complete; short enough that systemd's
+// default TimeoutStopSec (90s) doesn't have to escalate to SIGKILL.
+const SHUTDOWN_WATCHDOG_MS = 30_000;
+
 // Graceful shutdown handler
 async function handleGracefulShutdown(signal: string) {
 	console.log(`\n👋 Received ${signal}, shutting down gracefully...`);
+
+	// Hard upper bound on shutdown duration. unref'd so it doesn't itself
+	// prevent a clean exit if everything else finishes first.
+	const watchdog = setTimeout(() => {
+		console.error(
+			`⚠️ Shutdown watchdog (${SHUTDOWN_WATCHDOG_MS}ms) expired, forcing exit`,
+		);
+		process.exit(1);
+	}, SHUTDOWN_WATCHDOG_MS);
+	watchdog.unref();
+
 	try {
+		// 1. Stop scheduler triggers first so they don't add load while draining.
+		//    These calls only stop the recurring trigger; any in-flight task they
+		//    already kicked off continues until it finishes naturally.
 		if (stopRetentionJob) {
 			stopRetentionJob();
 			stopRetentionJob = null;
@@ -1384,8 +1403,29 @@ async function handleGracefulShutdown(signal: string) {
 		}
 
 		usageCache.clear(); // Stop all usage polling
+
+		// 2. Stop accepting new connections and wait for in-flight HTTP requests
+		//    (including streaming responses) to complete. stop() without args is
+		//    Bun's graceful variant; stop(true) would force-close active conns.
+		if (serverInstance) {
+			console.log("Draining in-flight HTTP requests...");
+			try {
+				await serverInstance.stop();
+			} catch (err) {
+				console.warn("⚠️ serverInstance.stop() threw:", err);
+			}
+			serverInstance = null;
+			console.log("HTTP drain complete");
+		}
+
+		// 3. Now that streams have finished, the usage worker has received all
+		//    end-of-stream analytics messages. Terminate it so its DB writes
+		//    flush into the AsyncDbWriter queue before we dispose that.
 		await terminateUsageWorker();
+
+		// 4. Flush AsyncDbWriter and other Disposables.
 		await shutdown();
+
 		console.log("✅ Shutdown complete");
 		process.exit(0);
 	} catch (error) {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1343,9 +1343,9 @@ async function handleGracefulShutdown(signal: string) {
 	watchdog.unref();
 
 	try {
-		// 1. Stop scheduler triggers first so they don't add load while draining.
-		//    These calls only stop the recurring trigger; any in-flight task they
-		//    already kicked off continues until it finishes naturally.
+		// Stop scheduler triggers first so they don't add load while draining.
+		// These calls only stop the recurring trigger; any in-flight task they
+		// already kicked off continues until it finishes naturally.
 		if (stopRetentionJob) {
 			stopRetentionJob();
 			stopRetentionJob = null;
@@ -1404,9 +1404,9 @@ async function handleGracefulShutdown(signal: string) {
 
 		usageCache.clear(); // Stop all usage polling
 
-		// 2. Stop accepting new connections and wait for in-flight HTTP requests
-		//    (including streaming responses) to complete. stop() without args is
-		//    Bun's graceful variant; stop(true) would force-close active conns.
+		// Stop accepting new connections and wait for in-flight HTTP requests
+		// (including streaming responses) to complete. stop() without args is
+		// Bun's graceful variant; stop(true) would force-close active conns.
 		if (serverInstance) {
 			console.log("Draining in-flight HTTP requests...");
 			try {
@@ -1418,12 +1418,12 @@ async function handleGracefulShutdown(signal: string) {
 			console.log("HTTP drain complete");
 		}
 
-		// 3. Now that streams have finished, the usage worker has received all
-		//    end-of-stream analytics messages. Terminate it so its DB writes
-		//    flush into the AsyncDbWriter queue before we dispose that.
+		// Now that streams have finished, the usage worker has received all
+		// end-of-stream analytics messages. Terminate it so its DB writes
+		// flush into the AsyncDbWriter queue before we dispose that.
 		await terminateUsageWorker();
 
-		// 4. Flush AsyncDbWriter and other Disposables.
+		// Flush AsyncDbWriter and other Disposables.
 		await shutdown();
 
 		console.log("✅ Shutdown complete");

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1328,17 +1328,31 @@ Available endpoints:
 // default TimeoutStopSec (90s) doesn't have to escalate to SIGKILL.
 const SHUTDOWN_WATCHDOG_MS = 30_000;
 
+// Deduplicates concurrent shutdown invocations (e.g. SIGINT arriving while
+// SIGTERM is still awaiting serverInstance.stop()). Without this, the second
+// invocation races on the same Bun server, worker, and DB writer.
+let isShuttingDown = false;
+
 // Graceful shutdown handler
 async function handleGracefulShutdown(signal: string) {
+	if (isShuttingDown) {
+		console.log(`Ignoring ${signal} — shutdown already in progress`);
+		return;
+	}
+	isShuttingDown = true;
+
 	console.log(`\n👋 Received ${signal}, shutting down gracefully...`);
 
 	// Hard upper bound on shutdown duration. unref'd so it doesn't itself
-	// prevent a clean exit if everything else finishes first.
+	// prevent a clean exit if everything else finishes first. Exits with 0
+	// because the watchdog only fires on an expected SIGTERM that ran long,
+	// not on a failure — code 1 would make systemd Restart=on-failure
+	// auto-restart the unit instead of treating it as a normal stop.
 	const watchdog = setTimeout(() => {
 		console.error(
 			`⚠️ Shutdown watchdog (${SHUTDOWN_WATCHDOG_MS}ms) expired, forcing exit`,
 		);
-		process.exit(1);
+		process.exit(0);
 	}, SHUTDOWN_WATCHDOG_MS);
 	watchdog.unref();
 

--- a/packages/core/src/interval-manager.ts
+++ b/packages/core/src/interval-manager.ts
@@ -252,15 +252,16 @@ export function registerHeartbeat(config: {
 	});
 }
 
-// Graceful shutdown on process exit
+// Stop intervals on signal, but defer process exit to the entry point's own
+// signal handler. Calling process.exit(0) here races with — and short-circuits
+// — async shutdown paths in the server (HTTP drain, worker termination, DB
+// flush), causing in-flight requests to be dropped and pending writes lost.
 if (typeof process !== "undefined") {
 	process.on("SIGINT", () => {
 		intervalManager.shutdown();
-		process.exit(0);
 	});
 
 	process.on("SIGTERM", () => {
 		intervalManager.shutdown();
-		process.exit(0);
 	});
 }


### PR DESCRIPTION
Two bugs were causing `systemctl restart` (or any SIGTERM) to abort in-flight
requests instead of draining them:

1. interval-manager.ts registered a module-scope SIGTERM/SIGINT handler that
   called `process.exit(0)` synchronously. This raced with the server's own
   async `handleGracefulShutdown` and short-circuited it — DB writes in the
   AsyncDbWriter queue, usage-worker analytics for finishing streams, and
   in-flight HTTP requests were all silently dropped.

2. handleGracefulShutdown cleaned up schedulers and workers but never called
   `serverInstance.stop()`. The HTTP listener only closed when the process
   exited, so streaming responses got abrupt RST/FIN with no chance to drain.

Fixes:

- interval-manager.ts: keep the signal handlers (they still stop intervals
  cleanly) but remove `process.exit(0)`. The entry point owns exit timing.
- server.ts/handleGracefulShutdown: reorder shutdown to (a) stop scheduler
  triggers, (b) await `serverInstance.stop()` for graceful HTTP drain,
  (c) terminate usage worker so it has flushed analytics for the drained
  streams, (d) dispose AsyncDbWriter. A 30s watchdog forces exit if drain
  hangs, bounding total SIGTERM-to-exit time.

`stop()` without args is Bun's graceful variant (waits for in-flight),
not `stop(true)` which is the force-close.