### PR TITLE
fix: API key copy button on non-secure contexts

### DIFF
--- a/packages/dashboard-web/src/components/ApiKeysTab.tsx
+++ b/packages/dashboard-web/src/components/ApiKeysTab.tsx
@@ -3,7 +3,6 @@ import { formatDistanceToNow } from "date-fns";
 import {
 	AlertTriangle,
 	ChevronDown,
-	Copy,
 	Plus,
 	Shield,
 	ToggleLeft,
@@ -12,6 +11,7 @@ import {
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { api } from "../api";
+import { CopyButton } from "./CopyButton";
 import { Button } from "./ui/button";
 import {
 	Card,
@@ -243,10 +243,6 @@ export function ApiKeysTab() {
 		}
 
 		return true;
-	};
-
-	const copyToClipboard = (text: string) => {
-		navigator.clipboard.writeText(text);
 	};
 
 	const stats = statsResponse?.data;
@@ -492,13 +488,11 @@ export function ApiKeysTab() {
 										</div>
 									</div>
 									<div className="flex items-center gap-2">
-										<Button
+										<CopyButton
 											variant="outline"
 											size="sm"
-											onClick={() => copyToClipboard(key.prefixLast8)}
-										>
-											<Copy className="h-4 w-4" />
-										</Button>
+											value={key.prefixLast8}
+										/>
 										<Button
 											variant="outline"
 											size="sm"
@@ -553,13 +547,11 @@ export function ApiKeysTab() {
 								<code className="flex-1 p-3 bg-muted rounded text-sm font-mono break-all">
 									{generatedKey}
 								</code>
-								<Button
+								<CopyButton
 									variant="outline"
 									size="sm"
-									onClick={() => generatedKey && copyToClipboard(generatedKey)}
-								>
-									<Copy className="h-4 w-4" />
-								</Button>
+									value={generatedKey ?? ""}
+								/>
 							</div>
 						</div>
 						<div className="p-4 bg-yellow-50 border border-yellow-200 rounded-lg">

--- a/packages/dashboard-web/src/components/CopyButton.tsx
+++ b/packages/dashboard-web/src/components/CopyButton.tsx
@@ -1,5 +1,6 @@
 import { Check, Copy } from "lucide-react";
 import { type ComponentProps, useRef, useState } from "react";
+import { copyText } from "../lib/clipboard";
 import { cn } from "../lib/utils";
 import { Button } from "./ui/button";
 
@@ -45,8 +46,7 @@ export function CopyButton({
 		const text = typeof getValue === "function" ? getValue() : (value ?? "");
 		if (!text) return;
 
-		navigator.clipboard
-			.writeText(text)
+		copyText(text)
 			.then(() => {
 				setCopied(true);
 				// Reset after 1.5s

--- a/packages/dashboard-web/src/lib/clipboard.ts
+++ b/packages/dashboard-web/src/lib/clipboard.ts
@@ -19,6 +19,8 @@ export async function copyText(text: string): Promise<void> {
 	document.body.appendChild(textarea);
 	try {
 		textarea.select();
+		// iOS Safari doesn't reliably select via select() alone; setSelectionRange is the standard fix.
+		textarea.setSelectionRange(0, textarea.value.length);
 		if (!document.execCommand("copy")) {
 			throw new Error("execCommand copy failed");
 		}

--- a/packages/dashboard-web/src/lib/clipboard.ts
+++ b/packages/dashboard-web/src/lib/clipboard.ts
@@ -1,0 +1,28 @@
+/** Copy `text` to the clipboard, with a fallback for non-secure contexts. */
+export async function copyText(text: string): Promise<void> {
+	if (
+		typeof navigator !== "undefined" &&
+		navigator.clipboard &&
+		window.isSecureContext
+	) {
+		await navigator.clipboard.writeText(text);
+		return;
+	}
+
+	// Fallback for plain HTTP on non-localhost hosts, where navigator.clipboard is undefined.
+	const textarea = document.createElement("textarea");
+	textarea.value = text;
+	textarea.setAttribute("readonly", "");
+	textarea.style.position = "fixed";
+	textarea.style.top = "0";
+	textarea.style.left = "-9999px";
+	document.body.appendChild(textarea);
+	try {
+		textarea.select();
+		if (!document.execCommand("copy")) {
+			throw new Error("execCommand copy failed");
+		}
+	} finally {
+		document.body.removeChild(textarea);
+	}
+}


### PR DESCRIPTION
The "Copy" button in the generated-key dialog silently failed when the dashboard was served over plain HTTP on a non-localhost host, because `navigator.clipboard` is undefined in non-secure contexts. The handler also gave no visual feedback even when the underlying call succeeded, so the button looked broken in every case.

Add a small `copyText` helper that prefers the async Clipboard API and falls back to an off-screen `<textarea>` + `document.execCommand("copy")` for non-secure contexts. Route `CopyButton` through it (so its existing checkmark animation now works in both cases for free), and replace the two inline copy buttons in `ApiKeysTab.tsx` with `<CopyButton>` so they share the same path and the dead `copyToClipboard` helper goes away.