### PR TITLE
fix: redesign request history row layout and fix slow load

### DIFF
--- a/packages/dashboard-web/src/components/CopyButton.tsx
+++ b/packages/dashboard-web/src/components/CopyButton.tsx
@@ -1,6 +1,5 @@
-import { Check, Copy } from "lucide-react";
+import { AlertCircle, Check, Copy, Loader2 } from "lucide-react";
 import { type ComponentProps, useRef, useState } from "react";
-import { copyText } from "../lib/clipboard";
 import { cn } from "../lib/utils";
 import { Button } from "./ui/button";
 
@@ -10,6 +9,12 @@ interface CopyButtonProps {
 	 */
 	value?: string;
 	getValue?: () => string;
+	/**
+	 * Async value resolver. Used when the value isn't available synchronously
+	 * (e.g. when bodies need to be lazy-fetched). When set, the button shows a
+	 * spinner while resolving.
+	 */
+	getValueAsync?: () => Promise<string>;
 	/**
 	 * Forwarded props to underlying Button
 	 */
@@ -33,6 +38,7 @@ interface CopyButtonProps {
 export function CopyButton({
 	value,
 	getValue,
+	getValueAsync,
 	variant = "ghost",
 	size = "sm",
 	className,
@@ -40,22 +46,49 @@ export function CopyButton({
 	title,
 }: CopyButtonProps) {
 	const [copied, setCopied] = useState(false);
+	const [loading, setLoading] = useState(false);
+	const [errored, setErrored] = useState(false);
 	const timeoutRef = useRef<number | null>(null);
 
-	const handleCopy = () => {
-		const text = typeof getValue === "function" ? getValue() : (value ?? "");
-		if (!text) return;
+	const flashError = (err: unknown) => {
+		console.error("Copy failed", err);
+		setErrored(true);
+		if (timeoutRef.current) {
+			window.clearTimeout(timeoutRef.current);
+		}
+		timeoutRef.current = window.setTimeout(() => setErrored(false), 1500);
+	};
 
-		copyText(text)
+	const finishCopy = (text: string) => {
+		if (!text) {
+			flashError(new Error("No value to copy"));
+			return;
+		}
+
+		navigator.clipboard
+			.writeText(text)
 			.then(() => {
 				setCopied(true);
-				// Reset after 1.5s
 				if (timeoutRef.current) {
 					window.clearTimeout(timeoutRef.current);
 				}
 				timeoutRef.current = window.setTimeout(() => setCopied(false), 1500);
 			})
-			.catch((err) => console.error("Failed to copy", err));
+			.catch((err) => flashError(err));
+	};
+
+	const handleCopy = () => {
+		if (loading) return;
+		if (typeof getValueAsync === "function") {
+			setLoading(true);
+			getValueAsync()
+				.then((text) => finishCopy(text))
+				.catch((err) => flashError(err))
+				.finally(() => setLoading(false));
+			return;
+		}
+		const text = typeof getValue === "function" ? getValue() : (value ?? "");
+		finishCopy(text);
 	};
 
 	return (
@@ -65,8 +98,15 @@ export function CopyButton({
 			onClick={handleCopy}
 			title={title}
 			className={cn("relative overflow-hidden", className)}
+			disabled={loading}
 		>
-			{copied ? (
+			{loading ? (
+				<Loader2 className="h-4 w-4 animate-spin" />
+			) : errored ? (
+				<span className="animate-pulse text-destructive" title="Copy failed">
+					<AlertCircle className="h-4 w-4" />
+				</span>
+			) : copied ? (
 				<span className="animate-pulse">
 					<Check className="h-4 w-4" />
 				</span>

--- a/packages/dashboard-web/src/components/CopyButton.tsx
+++ b/packages/dashboard-web/src/components/CopyButton.tsx
@@ -53,6 +53,11 @@ export function CopyButton({
 	const flashError = (err: unknown) => {
 		console.error("Copy failed", err);
 		setErrored(true);
+		// Clear any lingering success state — `clearTimeout` below cancels
+		// the success-reset job too, so without `setCopied(false)` a failure
+		// that follows a recent success within 1.5 s would leave the Check
+		// icon shown indefinitely (until unmount).
+		setCopied(false);
 		if (timeoutRef.current) {
 			window.clearTimeout(timeoutRef.current);
 		}
@@ -69,6 +74,12 @@ export function CopyButton({
 			.writeText(text)
 			.then(() => {
 				setCopied(true);
+				// Clear any lingering error state from a previous attempt.
+				// `clearTimeout` below cancels the error-reset job too, so
+				// without this `setErrored(false)` a retry that succeeds within
+				// 1.5 s of a failed attempt would leave the AlertCircle icon
+				// shown indefinitely (until unmount).
+				setErrored(false);
 				if (timeoutRef.current) {
 					window.clearTimeout(timeoutRef.current);
 				}

--- a/packages/dashboard-web/src/components/RequestDetailsModal.tsx
+++ b/packages/dashboard-web/src/components/RequestDetailsModal.tsx
@@ -42,8 +42,14 @@ export function RequestDetailsModal({
 	const effective: RequestPayload =
 		hydrated && hydrated.id === request.id ? hydrated : request;
 
+	// Hydrate when we have no request payload at all (legacy case), or when
+	// the list view handed us a body-less summary placeholder.
 	const needsHydration =
-		isOpen && !effective.error && !effective.request && failedId !== request.id;
+		isOpen &&
+		!effective.error &&
+		!effective.meta?.pending &&
+		(!effective.request || effective.meta?.bodiesOmitted === true) &&
+		failedId !== request.id;
 
 	useEffect(() => {
 		if (!needsHydration) return;
@@ -142,9 +148,6 @@ export function RequestDetailsModal({
 							)}
 							{summary?.costUsd && summary.costUsd > 0 && (
 								<Badge variant="default">{formatCost(summary.costUsd)}</Badge>
-							)}
-							{request.meta.rateLimited && (
-								<Badge variant="warning">Rate Limited</Badge>
 							)}
 						</div>
 						<div className="flex items-center gap-2">

--- a/packages/dashboard-web/src/components/RequestsTab.tsx
+++ b/packages/dashboard-web/src/components/RequestsTab.tsx
@@ -19,9 +19,9 @@ import {
 	X,
 } from "lucide-react";
 import { useMemo, useState } from "react";
-import type { RequestPayload, RequestSummary } from "../api";
+import { api, type RequestPayload, type RequestSummary } from "../api";
 import { API_LIMITS } from "../constants";
-import { useAccounts, useRequests } from "../hooks/queries";
+import { useAccounts, useApiKeys, useRequests } from "../hooks/queries";
 import { useRequestStream } from "../hooks/useRequestStream";
 import { isAnthropicPeakHour, isZaiPeakHour } from "../utils/provider-utils";
 import { CopyButton } from "./CopyButton";
@@ -77,6 +77,7 @@ export function RequestsTab() {
 	useRequestStream(API_LIMITS.requestsDetail);
 
 	const { data: accounts } = useAccounts();
+	const { data: configuredApiKeys } = useApiKeys();
 	const zaiAccountNames = new Set(
 		(accounts ?? []).filter((a) => a.provider === "zai").map((a) => a.name),
 	);
@@ -104,17 +105,16 @@ export function RequestsTab() {
 		};
 	}, [requestsData]);
 
-	// Extract unique accounts for filter dropdown - memoized
+	// Filter dropdown options come from dedicated endpoints (not from the loaded
+	// requests slice) so every configured account/API key is selectable, even
+	// when it doesn't appear in the most recent N requests.
 	const uniqueAccounts = useMemo(() => {
-		if (!data) return [];
-		return Array.from(
-			new Set(
-				data.requests
-					.map((r) => r.meta.accountName || r.meta.accountId)
-					.filter(Boolean),
-			),
-		).sort();
-	}, [data]);
+		const fromConfig = (accounts ?? []).map((a) => a.name).filter(Boolean);
+		const fromRequests = (data?.requests ?? [])
+			.map((r) => r.meta.accountName || r.meta.accountId)
+			.filter((v): v is string => Boolean(v));
+		return Array.from(new Set([...fromConfig, ...fromRequests])).sort();
+	}, [accounts, data]);
 
 	// Extract unique status codes for filter - memoized
 	const uniqueStatusCodes = useMemo(() => {
@@ -143,20 +143,18 @@ export function RequestsTab() {
 		).sort();
 	}, [data]);
 
-	// Extract unique API keys for filter - memoized
+	// API key filter: union of all configured keys (from /api/api-keys) and any
+	// keys observed in the loaded request slice (covers historical keys that
+	// were deleted but still appear on past requests).
 	const uniqueApiKeys = useMemo(() => {
-		if (!data) return [];
-		return Array.from(
-			new Set(
-				data.requests
-					.map((r) => {
-						const summary = data.summaries.get(r.id);
-						return summary?.apiKeyName;
-					})
-					.filter(Boolean),
-			),
-		).sort();
-	}, [data]);
+		const fromConfig = (configuredApiKeys ?? []).map((k) => k.name);
+		const fromRequests = data
+			? Array.from(data.summaries.values())
+					.map((s) => s.apiKeyName)
+					.filter((v): v is string => Boolean(v))
+			: [];
+		return Array.from(new Set([...fromConfig, ...fromRequests])).sort();
+	}, [configuredApiKeys, data]);
 
 	// Filter requests based on selected filters - memoized to avoid recalculation on every render
 	const filteredRequests = useMemo(() => {
@@ -713,59 +711,157 @@ export function RequestsTab() {
 							const isError = request.error || !request.meta.success;
 							const statusCode = request.response?.status;
 							const summary = data?.summaries.get(request.id);
+							const method = request.meta.method || summary?.method;
+							const path = request.meta.path || summary?.path;
+							const accountLabel =
+								request.meta.accountName ||
+								(request.meta.accountId
+									? `${request.meta.accountId.slice(0, 8)}...`
+									: null);
+							const agent = summary?.agentUsed || request.meta.agentUsed;
+							const isZaiPeak =
+								zaiAccountNames.has(request.meta.accountName ?? "") &&
+								isZaiPeakHour(request.meta.timestamp);
+							const isAnthropicPeak =
+								oauthAccountNames.has(request.meta.accountName ?? "") &&
+								isAnthropicPeakHour(request.meta.timestamp);
+							const statusClass =
+								statusCode == null
+									? ""
+									: statusCode >= 200 && statusCode < 300
+										? "bg-green-500/10 text-green-600 dark:text-green-400"
+										: statusCode >= 400 && statusCode < 500
+											? "bg-yellow-500/10 text-yellow-600 dark:text-yellow-400"
+											: statusCode >= 500
+												? "bg-red-500/10 text-red-600 dark:text-red-400"
+												: "bg-muted text-muted-foreground";
 
 							return (
 								<div
 									key={request.id}
-									className={`border rounded-lg p-3 transition-all duration-300 ${
+									className={`border rounded-lg transition-all duration-300 ${
 										isError ? "border-destructive/50" : "border-border"
 									} ${request.meta.pending ? "animate-pulse opacity-70" : "opacity-100"}`}
 								>
-									<button
-										type="button"
-										className="flex items-center justify-between cursor-pointer w-full text-left"
-										onClick={() => toggleExpanded(request.id)}
-									>
-										<div className="flex items-center gap-2 flex-wrap">
+									{/* Header row: single line, never wraps */}
+									<div className="flex items-center gap-2 p-3">
+										<button
+											type="button"
+											className="flex items-center gap-2 min-w-0 flex-1 text-left cursor-pointer"
+											onClick={() => toggleExpanded(request.id)}
+											aria-expanded={isExpanded}
+										>
 											{isExpanded ? (
-												<ChevronDown className="h-4 w-4" />
+												<ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
 											) : (
-												<ChevronRight className="h-4 w-4" />
+												<ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
 											)}
-											<span className="text-sm font-mono">
+											<span className="text-xs font-mono tabular-nums text-muted-foreground shrink-0">
 												{new Date(request.meta.timestamp).toLocaleTimeString()}
 											</span>
-											{(request.meta.method || summary?.method) && (
-												<span className="text-sm font-medium">
-													{request.meta.method || summary?.method}
-												</span>
-											)}
-											{(request.meta.path || summary?.path) && (
-												<span className="text-sm text-muted-foreground font-mono">
-													{request.meta.path || summary?.path}
-												</span>
-											)}
-											{statusCode && (
+											{statusCode != null && (
 												<span
-													className={`text-sm font-medium ${
-														statusCode >= 200 && statusCode < 300
-															? "text-green-600"
-															: statusCode >= 400 && statusCode < 500
-																? "text-yellow-600"
-																: "text-red-600"
-													}`}
+													className={`text-xs font-mono font-semibold tabular-nums px-1.5 py-0.5 rounded shrink-0 ${statusClass}`}
 												>
 													{statusCode}
 												</span>
 											)}
+											{method && (
+												<span className="text-xs font-semibold uppercase shrink-0">
+													{method}
+												</span>
+											)}
+											{path && (
+												<span className="text-xs font-mono text-muted-foreground truncate min-w-0 flex-1">
+													{path}
+												</span>
+											)}
+											{summary?.responseTimeMs != null && (
+												<span
+													className="text-xs font-mono tabular-nums text-muted-foreground shrink-0"
+													title="Response time"
+												>
+													{formatDuration(summary.responseTimeMs)}
+												</span>
+											)}
+											<span
+												className="text-[11px] font-mono text-muted-foreground/70 shrink-0 hidden sm:inline"
+												title={request.id}
+											>
+												{request.id.slice(0, 8)}
+											</span>
+										</button>
+
+										{/* Action buttons stay outside the toggle-expand button so they
+										    never get cut off by flex shrinking and have their own hit area. */}
+										<div className="flex items-center gap-1 shrink-0">
+											<Button
+												variant="ghost"
+												size="icon"
+												onClick={() => setModalRequest(request)}
+												title="View Details"
+											>
+												<Eye className="h-4 w-4" />
+											</Button>
+											<CopyButton
+												variant="ghost"
+												size="icon"
+												title="Copy as JSON"
+												getValueAsync={async () => {
+													const full = request.meta.bodiesOmitted
+														? await api.getRequestPayload(request.id)
+														: request;
+													const decoded: RequestPayload & {
+														decoded?: true;
+													} = {
+														...full,
+														request: full.request
+															? {
+																	...full.request,
+																	body: full.request.body
+																		? decodeBase64(full.request.body)
+																		: null,
+																}
+															: full.request,
+														response: full.response
+															? {
+																	...full.response,
+																	body: full.response.body
+																		? decodeBase64(full.response.body)
+																		: null,
+																}
+															: null,
+														decoded: true,
+													};
+													return JSON.stringify(decoded, null, 2);
+												}}
+											/>
+										</div>
+									</div>
+
+									{/* Badges row: wraps freely, holds all the non-essential context */}
+									{(summary?.model ||
+										agent ||
+										summary?.comboName ||
+										summary?.apiKeyName ||
+										summary?.totalTokens != null ||
+										summary?.costUsd != null ||
+										summary?.billingType ||
+										(summary?.tokensPerSecond ?? 0) > 0 ||
+										accountLabel ||
+										request.meta.rateLimited ||
+										isZaiPeak ||
+										isAnthropicPeak) && (
+										<div className="flex flex-wrap items-center gap-1.5 px-3 pb-2 pl-9 text-xs">
 											{summary?.model && (
 												<Badge variant="secondary" className="text-xs">
 													{summary.model}
 												</Badge>
 											)}
-											{(summary?.agentUsed || request.meta.agentUsed) && (
+											{agent && (
 												<Badge variant="secondary" className="text-xs">
-													Agent: {summary?.agentUsed || request.meta.agentUsed}
+													<Bot className="h-3 w-3 mr-1" />
+													{agent}
 												</Badge>
 											)}
 											{summary?.comboName && (
@@ -782,19 +878,14 @@ export function RequestsTab() {
 													{summary.apiKeyName}
 												</Badge>
 											)}
-											{(summary?.totalTokens || request.meta.pending) && (
+											{summary?.totalTokens != null && (
 												<Badge variant="outline" className="text-xs">
-													{summary?.totalTokens
-														? formatTokens(summary.totalTokens)
-														: "--"}{" "}
-													tokens
+													{formatTokens(summary.totalTokens)} tokens
 												</Badge>
 											)}
-											{(summary?.costUsd || request.meta.pending) && (
+											{summary?.costUsd != null && summary.costUsd > 0 && (
 												<Badge variant="default" className="text-xs">
-													{summary?.costUsd && summary.costUsd > 0
-														? formatCost(summary.costUsd)
-														: "--"}
+													{formatCost(summary.costUsd)}
 												</Badge>
 											)}
 											{summary?.billingType === "overage" && (
@@ -813,17 +904,15 @@ export function RequestsTab() {
 													Plan
 												</Badge>
 											)}
-											{summary?.tokensPerSecond &&
+											{summary?.tokensPerSecond != null &&
 												summary.tokensPerSecond > 0 && (
 													<Badge variant="secondary" className="text-xs">
 														{formatTokensPerSecond(summary.tokensPerSecond)}
 													</Badge>
 												)}
-											{(request.meta.accountName || request.meta.accountId) && (
-												<span className="text-sm text-muted-foreground">
-													via{" "}
-													{request.meta.accountName ||
-														`${request.meta.accountId?.slice(0, 8)}...`}
+											{accountLabel && (
+												<span className="text-xs text-muted-foreground">
+													via {accountLabel}
 												</span>
 											)}
 											{request.meta.rateLimited && (
@@ -831,86 +920,25 @@ export function RequestsTab() {
 													Rate Limited
 												</Badge>
 											)}
-											{zaiAccountNames.has(request.meta.accountName ?? "") &&
-												isZaiPeakHour(request.meta.timestamp) && (
-													<Badge
-														variant="outline"
-														className="text-xs border-orange-500 text-orange-500"
-													>
-														Peak
-													</Badge>
-												)}
-											{oauthAccountNames.has(request.meta.accountName ?? "") &&
-												isAnthropicPeakHour(request.meta.timestamp) && (
-													<Badge
-														variant="outline"
-														className="text-xs border-orange-500 text-orange-500"
-													>
-														Peak
-													</Badge>
-												)}
-											{request.error && (
-												<span className="text-sm text-destructive">
-													Error: {request.error}
-												</span>
+											{(isZaiPeak || isAnthropicPeak) && (
+												<Badge
+													variant="outline"
+													className="text-xs border-orange-500 text-orange-500"
+												>
+													Peak
+												</Badge>
 											)}
 										</div>
-										<div className="text-sm text-muted-foreground flex items-center gap-2">
-											{(summary?.responseTimeMs || request.meta.pending) && (
-												<span>
-													{summary?.responseTimeMs
-														? formatDuration(summary.responseTimeMs)
-														: "--"}
-												</span>
-											)}
-											{request.meta.retry !== undefined &&
-												request.meta.retry > 0 && (
-													<span>Retry {request.meta.retry}</span>
-												)}
-											<span>ID: {request.id.slice(0, 8)}...</span>
-										</div>
-									</button>
+									)}
 
-									{/* Action buttons */}
-									<div className="flex justify-end gap-2 mt-2">
-										<Button
-											variant="ghost"
-											size="icon"
-											onClick={() => setModalRequest(request)}
-											title="View Details"
-										>
-											<Eye className="h-4 w-4" />
-										</Button>
-										<CopyButton
-											variant="ghost"
-											size="icon"
-											title="Copy as JSON"
-											getValue={() => {
-												const decoded: RequestPayload & { decoded?: true } = {
-													...request,
-													request: {
-														...request.request,
-														body: request.request.body
-															? decodeBase64(request.request.body)
-															: null,
-													},
-													response: request.response
-														? {
-																...request.response,
-																body: request.response.body
-																	? decodeBase64(request.response.body)
-																	: null,
-															}
-														: null,
-													decoded: true,
-												};
-												return JSON.stringify(decoded, null, 2);
-											}}
-										/>
-									</div>
+									{request.error && (
+										<div className="text-xs text-destructive px-3 pb-2 pl-9 break-words">
+											Error: {request.error}
+										</div>
+									)}
 
 									{isExpanded && (
-										<div className="mt-3 space-y-3">
+										<div className="px-3 pb-3 pl-9 space-y-3">
 											<TokenUsageDisplay summary={summary} />
 											<Button
 												variant="outline"

--- a/packages/dashboard-web/src/hooks/queries.ts
+++ b/packages/dashboard-web/src/hooks/queries.ts
@@ -1,7 +1,42 @@
 import type { AgentUpdatePayload } from "@better-ccflare/types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { api } from "../api";
+import { api, type RequestPayload, type RequestSummary } from "../api";
 import { queryKeys } from "../lib/query-keys";
+
+/**
+ * Build a lightweight RequestPayload from a RequestSummary.
+ *
+ * The list view only needs metadata; full bodies (which can be ~256KB each)
+ * are lazy-loaded by RequestDetailsModal and CopyButton via /api/requests/payload/:id.
+ * `meta.bodiesOmitted` signals to consumers that the bodies must be hydrated.
+ */
+export function summaryToPlaceholder(summary: RequestSummary): RequestPayload {
+	// `accountUsed` is the resolved account name when the JOIN succeeds, else
+	// the raw account ID. We put it in accountName so the row renders the
+	// friendly name; the ID-only fallback is rare (only after account deletion).
+	const accountName = summary.accountUsed ?? undefined;
+	return {
+		id: summary.id,
+		request: { headers: {}, body: null },
+		response:
+			summary.statusCode != null
+				? { status: summary.statusCode, headers: {}, body: null }
+				: null,
+		error: summary.errorMessage ?? undefined,
+		meta: {
+			accountName,
+			timestamp: new Date(summary.timestamp).getTime(),
+			success: summary.success,
+			path: summary.path,
+			method: summary.method,
+			agentUsed: summary.agentUsed,
+			// Server derives this from statusCode === 429 so the list view can
+			// render the Rate Limited badge without lazy-loading the body.
+			rateLimited: summary.rateLimited,
+			bodiesOmitted: true,
+		},
+	};
+}
 
 export const useAccounts = () => {
 	return useQuery({
@@ -22,6 +57,34 @@ export const useAgents = () => {
 		refetchInterval: 60000, // Increase from 30 to 60 seconds
 		refetchIntervalInBackground: false, // Don't refresh when tab is not focused
 		gcTime: 10 * 60 * 1000, // Keep in cache for 10 minutes
+	});
+};
+
+interface ApiKeyListItem {
+	id: string;
+	name: string;
+	prefixLast8: string;
+	createdAt: string;
+	lastUsed: string | null;
+	usageCount: number;
+	isActive: boolean;
+}
+
+interface ApiKeysListResponse {
+	success: boolean;
+	data: ApiKeyListItem[];
+	count: number;
+}
+
+export const useApiKeys = () => {
+	return useQuery({
+		queryKey: queryKeys.apiKeys(),
+		queryFn: async () => {
+			const res = await api.get<ApiKeysListResponse>("/api/api-keys");
+			return res.data ?? [];
+		},
+		staleTime: 60000,
+		gcTime: 5 * 60 * 1000,
 	});
 };
 
@@ -119,15 +182,16 @@ export const useRequests = (limit: number, _refetchInterval?: number) => {
 	return useQuery({
 		queryKey: queryKeys.requests(limit),
 		queryFn: async () => {
-			const [requestsDetail, requestsSummary] = await Promise.all([
-				api.getRequestsDetail(limit),
-				api.getRequestsSummary(limit),
-			]);
-			// Convert array to Map for detailsMap
+			// Fetch only the summary endpoint - it has everything the list view needs.
+			// Full request/response bodies are lazy-loaded per row when needed
+			// (modal open, copy-as-JSON) via /api/requests/payload/:id.
+			const requestsSummary = await api.getRequestsSummary(limit);
 			const detailsMap = new Map(
 				requestsSummary.map((summary) => [summary.id, summary]),
 			);
-			return { requests: requestsDetail, detailsMap };
+			const requests: RequestPayload[] =
+				requestsSummary.map(summaryToPlaceholder);
+			return { requests, detailsMap };
 		},
 		staleTime: Infinity, // Consider data fresh until manually refetched
 		gcTime: 10 * 60 * 1000, // Keep in cache for 10 minutes

--- a/packages/dashboard-web/src/hooks/useRequestStream.ts
+++ b/packages/dashboard-web/src/hooks/useRequestStream.ts
@@ -126,7 +126,12 @@ export function useRequestStream(limit = 200) {
 							);
 							const account = accounts?.find((a) => a.id === evt.accountId);
 
-							// Create a lightweight placeholder payload
+							// Create a lightweight placeholder payload.
+							// `bodiesOmitted: true` is required so that opening the
+							// details modal or pressing Copy-as-JSON triggers the
+							// lazy /api/requests/payload/:id fetch — without it the
+							// modal shows empty headers/body and the copy returns
+							// nulled-out bodies.
 							const placeholder: RequestPayload = {
 								id: evt.id,
 								request: { headers: {}, body: null },
@@ -144,6 +149,8 @@ export function useRequestStream(limit = 200) {
 									success: false,
 									pending: true,
 									agentUsed: evt.agentUsed || undefined,
+									rateLimited: evt.statusCode === 429,
+									bodiesOmitted: true,
 								},
 							};
 
@@ -179,7 +186,11 @@ export function useRequestStream(limit = 200) {
 						);
 						if (requestIndex >= 0) {
 							const newRequests = [...current.requests];
-							// Update meta to remove pending status
+							// Update meta to remove pending status. Preserve
+							// `bodiesOmitted: true` so consumers continue to lazy-
+							// load bodies, and refresh `rateLimited` from the final
+							// statusCode (the placeholder set it from `evt.statusCode`
+							// which is 0 until the response lands).
 							if (newRequests[requestIndex].meta) {
 								newRequests[requestIndex] = {
 									...newRequests[requestIndex],
@@ -187,6 +198,8 @@ export function useRequestStream(limit = 200) {
 										...newRequests[requestIndex].meta,
 										pending: false,
 										success: evt.payload.success,
+										rateLimited: evt.payload.rateLimited,
+										bodiesOmitted: true,
 									},
 								};
 							}

--- a/packages/dashboard-web/src/hooks/useRequestStream.ts
+++ b/packages/dashboard-web/src/hooks/useRequestStream.ts
@@ -132,14 +132,23 @@ export function useRequestStream(limit = 200) {
 							// lazy /api/requests/payload/:id fetch — without it the
 							// modal shows empty headers/body and the copy returns
 							// nulled-out bodies.
+							//
+							// `response: null` when no status is known yet so the
+							// status chip (guarded by `statusCode != null`) does NOT
+							// render a "0" before the response lands. The summary
+							// handler below patches response.status from
+							// `evt.payload.statusCode` once the request completes.
+							const hasStatus = evt.statusCode > 0;
 							const placeholder: RequestPayload = {
 								id: evt.id,
 								request: { headers: {}, body: null },
-								response: {
-									status: evt.statusCode,
-									headers: {},
-									body: null,
-								},
+								response: hasStatus
+									? {
+											status: evt.statusCode,
+											headers: {},
+											body: null,
+										}
+									: null,
 								meta: {
 									timestamp: evt.timestamp,
 									path: evt.path,
@@ -194,6 +203,22 @@ export function useRequestStream(limit = 200) {
 							if (newRequests[requestIndex].meta) {
 								newRequests[requestIndex] = {
 									...newRequests[requestIndex],
+									// Refresh response.status from the final summary —
+									// the start placeholder set it to 0 before the HTTP
+									// response landed, and the new header-row chip uses
+									// a `statusCode != null` guard (0 is not null), so
+									// without this every SSE-completed request would
+									// permanently display a grey "0" chip.
+									response:
+										evt.payload.statusCode != null
+											? {
+													...(newRequests[requestIndex].response ?? {
+														headers: {},
+														body: null,
+													}),
+													status: evt.payload.statusCode,
+												}
+											: null,
 									meta: {
 										...newRequests[requestIndex].meta,
 										pending: false,

--- a/packages/dashboard-web/src/lib/query-keys.ts
+++ b/packages/dashboard-web/src/lib/query-keys.ts
@@ -3,9 +3,9 @@ export const queryKeys = {
 	accounts: () => [...queryKeys.all, "accounts"] as const,
 	agents: () => [...queryKeys.all, "agents"] as const,
 	stats: (errorsSinceHours?: number) =>
-		errorsSinceHours === undefined
-			? ([...queryKeys.all, "stats"] as const)
-			: ([...queryKeys.all, "stats", { errorsSinceHours }] as const),
+		errorsSinceHours !== undefined
+			? ([...queryKeys.all, "stats", { errorsSinceHours }] as const)
+			: ([...queryKeys.all, "stats"] as const),
 	analytics: (
 		timeRange?: string,
 		filters?: unknown,
@@ -25,4 +25,5 @@ export const queryKeys = {
 		[...queryKeys.all, "config", "defaultAgentModel"] as const,
 	combos: () => [...queryKeys.all, "combos"] as const,
 	families: () => [...queryKeys.all, "families"] as const,
+	apiKeys: () => [...queryKeys.all, "api-keys"] as const,
 } as const;

--- a/packages/http-api/src/handlers/requests.ts
+++ b/packages/http-api/src/handlers/requests.ts
@@ -100,6 +100,7 @@ export function createRequestsSummaryHandler(db: BunSqlAdapter) {
 			apiKeyName: request.api_key_name || undefined,
 			billingType: request.billing_type || undefined,
 			comboName: request.combo_name || undefined,
+			rateLimited: request.status_code === 429,
 		}));
 
 		return jsonResponse(response);

--- a/packages/types/src/request.ts
+++ b/packages/types/src/request.ts
@@ -86,6 +86,9 @@ export interface RequestResponse {
 	project?: string;
 	billingType?: string;
 	comboName?: string;
+	// Derived from statusCode === 429 server-side so the list view can render
+	// the "Rate Limited" badge without lazy-loading the full payload.
+	rateLimited?: boolean;
 }
 
 // Detailed request with payload
@@ -109,7 +112,6 @@ export interface RequestPayload {
 		retry?: number;
 		timestamp: number;
 		success?: boolean;
-		rateLimited?: boolean;
 		accountsAttempted?: number;
 		pending?: boolean;
 		path?: string;
@@ -118,6 +120,14 @@ export interface RequestPayload {
 		requestBodyTruncated?: boolean;
 		responseBodyTruncated?: boolean;
 		limitApplied?: number;
+		// True when the server (or client-side synthesis) returned this payload
+		// without request/response bodies. Consumers that need bodies must
+		// re-fetch via GET /api/requests/payload/:id.
+		bodiesOmitted?: boolean;
+		// Mirror of RequestResponse.rateLimited so the list view can render
+		// the "Rate Limited" badge from a summary-only payload (no body
+		// hydration required).
+		rateLimited?: boolean;
 	};
 }
 
@@ -196,6 +206,7 @@ export function toRequestResponse(request: Request): RequestResponse {
 		project: request.project,
 		billingType: request.billingType,
 		comboName: request.comboName,
+		rateLimited: request.statusCode === 429,
 	};
 }
 


### PR DESCRIPTION
The Request History page suffered three issues:

1. Cramped layout: the top row mashed the timestamp, status, method, path, status code, every badge (model, agent, combo, api-key, tokens, cost, billing, TPS, account, peak, etc.), response time, retry counter and request ID into a single flex-wrap. With many badges, the response time, ID and action buttons (Eye, Copy) on the right got pushed onto a second line or visually cut off.

2. Slow page load: the list view called /api/requests/detail, which returns full request and response bodies (up to 256KB each, so ~12MB of base64 per page load before any decrypt/parse cost), even though the row only needs summary metadata.

3. API key filter was incomplete: filter options were derived only from the loaded 50 requests, so any key not used in those requests was unselectable.

Changes:

- Two-row card layout. Top row is a single line that never wraps: chevron, time, colored status chip, method, truncating path, response time, 8-char id, then Eye and Copy buttons in their own hit area outside the toggle-expand button so they can never be shrunk away. Second row holds all badges (model, agent, combo, api-key, tokens, cost, billing, TPS, "via account", peak, rate-limited) and wraps freely.

- Switch useRequests to fetch only the summary endpoint and build lightweight RequestPayload placeholders client-side (marked meta.bodiesOmitted = true). RequestDetailsModal already lazy- loads via /api/requests/payload/:id; trigger that hydration when bodiesOmitted is set. CopyButton gains an async resolver (getValueAsync) with a loader state so Copy-as-JSON can hydrate bodies on demand.

- API key filter options come from the dedicated /api/api-keys endpoint (new useApiKeys hook) unioned with keys observed in the loaded slice. Same union treatment for the account filter using useAccounts so deleted-but-historical entries remain selectable.

- Drop the dead retry counter display - response-handler.ts notes retryAttempt is always 0 in the current flow.