### PR TITLE
improve: use VACUUM INTO + atomic rename for migration backup

### DIFF
--- a/packages/database/src/migrations.ts
+++ b/packages/database/src/migrations.ts
@@ -374,23 +374,31 @@ export function runMigrations(db: Database, dbPath?: string): void {
 					// the migration's own writes. Two-phase rename avoids leaving a
 					// half-written `.backup.<ts>` if SIGTERM hits mid-VACUUM.
 					const tempBackupPath = `${backupPath}.partial`;
+					// SQLite string literals only need single-quote doubling for
+					// escaping — backslash is not special. Embedding the path as a
+					// quoted literal is required because VACUUM INTO does not
+					// support host parameter binding for the destination path.
 					const escapedTempPath = tempBackupPath.replace(/'/g, "''");
 					try {
 						// VACUUM INTO refuses if the target exists, and a SIGTERM during
-						// a previous attempt may have left one behind.
-						if (fs.existsSync(tempBackupPath)) {
+						// a previous attempt may have left one behind. Unlink directly
+						// and swallow ENOENT (no exists+unlink TOCTOU window — a parallel
+						// cleanup between the two calls would otherwise misreport the
+						// race as a backup failure).
+						try {
 							fs.unlinkSync(tempBackupPath);
+						} catch (e) {
+							if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
 						}
 						db.exec(`VACUUM INTO '${escapedTempPath}'`);
 						fs.renameSync(tempBackupPath, backupPath);
 						log.info(`Database backup created at: ${backupPath}`);
 					} catch (vacuumError) {
-						if (fs.existsSync(tempBackupPath)) {
-							try {
-								fs.unlinkSync(tempBackupPath);
-							} catch {
-								// Best-effort cleanup
-							}
+						try {
+							fs.unlinkSync(tempBackupPath);
+						} catch {
+							// Best-effort cleanup; ENOENT here is the normal case
+							// (VACUUM never created the file).
 						}
 						throw vacuumError;
 					}

--- a/packages/database/src/migrations.ts
+++ b/packages/database/src/migrations.ts
@@ -368,8 +368,32 @@ export function runMigrations(db: Database, dbPath?: string): void {
 					log.debug("Database file is empty, skipping backup.");
 				} else {
 					const backupPath = `${absoluteSourcePath}.backup.${Date.now()}`;
-					fs.copyFileSync(absoluteSourcePath, backupPath);
-					log.info(`Database backup created at: ${backupPath}`);
+					// VACUUM INTO writes a defragmented copy via SQLite's pager.
+					// vs fs.copyFileSync: atomic page-by-page (no torn output mid-write
+					// across a checkpoint), produces a smaller file, and doesn't race
+					// the migration's own writes. Two-phase rename avoids leaving a
+					// half-written `.backup.<ts>` if SIGTERM hits mid-VACUUM.
+					const tempBackupPath = `${backupPath}.partial`;
+					const escapedTempPath = tempBackupPath.replace(/'/g, "''");
+					try {
+						// VACUUM INTO refuses if the target exists, and a SIGTERM during
+						// a previous attempt may have left one behind.
+						if (fs.existsSync(tempBackupPath)) {
+							fs.unlinkSync(tempBackupPath);
+						}
+						db.exec(`VACUUM INTO '${escapedTempPath}'`);
+						fs.renameSync(tempBackupPath, backupPath);
+						log.info(`Database backup created at: ${backupPath}`);
+					} catch (vacuumError) {
+						if (fs.existsSync(tempBackupPath)) {
+							try {
+								fs.unlinkSync(tempBackupPath);
+							} catch {
+								// Best-effort cleanup
+							}
+						}
+						throw vacuumError;
+					}
 				}
 			} else {
 				log.warn(


### PR DESCRIPTION
Replace the `fs.copyFileSync` migration backup with SQLite's `VACUUM INTO`, written to a `.partial` path and atomically renamed on success. Three wins:

1. Atomicity. fs.copyFileSync streams raw bytes; if SIGTERM hits mid-copy, the `.backup.<ts>` file is left torn and indistinguishable from a real backup. With the temp-file + rename pattern, the named `.backup.<ts>` only ever appears in its complete form.

2. Defragmented output. VACUUM INTO produces a compact copy of the live DB — useful when the source has fragmented heavily (large blob churn in `request_payloads` is the obvious case).

3. Cleaner write semantics. fs.copyFileSync races any concurrent writer; VACUUM INTO holds a read transaction over its own pager and emits a consistent snapshot, even if the migration transaction is about to acquire the write lock.

Defensive `.partial` unlink at the start handles the case where a prior attempt died and left an orphan — VACUUM INTO refuses if the target exists. On VACUUM failure, the catch unlinks the partial so the named backup slot stays clean.

Existing migration tests (18) pass unchanged — they assert "a backup file exists with size > 0", which the new path satisfies.