### PR TITLE
feat: configurable worker startup timeout, bump default to 60s

### DIFF
--- a/packages/proxy/src/usage-worker-controller.ts
+++ b/packages/proxy/src/usage-worker-controller.ts
@@ -23,6 +23,26 @@ interface PendingAck {
 
 const MAX_RESTARTS = 3;
 const SHUTDOWN_GRACE_MS = 2_000;
+const DEFAULT_STARTUP_TIMEOUT_MS = 60_000;
+
+/**
+ * Resolve the worker startup timeout from `CF_WORKER_STARTUP_TIMEOUT_MS`,
+ * falling back to {@link DEFAULT_STARTUP_TIMEOUT_MS}.
+ *
+ * The worker opens its own SQLite handle on startup; on operators with large
+ * (multi-GB) databases the per-handle PRAGMA work can blow past the historical
+ * 10 s timeout and silently strand request analytics. 60 s gives that path
+ * headroom; ops with massive DBs or slow disks can raise it further via env.
+ */
+function resolveStartupTimeoutMs(): number {
+	const raw = process.env.CF_WORKER_STARTUP_TIMEOUT_MS;
+	if (raw === undefined || raw === "") return DEFAULT_STARTUP_TIMEOUT_MS;
+	const parsed = Number.parseInt(raw, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) {
+		return DEFAULT_STARTUP_TIMEOUT_MS;
+	}
+	return parsed;
+}
 
 export class UsageWorkerController {
 	private state: WorkerState = "stopped";
@@ -37,7 +57,7 @@ export class UsageWorkerController {
 	constructor(
 		private readonly onSummary: (msg: SummaryMessage) => void,
 		private readonly onReady?: () => void,
-		private readonly startupTimeoutMs = 10_000,
+		private readonly startupTimeoutMs = resolveStartupTimeoutMs(),
 		private readonly ackTimeoutMs = 30_000,
 	) {}
 

--- a/packages/proxy/src/usage-worker-controller.ts
+++ b/packages/proxy/src/usage-worker-controller.ts
@@ -37,8 +37,14 @@ const DEFAULT_STARTUP_TIMEOUT_MS = 60_000;
 function resolveStartupTimeoutMs(): number {
 	const raw = process.env.CF_WORKER_STARTUP_TIMEOUT_MS;
 	if (raw === undefined || raw === "") return DEFAULT_STARTUP_TIMEOUT_MS;
-	const parsed = Number.parseInt(raw, 10);
-	if (!Number.isFinite(parsed) || parsed <= 0) {
+	// Number() rejects trailing garbage that Number.parseInt would silently
+	// accept ("100ms" → 100 was a real foot-gun); isInteger catches NaN,
+	// Infinity, and fractional values in one check.
+	const parsed = Number(raw);
+	if (!Number.isInteger(parsed) || parsed <= 0) {
+		log.warn(
+			`CF_WORKER_STARTUP_TIMEOUT_MS="${raw}" is not a positive integer — falling back to default ${DEFAULT_STARTUP_TIMEOUT_MS}ms`,
+		);
 		return DEFAULT_STARTUP_TIMEOUT_MS;
 	}
 	return parsed;


### PR DESCRIPTION
The post-processor worker's startup timeout was a hard-coded 10s. That covered the common case but silently broke when the worker's own `DatabaseOperations` init took longer — most visibly when the live DB grew past a few GB and the per-handle `PRAGMA integrity_check` synchronously blocked startup for tens of seconds.

When the timer fires, the worker controller terminates the worker, restarts it (up to MAX_RESTARTS=3), then gives up. Once it gives up, `safePostMessage` from the proxy hot path silently drops every "start/chunk/end" message until process restart — analytics simply stop landing in the DB, with no error visible to clients.

Bump the default to 60s and make it overridable via `CF_WORKER_STARTUP_TIMEOUT_MS`. The env var follows the existing `CF_STREAM_USAGE_BUFFER_KB` / `CF_STREAM_TIMEOUT_MS` convention. Falls back to default on missing/empty/unparseable/non-positive input so a stray env value can't lock the worker out at 0ms.

Note: a separate fix should also make the worker skip the redundant per-handle integrity check, since the main thread already ran it. This change is the safety net.