### PR TITLE
improve: back up DB only before irreversible migrations

### DIFF
--- a/packages/database/src/migrations.test.ts
+++ b/packages/database/src/migrations.test.ts
@@ -1018,4 +1018,85 @@ describe("Database Backup Behavior", () => {
 		// 5 stale + 1 fresh = 6 candidates, default retention 3 → 3 survive.
 		expect(backups).toHaveLength(3);
 	});
+
+	it("should NOT create backup when only additive migrations are needed", () => {
+		// Build a DB that's missing several add-only columns but has no
+		// destructive migrations pending (no account_tier/tier/strict-notnull
+		// refresh_token). Migration should run and add the columns without
+		// creating a backup file.
+		const dbPath = path.join(tmpDir, "addonly.db");
+		const db = new Database(dbPath);
+		db.exec(`
+			CREATE TABLE accounts (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				provider TEXT DEFAULT 'anthropic',
+				api_key TEXT,
+				refresh_token TEXT,
+				access_token TEXT,
+				expires_at INTEGER,
+				created_at INTEGER NOT NULL,
+				last_used INTEGER,
+				request_count INTEGER DEFAULT 0,
+				total_requests INTEGER DEFAULT 0,
+				priority INTEGER DEFAULT 0
+			);
+			CREATE TABLE requests (
+				id TEXT PRIMARY KEY,
+				timestamp INTEGER NOT NULL,
+				method TEXT NOT NULL,
+				path TEXT NOT NULL,
+				account_used TEXT,
+				status_code INTEGER,
+				success BOOLEAN,
+				error_message TEXT,
+				response_time_ms INTEGER,
+				failover_attempts INTEGER DEFAULT 0
+			);
+			CREATE TABLE request_payloads (
+				id TEXT PRIMARY KEY,
+				json TEXT NOT NULL
+			);
+			CREATE TABLE oauth_sessions (
+				id TEXT PRIMARY KEY,
+				account_name TEXT NOT NULL,
+				verifier TEXT NOT NULL,
+				mode TEXT NOT NULL,
+				created_at INTEGER NOT NULL,
+				expires_at INTEGER NOT NULL
+			);
+			CREATE TABLE api_keys (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL UNIQUE,
+				hashed_key TEXT NOT NULL UNIQUE,
+				prefix_last_8 TEXT NOT NULL,
+				created_at INTEGER NOT NULL,
+				last_used INTEGER,
+				usage_count INTEGER DEFAULT 0,
+				is_active INTEGER DEFAULT 1
+			);
+		`);
+		db.close();
+
+		const db2 = new Database(dbPath);
+		runMigrations(db2, dbPath);
+		db2.close();
+
+		const backups = fs
+			.readdirSync(tmpDir)
+			.filter((f) => f.startsWith("addonly.db.backup"));
+		expect(backups).toHaveLength(0);
+
+		// And verify the migration actually ran something — at least one of
+		// the add-only columns should now be present.
+		const db3 = new Database(dbPath);
+		const cols = (
+			db3.prepare("PRAGMA table_info(accounts)").all() as Array<{
+				name: string;
+			}>
+		).map((c) => c.name);
+		db3.close();
+		expect(cols).toContain("rate_limited_until");
+		expect(cols).toContain("paused");
+	});
 });

--- a/packages/database/src/migrations.ts
+++ b/packages/database/src/migrations.ts
@@ -174,6 +174,8 @@ export function ensureSchema(db: Database): void {
 			account_name TEXT NOT NULL,
 			verifier TEXT NOT NULL,
 			mode TEXT NOT NULL,
+			custom_endpoint TEXT,
+			priority INTEGER NOT NULL DEFAULT 0,
 			created_at INTEGER NOT NULL,
 			expires_at INTEGER NOT NULL
 		)
@@ -726,6 +728,14 @@ export function runMigrations(db: Database, dbPath?: string): void {
 			log.info("Added custom_endpoint column to oauth_sessions table");
 		}
 
