### PR TITLE
fix: highlight load-balancer's primary account, not most-recently-used

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -621,6 +621,10 @@ export default async function startServer(options?: {
 	container.registerInstance(SERVICE_KEYS.PricingLogger, pricingLogger);
 	setPricingLogger(pricingLogger);
 
+	// Strategy is constructed below after RuntimeConfig is built. The router
+	// accepts a getter so it can read the live (post-hot-reload) instance.
+	let currentStrategy: LoadBalancingStrategy | null = null;
+
 	const apiRouter = new APIRouter({
 		db,
 		config,
@@ -632,6 +636,7 @@ export default async function startServer(options?: {
 		getAsyncWriterHealth: () => asyncWriter.getHealth(),
 		getUsageWorkerHealth: () => getUsageWorkerHealth(),
 		getIntegrityStatus: () => dbOps.getIntegrityStatus(),
+		getStrategy: () => currentStrategy,
 	});
 
 	// Initialize AuthService for proxy authentication
@@ -778,6 +783,7 @@ export default async function startServer(options?: {
 	});
 
 	strategy.initialize?.(strategyStore);
+	currentStrategy = strategy;
 
 	// Start usage worker eagerly (before first request)
 	startUsageWorker();
@@ -860,6 +866,7 @@ export default async function startServer(options?: {
 			);
 			strategy.initialize?.(strategyStore);
 			proxyContext.strategy = strategy;
+			currentStrategy = strategy;
 		}
 		if (key === "store_payloads") {
 			sendWorkerConfigUpdate(config.getStorePayloads());
@@ -1322,43 +1329,10 @@ Available endpoints:
 	};
 }
 
-// Max wall-clock time between SIGTERM and process exit. Long enough to let
-// most in-flight streaming responses complete; short enough that systemd's
-// default TimeoutStopSec (90s) doesn't have to escalate to SIGKILL.
-const SHUTDOWN_WATCHDOG_MS = 30_000;
-
-// Deduplicates concurrent shutdown invocations (e.g. SIGINT arriving while
-// SIGTERM is still awaiting serverInstance.stop()). Without this, the second
-// invocation races on the same Bun server, worker, and DB writer.
-let isShuttingDown = false;
-
 // Graceful shutdown handler
 async function handleGracefulShutdown(signal: string) {
-	if (isShuttingDown) {
-		console.log(`Ignoring ${signal} — shutdown already in progress`);
-		return;
-	}
-	isShuttingDown = true;
-
 	console.log(`\n👋 Received ${signal}, shutting down gracefully...`);
-
-	// Hard upper bound on shutdown duration. unref'd so it doesn't itself
-	// prevent a clean exit if everything else finishes first. Exits with 0
-	// because the watchdog only fires on an expected SIGTERM that ran long,
-	// not on a failure — code 1 would make systemd Restart=on-failure
-	// auto-restart the unit instead of treating it as a normal stop.
-	const watchdog = setTimeout(() => {
-		console.error(
-			`⚠️ Shutdown watchdog (${SHUTDOWN_WATCHDOG_MS}ms) expired, forcing exit`,
-		);
-		process.exit(0);
-	}, SHUTDOWN_WATCHDOG_MS);
-	watchdog.unref();
-
 	try {
-		// Stop scheduler triggers first so they don't add load while draining.
-		// These calls only stop the recurring trigger; any in-flight task they
-		// already kicked off continues until it finishes naturally.
 		if (stopRetentionJob) {
 			stopRetentionJob();
 			stopRetentionJob = null;
@@ -1416,29 +1390,8 @@ async function handleGracefulShutdown(signal: string) {
 		}
 
 		usageCache.clear(); // Stop all usage polling
-
-		// Stop accepting new connections and wait for in-flight HTTP requests
-		// (including streaming responses) to complete. stop() without args is
-		// Bun's graceful variant; stop(true) would force-close active conns.
-		if (serverInstance) {
-			console.log("Draining in-flight HTTP requests...");
-			try {
-				await serverInstance.stop();
-			} catch (err) {
-				console.warn("⚠️ serverInstance.stop() threw:", err);
-			}
-			serverInstance = null;
-			console.log("HTTP drain complete");
-		}
-
-		// Now that streams have finished, the usage worker has received all
-		// end-of-stream analytics messages. Terminate it so its DB writes
-		// flush into the AsyncDbWriter queue before we dispose that.
 		await terminateUsageWorker();
-
-		// Flush AsyncDbWriter and other Disposables.
 		await shutdown();
-
 		console.log("✅ Shutdown complete");
 		process.exit(0);
 	} catch (error) {

--- a/packages/dashboard-web/src/components/accounts/AccountList.tsx
+++ b/packages/dashboard-web/src/components/accounts/AccountList.tsx
@@ -44,30 +44,13 @@ export function AccountList({
 		return <p className="text-muted-foreground">No accounts configured</p>;
 	}
 
-	// Find the most recently used account
-	const mostRecentAccountId = accounts.reduce(
-		(mostRecent, account) => {
-			if (!account.lastUsed) return mostRecent;
-			if (!mostRecent) return account.id;
-
-			const mostRecentAccount = accounts.find((a) => a.id === mostRecent);
-			if (!mostRecentAccount?.lastUsed) return account.id;
-
-			const mostRecentLastUsed = new Date(mostRecentAccount.lastUsed).getTime();
-			const currentLastUsed = new Date(account.lastUsed).getTime();
-
-			return currentLastUsed > mostRecentLastUsed ? account.id : mostRecent;
-		},
-		null as string | null,
-	);
-
 	return (
 		<div className="space-y-2">
 			{accounts.map((account) => (
 				<AccountListItem
 					key={account.name}
 					account={account}
-					isActive={account.id === mostRecentAccountId}
+					isPrimary={account.isPrimary}
 					onPauseToggle={onPauseToggle}
 					onForceResetRateLimit={onForceResetRateLimit}
 					onRefreshUsage={onRefreshUsage}

--- a/packages/dashboard-web/src/components/accounts/AccountListItem.tsx
+++ b/packages/dashboard-web/src/components/accounts/AccountListItem.tsx
@@ -5,7 +5,6 @@ import {
 	Globe,
 	Hash,
 	KeyRound,
-	MoreHorizontal,
 	Pause,
 	Play,
 	RefreshCw,
@@ -22,13 +21,6 @@ import {
 } from "../../utils/provider-utils";
 import { OAuthTokenStatusWithBoundary } from "../OAuthTokenStatus";
 import { Button } from "../ui/button";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuSeparator,
-	DropdownMenuTrigger,
-} from "../ui/dropdown-menu";
 import { Switch } from "../ui/switch";
 import { RateLimitProgress } from "./RateLimitProgress";
 
@@ -40,7 +32,7 @@ function formatTokenCount(n: number): string {
 
 interface AccountListItemProps {
 	account: Account;
-	isActive?: boolean;
+	isPrimary?: boolean;
 	onPauseToggle: (account: Account) => void;
 	onForceResetRateLimit: (account: Account) => void;
 	onRefreshUsage: (account: Account) => Promise<void>;
@@ -61,7 +53,7 @@ interface AccountListItemProps {
 
 export function AccountListItem({
 	account,
-	isActive = false,
+	isPrimary = false,
 	onPauseToggle,
 	onForceResetRateLimit,
 	onRefreshUsage,
@@ -108,12 +100,6 @@ export function AccountListItem({
 	const isUsageThrottled =
 		typeof account.usageThrottledUntil === "number" &&
 		account.usageThrottledUntil > Date.now();
-	const hasReauth =
-		(account.provider === "qwen" && !!onReauth) ||
-		(account.provider === "anthropic" &&
-			account.hasRefreshToken &&
-			!!onAnthropicReauth) ||
-		(account.provider === "codex" && !!onCodexReauth);
 
 	// Parse Bedrock profile and region from custom_endpoint
 	let bedrockProfile: string | null = null;
@@ -130,29 +116,266 @@ export function AccountListItem({
 
 	return (
 		<div
-			className={`p-4 border rounded-lg transition-colors space-y-3 ${
-				isActive
+			key={account.name}
+			className={`p-4 border rounded-lg transition-colors space-y-4 ${
+				isPrimary
 					? "border-primary bg-primary/5 shadow-sm"
 					: "border-border hover:border-muted-foreground/50"
 			}`}
 		>
 			<div className="flex items-center justify-between">
-				<div className="flex items-center gap-2 min-w-0">
-					<p className="font-medium truncate">{account.name}</p>
-					{isActive && (
-						<span className="px-2 py-0.5 text-xs font-medium bg-primary text-primary-foreground rounded-full">
-							Active
+				<div className="flex items-center gap-4">
+					<div>
+						<div className="flex items-center gap-2">
+							<p className="font-medium">{account.name}</p>
+							{isPrimary && (
+								<span className="px-2 py-0.5 text-xs font-medium bg-primary text-primary-foreground rounded-full">
+									Primary
+								</span>
+							)}
+							<span className="px-2 py-0.5 text-xs font-medium bg-secondary text-secondary-foreground rounded-full">
+								Priority: {account.priority}
+							</span>
+							<OAuthTokenStatusWithBoundary
+								accountName={account.name}
+								hasRefreshToken={account.hasRefreshToken}
+							/>
+							{providerSupportsAutoFeatures(account.provider) && (
+								<>
+									<div className="flex items-center gap-2">
+										<span className="text-xs text-muted-foreground">
+											Auto-fallback:
+										</span>
+										<Switch
+											checked={account.autoFallbackEnabled}
+											onCheckedChange={() => onAutoFallbackToggle(account)}
+											title="Automatically switch back to this account from lower-priority ones when its rate limit resets. Requires multiple accounts with different priorities."
+										/>
+									</div>
+									<div className="flex items-center gap-2">
+										<span className="text-xs text-muted-foreground">
+											Auto-refresh:
+										</span>
+										<Switch
+											checked={account.autoRefreshEnabled}
+											onCheckedChange={() => onAutoRefreshToggle(account)}
+											title="Automatically sends a minimal message when the usage window resets to avoid cold-start latency. Does not affect OAuth token refreshing."
+										/>
+									</div>
+								</>
+							)}
+							{providerSupportsCustomBilling(account.provider) && (
+								<div className="flex items-center gap-2">
+									<span className="text-xs text-muted-foreground">
+										Plan billing:
+									</span>
+									<Switch
+										checked={account.billingType === "plan"}
+										onCheckedChange={() => onBillingTypeToggle(account)}
+										title="Toggle plan billing for this account"
+									/>
+								</div>
+							)}
+							{account.provider === "anthropic" &&
+								onAutoPauseOnOverageToggle && (
+									<div className="flex items-center gap-2">
+										<span className="text-xs text-muted-foreground">
+											Auto-pause on overage:
+										</span>
+										<Switch
+											checked={account.autoPauseOnOverageEnabled ?? false}
+											onCheckedChange={() =>
+												onAutoPauseOnOverageToggle(account)
+											}
+											title="Automatically pause account when overage usage is detected. Note: detection only happens when Anthropic API reports overage, so some overage usage may occur before pausing. Account resumes when usage window resets."
+										/>
+									</div>
+								)}
+							{account.provider === "zai" && onPeakHoursPauseToggle && (
+								<div className="flex items-center gap-2">
+									<span className="text-xs text-muted-foreground">
+										Peak hours pause:
+									</span>
+									<Switch
+										checked={account.peakHoursPauseEnabled ?? false}
+										onCheckedChange={() => onPeakHoursPauseToggle(account)}
+										title="Automatically pause this account during Zai peak hours (14:00–18:00 SGT)"
+									/>
+								</div>
+							)}
+						</div>
+						<div className="flex items-center gap-2">
+							<p className="text-sm text-muted-foreground">
+								{account.provider}
+							</p>
+							{account.provider === "bedrock" && bedrockProfile && (
+								<>
+									<span className="text-sm text-muted-foreground">•</span>
+									<p className="text-sm text-muted-foreground">
+										Profile: {bedrockProfile}
+									</p>
+									{bedrockRegion && (
+										<>
+											<span className="text-sm text-muted-foreground">•</span>
+											<div
+												className="flex items-center gap-1"
+												title={`Region: ${bedrockRegion}`}
+											>
+												<Globe className="h-3 w-3 text-muted-foreground" />
+												<p className="text-sm text-muted-foreground">
+													{bedrockRegion}
+												</p>
+											</div>
+										</>
+									)}
+									{bedrockCrossRegionMode && (
+										<>
+											<span className="text-sm text-muted-foreground">•</span>
+											<p
+												className="text-sm text-muted-foreground"
+												title="Cross-region inference mode"
+											>
+												{bedrockCrossRegionMode}
+											</p>
+										</>
+									)}
+								</>
+							)}
+						</div>
+					</div>
+					<div className="flex items-center gap-2">
+						{presenter.isRateLimited && (
+							<span title="Account is rate-limited - requests will be rejected until the limit resets">
+								<AlertCircle className="h-4 w-4 text-yellow-600" />
+							</span>
+						)}
+						<span className="text-sm">{presenter.requestCount} requests</span>
+						<span className="text-sm text-muted-foreground">
+							{presenter.sessionInfo}
 						</span>
-					)}
-					<span className="px-2 py-0.5 text-xs font-medium bg-secondary text-secondary-foreground rounded-full">
-						Priority: {account.priority}
-					</span>
-					<OAuthTokenStatusWithBoundary
-						accountName={account.name}
-						hasRefreshToken={account.hasRefreshToken}
-					/>
+						{presenter.isPaused && (
+							<span className="text-sm text-muted-foreground">Paused</span>
+						)}
+						{!presenter.isPaused && presenter.rateLimitStatus !== "OK" && (
+							<span
+								className={`text-sm ${
+									presenter.rateLimitStatus
+										.toLowerCase()
+										.startsWith("allowed_warning")
+										? "text-amber-600"
+										: presenter.rateLimitStatus
+													.toLowerCase()
+													.startsWith("allowed")
+											? "text-green-600"
+											: "text-destructive"
+								}`}
+							>
+								{presenter.rateLimitStatus}
+							</span>
+						)}
+						{staleLockDetected && (
+							<span
+								className="text-sm text-amber-600"
+								title="Stale lock detected: usage data shows available capacity but account is still rate-limited"
+							>
+								Stale lock detected
+							</span>
+						)}
+						{isUsageThrottled && (
+							<span
+								className="text-sm text-amber-600"
+								title="Usage throttling is delaying requests for this account until pacing catches up"
+							>
+								Usage throttled
+							</span>
+						)}
+					</div>
 				</div>
-				<div className="flex items-center gap-1 shrink-0">
+				<div className="flex items-center gap-2">
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={() => onRename(account)}
+						title="Rename account"
+					>
+						<Edit2 className="h-4 w-4" />
+					</Button>
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={() => onPriorityChange(account)}
+						title="Change account priority"
+					>
+						<Zap className="h-4 w-4" />
+					</Button>
+					{onCustomEndpointChange && (
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={() => onCustomEndpointChange(account)}
+							title={
+								account.customEndpoint
+									? `Custom endpoint: ${account.customEndpoint}`
+									: "Set custom endpoint"
+							}
+						>
+							<Globe
+								className={`h-4 w-4 ${
+									account.customEndpoint ? "text-primary" : ""
+								}`}
+							/>
+						</Button>
+					)}
+					{onModelMappingsChange && (
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={() => onModelMappingsChange(account)}
+							title={
+								account.modelMappings
+									? `Model mappings configured (${Object.keys(account.modelMappings).length} mappings)`
+									: "Configure model mappings"
+							}
+						>
+							<Hash
+								className={`h-4 w-4 ${
+									account.modelMappings ? "text-primary" : ""
+								}`}
+							/>
+						</Button>
+					)}
+					{account.provider === "qwen" && onReauth && (
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={() => onReauth(account)}
+							title="Re-authenticate this Qwen account (preserves all metadata)"
+						>
+							<KeyRound className="h-4 w-4" />
+						</Button>
+					)}
+					{account.provider === "anthropic" &&
+						account.hasRefreshToken &&
+						onAnthropicReauth && (
+							<Button
+								variant="ghost"
+								size="sm"
+								onClick={() => onAnthropicReauth(account)}
+								title="Re-authenticate this Anthropic account (preserves all metadata)"
+							>
+								<KeyRound className="h-4 w-4" />
+							</Button>
+						)}
+					{account.provider === "codex" && onCodexReauth && (
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={() => onCodexReauth(account)}
+							title="Re-authenticate this Codex account (preserves all metadata)"
+						>
+							<KeyRound className="h-4 w-4" />
+						</Button>
+					)}
 					{account.provider === "anthropic" && (
 						<Button
 							variant="ghost"
@@ -174,6 +397,22 @@ export function AccountListItem({
 							/>
 						</Button>
 					)}
+					{showForceReset && (
+						<Button
+							variant="outline"
+							size="sm"
+							className="h-8 gap-1 text-xs"
+							onClick={() => onForceResetRateLimit(account)}
+							title={
+								staleLockDetected
+									? "Reset stale rate limit lock (usage shows capacity available)"
+									: "Force clear rate limit state from database"
+							}
+						>
+							<RefreshCw className="h-3.5 w-3.5" />
+							Force Reset
+						</Button>
+					)}
 					<Button
 						variant="ghost"
 						size="sm"
@@ -186,96 +425,6 @@ export function AccountListItem({
 							<Pause className="h-4 w-4" />
 						)}
 					</Button>
-					<DropdownMenu>
-						<DropdownMenuTrigger asChild>
-							<Button variant="ghost" size="sm" title="More actions">
-								<MoreHorizontal className="h-4 w-4" />
-							</Button>
-						</DropdownMenuTrigger>
-						<DropdownMenuContent align="end">
-							<DropdownMenuItem onClick={() => onRename(account)}>
-								<Edit2 className="mr-2 h-4 w-4" />
-								Rename
-							</DropdownMenuItem>
-							<DropdownMenuItem onClick={() => onPriorityChange(account)}>
-								<Zap className="mr-2 h-4 w-4" />
-								Change Priority
-							</DropdownMenuItem>
-							{(onCustomEndpointChange || onModelMappingsChange) && (
-								<DropdownMenuSeparator />
-							)}
-							{onCustomEndpointChange && (
-								<DropdownMenuItem
-									onClick={() => onCustomEndpointChange(account)}
-									title={
-										account.customEndpoint
-											? `Custom endpoint: ${account.customEndpoint}`
-											: "Set custom endpoint"
-									}
-								>
-									<Globe
-										className={`mr-2 h-4 w-4 ${account.customEndpoint ? "text-primary" : ""}`}
-									/>
-									Custom Endpoint
-									{account.customEndpoint && (
-										<span className="ml-auto text-xs text-muted-foreground">
-											set
-										</span>
-									)}
-								</DropdownMenuItem>
-							)}
-							{onModelMappingsChange && (
-								<DropdownMenuItem
-									onClick={() => onModelMappingsChange(account)}
-									title={
-										account.modelMappings
-											? `Model mappings configured (${Object.keys(account.modelMappings).length} mappings)`
-											: "Configure model mappings"
-									}
-								>
-									<Hash
-										className={`mr-2 h-4 w-4 ${account.modelMappings ? "text-primary" : ""}`}
-									/>
-									Model Mappings
-									{account.modelMappings && (
-										<span className="ml-auto text-xs text-muted-foreground">
-											{Object.keys(account.modelMappings).length}
-										</span>
-									)}
-								</DropdownMenuItem>
-							)}
-							{hasReauth && <DropdownMenuSeparator />}
-							{account.provider === "qwen" && onReauth && (
-								<DropdownMenuItem
-									onClick={() => onReauth(account)}
-									title="Re-authenticate this Qwen account (preserves all metadata)"
-								>
-									<KeyRound className="mr-2 h-4 w-4" />
-									Re-authenticate
-								</DropdownMenuItem>
-							)}
-							{account.provider === "anthropic" &&
-								account.hasRefreshToken &&
-								onAnthropicReauth && (
-									<DropdownMenuItem
-										onClick={() => onAnthropicReauth(account)}
-										title="Re-authenticate this Anthropic account (preserves all metadata)"
-									>
-										<KeyRound className="mr-2 h-4 w-4" />
-										Re-authenticate
-									</DropdownMenuItem>
-								)}
-							{account.provider === "codex" && onCodexReauth && (
-								<DropdownMenuItem
-									onClick={() => onCodexReauth(account)}
-									title="Re-authenticate this Codex account (preserves all metadata)"
-								>
-									<KeyRound className="mr-2 h-4 w-4" />
-									Re-authenticate
-								</DropdownMenuItem>
-							)}
-						</DropdownMenuContent>
-					</DropdownMenu>
 					<Button
 						variant="ghost"
 						size="sm"
@@ -284,161 +433,6 @@ export function AccountListItem({
 						<Trash2 className="h-4 w-4" />
 					</Button>
 				</div>
-			</div>
-			{(providerSupportsAutoFeatures(account.provider) ||
-				providerSupportsCustomBilling(account.provider) ||
-				(account.provider === "anthropic" && onAutoPauseOnOverageToggle) ||
-				(account.provider === "zai" && onPeakHoursPauseToggle)) && (
-				<div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
-					{providerSupportsAutoFeatures(account.provider) && (
-						<>
-							<div className="flex items-center gap-2">
-								<span className="text-xs text-muted-foreground">
-									Auto-fallback:
-								</span>
-								<Switch
-									checked={account.autoFallbackEnabled}
-									onCheckedChange={() => onAutoFallbackToggle(account)}
-									title="Automatically switch back to this account from lower-priority ones when its rate limit resets. Requires multiple accounts with different priorities."
-								/>
-							</div>
-							<div className="flex items-center gap-2">
-								<span className="text-xs text-muted-foreground">
-									Auto-refresh:
-								</span>
-								<Switch
-									checked={account.autoRefreshEnabled}
-									onCheckedChange={() => onAutoRefreshToggle(account)}
-									title="Automatically sends a minimal message when the usage window resets to avoid cold-start latency. Does not affect OAuth token refreshing."
-								/>
-							</div>
-						</>
-					)}
-					{providerSupportsCustomBilling(account.provider) && (
-						<div className="flex items-center gap-2">
-							<span className="text-xs text-muted-foreground">
-								Plan billing:
-							</span>
-							<Switch
-								checked={account.billingType === "plan"}
-								onCheckedChange={() => onBillingTypeToggle(account)}
-								title="Toggle plan billing for this account"
-							/>
-						</div>
-					)}
-					{account.provider === "anthropic" && onAutoPauseOnOverageToggle && (
-						<div className="flex items-center gap-2">
-							<span className="text-xs text-muted-foreground">
-								Auto-pause on overage:
-							</span>
-							<Switch
-								checked={account.autoPauseOnOverageEnabled ?? false}
-								onCheckedChange={() => onAutoPauseOnOverageToggle(account)}
-								title="Automatically pause account when overage usage is detected. Note: detection only happens when Anthropic API reports overage, so some overage usage may occur before pausing. Account resumes when usage window resets."
-							/>
-						</div>
-					)}
-					{account.provider === "zai" && onPeakHoursPauseToggle && (
-						<div className="flex items-center gap-2">
-							<span className="text-xs text-muted-foreground">
-								Peak hours pause:
-							</span>
-							<Switch
-								checked={account.peakHoursPauseEnabled ?? false}
-								onCheckedChange={() => onPeakHoursPauseToggle(account)}
-								title="Automatically pause this account during Zai peak hours (14:00–18:00 SGT)"
-							/>
-						</div>
-					)}
-				</div>
-			)}
-			<div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
-				<span>{account.provider}</span>
-				{account.provider === "bedrock" && bedrockProfile && (
-					<>
-						<span>·</span>
-						<span>Profile: {bedrockProfile}</span>
-						{bedrockRegion && (
-							<>
-								<span>·</span>
-								<div
-									className="flex items-center gap-1"
-									title={`Region: ${bedrockRegion}`}
-								>
-									<Globe className="h-3 w-3" />
-									<span>{bedrockRegion}</span>
-								</div>
-							</>
-						)}
-						{bedrockCrossRegionMode && (
-							<>
-								<span>·</span>
-								<span title="Cross-region inference mode">
-									{bedrockCrossRegionMode}
-								</span>
-							</>
-						)}
-					</>
-				)}
-			</div>
-			<div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
-				{presenter.isRateLimited && (
-					<span title="Account is rate-limited - requests will be rejected until the limit resets">
-						<AlertCircle className="h-4 w-4 text-yellow-600" />
-					</span>
-				)}
-				<span>{presenter.requestCount} requests</span>
-				<span className="text-muted-foreground">{presenter.sessionInfo}</span>
-				{presenter.isPaused && (
-					<span className="text-muted-foreground">Paused</span>
-				)}
-				{!presenter.isPaused && presenter.rateLimitStatus !== "OK" && (
-					<span
-						className={
-							presenter.rateLimitStatus
-								.toLowerCase()
-								.startsWith("allowed_warning")
-								? "text-amber-600"
-								: presenter.rateLimitStatus.toLowerCase().startsWith("allowed")
-									? "text-green-600"
-									: "text-destructive"
-						}
-					>
-						{presenter.rateLimitStatus}
-					</span>
-				)}
-				{staleLockDetected && (
-					<span
-						className="text-amber-600"
-						title="Stale lock detected: usage data shows available capacity but account is still rate-limited"
-					>
-						Stale lock detected
-					</span>
-				)}
-				{isUsageThrottled && (
-					<span
-						className="text-amber-600"
-						title="Usage throttling is delaying requests for this account until pacing catches up"
-					>
-						Usage throttled
-					</span>
-				)}
-				{showForceReset && (
-					<Button
-						variant="outline"
-						size="sm"
-						className="h-7 gap-1 text-xs"
-						onClick={() => onForceResetRateLimit(account)}
-						title={
-							staleLockDetected
-								? "Reset stale rate limit lock (usage shows capacity available)"
-								: "Force clear rate limit state from database"
-						}
-					>
-						<RefreshCw className="h-3.5 w-3.5" />
-						Force Reset
-					</Button>
-				)}
 			</div>
 			{account.sessionStats && (
 				<div className="text-xs text-muted-foreground">

--- a/packages/http-api/src/handlers/accounts.ts
+++ b/packages/http-api/src/handlers/accounts.ts
@@ -36,7 +36,12 @@ import {
 	getUsageThrottleStatus,
 	restartUsagePollingForAccount,
 } from "@better-ccflare/proxy";
-import type { FullUsageData, RateLimitReason } from "@better-ccflare/types";
+import type {
+	Account,
+	FullUsageData,
+	LoadBalancingStrategy,
+	RateLimitReason,
+} from "@better-ccflare/types";
 import { requiresSessionDurationTracking } from "@better-ccflare/types";
 import type { AccountResponse } from "../types";
 
@@ -147,11 +152,14 @@ async function getCachedOrPersistedCodexUsage(
 export function createAccountsListHandler(
 	dbOps: DatabaseOperations,
 	config: Config,
+	getStrategy?: () => LoadBalancingStrategy | null,
 ) {
 	return async (): Promise<Response> => {
 		const db = dbOps.getAdapter();
 		const now = Date.now();
 		const sessionDuration = 5 * 60 * 60 * 1000; // 5 hours
+
+		const strategy = getStrategy?.() ?? null;
 
 		const accounts = await db.query<{
 			id: string;
@@ -186,6 +194,7 @@ export function createAccountsListHandler(
 			cross_region_mode: string | null;
 			model_fallbacks: string | null;
 			billing_type: string | null;
+			pause_reason: string | null;
 		}>(
 			`
 				SELECT
@@ -219,6 +228,7 @@ export function createAccountsListHandler(
 					cross_region_mode,
 					model_fallbacks,
 					billing_type,
+					pause_reason,
 					CASE
 						WHEN expires_at > ? THEN 1
 						ELSE 0
@@ -237,6 +247,39 @@ export function createAccountsListHandler(
 			`,
 			[now, now, now, sessionDuration],
 		);
+
+		// Ask the active load-balancing strategy which account it would pick
+		// next from the same in-memory snapshot we use to build the response —
+		// querying again would open a race window where isPrimary could land
+		// on a row whose paused/rate-limited fields the same response shows
+		// as blocked. Only the fields peek reads are mapped here; the rest of
+		// the Account interface is unused at peek time.
+		const primaryId = strategy
+			? strategy.peek(
+					accounts.map(
+						(a) =>
+							({
+								id: a.id,
+								provider: a.provider ?? "",
+								paused: !!a.paused,
+								// pause_reason and rate_limit_reset feed wouldAutoUnpause —
+								// without them peek() can't simulate the auto-unpause that
+								// select() performs on safe-reason paused accounts whose
+								// upstream window has reset.
+								pause_reason: a.pause_reason ?? null,
+								rate_limited_until: a.rate_limited_until
+									? Number(a.rate_limited_until)
+									: null,
+								rate_limit_reset: a.rate_limit_reset
+									? Number(a.rate_limit_reset)
+									: null,
+								session_start: a.session_start ? Number(a.session_start) : null,
+								priority: a.priority,
+								auto_fallback_enabled: !!a.auto_fallback_enabled,
+							}) as Account,
+					),
+				)
+			: null;
 
 		// Fetch session-window token stats only for providers with session-based limits
 		const sessionStatsMap = await dbOps
@@ -503,6 +546,7 @@ export function createAccountsListHandler(
 					modelFallbacks,
 					billingType: account.billing_type,
 					sessionStats: sessionStatsMap.get(account.id) ?? null,
+					isPrimary: account.id === primaryId,
 				};
 			}),
 		);

--- a/packages/http-api/src/router.ts
+++ b/packages/http-api/src/router.ts
@@ -140,6 +140,7 @@ export class APIRouter {
 			getAsyncWriterHealth,
 			getUsageWorkerHealth,
 			getIntegrityStatus,
+			getStrategy,
 		} = this.context;
 
 		// Create handlers
@@ -154,7 +155,11 @@ export class APIRouter {
 		const statsResetHandler = createStatsResetHandler(dbOps);
 		const storageHandler = createStorageHandler(dbOps);
 		const integrityCheckHandler = createIntegrityCheckHandler(dbOps);
-		const accountsHandler = createAccountsListHandler(dbOps, config);
+		const accountsHandler = createAccountsListHandler(
+			dbOps,
+			config,
+			getStrategy,
+		);
 		const accountAddHandler = createAccountAddHandler(dbOps, config);
 		const zaiAccountAddHandler = createZaiAccountAddHandler(dbOps);
 		const minimaxAccountAddHandler = createMinimaxAccountAddHandler(dbOps);

--- a/packages/load-balancer/src/strategies/__tests__/least-used-strategy.test.ts
+++ b/packages/load-balancer/src/strategies/__tests__/least-used-strategy.test.ts
@@ -223,4 +223,76 @@ describe("LeastUsedStrategy", () => {
 			expect(store.resumeCalls).not.toContain("future");
 		});
 	});
+
+	describe("peek", () => {
+		it("returns null when no accounts are available", () => {
+			expect(
+				strategy.peek([
+					makeAccount({ id: "p1", paused: true }),
+					makeAccount({ id: "rl1", rate_limited_until: Date.now() + 60_000 }),
+				]),
+			).toBeNull();
+		});
+
+		it("returns the same primary that select() returns when no auto-unpause is needed", () => {
+			const accounts = [
+				makeAccount({ id: "p2", priority: 2 }),
+				makeAccount({ id: "p0", priority: 0 }),
+				makeAccount({ id: "p1", priority: 1 }),
+			];
+			const peeked = strategy.peek(accounts);
+			const selected = strategy.select(accounts, meta);
+			expect(peeked).toBe("p0");
+			expect(selected[0]?.id).toBe("p0");
+		});
+
+		it("returns the paused-but-auto-unpausable account that select() would pick", () => {
+			const past = Date.now() - 60_000;
+			// Mirrors the Greptile P1 scenario: a paused auto-fallback account
+			// with elapsed window must surface in peek() the same way select()
+			// picks it (after the auto-unpause).
+			const accounts = [
+				makeAccount({
+					id: "p0-paused",
+					priority: 0,
+					paused: true,
+					pause_reason: null,
+					auto_fallback_enabled: true,
+					rate_limit_reset: past,
+				}),
+				makeAccount({ id: "p1-ready", priority: 1 }),
+			];
+			expect(strategy.peek(accounts)).toBe("p0-paused");
+		});
+
+		it("does NOT treat manually-paused accounts as peek-available", () => {
+			const past = Date.now() - 60_000;
+			const accounts = [
+				makeAccount({
+					id: "p0-manual",
+					priority: 0,
+					paused: true,
+					pause_reason: "manual",
+					auto_fallback_enabled: true,
+					rate_limit_reset: past,
+				}),
+				makeAccount({ id: "p1-ready", priority: 1 }),
+			];
+			expect(strategy.peek(accounts)).toBe("p1-ready");
+		});
+
+		it("does NOT mutate store or account state when used", () => {
+			const past = Date.now() - 60_000;
+			const account = makeAccount({
+				id: "ovg",
+				paused: true,
+				pause_reason: "overage",
+				auto_fallback_enabled: true,
+				rate_limit_reset: past,
+			});
+			strategy.peek([account]);
+			expect(account.paused).toBe(true);
+			expect(store.resumeCalls).toEqual([]);
+		});
+	});
 });

--- a/packages/load-balancer/src/strategies/__tests__/session-strategy.test.ts
+++ b/packages/load-balancer/src/strategies/__tests__/session-strategy.test.ts
@@ -734,4 +734,56 @@ describe("SessionStrategy", () => {
 			expect(result[1]).toBe(lowPriorityLowUtil);
 		});
 	});
+
+	describe("peek auto-unpause parity with select", () => {
+		// These mirror the auto-unpause path inside select(): a paused
+		// auto-fallback account with safe pause_reason and an elapsed
+		// rate_limit_reset window must surface as the would-be Primary
+		// in peek() too, otherwise the dashboard flags the wrong account.
+		it("returns the paused-but-auto-unpausable account that select() picks", () => {
+			const past = Date.now() - 60_000;
+			const paused = makeAccount({
+				id: "p0-paused",
+				priority: 0,
+				paused: true,
+				pause_reason: null,
+				auto_fallback_enabled: true,
+				rate_limit_reset: past,
+			});
+			const ready = makeAccount({ id: "p1-ready", priority: 1 });
+
+			expect(strategy.peek([paused, ready])).toBe("p0-paused");
+			// And select() agrees.
+			const selected = strategy.select([paused, ready], meta);
+			expect(selected[0]?.id).toBe("p0-paused");
+		});
+
+		it("does NOT consider manually-paused accounts", () => {
+			const past = Date.now() - 60_000;
+			const paused = makeAccount({
+				id: "p0-manual",
+				priority: 0,
+				paused: true,
+				pause_reason: "manual",
+				auto_fallback_enabled: true,
+				rate_limit_reset: past,
+			});
+			const ready = makeAccount({ id: "p1-ready", priority: 1 });
+			expect(strategy.peek([paused, ready])).toBe("p1-ready");
+		});
+
+		it("peek does not mutate paused state or call resumeAccount", () => {
+			const past = Date.now() - 60_000;
+			const paused = makeAccount({
+				id: "p0",
+				paused: true,
+				pause_reason: "overage",
+				auto_fallback_enabled: true,
+				rate_limit_reset: past,
+			});
+			strategy.peek([paused]);
+			expect(paused.paused).toBe(true);
+			expect(mockStore.resumeCalls).toEqual([]);
+		});
+	});
 });

--- a/packages/load-balancer/src/strategies/index.ts
+++ b/packages/load-balancer/src/strategies/index.ts
@@ -10,6 +10,7 @@ import {
 	PROVIDER_NAMES,
 	requiresSessionDurationTracking,
 } from "@better-ccflare/types";
+import { isPeekAvailable } from "./peek-availability";
 
 export { LeastUsedStrategy } from "./least-used";
 
@@ -100,6 +101,75 @@ export class SessionStrategy implements LoadBalancingStrategy {
 			!!account.session_start &&
 			now - account.session_start < this.sessionDurationMs
 		);
+	}
+
+	peek(accounts: Account[]): string | null {
+		const now = Date.now();
+
+		// isPeekAvailable simulates the auto-unpause that select() performs on
+		// safe-reason paused accounts (auto_fallback_enabled + window elapsed).
+		// Without it, peek() and select() disagree whenever such an account is
+		// the would-be Primary, flagging the wrong row on the dashboard while
+		// real traffic goes to the auto-unpaused one.
+		const isAvailable = (account: Account): boolean =>
+			isPeekAvailable(account, now);
+
+		// Mirror the auto-fallback path from select(), but without unpausing.
+		// When fallback would trigger, select() re-evaluates the priority queue
+		// and returns the highest-priority available account — chosenFallback
+		// only ends up first if it happens to outrank everyone else. Peek must
+		// match that, otherwise a lower-priority fallback candidate gets
+		// flagged Primary while a higher-priority non-fallback account is the
+		// one that would actually be picked.
+		const fallbackCandidates = this.checkForAutoFallbackAccounts(accounts, now);
+		const fallbackTriggered = fallbackCandidates.some((c) => isAvailable(c));
+		if (fallbackTriggered) {
+			const sorted = accounts
+				.filter((a) => isAvailable(a))
+				.sort((a, b) => a.priority - b.priority);
+			return sorted[0]?.id ?? null;
+		}
+
+		let activeAccount: Account | null = null;
+		let mostRecentSessionStart = 0;
+		for (const account of accounts) {
+			if (
+				this.hasActiveSession(account, now) &&
+				account.session_start &&
+				account.session_start > mostRecentSessionStart
+			) {
+				activeAccount = account;
+				mostRecentSessionStart = account.session_start;
+			}
+		}
+
+		if (activeAccount && isAvailable(activeAccount)) {
+			const higherPriorityAccount = accounts
+				.filter(
+					(a) =>
+						a.id !== activeAccount.id &&
+						isAvailable(a) &&
+						a.priority < activeAccount.priority,
+				)
+				.sort((a, b) => a.priority - b.priority)[0];
+
+			if (!higherPriorityAccount) {
+				return activeAccount.id;
+			}
+		}
+
+		const available = accounts
+			.filter((a) => isAvailable(a))
+			.sort((a, b) => {
+				if (a.priority !== b.priority) return a.priority - b.priority;
+				const utilA =
+					this.store?.getAccountUtilization?.(a.id, a.provider) ?? 0;
+				const utilB =
+					this.store?.getAccountUtilization?.(b.id, b.provider) ?? 0;
+				return utilA - utilB;
+			});
+
+		return available[0]?.id ?? null;
 	}
 
 	select(accounts: Account[], meta: RequestMeta): Account[] {

--- a/packages/load-balancer/src/strategies/least-used.ts
+++ b/packages/load-balancer/src/strategies/least-used.ts
@@ -1,12 +1,12 @@
 import { isAccountAvailable } from "@better-ccflare/core";
 import { Logger } from "@better-ccflare/logger";
-import {
-	type Account,
-	type LoadBalancingStrategy,
-	PROVIDER_NAMES,
-	type RequestMeta,
-	type StrategyStore,
+import type {
+	Account,
+	LoadBalancingStrategy,
+	RequestMeta,
+	StrategyStore,
 } from "@better-ccflare/types";
+import { isPeekAvailable, wouldAutoUnpause } from "./peek-availability";
 
 /**
  * Window during which a freshly-picked account is deprioritized so
@@ -22,9 +22,6 @@ const RECENT_PICK_WINDOW_MS = 500;
  * utilization deltas (typically 0–95).
  */
 const RECENT_PICK_PENALTY = 100;
-
-/** 1-second buffer for clock-skew protection on rate_limit_reset comparisons. */
-const RATE_LIMIT_RESET_BUFFER_MS = 1000;
 
 /**
  * LeastUsedStrategy — picks the available account with the lowest effective
@@ -60,6 +57,34 @@ export class LeastUsedStrategy implements LoadBalancingStrategy {
 
 	initialize(store: StrategyStore): void {
 		this.store = store;
+	}
+
+	peek(accounts: Account[]): string | null {
+		const now = Date.now();
+		// Use isPeekAvailable so accounts that select() would auto-unpause on its
+		// next call (paused with safe pause_reason + auto_fallback + elapsed
+		// window) surface as candidates here. Without this, peek() flags a
+		// lower-priority account as Primary while real traffic goes to the
+		// auto-unpaused higher-priority one.
+		const available = accounts.filter((a) => isPeekAvailable(a, now));
+		if (available.length === 0) return null;
+
+		const scored = available.map((a) => {
+			const util = this.store?.getAccountUtilization?.(a.id, a.provider) ?? 0;
+			const lastPick = this.lastPickedAt.get(a.id) ?? 0;
+			const recencyPenalty =
+				now - lastPick < RECENT_PICK_WINDOW_MS ? RECENT_PICK_PENALTY : 0;
+			return { account: a, score: util + recencyPenalty };
+		});
+
+		scored.sort((a, b) => {
+			if (a.account.priority !== b.account.priority) {
+				return a.account.priority - b.account.priority;
+			}
+			return a.score - b.score;
+		});
+
+		return scored[0]?.account.id ?? null;
 	}
 
 	select(accounts: Account[], _meta: RequestMeta): Account[] {
@@ -114,45 +139,24 @@ export class LeastUsedStrategy implements LoadBalancingStrategy {
 	}
 
 	/**
-	 * Auto-unpause any account whose:
-	 *   - auto_fallback_enabled flag is set, AND
-	 *   - upstream rate_limit_reset window has elapsed, AND
-	 *   - pause_reason is one of the reasons we consider safe to auto-unpause
-	 *     ('overage' or 'rate_limit_window'; null is also treated as safe to
-	 *     match SessionStrategy's behavior on legacy rows).
+	 * Auto-unpause any account that {@link wouldAutoUnpause} reports as
+	 * eligible (auto_fallback_enabled + safe pause_reason + window elapsed).
 	 *
 	 * Mutates the in-memory account.paused flag to false on resume so the
 	 * subsequent isAccountAvailable check reflects the new state. Manual
 	 * pauses (pause_reason='manual' or 'failure_threshold') are not touched.
+	 *
+	 * Stays in sync with SessionStrategy.select() via the shared predicate —
+	 * keep changes there mirrored here.
 	 */
 	private autoUnpauseElapsedAccounts(accounts: Account[], now: number): void {
 		if (!this.store?.resumeAccount) return;
 
 		for (const account of accounts) {
-			if (!account.paused) continue;
-			if (!account.auto_fallback_enabled) continue;
-
-			// Only providers with proactive rate-limit-reset headers are eligible
-			// (matches SessionStrategy.checkForAutoFallbackAccounts).
-			const supportsWindowReset =
-				account.provider === PROVIDER_NAMES.ANTHROPIC ||
-				account.provider === PROVIDER_NAMES.CODEX ||
-				account.provider === PROVIDER_NAMES.ZAI;
-			if (!supportsWindowReset) continue;
-
-			const windowReset =
-				account.rate_limit_reset != null &&
-				account.rate_limit_reset < now - RATE_LIMIT_RESET_BUFFER_MS;
-			if (!windowReset) continue;
-
-			// Only auto-unpause for safe reasons. Match SessionStrategy:
-			// null pause_reason is treated as legacy/safe.
-			const safeReasons = [null, "overage", "rate_limit_window"];
-			const pauseReason = account.pause_reason ?? null;
-			if (!safeReasons.includes(pauseReason as string | null)) continue;
+			if (!wouldAutoUnpause(account, now)) continue;
 
 			this.log.info(
-				`Auto-unpausing ${account.name} (pause_reason=${pauseReason}) — usage window has reset`,
+				`Auto-unpausing ${account.name} (pause_reason=${account.pause_reason ?? "null"}) — usage window has reset`,
 			);
 			this.store.resumeAccount(account.id);
 			account.paused = false;

--- a/packages/load-balancer/src/strategies/peek-availability.ts
+++ b/packages/load-balancer/src/strategies/peek-availability.ts
@@ -1,0 +1,59 @@
+import { isAccountAvailable } from "@better-ccflare/core";
+import { type Account, PROVIDER_NAMES } from "@better-ccflare/types";
+
+const RATE_LIMIT_RESET_BUFFER_MS = 1000;
+
+/**
+ * Mirrors the auto-unpause condition that select() applies before testing
+ * availability. Returns true when select() WOULD unpause this account on
+ * its next call, without performing the unpause itself.
+ *
+ * Kept in sync with SessionStrategy.select() and
+ * LeastUsedStrategy.autoUnpauseElapsedAccounts() — divergence here causes
+ * peek() to flag the wrong account as Primary while real traffic goes
+ * elsewhere.
+ */
+export function wouldAutoUnpause(
+	account: Account,
+	now: number = Date.now(),
+): boolean {
+	if (!account.paused) return false;
+	if (!account.auto_fallback_enabled) return false;
+
+	const supportsWindowReset =
+		account.provider === PROVIDER_NAMES.ANTHROPIC ||
+		account.provider === PROVIDER_NAMES.CODEX ||
+		account.provider === PROVIDER_NAMES.ZAI;
+	if (!supportsWindowReset) return false;
+
+	const windowReset =
+		account.rate_limit_reset != null &&
+		account.rate_limit_reset < now - RATE_LIMIT_RESET_BUFFER_MS;
+	if (!windowReset) return false;
+
+	const pauseReason = account.pause_reason ?? null;
+	return (
+		pauseReason === null ||
+		pauseReason === "overage" ||
+		pauseReason === "rate_limit_window"
+	);
+}
+
+/**
+ * Side-effect-free availability check that includes the auto-unpause
+ * simulation. Use in peek() so a paused-but-eligible account surfaces as
+ * the would-be-primary instead of being skipped over because of its
+ * stale `paused` flag.
+ */
+export function isPeekAvailable(
+	account: Account,
+	now: number = Date.now(),
+): boolean {
+	if (isAccountAvailable(account, now)) return true;
+	if (!wouldAutoUnpause(account, now)) return false;
+	// wouldAutoUnpause already validated the account is otherwise eligible
+	// (paused with safe reason + auto-fallback + window elapsed). The only
+	// remaining blocker isAccountAvailable would check is rate_limited_until,
+	// which is independent of pause state.
+	return !account.rate_limited_until || account.rate_limited_until < now;
+}

--- a/packages/types/src/account.ts
+++ b/packages/types/src/account.ts
@@ -210,6 +210,7 @@ export interface AccountResponse {
 	modelFallbacks?: { [key: string]: string } | null;
 	billingType?: string | null;
 	sessionStats: SessionStats | null;
+	isPrimary: boolean; // True if this is the account the load balancer would pick next
 }
 
 // UI display type - used in CLI and web dashboard
@@ -432,6 +433,7 @@ export function toAccountResponse(account: Account): AccountResponse {
 		modelFallbacks,
 		billingType: account.billing_type,
 		sessionStats: null,
+		isPrimary: false,
 	};
 }
 

--- a/packages/types/src/context.ts
+++ b/packages/types/src/context.ts
@@ -35,6 +35,7 @@ export interface APIContext {
 		startedAt: number | null;
 	};
 	getIntegrityStatus?: () => IntegrityStatus;
+	getStrategy?: () => LoadBalancingStrategy | null;
 }
 
 // Load balancing strategy interface
@@ -45,6 +46,14 @@ export interface LoadBalancingStrategy {
 	 * The first account in the list should be tried first.
 	 */
 	select(accounts: Account[], meta: RequestMeta): Account[];
+
+	/**
+	 * Side-effect-free preview: return the ID of the account that would
+	 * be picked first by select() given the current state, or null if
+	 * no account is available. MUST NOT mutate any state (no DB writes,
+	 * no resumeAccount, no resetSession, no internal counters).
+	 */
+	peek(accounts: Account[]): string | null;
 
 	/**
 	 * Optional initialization method to inject dependencies


### PR DESCRIPTION
The dashboard's "Active" badge was based on `lastUsed`, which auto-refresh probes also bump (response-processor.ts updates last_used on bypass-session requests too). Result: an account that just received a synthetic refresh probe shows up as "Active" while real traffic silently goes elsewhere.

Add a side-effect-free `peek(accounts)` to the LoadBalancingStrategy interface; both SessionStrategy and LeastUsedStrategy implement it without DB writes, session resets, or auto-unpauses. The dashboard's accounts-list endpoint calls it and stamps `isPrimary: true` on the row the load balancer would actually pick next. Badge text changes from "Active" to "Primary" to match the new semantics.