### PR TITLE
fix: serialize Error in Logger; reduce agent-interceptor log noise

### DIFF
--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -14,6 +14,27 @@ export type LogFormat = "pretty" | "json";
 // Event emitter for log streaming
 export const logBus = new EventEmitter();
 
+// Error's name/message/stack are non-enumerable, so JSON.stringify(err) returns "{}".
+// Convert Errors to plain objects before they flow into formatMessage / LogEvent /
+// the file writer, which all use JSON.stringify downstream.
+// biome-ignore lint/suspicious/noExplicitAny: payload is intentionally untyped
+function normalizeLogData(data: any): any {
+	if (data === undefined || data === null) return data;
+	if (data instanceof Error) {
+		const out: Record<string, unknown> = {
+			name: data.name,
+			message: data.message,
+			stack: data.stack,
+		};
+		if (data.cause !== undefined) {
+			out.cause =
+				data.cause instanceof Error ? normalizeLogData(data.cause) : data.cause;
+		}
+		return out;
+	}
+	return data;
+}
+
 export class Logger {
 	private level: LogLevel;
 	private prefix: string;
@@ -84,12 +105,13 @@ export class Logger {
 	// biome-ignore lint/suspicious/noExplicitAny: Logger needs to accept any data type
 	debug(message: string, data?: any): void {
 		if (this.level <= LogLevel.DEBUG) {
-			const msg = this.formatMessage("DEBUG", message, data);
+			const normalized = normalizeLogData(data);
+			const msg = this.formatMessage("DEBUG", message, normalized);
 			const event: LogEvent = {
 				ts: Date.now(),
 				level: "DEBUG",
 				msg: message,
-				...(data !== undefined && { data }),
+				...(normalized !== undefined && { data: normalized }),
 			};
 			logBus.emit("log", event);
 			logFileWriter?.write(event);
@@ -100,12 +122,13 @@ export class Logger {
 	// biome-ignore lint/suspicious/noExplicitAny: Logger needs to accept any data type
 	info(message: string, data?: any): void {
 		if (this.level <= LogLevel.INFO) {
-			const msg = this.formatMessage("INFO", message, data);
+			const normalized = normalizeLogData(data);
+			const msg = this.formatMessage("INFO", message, normalized);
 			const event: LogEvent = {
 				ts: Date.now(),
 				level: "INFO",
 				msg: message,
-				...(data !== undefined && { data }),
+				...(normalized !== undefined && { data: normalized }),
 			};
 			logBus.emit("log", event);
 			logFileWriter?.write(event);
@@ -116,12 +139,13 @@ export class Logger {
 	// biome-ignore lint/suspicious/noExplicitAny: Logger needs to accept any data type
 	warn(message: string, data?: any): void {
 		if (this.level <= LogLevel.WARN) {
-			const msg = this.formatMessage("WARN", message, data);
+			const normalized = normalizeLogData(data);
+			const msg = this.formatMessage("WARN", message, normalized);
 			const event: LogEvent = {
 				ts: Date.now(),
 				level: "WARN",
 				msg: message,
-				...(data !== undefined && { data }),
+				...(normalized !== undefined && { data: normalized }),
 			};
 			logBus.emit("log", event);
 			logFileWriter?.write(event);
@@ -132,12 +156,13 @@ export class Logger {
 	// biome-ignore lint/suspicious/noExplicitAny: Logger needs to accept any error type
 	error(message: string, error?: any): void {
 		if (this.level <= LogLevel.ERROR) {
-			const msg = this.formatMessage("ERROR", message, error);
+			const normalized = normalizeLogData(error);
+			const msg = this.formatMessage("ERROR", message, normalized);
 			const event: LogEvent = {
 				ts: Date.now(),
 				level: "ERROR",
 				msg: message,
-				...(error !== undefined && { data: error }),
+				...(normalized !== undefined && { data: normalized }),
 			};
 			logBus.emit("log", event);
 			logFileWriter?.write(event);

--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import type { LogEvent } from "@better-ccflare/types";
+import { Logger, LogLevel, logBus } from "./index";
+
+describe("Logger error serialization", () => {
+	let captured: LogEvent[] = [];
+	const handler = (event: LogEvent) => {
+		captured.push(event);
+	};
+
+	beforeEach(() => {
+		captured = [];
+		logBus.on("log", handler);
+	});
+
+	afterEach(() => {
+		logBus.off("log", handler);
+	});
+
+	it("emits Error name, message, and stack as plain object data", () => {
+		const logger = new Logger("Test", LogLevel.ERROR);
+		const err = new Error("boom");
+		logger.error("Failed:", err);
+
+		expect(captured.length).toBe(1);
+		const data = captured[0].data as {
+			name?: string;
+			message?: string;
+			stack?: string;
+		};
+		expect(data.name).toBe("Error");
+		expect(data.message).toBe("boom");
+		expect(typeof data.stack).toBe("string");
+	});
+
+	it("survives JSON.stringify roundtrip (the file writer's actual path)", () => {
+		const logger = new Logger("Test", LogLevel.ERROR);
+		logger.error("Failed:", new Error("disk-bound"));
+
+		const roundtripped = JSON.parse(JSON.stringify(captured[0])) as LogEvent;
+		const data = roundtripped.data as { message?: string };
+		expect(data.message).toBe("disk-bound");
+	});
+
+	it("recursively serializes Error.cause", () => {
+		const logger = new Logger("Test", LogLevel.ERROR);
+		const inner = new Error("inner cause");
+		const outer = new Error("outer", { cause: inner });
+		logger.error("wrapped:", outer);
+
+		const data = captured[0].data as { cause?: { message?: string } };
+		expect(data.cause?.message).toBe("inner cause");
+	});
+
+	it("preserves non-Error data unchanged", () => {
+		const logger = new Logger("Test", LogLevel.ERROR);
+		logger.error("payload:", { foo: "bar" });
+
+		expect(captured[0].data).toEqual({ foo: "bar" });
+	});
+
+	it("preserves Error serialization across all log levels (roundtrip)", () => {
+		const logger = new Logger("Test", LogLevel.DEBUG);
+		logger.warn("warn-path:", new Error("warned"));
+		logger.info("info-path:", new Error("informed"));
+		logger.debug("debug-path:", new Error("debugged"));
+
+		expect(captured.length).toBe(3);
+		const round = captured.map(
+			(e) => JSON.parse(JSON.stringify(e)) as LogEvent,
+		);
+		expect((round[0].data as { message?: string }).message).toBe("warned");
+		expect((round[1].data as { message?: string }).message).toBe("informed");
+		expect((round[2].data as { message?: string }).message).toBe("debugged");
+	});
+
+	it("omits data when no second argument is passed", () => {
+		const logger = new Logger("Test", LogLevel.ERROR);
+		logger.error("just a message");
+		expect("data" in captured[0]).toBe(false);
+	});
+});

--- a/packages/proxy/src/handlers/agent-interceptor.ts
+++ b/packages/proxy/src/handlers/agent-interceptor.ts
@@ -57,7 +57,7 @@ export async function interceptAndModifyRequest(
 		const systemPrompt = extractSystemPrompt(parsedBody as RequestBody);
 		if (!systemPrompt) {
 			// No system prompt, no agent detection possible
-			log.info("No system prompt found in request");
+			log.debug("No system prompt found in request");
 			return {
 				modifiedBody: requestBodyBuffer,
 				agentUsed: null,
@@ -67,9 +67,9 @@ export async function interceptAndModifyRequest(
 		}
 
 		// Register additional agent directories from system prompt
-		log.info(`System prompt length: ${systemPrompt.length} chars`);
+		log.debug(`System prompt length: ${systemPrompt.length} chars`);
 		if (systemPrompt.includes("CLAUDE.md")) {
-			log.info("System prompt contains CLAUDE.md reference");
+			log.debug("System prompt contains CLAUDE.md reference");
 
 			// Look specifically for the Contents pattern
 			if (systemPrompt.includes("Contents of")) {
@@ -77,7 +77,7 @@ export async function interceptAndModifyRequest(
 				const start = contentsIndex;
 				const end = Math.min(systemPrompt.length, contentsIndex + 200);
 				const sample = systemPrompt.substring(start, end);
-				log.info(`Found 'Contents of' pattern: ${sample}`);
+				log.debug(`Found 'Contents of' pattern: ${sample}`);
 			} else {
 				log.debug("System prompt does NOT contain 'Contents of' pattern");
 				// Show a sample of what we do have
@@ -94,12 +94,12 @@ export async function interceptAndModifyRequest(
 		}
 
 		const extraDirs = extractAgentDirectories(systemPrompt);
-		log.info(
-			`Found ${extraDirs.length} potential agent directories in system prompt`,
+		log.debug(
+			`Validated ${extraDirs.length} agent directories from system prompt`,
 		);
 
 		for (const dir of extraDirs) {
-			log.info(`Checking potential workspace from agents directory: ${dir}`);
+			log.debug(`Checking potential workspace from agents directory: ${dir}`);
 			// Extract workspace path from agents directory
 			// Convert /path/to/project/.claude/agents to /path/to/project
 			const workspacePath = dir.replace(/\/.claude\/agents$/, "");
@@ -109,7 +109,7 @@ export async function interceptAndModifyRequest(
 				await agentRegistry.registerWorkspace(workspacePath);
 				log.info(`Registered workspace: ${workspacePath}`);
 			} else {
-				log.info(`Workspace path does not exist: ${workspacePath}`);
+				log.debug(`Workspace path does not exist: ${workspacePath}`);
 			}
 		}
 
@@ -205,15 +205,15 @@ function extractSystemPrompt(requestBody: RequestBody): string | null {
 
 	// First check for system field at root level (Claude Code pattern)
 	if (requestBody.system) {
-		extractLog.info("Found system field at root level");
+		extractLog.debug("Found system field at root level");
 		if (typeof requestBody.system === "string") {
-			extractLog.info(
+			extractLog.debug(
 				`System field is string, length: ${requestBody.system.length}`,
 			);
 			allSystemContent.push(requestBody.system);
 		}
 		if (Array.isArray(requestBody.system)) {
-			extractLog.info(
+			extractLog.debug(
 				`System field is array with ${requestBody.system.length} items`,
 			);
 			// Concatenate all text from system messages
@@ -223,7 +223,7 @@ function extractSystemPrompt(requestBody: RequestBody): string | null {
 				)
 				.map((item) => item.text)
 				.join("\n");
-			extractLog.info(`Extracted system text length: ${systemText.length}`);
+			extractLog.debug(`Extracted system text length: ${systemText.length}`);
 			if (systemText) {
 				allSystemContent.push(systemText);
 			}
@@ -232,7 +232,7 @@ function extractSystemPrompt(requestBody: RequestBody): string | null {
 
 	// Then check messages array
 	if (requestBody.messages && Array.isArray(requestBody.messages)) {
-		extractLog.info(
+		extractLog.debug(
 			`Checking messages array with ${requestBody.messages.length} messages`,
 		);
 
@@ -242,15 +242,15 @@ function extractSystemPrompt(requestBody: RequestBody): string | null {
 		);
 
 		if (systemMessage) {
-			extractLog.info("Found system role message");
+			extractLog.debug("Found system role message");
 			if (typeof systemMessage.content === "string") {
-				extractLog.info(
+				extractLog.debug(
 					`System message content is string, length: ${systemMessage.content.length}`,
 				);
 				allSystemContent.push(systemMessage.content);
 			}
 			if (Array.isArray(systemMessage.content)) {
-				extractLog.info(
+				extractLog.debug(
 					`System message content is array with ${systemMessage.content.length} items`,
 				);
 				const systemText = systemMessage.content
@@ -260,7 +260,7 @@ function extractSystemPrompt(requestBody: RequestBody): string | null {
 					)
 					.map((item) => item.text)
 					.join("\n");
-				extractLog.info(
+				extractLog.debug(
 					`Extracted system message text length: ${systemText.length}`,
 				);
 				if (systemText) {
@@ -268,7 +268,7 @@ function extractSystemPrompt(requestBody: RequestBody): string | null {
 				}
 			}
 		} else {
-			extractLog.info("No system role message found, checking user messages");
+			extractLog.debug("No system role message found, checking user messages");
 		}
 
 		// Also check for system prompt in user messages
@@ -281,7 +281,7 @@ function extractSystemPrompt(requestBody: RequestBody): string | null {
 					item.type === "text" && !!item.text,
 			);
 
-			extractLog.info(
+			extractLog.debug(
 				`Found ${textContents.length} text content items in user message`,
 			);
 
@@ -291,7 +291,7 @@ function extractSystemPrompt(requestBody: RequestBody): string | null {
 				allUserText.includes("Contents of") &&
 				allUserText.includes("CLAUDE.md")
 			) {
-				extractLog.info(
+				extractLog.debug(
 					"User message contains 'Contents of' and 'CLAUDE.md' - including in system prompt",
 				);
 				allSystemContent.push(allUserText);
@@ -301,7 +301,7 @@ function extractSystemPrompt(requestBody: RequestBody): string | null {
 				userMessage.content.includes("Contents of") &&
 				userMessage.content.includes("CLAUDE.md")
 			) {
-				extractLog.info(
+				extractLog.debug(
 					"User message string contains 'Contents of' and 'CLAUDE.md' - including in system prompt",
 				);
 				allSystemContent.push(userMessage.content);
@@ -312,7 +312,7 @@ function extractSystemPrompt(requestBody: RequestBody): string | null {
 	// Combine all system content
 	if (allSystemContent.length > 0) {
 		const combined = allSystemContent.join("\n\n");
-		extractLog.info(
+		extractLog.debug(
 			`Combined system prompt length: ${combined.length} from ${allSystemContent.length} sources`,
 		);
 		return combined;
@@ -393,11 +393,22 @@ function extractAgentDirectories(systemPrompt: string): string[] {
 	// Regex #2: Look for repo root pattern "Contents of (.*?)/CLAUDE.md"
 	const repoRootRegex = /Contents of ([^\n]+?)\/CLAUDE\.md/g;
 	const repoRootMatches = systemPrompt.matchAll(repoRootRegex);
+	const homeClaudeDir = join(homedir(), ".claude");
 	for (const match of repoRootMatches) {
 		const repoRoot = match[1];
 
 		// Clean up any escaped slashes and construct agents directory first
 		const cleanedRoot = repoRoot.replace(/\\\//g, "/");
+
+		// ~/.claude/CLAUDE.md is the user's global Claude Code config, not a
+		// project repo root. Global agents at ~/.claude/agents are loaded
+		// unconditionally by AgentRegistry.loadAgents() via getAgentsDirectory(),
+		// so constructing ~/.claude/.claude/agents here would only produce a
+		// non-existent path and a noisy security-validation warning.
+		if (cleanedRoot === homeClaudeDir) {
+			continue;
+		}
+
 		const agentsDir = join(cleanedRoot, ".claude", "agents");
 
 		// Validate the constructed agents directory directly
@@ -405,7 +416,7 @@ function extractAgentDirectories(systemPrompt: string): string[] {
 		// SECURITY NOTE: This is a deliberate decision to allow Claude Code to access agents in ~/.claude directory.
 		// The path validation system was restricting access to ~/.claude/.claude/agents which is needed for proper agent functionality.
 		// This addition maintains security by only allowing this specific path while keeping all other restrictions in place.
-		const additionalAllowedPaths = [join(homedir(), ".claude")];
+		const additionalAllowedPaths = [homeClaudeDir];
 		processPath(
 			agentsDir,
 			"constructed agents directory from CLAUDE.md",

--- a/packages/proxy/src/post-processor.worker.ts
+++ b/packages/proxy/src/post-processor.worker.ts
@@ -552,8 +552,8 @@ async function handleStart(msg: StartMessage): Promise<void> {
 			"zai",
 			"alibaba-coding-plan",
 			"ollama",
-				"ollama-cloud",
-				"qwen",
+			"ollama-cloud",
+			"qwen",
 			"codex",
 		]);
 		state.billingType = planProviders.has(msg.providerName) ? "plan" : "api";


### PR DESCRIPTION
- Logger.{error,warn,info,debug} now convert Error instances to plain objects with name/message/stack/cause before emitting, so they survive formatMessage's JSON.stringify and the file writer's serialization. Previously every log.error(msg, err) on an Error printed "{}" because Error's properties are non-enumerable — affects 159 call sites including the visible "Failed to intercept/modify request:" line in agent-interceptor.

- Demote the remaining per-request INFO logs in agent-interceptor and extractSystemPrompt to DEBUG (continuation of b0e5a3a).

- Skip regex #2 construction when repoRoot resolves to ~/.claude. Global agents at ~/.claude/agents are already loaded unconditionally by AgentRegistry.loadAgents() via getAgentsDirectory(), so building ~/.claude/.claude/agents only produces a non-existent path and a spurious "Rejected invalid constructed agents directory" WARN.

- Rename "Found N potential agent directories" → "Validated N agent directories" since the count is post-validation, not pre-validation.

- Incidental biome-format whitespace in post-processor.worker.ts from the mandated `bun run format` step (unrelated to the logic changes).