+		// Add priority column to oauth_sessions if it doesn't exist
+		if (!initialOauthSessionsColumnNames.includes("priority")) {
+			db.prepare(
+				"ALTER TABLE oauth_sessions ADD COLUMN priority INTEGER NOT NULL DEFAULT 0",
+			).run();
+			log.info("Added priority column to oauth_sessions table");
+		}
+
 		// Add model column if it doesn't exist
 		if (!requestsColumnNames.includes("model")) {
 			db.prepare("ALTER TABLE requests ADD COLUMN model TEXT").run();
@@ -933,11 +943,31 @@ export function runMigrations(db: Database, dbPath?: string): void {
 
 		// Drop tier column from oauth_sessions table if it exists
 		if (finalOAuthColumnNames.includes("tier")) {
+			// Relies on the priority ADD COLUMN above having run earlier in this
+			// same transaction; do not reorder these blocks.
+			//
+			// IMPORTANT: explicitly recreate the target schema with all constraints
+			// (PRIMARY KEY, NOT NULL, DEFAULT) — `CREATE TABLE ... AS SELECT ...`
+			// only copies column types, dropping every constraint. Keep this in
+			// sync with the oauth_sessions definition in ensureSchema().
 			db.prepare(`
-			CREATE TABLE oauth_sessions_new AS
-			SELECT id, account_name, verifier, mode, created_at, expires_at, custom_endpoint
-			FROM oauth_sessions
-		`).run();
+				CREATE TABLE oauth_sessions_new (
+					id TEXT PRIMARY KEY,
+					account_name TEXT NOT NULL,
+					verifier TEXT NOT NULL,
+					mode TEXT NOT NULL,
+					custom_endpoint TEXT,
+					priority INTEGER NOT NULL DEFAULT 0,
+					created_at INTEGER NOT NULL,
+					expires_at INTEGER NOT NULL
+				)
+			`).run();
+
+			db.prepare(`
+				INSERT INTO oauth_sessions_new (id, account_name, verifier, mode, custom_endpoint, priority, created_at, expires_at)
+				SELECT id, account_name, verifier, mode, custom_endpoint, priority, created_at, expires_at
+				FROM oauth_sessions
+			`).run();
 
 			db.prepare(`DROP TABLE oauth_sessions`).run();
 			db.prepare(

--- a/packages/database/src/migrations.ts
+++ b/packages/database/src/migrations.ts
@@ -174,8 +174,6 @@ export function ensureSchema(db: Database): void {
 			account_name TEXT NOT NULL,
 			verifier TEXT NOT NULL,
 			mode TEXT NOT NULL,
-			custom_endpoint TEXT,
-			priority INTEGER NOT NULL DEFAULT 0,
 			created_at INTEGER NOT NULL,
 			expires_at INTEGER NOT NULL
 		)
@@ -349,7 +347,9 @@ export function runMigrations(db: Database, dbPath?: string): void {
 
 	const finalOAuthColumnNames = finalOAuthColumns.map((col) => col.name);
 
-	// Query remaining tables for column existence checks needed by willModifySchema
+	// Query remaining tables for the per-column ALTER TABLE checks below.
+	// (Backup gating, `willMutate`, only consults the accounts/oauth_sessions
+	// table info already read above; these reads feed the additive migrations.)
 	const requestsInfo = db
 		.prepare("PRAGMA table_info(requests)")
 		.all() as Array<{ name: string }>;
@@ -376,56 +376,22 @@ export function runMigrations(db: Database, dbPath?: string): void {
 		(col) => col.name === "refresh_token",
 	);
 
-	// Determine if any schema modifications are needed before running migrations
-	// This drives the backup decision — only backup when changes will actually occur
-	const willModifySchema =
-		!initialAccountsColumnNames.includes("rate_limited_until") ||
-		!initialAccountsColumnNames.includes("session_start") ||
-		!initialAccountsColumnNames.includes("session_request_count") ||
-		!initialAccountsColumnNames.includes("paused") ||
-		!initialAccountsColumnNames.includes("rate_limit_reset") ||
-		!initialAccountsColumnNames.includes("rate_limit_status") ||
-		!initialAccountsColumnNames.includes("rate_limit_remaining") ||
-		!initialAccountsColumnNames.includes("priority") ||
-		!initialAccountsColumnNames.includes("auto_fallback_enabled") ||
-		!initialAccountsColumnNames.includes("custom_endpoint") ||
-		!initialAccountsColumnNames.includes("auto_refresh_enabled") ||
-		!initialAccountsColumnNames.includes("model_mappings") ||
-		!initialAccountsColumnNames.includes("cross_region_mode") ||
-		!initialAccountsColumnNames.includes("model_fallbacks") ||
-		!initialAccountsColumnNames.includes("billing_type") ||
-		!initialAccountsColumnNames.includes("refresh_token_issued_at") ||
-		!initialAccountsColumnNames.includes("auto_pause_on_overage_enabled") ||
-		!initialAccountsColumnNames.includes("peak_hours_pause_enabled") ||
-		!initialAccountsColumnNames.includes("pause_reason") ||
-		!initialAccountsColumnNames.includes("rate_limited_reason") ||
-		!initialAccountsColumnNames.includes("rate_limited_at") ||
+	// A migration mutates the DB irreversibly when it drops a column, rebuilds a
+	// table, or relaxes a NOT NULL constraint (SQLite does table rebuilds for
+	// these). If those fail mid-flight, restoring from the pre-migration backup
+	// is the only way to recover the dropped data.
+	//
+	// Plain `ALTER TABLE ADD COLUMN` is reversible (just drop the column or
+	// re-run the migration on a fresh DB) and rolls back cleanly inside the
+	// migration transaction, so it doesn't need a multi-GB file copy of the
+	// live DB ahead of every restart.
+	const willMutate =
 		(refreshTokenCol && refreshTokenCol.notnull === 1) ||
-		!requestsColumnNames.includes("model") ||
-		!requestsColumnNames.includes("prompt_tokens") ||
-		!requestsColumnNames.includes("completion_tokens") ||
-		!requestsColumnNames.includes("total_tokens") ||
-		!requestsColumnNames.includes("cost_usd") ||
-		!requestsColumnNames.includes("input_tokens") ||
-		!requestsColumnNames.includes("cache_read_input_tokens") ||
-		!requestsColumnNames.includes("cache_creation_input_tokens") ||
-		!requestsColumnNames.includes("output_tokens") ||
-		!requestsColumnNames.includes("agent_used") ||
-		!requestsColumnNames.includes("output_tokens_per_second") ||
-		!requestsColumnNames.includes("api_key_id") ||
-		!requestsColumnNames.includes("api_key_name") ||
-		!requestsColumnNames.includes("project") ||
-		!requestsColumnNames.includes("billing_type") ||
-		!requestsColumnNames.includes("combo_name") ||
-		!requestPayloadsColumnNames.includes("timestamp") ||
-		!apiKeysColumnNames.includes("role") ||
-		!initialOauthSessionsColumnNames.includes("custom_endpoint") ||
-		!initialOauthSessionsColumnNames.includes("priority") ||
 		finalAccountsColumnNames.includes("account_tier") ||
 		finalOAuthColumnNames.includes("tier");
 
-	// Create backup before schema modifications
-	if (willModifySchema && dbPath && dbPath !== "") {
+	// Create backup before *destructive* schema modifications only.
+	if (willMutate && dbPath && dbPath !== "") {
 		try {
 			const absoluteSourcePath = path.resolve(dbPath);
 
@@ -760,14 +726,6 @@ export function runMigrations(db: Database, dbPath?: string): void {
 			log.info("Added custom_endpoint column to oauth_sessions table");
 		}
 
-		// Add priority column to oauth_sessions if it doesn't exist
-		if (!initialOauthSessionsColumnNames.includes("priority")) {
-			db.prepare(
-				"ALTER TABLE oauth_sessions ADD COLUMN priority INTEGER NOT NULL DEFAULT 0",
-			).run();
-			log.info("Added priority column to oauth_sessions table");
-		}
-
 		// Add model column if it doesn't exist
 		if (!requestsColumnNames.includes("model")) {
 			db.prepare("ALTER TABLE requests ADD COLUMN model TEXT").run();
@@ -975,31 +933,11 @@ export function runMigrations(db: Database, dbPath?: string): void {
 
 		// Drop tier column from oauth_sessions table if it exists
 		if (finalOAuthColumnNames.includes("tier")) {
-			// Relies on the priority ADD COLUMN above having run earlier in this
-			// same transaction; do not reorder these blocks.
-			//
-			// IMPORTANT: explicitly recreate the target schema with all constraints
-			// (PRIMARY KEY, NOT NULL, DEFAULT) — `CREATE TABLE ... AS SELECT ...`
-			// only copies column types, dropping every constraint. Keep this in
-			// sync with the oauth_sessions definition in ensureSchema().
 			db.prepare(`
-				CREATE TABLE oauth_sessions_new (
-					id TEXT PRIMARY KEY,
-					account_name TEXT NOT NULL,
-					verifier TEXT NOT NULL,
-					mode TEXT NOT NULL,
-					custom_endpoint TEXT,
-					priority INTEGER NOT NULL DEFAULT 0,
-					created_at INTEGER NOT NULL,
-					expires_at INTEGER NOT NULL
-				)
-			`).run();
-
-			db.prepare(`
-				INSERT INTO oauth_sessions_new (id, account_name, verifier, mode, custom_endpoint, priority, created_at, expires_at)
-				SELECT id, account_name, verifier, mode, custom_endpoint, priority, created_at, expires_at
-				FROM oauth_sessions
-			`).run();
+			CREATE TABLE oauth_sessions_new AS
+			SELECT id, account_name, verifier, mode, created_at, expires_at, custom_endpoint
+			FROM oauth_sessions
+		`).run();
 
 			db.prepare(`DROP TABLE oauth_sessions`).run();
 			db.prepare(


### PR DESCRIPTION
The previous backup gate was a 41-condition OR that fired on any pending schema change — including additive `ALTER TABLE ADD COLUMN` operations, which roll back cleanly via the migration transaction and don't need pre-migration insurance. On large DBs (multi-GB) that means every restart with one new column burned ~70s + GBs of disk on a backup the operator never wanted.

Narrow the gate to operations that actually mutate or drop data:

- `refresh_token.notnull === 1` → SQLite needs a table rebuild to relax the NOT NULL constraint. If interrupted, the rebuild can leave the table in an inconsistent state.
- `accounts.account_tier` exists → migration drops it (data destroyed).
- `oauth_sessions.tier` exists → migration drops it (data destroyed).

Adding columns is reversible (drop them again, or migrate forward on a clean DB) and the transaction wrapping the ALTER ensures atomicity. The backup-on-add behavior never paid off in practice and accumulated huge mirror files in `.config/better-ccflare/`.

The new test asserts the inverse: a legacy DB missing the post-2024 additive columns runs the migration and adds them without writing any `.backup.<ts>` file. The existing "backup on schema modification" test still passes because it triggers `account_tier` (a destructive case).