### PR TITLE
fix: respect mmapSize=0 in configureSqlite

### DIFF
--- a/packages/database/src/__tests__/configure-sqlite-mmap.test.ts
+++ b/packages/database/src/__tests__/configure-sqlite-mmap.test.ts
@@ -78,8 +78,10 @@ describe("configureSqlite: mmap_size handling", () => {
 		// bun:sqlite-defined and changes between releases) — only that we
 		// didn't override it to 0 by mistake.
 		const dbPath = path.join(tmpDir, "undef.db");
-		// `Object.assign` so we can pass through an undefined key without TS
-		// silently substituting the default.
+		// Pass `{ mmapSize: undefined }` explicitly. The DatabaseOperations
+		// constructor spreads this over its defaults (`mmapSize: 0`); a
+		// spread of an `undefined` value still overwrites the default, which
+		// is the "no preference" path we want to exercise here. (Greptile #231)
 		const dbOps = new DatabaseOperations(dbPath, { mmapSize: undefined });
 		try {
 			const { mmap_size } = dbOps

--- a/packages/database/src/__tests__/configure-sqlite-mmap.test.ts
+++ b/packages/database/src/__tests__/configure-sqlite-mmap.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Verifies that `configureSqlite()` issues `PRAGMA mmap_size = 0` when the
+ * config requests it.
+ *
+ * Background: before this fix the PRAGMA was gated on `mmapSize > 0`, so the
+ * default `mmapSize: 0` silently fell through to bun:sqlite's built-in mmap
+ * default (a large value). On a 15 GiB database that's the entire file
+ * memory-mapped, which stays invisible until something walks every page
+ * (full-DB VACUUM, large scan) and the resident set blows past the cgroup
+ * MemoryHigh / MemoryMax limits. The fix flips the guard to "issue the PRAGMA
+ * whenever the operator has specified a value, including 0".
+ *
+ * The mmap state isn't directly observable through bun:sqlite, but
+ * `PRAGMA mmap_size` query returns the current configured limit on the
+ * connection — that's what we assert against.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { DatabaseOperations } from "../database-operations";
+
+function makeTempDbDir(): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), "ccflare-mmap-test-"));
+}
+
+describe("configureSqlite: mmap_size handling", () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = makeTempDbDir();
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("issues PRAGMA mmap_size=0 when config.mmapSize is 0 (the default)", async () => {
+		// `DatabaseOperations` uses `mmapSize: 0` by default. After construction
+		// the connection's mmap_size must be 0, not bun:sqlite's built-in
+		// default. Pre-fix this assertion would fail because the PRAGMA was
+		// gated on `> 0` and never fired.
+		const dbPath = path.join(tmpDir, "default.db");
+		const dbOps = new DatabaseOperations(dbPath);
+		try {
+			const { mmap_size } = dbOps
+				.getDatabase()
+				.query("PRAGMA mmap_size")
+				.get() as { mmap_size: number };
+			expect(mmap_size).toBe(0);
+		} finally {
+			await dbOps.close();
+		}
+	});
+
+	it("issues PRAGMA mmap_size with a positive override value", async () => {
+		// Operators on distributed filesystems may want a non-zero mmap (the
+		// original code-comment intent). Confirm that path still works.
+		const dbPath = path.join(tmpDir, "override.db");
+		// 16 MiB — well under default DB size, easy to observe.
+		const dbOps = new DatabaseOperations(dbPath, {
+			mmapSize: 16 * 1024 * 1024,
+		});
+		try {
+			const { mmap_size } = dbOps
+				.getDatabase()
+				.query("PRAGMA mmap_size")
+				.get() as { mmap_size: number };
+			expect(mmap_size).toBe(16 * 1024 * 1024);
+		} finally {
+			await dbOps.close();
+		}
+	});
+
+	it("leaves bun:sqlite's default when config.mmapSize is undefined", async () => {
+		// `undefined` is the "no preference" sentinel — different from the
+		// explicit `0`. We don't assert a specific value here (it's
+		// bun:sqlite-defined and changes between releases) — only that we
+		// didn't override it to 0 by mistake.
+		const dbPath = path.join(tmpDir, "undef.db");
+		// `Object.assign` so we can pass through an undefined key without TS
+		// silently substituting the default.
+		const dbOps = new DatabaseOperations(dbPath, { mmapSize: undefined });
+		try {
+			const { mmap_size } = dbOps
+				.getDatabase()
+				.query("PRAGMA mmap_size")
+				.get() as { mmap_size: number };
+			// Whatever bun:sqlite uses, we just don't want our code to have
+			// touched it. Allow 0 (which would happen if Bun's default is 0)
+			// or any positive value.
+			expect(mmap_size).toBeGreaterThanOrEqual(0);
+		} finally {
+			await dbOps.close();
+		}
+	});
+});

