### PR TITLE
fix: respect LOG_LEVEL=DEBUG env var in Logger

### DIFF
--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -22,7 +22,7 @@ export class Logger {
 
 	constructor(prefix: string = "", level: LogLevel = LogLevel.INFO) {
 		this.prefix = prefix;
-		this.level = this.getLogLevelFromEnv() || level;
+		this.level = this.getLogLevelFromEnv() ?? level;
 		this.format = this.getFormatFromEnv();
 		// Only show console output in debug mode or if BETTER_CCFLARE_DEBUG or legacy ccflare_DEBUG is set
 		this.silentConsole = !(

--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Logger, LogLevel } from "./index";
+
+describe("Logger env LOG_LEVEL handling", () => {
+	const original = process.env.LOG_LEVEL;
+
+	beforeEach(() => {
+		delete process.env.LOG_LEVEL;
+	});
+
+	afterEach(() => {
+		if (original === undefined) delete process.env.LOG_LEVEL;
+		else process.env.LOG_LEVEL = original;
+	});
+
+	it("defaults to INFO when LOG_LEVEL is unset", () => {
+		expect(new Logger().getLevel()).toBe(LogLevel.INFO);
+	});
+
+	it("respects LOG_LEVEL=DEBUG (regression: || vs ?? on LogLevel.DEBUG === 0)", () => {
+		process.env.LOG_LEVEL = "DEBUG";
+		expect(new Logger().getLevel()).toBe(LogLevel.DEBUG);
+	});
+
+	it("respects LOG_LEVEL=WARN", () => {
+		process.env.LOG_LEVEL = "WARN";
+		expect(new Logger().getLevel()).toBe(LogLevel.WARN);
+	});
+
+	it("respects LOG_LEVEL=ERROR", () => {
+		process.env.LOG_LEVEL = "ERROR";
+		expect(new Logger().getLevel()).toBe(LogLevel.ERROR);
+	});
+
+	it("ignores unknown LOG_LEVEL values and falls back to constructor default", () => {
+		process.env.LOG_LEVEL = "BANANA";
+		expect(new Logger("", LogLevel.WARN).getLevel()).toBe(LogLevel.WARN);
+	});
+});

--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { Logger, LogLevel } from "./index";
 
 describe("Logger env LOG_LEVEL handling", () => {
@@ -35,5 +35,28 @@ describe("Logger env LOG_LEVEL handling", () => {
 	it("ignores unknown LOG_LEVEL values and falls back to constructor default", () => {
 		process.env.LOG_LEVEL = "BANANA";
 		expect(new Logger("", LogLevel.WARN).getLevel()).toBe(LogLevel.WARN);
+	});
+
+	it("emits debug() output to console when LOG_LEVEL=DEBUG (silentConsole side-effect)", () => {
+		process.env.LOG_LEVEL = "DEBUG";
+		const spy = spyOn(console, "log").mockImplementation(() => {});
+		try {
+			new Logger("Test").debug("hello");
+			expect(spy).toHaveBeenCalledTimes(1);
+			expect(String(spy.mock.calls[0][0])).toContain("DEBUG");
+			expect(String(spy.mock.calls[0][0])).toContain("hello");
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
+	it("suppresses debug() console output by default (LOG_LEVEL unset)", () => {
+		const spy = spyOn(console, "log").mockImplementation(() => {});
+		try {
+			new Logger("Test").debug("hello");
+			expect(spy).not.toHaveBeenCalled();
+		} finally {
+			spy.mockRestore();
+		}
 	});
 });


### PR DESCRIPTION
LogLevel.DEBUG === 0 is falsy, so `getLogLevelFromEnv() || level` silently fell back to the constructor default (INFO) when LOG_LEVEL=DEBUG was set. log.debug() calls were short-circuited at the level gate and silentConsole stayed true, so the proxy emitted nothing to stdout/journal even with the env var configured.

Switch to ?? so the env override applies for DEBUG too. Other levels (INFO/WARN/ERROR) were unaffected because their numeric values are truthy.

Adds packages/logger/src/logger.test.ts covering DEBUG, WARN, ERROR, unset, and unknown values to prevent regression.