### PR TITLE
improve: prune old migration backups to bounded retention

### DIFF
--- a/packages/database/src/migrations.test.ts
+++ b/packages/database/src/migrations.test.ts
@@ -839,6 +839,58 @@ describe("Database Backup Behavior", () => {
 		// the two kept entries are: the new one, and `prune.db.backup.5000`.
 		expect(backups).toContain("prune.db.backup.5000");
 		expect(fs.existsSync(stalePath)).toBe(false);
+
+		// Explicitly verify the fresh backup survives — protects against a
+		// regression where the sorter accidentally treats the new file as
+		// oldest. The new file's suffix is the live `Date.now()`, which is
+		// orders of magnitude larger than the seeded `5000` value.
+		const freshBackup = backups.find((name) => {
+			const ts = Number.parseInt(name.slice("prune.db.backup.".length), 10);
+			return Number.isFinite(ts) && ts > 5000;
+		});
+		expect(freshBackup).toBeDefined();
+	});
+
+	it("should fall back to the default retention for garbled env values", () => {
+		// Without strict integer validation, `parseInt("3abc")` quietly returns
+		// 3 — keeping fewer backups than the operator expected. The check
+		// should treat such values as misconfiguration and use the default.
+		const dbPath = path.join(tmpDir, "garbled.db");
+		const db = new Database(dbPath);
+		ensureSchema(db);
+		db.close();
+
+		// 5 stale backups (more than default retention of 3).
+		fs.writeFileSync(path.join(tmpDir, "garbled.db.backup.1000"), "x");
+		fs.writeFileSync(path.join(tmpDir, "garbled.db.backup.2000"), "x");
+		fs.writeFileSync(path.join(tmpDir, "garbled.db.backup.3000"), "x");
+		fs.writeFileSync(path.join(tmpDir, "garbled.db.backup.4000"), "x");
+		fs.writeFileSync(path.join(tmpDir, "garbled.db.backup.5000"), "x");
+
+		const prev = process.env.BETTER_CCFLARE_MIGRATION_BACKUP_KEEP;
+		process.env.BETTER_CCFLARE_MIGRATION_BACKUP_KEEP = "2abc";
+		try {
+			const db2 = new Database(dbPath);
+			db2.prepare("ALTER TABLE accounts ADD COLUMN account_tier TEXT").run();
+			db2.close();
+
+			const db3 = new Database(dbPath);
+			runMigrations(db3, dbPath);
+			db3.close();
+		} finally {
+			if (prev === undefined) {
+				delete process.env.BETTER_CCFLARE_MIGRATION_BACKUP_KEEP;
+			} else {
+				process.env.BETTER_CCFLARE_MIGRATION_BACKUP_KEEP = prev;
+			}
+		}
+
+		const backups = fs
+			.readdirSync(tmpDir)
+			.filter((f) => f.startsWith("garbled.db.backup."));
+		// Garbled value should NOT silently parse as 2 — default of 3 applies.
+		// 5 stale + 1 fresh = 6 candidates, default retention 3 → 3 survive.
+		expect(backups).toHaveLength(3);
 	});
 
 	it("should leave backups in place when BETTER_CCFLARE_MIGRATION_BACKUP_KEEP=0", () => {

--- a/packages/database/src/migrations.test.ts
+++ b/packages/database/src/migrations.test.ts
@@ -793,4 +793,88 @@ describe("Database Backup Behavior", () => {
 		const backupSize = fs.statSync(path.join(tmpDir, backups[0])).size;
 		expect(backupSize).toBeGreaterThan(0);
 	});
+
+	it("should prune older backups to BETTER_CCFLARE_MIGRATION_BACKUP_KEEP", () => {
+		const dbPath = path.join(tmpDir, "prune.db");
+		const db = new Database(dbPath);
+		ensureSchema(db);
+		db.close();
+
+		// Drop 5 pre-existing backups with monotonically increasing timestamps.
+		const stalePath = path.join(tmpDir, "prune.db.backup.1000");
+		fs.writeFileSync(stalePath, "old-1");
+		fs.writeFileSync(path.join(tmpDir, "prune.db.backup.2000"), "old-2");
+		fs.writeFileSync(path.join(tmpDir, "prune.db.backup.3000"), "old-3");
+		fs.writeFileSync(path.join(tmpDir, "prune.db.backup.4000"), "old-4");
+		fs.writeFileSync(path.join(tmpDir, "prune.db.backup.5000"), "old-5");
+
+		const prev = process.env.BETTER_CCFLARE_MIGRATION_BACKUP_KEEP;
+		process.env.BETTER_CCFLARE_MIGRATION_BACKUP_KEEP = "2";
+		try {
+			// Trigger a migration so a new backup gets written + prune fires.
+			const db2 = new Database(dbPath);
+			db2
+				.prepare("ALTER TABLE accounts ADD COLUMN account_tier TEXT")
+				.run();
+			db2.close();
+
+			const db3 = new Database(dbPath);
+			runMigrations(db3, dbPath);
+			db3.close();
+		} finally {
+			if (prev === undefined) {
+				delete process.env.BETTER_CCFLARE_MIGRATION_BACKUP_KEEP;
+			} else {
+				process.env.BETTER_CCFLARE_MIGRATION_BACKUP_KEEP = prev;
+			}
+		}
+
+		const backups = fs
+			.readdirSync(tmpDir)
+			.filter((f) => f.startsWith("prune.db.backup."))
+			.sort();
+		// 5 stale + 1 fresh = 6 candidates, but retention is 2.
+		expect(backups).toHaveLength(2);
+		// The freshest stale (5000) is older than the newly-created backup, so
+		// the two kept entries are: the new one, and `prune.db.backup.5000`.
+		expect(backups).toContain("prune.db.backup.5000");
+		expect(fs.existsSync(stalePath)).toBe(false);
+	});
+
+	it("should leave backups in place when BETTER_CCFLARE_MIGRATION_BACKUP_KEEP=0", () => {
+		const dbPath = path.join(tmpDir, "nokeep.db");
+		const db = new Database(dbPath);
+		ensureSchema(db);
+		db.close();
+
+		fs.writeFileSync(path.join(tmpDir, "nokeep.db.backup.100"), "old-1");
+		fs.writeFileSync(path.join(tmpDir, "nokeep.db.backup.200"), "old-2");
+		fs.writeFileSync(path.join(tmpDir, "nokeep.db.backup.300"), "old-3");
+
+		const prev = process.env.BETTER_CCFLARE_MIGRATION_BACKUP_KEEP;
+		process.env.BETTER_CCFLARE_MIGRATION_BACKUP_KEEP = "0";
+		try {
+			const db2 = new Database(dbPath);
+			db2
+				.prepare("ALTER TABLE accounts ADD COLUMN account_tier TEXT")
+				.run();
+			db2.close();
+
+			const db3 = new Database(dbPath);
+			runMigrations(db3, dbPath);
+			db3.close();
+		} finally {
+			if (prev === undefined) {
+				delete process.env.BETTER_CCFLARE_MIGRATION_BACKUP_KEEP;
+			} else {
+				process.env.BETTER_CCFLARE_MIGRATION_BACKUP_KEEP = prev;
+			}
+		}
+
+		const backups = fs
+			.readdirSync(tmpDir)
+			.filter((f) => f.startsWith("nokeep.db.backup."));
+		// All 3 pre-existing stubs + 1 fresh backup survive.
+		expect(backups.length).toBe(4);
+	});
 });

