### PR TITLE
feat: show daily/weekly plan-value burn rate on Overview

### DIFF
--- a/packages/dashboard-web/src/components/OverviewTab.tsx
+++ b/packages/dashboard-web/src/components/OverviewTab.tsx
@@ -240,6 +240,19 @@ export const OverviewTab = React.memo(() => {
 					}
 					trendPeriod={trendPeriod}
 					icon={DollarSign}
+					subRows={[
+						{
+							label: "Avg / day",
+							value: formatCost(analytics?.totals.avgDailyPlanCostUsd ?? 0),
+							tooltip: "Average daily plan value over the last 7 days",
+						},
+						{
+							label: "Avg / week",
+							value: formatCost(analytics?.totals.avgWeeklyPlanCostUsd ?? 0),
+							tooltip:
+								"Average weekly plan value, derived from the last 30 days",
+						},
+					]}
 				/>
 				<MetricCard
 					title="API Cost"

--- a/packages/dashboard-web/src/components/overview/MetricCard.tsx
+++ b/packages/dashboard-web/src/components/overview/MetricCard.tsx
@@ -3,6 +3,12 @@ import { Info, TrendingDown, TrendingUp } from "lucide-react";
 import { Card, CardContent } from "../ui/card";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 
+export interface MetricCardSubRow {
+	label: string;
+	value: string | number;
+	tooltip?: string;
+}
+
 export interface MetricCardProps {
 	title: string;
 	value: string | number;
@@ -10,6 +16,7 @@ export interface MetricCardProps {
 	icon: React.ComponentType<{ className?: string }>;
 	trend?: "up" | "down" | "flat";
 	trendPeriod?: string;
+	subRows?: MetricCardSubRow[];
 }
 
 export function MetricCard({
@@ -19,6 +26,7 @@ export function MetricCard({
 	icon: Icon,
 	trend,
 	trendPeriod,
+	subRows,
 }: MetricCardProps) {
 	const trendElement = trend !== "flat" && change !== undefined && (
 		<div
@@ -60,6 +68,20 @@ export function MetricCard({
 					<p className="text-sm text-muted-foreground">{title}</p>
 					<p className="text-2xl font-bold">{value}</p>
 				</div>
+				{subRows && subRows.length > 0 && (
+					<div className="mt-3 pt-3 border-t border-border/50 space-y-1">
+						{subRows.map((row) => (
+							<div
+								key={row.label}
+								className="flex items-baseline justify-between text-xs"
+								title={row.tooltip}
+							>
+								<span className="text-muted-foreground">{row.label}</span>
+								<span className="font-medium tabular-nums">{row.value}</span>
+							</div>
+						))}
+					</div>
+				)}
 			</CardContent>
 		</Card>
 	);

--- a/packages/dashboard-web/src/components/overview/MetricCard.tsx
+++ b/packages/dashboard-web/src/components/overview/MetricCard.tsx
@@ -74,10 +74,22 @@ export function MetricCard({
 							<div
 								key={row.label}
 								className="flex items-baseline justify-between text-xs"
-								title={row.tooltip}
 							>
 								<span className="text-muted-foreground">{row.label}</span>
-								<span className="font-medium tabular-nums">{row.value}</span>
+								{row.tooltip ? (
+									<Popover>
+										<PopoverTrigger asChild>
+											<span className="font-medium tabular-nums cursor-help">
+												{row.value}
+											</span>
+										</PopoverTrigger>
+										<PopoverContent className="w-auto p-2 text-xs">
+											<p>{row.tooltip}</p>
+										</PopoverContent>
+									</Popover>
+								) : (
+									<span className="font-medium tabular-nums">{row.value}</span>
+								)}
 							</div>
 						))}
 					</div>

--- a/packages/http-api/src/handlers/__tests__/analytics-burn-rate.test.ts
+++ b/packages/http-api/src/handlers/__tests__/analytics-burn-rate.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+import { effectiveBurnRateDays } from "../analytics";
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = 1_700_000_000_000;
+
+describe("effectiveBurnRateDays", () => {
+	it("returns the full window when there is no data", () => {
+		expect(effectiveBurnRateDays(null, NOW - 7 * DAY, 7, NOW)).toBe(7);
+		expect(effectiveBurnRateDays(null, NOW - 30 * DAY, 30, NOW)).toBe(30);
+	});
+
+	it("returns the full window when history extends back to (or past) the window start", () => {
+		expect(effectiveBurnRateDays(NOW - 9 * DAY, NOW - 7 * DAY, 7, NOW)).toBe(7);
+		expect(effectiveBurnRateDays(NOW - 7 * DAY, NOW - 7 * DAY, 7, NOW)).toBe(7);
+		expect(effectiveBurnRateDays(NOW - 60 * DAY, NOW - 30 * DAY, 30, NOW)).toBe(
+			30,
+		);
+	});
+
+	it("clamps to the actual age of the data when history is thinner than the window", () => {
+		// 5 full days of data, 7d window → divide by 5, not 7
+		expect(effectiveBurnRateDays(NOW - 5 * DAY, NOW - 7 * DAY, 7, NOW)).toBe(5);
+		// 5 full days of data, 30d window → divide by 5, not 30
+		expect(effectiveBurnRateDays(NOW - 5 * DAY, NOW - 30 * DAY, 30, NOW)).toBe(
+			5,
+		);
+	});
+
+	it("rounds a partial first day up to a whole day and clamps to a minimum of 1", () => {
+		// First row 30 minutes ago — Avg/day should not divide by 0.02 days
+		expect(
+			effectiveBurnRateDays(NOW - 30 * 60 * 1000, NOW - 7 * DAY, 7, NOW),
+		).toBe(1);
+		// First row 25 hours ago → 2 days (ceil)
+		expect(
+			effectiveBurnRateDays(NOW - 25 * 60 * 60 * 1000, NOW - 7 * DAY, 7, NOW),
+		).toBe(2);
+	});
+
+	it("matches the weekly-from-30d use case under thin history", () => {
+		// Five days of data with $8000 total plan cost.
+		// 30d weekly = (sum / effectiveDays) * 7 = (8000 / 5) * 7 = 11200
+		const planCost30d = 8000;
+		const firstPlanTs = NOW - 5 * DAY;
+		const divisor = effectiveBurnRateDays(firstPlanTs, NOW - 30 * DAY, 30, NOW);
+		const weekly = (planCost30d / divisor) * 7;
+		expect(divisor).toBe(5);
+		expect(weekly).toBe(11200);
+	});
+});

--- a/packages/http-api/src/handlers/analytics.ts
+++ b/packages/http-api/src/handlers/analytics.ts
@@ -9,6 +9,20 @@ import type { AnalyticsResponse, APIContext } from "../types";
 
 const log = new Logger("AnalyticsHandler");
 
+// Exported for unit tests.
+export function effectiveBurnRateDays(
+	firstTs: number | null,
+	windowStartMs: number,
+	windowDays: number,
+	nowMs: number,
+): number {
+	if (firstTs == null) return windowDays;
+	const dayMs = 24 * 60 * 60 * 1000;
+	const start = Math.max(firstTs, windowStartMs);
+	const days = Math.ceil((nowMs - start) / dayMs);
+	return Math.min(windowDays, Math.max(1, days));
+}
+
 interface BucketConfig {
 	bucketMs: number;
 	displayName: string;
@@ -156,22 +170,29 @@ export function createAnalyticsHandler(context: APIContext) {
 
 			// Fixed-window burn-rate aggregates. Independent of the user's range
 			// or filters so "Avg / day" and "Avg / week" stay stable when the
-			// dashboard range filter changes. Daily = sum(7d) / 7, weekly = sum(30d) * 7/30.
+			// dashboard range filter changes. Divisor is clamped to the actual
+			// age of the data so thin history (e.g. the proxy was started 3 days
+			// ago) doesn't get padded with imaginary zero days.
+			const dayMs = 24 * 60 * 60 * 1000;
 			const nowMs = Date.now();
-			const sevenDayStart = nowMs - 7 * 24 * 60 * 60 * 1000;
-			const thirtyDayStart = nowMs - 30 * 24 * 60 * 60 * 1000;
+			const sevenDayStart = nowMs - 7 * dayMs;
+			const thirtyDayStart = nowMs - 30 * dayMs;
 			const burnRateResult = await db.get<{
 				plan_cost_7d: number;
 				api_cost_7d: number;
 				plan_cost_30d: number;
 				api_cost_30d: number;
+				first_plan_ts: number | null;
+				first_api_ts: number | null;
 			}>(
 				`
 				SELECT
 					SUM(CASE WHEN timestamp > ? AND billing_type = 'plan' THEN COALESCE(cost_usd, 0) ELSE 0 END) as plan_cost_7d,
 					SUM(CASE WHEN timestamp > ? AND billing_type != 'plan' THEN COALESCE(cost_usd, 0) ELSE 0 END) as api_cost_7d,
 					SUM(CASE WHEN billing_type = 'plan' THEN COALESCE(cost_usd, 0) ELSE 0 END) as plan_cost_30d,
-					SUM(CASE WHEN billing_type != 'plan' THEN COALESCE(cost_usd, 0) ELSE 0 END) as api_cost_30d
+					SUM(CASE WHEN billing_type != 'plan' THEN COALESCE(cost_usd, 0) ELSE 0 END) as api_cost_30d,
+					MIN(CASE WHEN billing_type = 'plan' THEN timestamp ELSE NULL END) as first_plan_ts,
+					MIN(CASE WHEN billing_type != 'plan' THEN timestamp ELSE NULL END) as first_api_ts
 				FROM requests
 				WHERE timestamp > ?
 			`,
@@ -181,10 +202,27 @@ export function createAnalyticsHandler(context: APIContext) {
 			const apiCost7d = Number(burnRateResult?.api_cost_7d) || 0;
 			const planCost30d = Number(burnRateResult?.plan_cost_30d) || 0;
 			const apiCost30d = Number(burnRateResult?.api_cost_30d) || 0;
-			const avgDailyPlanCostUsd = planCost7d / 7;
-			const avgDailyApiCostUsd = apiCost7d / 7;
-			const avgWeeklyPlanCostUsd = (planCost30d * 7) / 30;
-			const avgWeeklyApiCostUsd = (apiCost30d * 7) / 30;
+			const firstPlanTs =
+				burnRateResult?.first_plan_ts != null
+					? Number(burnRateResult.first_plan_ts)
+					: null;
+			const firstApiTs =
+				burnRateResult?.first_api_ts != null
+					? Number(burnRateResult.first_api_ts)
+					: null;
+			const avgDailyPlanCostUsd =
+				planCost7d /
+				effectiveBurnRateDays(firstPlanTs, sevenDayStart, 7, nowMs);
+			const avgDailyApiCostUsd =
+				apiCost7d / effectiveBurnRateDays(firstApiTs, sevenDayStart, 7, nowMs);
+			const avgWeeklyPlanCostUsd =
+				(planCost30d /
+					effectiveBurnRateDays(firstPlanTs, thirtyDayStart, 30, nowMs)) *
+				7;
+			const avgWeeklyApiCostUsd =
+				(apiCost30d /
+					effectiveBurnRateDays(firstApiTs, thirtyDayStart, 30, nowMs)) *
+				7;
 
 			// Get time series data
 			const timeSeries = await db.query<{

--- a/packages/http-api/src/handlers/analytics.ts
+++ b/packages/http-api/src/handlers/analytics.ts
@@ -154,6 +154,38 @@ export function createAnalyticsHandler(context: APIContext) {
 				[...queryParams, NO_ACCOUNT_ID],
 			);
 
+			// Fixed-window burn-rate aggregates. Independent of the user's range
+			// or filters so "Avg / day" and "Avg / week" stay stable when the
+			// dashboard range filter changes. Daily = sum(7d) / 7, weekly = sum(30d) * 7/30.
+			const nowMs = Date.now();
+			const sevenDayStart = nowMs - 7 * 24 * 60 * 60 * 1000;
+			const thirtyDayStart = nowMs - 30 * 24 * 60 * 60 * 1000;
+			const burnRateResult = await db.get<{
+				plan_cost_7d: number;
+				api_cost_7d: number;
+				plan_cost_30d: number;
+				api_cost_30d: number;
+			}>(
+				`
+				SELECT
+					SUM(CASE WHEN timestamp > ? AND billing_type = 'plan' THEN COALESCE(cost_usd, 0) ELSE 0 END) as plan_cost_7d,
+					SUM(CASE WHEN timestamp > ? AND billing_type != 'plan' THEN COALESCE(cost_usd, 0) ELSE 0 END) as api_cost_7d,
+					SUM(CASE WHEN billing_type = 'plan' THEN COALESCE(cost_usd, 0) ELSE 0 END) as plan_cost_30d,
+					SUM(CASE WHEN billing_type != 'plan' THEN COALESCE(cost_usd, 0) ELSE 0 END) as api_cost_30d
+				FROM requests
+				WHERE timestamp > ?
+			`,
+				[sevenDayStart, sevenDayStart, thirtyDayStart],
+			);
+			const planCost7d = Number(burnRateResult?.plan_cost_7d) || 0;
+			const apiCost7d = Number(burnRateResult?.api_cost_7d) || 0;
+			const planCost30d = Number(burnRateResult?.plan_cost_30d) || 0;
+			const apiCost30d = Number(burnRateResult?.api_cost_30d) || 0;
+			const avgDailyPlanCostUsd = planCost7d / 7;
+			const avgDailyApiCostUsd = apiCost7d / 7;
+			const avgWeeklyPlanCostUsd = (planCost30d * 7) / 30;
+			const avgWeeklyApiCostUsd = (apiCost30d * 7) / 30;
+
 			// Get time series data
 			const timeSeries = await db.query<{
 				ts: number;
@@ -554,6 +586,10 @@ export function createAnalyticsHandler(context: APIContext) {
 						consolidatedResult?.avg_tokens_per_second != null
 							? Number(consolidatedResult.avg_tokens_per_second)
 							: null,
+					avgDailyPlanCostUsd,
+					avgWeeklyPlanCostUsd,
+					avgDailyApiCostUsd,
+					avgWeeklyApiCostUsd,
 				},
 				timeSeries: transformedTimeSeries,
 				tokenBreakdown: {

--- a/packages/types/src/stats.ts
+++ b/packages/types/src/stats.ts
@@ -105,6 +105,12 @@ export interface AnalyticsResponse {
 		planCostUsd: number;
 		apiCostUsd: number;
 		avgTokensPerSecond: number | null;
+		// Fixed-window burn-rate KPIs, independent of the active range/filters.
+		// Daily: sum over the last 7 days / 7. Weekly: sum over the last 30 days × 7 / 30.
+		avgDailyPlanCostUsd: number;
+		avgWeeklyPlanCostUsd: number;
+		avgDailyApiCostUsd: number;
+		avgWeeklyApiCostUsd: number;
 	};
 	timeSeries: TimePoint[];
 	tokenBreakdown: TokenBreakdown;

--- a/packages/types/src/stats.ts
+++ b/packages/types/src/stats.ts
@@ -106,11 +106,13 @@ export interface AnalyticsResponse {
 		apiCostUsd: number;
 		avgTokensPerSecond: number | null;
 		// Fixed-window burn-rate KPIs, independent of the active range/filters.
-		// Daily: sum over the last 7 days / 7. Weekly: sum over the last 30 days × 7 / 30.
-		avgDailyPlanCostUsd: number;
-		avgWeeklyPlanCostUsd: number;
-		avgDailyApiCostUsd: number;
-		avgWeeklyApiCostUsd: number;
+		// Daily: sum(last 7d) / effectiveDays(≤7). Weekly: sum(last 30d) × 7 / effectiveDays(≤30).
+		// effectiveDays is clamped to the actual age of data so thin history doesn't inflate the average.
+		// Optional because an older server may not populate them — consumers should `?? 0`.
+		avgDailyPlanCostUsd?: number;
+		avgWeeklyPlanCostUsd?: number;
+		avgDailyApiCostUsd?: number;
+		avgWeeklyApiCostUsd?: number;
 	};
 	timeSeries: TimePoint[];
 	tokenBreakdown: TokenBreakdown;


### PR DESCRIPTION
Adds "Avg / day" and "Avg / week" rows under the Plan Value tile, derived from fixed windows (last 7d for daily, last 30d scaled to a week for weekly) so the numbers stay stable when the user changes the dashboard range filter.

- packages/types/src/stats.ts: extend AnalyticsResponse.totals with avgDaily/WeeklyPlanCostUsd and avgDaily/WeeklyApiCostUsd. API-cost variants are populated server-side even though the UI only renders plan, so the same rows can be added to the API Cost tile without a backend change.
- packages/http-api/src/handlers/analytics.ts: one extra db.get scanning the last 30 days, computing 7d/30d plan-vs-api sums via CASE WHEN. Filter-independent by design.
- packages/dashboard-web/src/components/overview/MetricCard.tsx: optional subRows prop renders label/value pairs below the main value with a divider and tabular-nums.
- packages/dashboard-web/src/components/OverviewTab.tsx: Plan Value tile passes the two subRows.