### PR TITLE
fix: skip PRAGMA integrity_check in post-processor worker

### DIFF
--- a/packages/proxy/src/post-processor.worker.ts
+++ b/packages/proxy/src/post-processor.worker.ts
@@ -102,8 +102,11 @@ let tokenEncoder: Tiktoken | null = null;
 // initialized inside the worker, not just on the main thread.
 await initPayloadEncryption();
 
-// Initialize database connection for worker
-const dbOps = new DatabaseOperations();
+// Initialize database connection for worker.
+// fastMode=true skips PRAGMA integrity_check — the main thread already ran it on
+// the same file, and on large DBs (multi-GB) this PRAGMA can take minutes,
+// blowing past the worker controller's 10s startup timeout.
+const dbOps = new DatabaseOperations(undefined, undefined, undefined, true);
 dbOps.initializeAsync().catch((err: unknown) => {
 	log.error("Failed to initialize database async connection:", err);
 });


### PR DESCRIPTION
The worker constructs its own `DatabaseOperations` instance, which by default runs `PRAGMA integrity_check` in `configureSqlite()`. The main thread has already run that check against the same file, and on multi-GB databases the PRAGMA can take minutes — far longer than the worker controller's 10s startup timeout. The controller then declares the worker dead, retries up to MAX_RESTARTS=3, gives up, and silently drops all request records (the proxy's `safePostMessage` swallows the worker-not-ready error so users only see "Request & Analytics is stuck" with no proxy errors).

Pass `fastMode=true` to skip the redundant check. The main thread's result is authoritative for the file; per-handle re-checks add no signal.

Repro: any deployment with a sufficiently large SQLite DB (~7 GB observed) where the integrity check exceeds the worker's 10s startup window. After this fix the worker reaches "ready" within a second on the same DB.