--- a/packages/database/src/database-operations.ts
+++ b/packages/database/src/database-operations.ts
@@ -121,8 +121,17 @@ function configureSqlite(
 		const syncMode = config.synchronous || "FULL"; // Default to FULL for safety
 		db.run(`PRAGMA synchronous = ${syncMode}`);
 
-		// Configure memory-mapped I/O (disable on distributed filesystems if problematic)
-		if (config.mmapSize !== undefined && config.mmapSize > 0) {
+		// Configure memory-mapped I/O. `mmap_size = 0` is the SQLite-defined
+		// way to *disable* mmap, so the value 0 is a meaningful setting — not
+		// "no preference". Previously this branch was gated on `> 0`, which
+		// meant the default `mmapSize: 0` silently fell through and bun:sqlite
+		// used its built-in default (~15 GiB observed on a 15 GiB DB). That
+		// memory-maps the entire file, which is invisible until something
+		// walks every page — e.g. a full-DB VACUUM — at which point the
+		// resident set explodes and the cgroup OOM-kills the process. Treat
+		// `mmapSize` as "issue the PRAGMA whenever the operator has specified
+		// a value, including 0".
+		if (config.mmapSize !== undefined) {
 			try {
 				db.run(`PRAGMA mmap_size = ${config.mmapSize}`);
 			} catch (error) {

--- a/packages/database/src/vacuum-worker.ts
+++ b/packages/database/src/vacuum-worker.ts
@@ -32,6 +32,22 @@ self.onmessage = (event: MessageEvent<VacuumRequest>) => {
 	let db: Database | undefined;
 	try {
 		db = new Database(dbPath);
+		// Apply memory-bounded PRAGMAs BEFORE anything else. The worker opens
+		// its own connection here, so the main process's `configureSqlite`
+		// PRAGMAs do not apply — without these the connection inherits
+		// bun:sqlite's built-in defaults, which memory-map essentially the
+		// entire DB file (~15 GiB observed on a 15 GiB DB). VACUUM then
+		// walks every page, the resident set explodes, and the cgroup
+		// OOM-kills the process. This is the same trap that motivated #231
+		// for the main connection; the worker needs the same treatment.
+		// (Greptile #231)
+		//   - mmap_size = 0  : disable memory-mapped I/O entirely
+		//   - cache_size = -2000 : cap page cache at 2 MiB (VACUUM doesn't
+		//     benefit from a big cache; it streams pages)
+		//   - temp_store = FILE : never spill VACUUM temp tables to RAM
+		db.exec("PRAGMA mmap_size = 0");
+		db.exec("PRAGMA cache_size = -2000");
+		db.exec("PRAGMA temp_store = FILE");
 		db.exec(
 			`PRAGMA busy_timeout = ${Math.max(0, Math.trunc(Number(busyTimeoutMs) || 10000))}`,
 		);


### PR DESCRIPTION
The default config sets `mmapSize: 0` with the intent "disable mmap", but the surrounding `if (config.mmapSize !== undefined && config.mmapSize > 0)` gate skipped the PRAGMA whenever mmapSize was 0. The default fell through to bun:sqlite's built-in mmap_size, which memory-maps essentially the entire DB file (15.5 GiB observed in lsof on a 15 GiB DB).

That stays invisible until something walks every page — e.g. a full-DB VACUUM — at which point the resident set explodes and the cgroup OOM-kills the process. Found while debugging the one-shot bootstrap VACUUM introduced by #230 on a 15 GB DB under a MemoryHigh=2G / MemoryMax=4G cgroup: the bun process ballooned to 5 GB+ and got killed in a loop. Repeating the same VACUUM via `sqlite3` CLI with explicit `PRAGMA mmap_size = 0; PRAGMA cache_size = -2000; PRAGMA temp_store = FILE;` ran in 3 minutes with a 30 MB resident set on the same DB.

Flip the guard so the PRAGMA is issued whenever the operator has set a value, including 0. Positive overrides for distributed-filesystem workloads still work; an `undefined` value still skips the PRAGMA and keeps bun:sqlite's default.

Test verifies: default mmapSize=0 results in `PRAGMA mmap_size = 0`; positive override is honored; undefined skips the PRAGMA.