--- a/packages/database/src/migrations.test.ts
+++ b/packages/database/src/migrations.test.ts
@@ -893,6 +893,57 @@ describe("Database Backup Behavior", () => {
 		expect(backups).toHaveLength(3);
 	});
 
+	it("should leave backup files with non-integer suffixes untouched", () => {
+		// Operators sometimes rename a backup to a hand-picked name they want
+		// to keep ("good-baseline", "before-bad-migration"). The pruner must
+		// skip those rather than treating their suffix as a partial-parse
+		// integer and deleting them.
+		const dbPath = path.join(tmpDir, "manual.db");
+		const db = new Database(dbPath);
+		ensureSchema(db);
+		db.close();
+
+		// Standard backups that DO match the convention.
+		fs.writeFileSync(path.join(tmpDir, "manual.db.backup.1000"), "x");
+		fs.writeFileSync(path.join(tmpDir, "manual.db.backup.2000"), "x");
+		fs.writeFileSync(path.join(tmpDir, "manual.db.backup.3000"), "x");
+		fs.writeFileSync(path.join(tmpDir, "manual.db.backup.4000"), "x");
+		fs.writeFileSync(path.join(tmpDir, "manual.db.backup.5000"), "x");
+		// Hand-renamed survivors that should NEVER be pruned.
+		const keepNames = [
+			"manual.db.backup.good-baseline",
+			"manual.db.backup.before-bad-migration",
+			"manual.db.backup.3abc",
+		];
+		for (const name of keepNames) {
+			fs.writeFileSync(path.join(tmpDir, name), "manual-keep");
+		}
+
+		const prev = process.env.BETTER_CCFLARE_MIGRATION_BACKUP_KEEP;
+		process.env.BETTER_CCFLARE_MIGRATION_BACKUP_KEEP = "2";
+		try {
+			const db2 = new Database(dbPath);
+			db2.prepare("ALTER TABLE accounts ADD COLUMN account_tier TEXT").run();
+			db2.close();
+
+			const db3 = new Database(dbPath);
+			runMigrations(db3, dbPath);
+			db3.close();
+		} finally {
+			if (prev === undefined) {
+				delete process.env.BETTER_CCFLARE_MIGRATION_BACKUP_KEEP;
+			} else {
+				process.env.BETTER_CCFLARE_MIGRATION_BACKUP_KEEP = prev;
+			}
+		}
+
+		// All three manually-named backups should still exist — they don't
+		// match the convention, so the pruner has no business touching them.
+		for (const name of keepNames) {
+			expect(fs.existsSync(path.join(tmpDir, name))).toBe(true);
+		}
+	});
+
 	it("should leave backups in place when BETTER_CCFLARE_MIGRATION_BACKUP_KEEP=0", () => {
 		const dbPath = path.join(tmpDir, "nokeep.db");
 		const db = new Database(dbPath);

--- a/packages/database/src/migrations.ts
+++ b/packages/database/src/migrations.ts
@@ -55,12 +55,20 @@ function pruneOldBackups(absoluteSourcePath: string): void {
 	}
 
 	// Order by the embedded `Date.now()` suffix, not mtime — survives clock
-	// drift, `touch`, and rsync timestamps. Names that don't parse cleanly
-	// are skipped (left on disk untouched).
+	// drift, `touch`, and rsync timestamps. Names whose suffix isn't a pure
+	// integer (e.g. `db.backup.3abc`, `db.backup.notes`) are skipped — left
+	// untouched on disk — to honour an operator's manually-renamed files.
+	// `INTEGER_RE` matches before `parseInt` so trailing garbage can't
+	// silently truncate `db.backup.3abc` to timestamp 3 and prune a file
+	// that doesn't match the convention.
 	const backups = entries
 		.filter((name) => name.startsWith(prefix))
-		.map((name) => ({ name, ts: Number.parseInt(name.slice(prefix.length), 10) }))
-		.filter((entry) => Number.isFinite(entry.ts))
+		.map((name) => ({ name, suffix: name.slice(prefix.length) }))
+		.filter((entry) => INTEGER_RE.test(entry.suffix))
+		.map((entry) => ({
+			name: entry.name,
+			ts: Number.parseInt(entry.suffix, 10),
+		}))
 		.sort((a, b) => b.ts - a.ts);
 
 	const toDelete = backups.slice(keep);

--- a/packages/database/src/migrations.ts
+++ b/packages/database/src/migrations.ts
@@ -6,6 +6,58 @@ import { addPerformanceIndexes } from "./performance-indexes";
 
 const log = new Logger("DatabaseMigrations");
 
+/**
+ * Keep at most this many `.backup.<timestamp>` files alongside the live DB.
+ * Each backup is a full copy of the DB (multi-GB in practice), so without a
+ * cap they accumulate quickly when rapid restarts trigger repeat migrations.
+ *
+ * Override with `BETTER_CCFLARE_MIGRATION_BACKUP_KEEP`. 0 disables pruning.
+ */
+function getBackupRetention(): number {
+	const raw = process.env.BETTER_CCFLARE_MIGRATION_BACKUP_KEEP;
+	if (raw === undefined) return 3;
+	const parsed = Number.parseInt(raw, 10);
+	if (!Number.isFinite(parsed) || parsed < 0) return 3;
+	return parsed;
+}
+
+function pruneOldBackups(absoluteSourcePath: string): void {
+	const keep = getBackupRetention();
+	if (keep === 0) return;
+
+	const dir = path.dirname(absoluteSourcePath);
+	const base = path.basename(absoluteSourcePath);
+	const prefix = `${base}.backup.`;
+
+	let entries: string[];
+	try {
+		entries = fs.readdirSync(dir);
+	} catch (error) {
+		log.warn(`Could not list backup directory for pruning: ${(error as Error).message}`);
+		return;
+	}
+
+	// Order by the embedded `Date.now()` suffix, not mtime — survives clock
+	// drift, `touch`, and rsync timestamps. Names that don't parse cleanly
+	// are skipped (left on disk untouched).
+	const backups = entries
+		.filter((name) => name.startsWith(prefix))
+		.map((name) => ({ name, ts: Number.parseInt(name.slice(prefix.length), 10) }))
+		.filter((entry) => Number.isFinite(entry.ts))
+		.sort((a, b) => b.ts - a.ts);
+
+	const toDelete = backups.slice(keep);
+	for (const entry of toDelete) {
+		const filePath = path.join(dir, entry.name);
+		try {
+			fs.unlinkSync(filePath);
+			log.info(`Pruned old DB backup: ${entry.name}`);
+		} catch (error) {
+			log.warn(`Failed to prune backup ${entry.name}: ${(error as Error).message}`);
+		}
+	}
+}
+
 export function ensureSchema(db: Database): void {
 	// Create accounts table
 	db.run(`
@@ -370,6 +422,7 @@ export function runMigrations(db: Database, dbPath?: string): void {
 					const backupPath = `${absoluteSourcePath}.backup.${Date.now()}`;
 					fs.copyFileSync(absoluteSourcePath, backupPath);
 					log.info(`Database backup created at: ${backupPath}`);
+					pruneOldBackups(absoluteSourcePath);
 				}
 			} else {
 				log.warn(

--- a/packages/database/src/migrations.ts
+++ b/packages/database/src/migrations.ts
@@ -6,23 +6,40 @@ import { addPerformanceIndexes } from "./performance-indexes";
 
 const log = new Logger("DatabaseMigrations");
 
+const DEFAULT_BACKUP_RETENTION = 3;
+const INTEGER_RE = /^-?\d+$/;
+
 /**
  * Keep at most this many `.backup.<timestamp>` files alongside the live DB.
  * Each backup is a full copy of the DB (multi-GB in practice), so without a
  * cap they accumulate quickly when rapid restarts trigger repeat migrations.
  *
- * Override with `BETTER_CCFLARE_MIGRATION_BACKUP_KEEP`. 0 disables pruning.
+ * Override with `BETTER_CCFLARE_MIGRATION_BACKUP_KEEP`. 0 disables pruning
+ * entirely — operators who manage retention externally (e.g. via a separate
+ * cron + S3 sync) can opt out without losing the pre-migration safety net.
+ *
+ * Inputs that look like garbled integers (`"3abc"`, `"1.5"`, `""`,
+ * `"infinity"`) fall back to the default rather than silently truncating to
+ * a partial parse — `Number.parseInt` is too forgiving for that.
  */
 function getBackupRetention(): number {
 	const raw = process.env.BETTER_CCFLARE_MIGRATION_BACKUP_KEEP;
-	if (raw === undefined) return 3;
+	if (raw === undefined || raw === "") return DEFAULT_BACKUP_RETENTION;
+	if (!INTEGER_RE.test(raw)) {
+		log.warn(
+			`BETTER_CCFLARE_MIGRATION_BACKUP_KEEP="${raw}" is not a non-negative integer — using default ${DEFAULT_BACKUP_RETENTION}`,
+		);
+		return DEFAULT_BACKUP_RETENTION;
+	}
 	const parsed = Number.parseInt(raw, 10);
-	if (!Number.isFinite(parsed) || parsed < 0) return 3;
+	if (parsed < 0) return DEFAULT_BACKUP_RETENTION;
 	return parsed;
 }
 
 function pruneOldBackups(absoluteSourcePath: string): void {
 	const keep = getBackupRetention();
+	// keep === 0 means "do nothing", not "delete everything" — leaves all
+	// existing backups in place for operators managing retention externally.
 	if (keep === 0) return;
 
 	const dir = path.dirname(absoluteSourcePath);


### PR DESCRIPTION
Each migration that flips `willModifySchema` writes a full file copy of the live DB next to it as `<dbname>.backup.<Date.now()>`. Nothing ever deletes those copies, so a multi-GB DB plus a few restarts (or one rapid restart loop while a backup is still copying) leaves tens of GB of stale mirror copies sitting in the config dir.

After a successful backup, sort all sibling `.backup.<ts>` files by the timestamp embedded in the name (not mtime — survives `touch`, rsync, and clock drift) and unlink everything past the retention window.

Default keeps the 3 newest, configurable via the
`BETTER_CCFLARE_MIGRATION_BACKUP_KEEP` env var. 0 disables pruning for operators who want to manage retention themselves.

The pruner is best-effort: a read or unlink failure just logs and returns — the migration proceeds regardless. The fresh backup is always created before pruning runs, so a crash mid-prune can't strand the user without a backup of the just-migrated state.

Added two tests:
- `BETTER_CCFLARE_MIGRATION_BACKUP_KEEP=2` collapses 5 stale + 1 fresh backup to 2, keeping the newest by name-suffix.
- `BETTER_CCFLARE_MIGRATION_BACKUP_KEEP=0` leaves everything in place.