### PR TITLE
fix: Anthropic 529 overloaded triggers temporary account cooldown

### DIFF
--- a/packages/dashboard-web/src/components/overview/system-status/__tests__/errorCodeMeta.test.ts
+++ b/packages/dashboard-web/src/components/overview/system-status/__tests__/errorCodeMeta.test.ts
@@ -50,6 +50,11 @@ describe("getErrorMeta", () => {
 		expect(meta.title).toBe("Provider overload");
 		expect(meta.severity).toBe("warning");
 		expect(meta.description).toContain("529");
+		// Reason is also used for mid-stream overloaded_error detections where
+		// no Retry-After header is parsed; the description must acknowledge that
+		// path so a dashboard reader doesn't assume the cooldown always came
+		// from an HTTP header.
+		expect(meta.description).toContain("mid-stream");
 		expect(meta.suggestion).toContain("automatically");
 	});
 

--- a/packages/dashboard-web/src/components/overview/system-status/__tests__/errorCodeMeta.test.ts
+++ b/packages/dashboard-web/src/components/overview/system-status/__tests__/errorCodeMeta.test.ts
@@ -44,4 +44,20 @@ describe("getErrorMeta", () => {
 		expect(meta.title).toBe("Provider rate limit");
 		expect(meta.severity).toBe("warning");
 	});
+
+	test("upstream_529_overloaded_with_reset returns provider overload warning", () => {
+		const meta = getErrorMeta("upstream_529_overloaded_with_reset");
+		expect(meta.title).toBe("Provider overload");
+		expect(meta.severity).toBe("warning");
+		expect(meta.description).toContain("529");
+		expect(meta.suggestion).toContain("automatically");
+	});
+
+	test("upstream_529_overloaded_no_reset returns provider overload (no Retry-After) warning", () => {
+		const meta = getErrorMeta("upstream_529_overloaded_no_reset");
+		expect(meta.title).toBe("Provider overload (no Retry-After)");
+		expect(meta.severity).toBe("warning");
+		expect(meta.description).toContain("529");
+		expect(meta.suggestion).toContain("CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS");
+	});
 });

--- a/packages/dashboard-web/src/components/overview/system-status/errorCodeMeta.ts
+++ b/packages/dashboard-web/src/components/overview/system-status/errorCodeMeta.ts
@@ -48,7 +48,7 @@ const KNOWN_ERROR_META: Record<
 	upstream_529_overloaded_with_reset: {
 		title: "Provider overload",
 		description:
-			"The upstream provider returned 529 (overloaded). Account temporarily cooled down until the provided Retry-After elapses.",
+			"The upstream provider returned 529 (overloaded). Account temporarily cooled down — the cooldown window comes from the Retry-After header when provided, or a synthesized window for mid-stream overloaded_error detections (no Retry-After is available in that path).",
 		suggestion:
 			"No action needed — the account will recover automatically. Traffic will shift to other configured accounts in the meantime.",
 		severity: "warning",

--- a/packages/dashboard-web/src/components/overview/system-status/errorCodeMeta.ts
+++ b/packages/dashboard-web/src/components/overview/system-status/errorCodeMeta.ts
@@ -45,6 +45,22 @@ const KNOWN_ERROR_META: Record<
 		suggestion: "Wait for cooldown, or add more diverse fallback models.",
 		severity: "error",
 	},
+	upstream_529_overloaded_with_reset: {
+		title: "Provider overload",
+		description:
+			"The upstream provider returned 529 (overloaded). Account temporarily cooled down until the provided Retry-After elapses.",
+		suggestion:
+			"No action needed — the account will recover automatically. Traffic will shift to other configured accounts in the meantime.",
+		severity: "warning",
+	},
+	upstream_529_overloaded_no_reset: {
+		title: "Provider overload (no Retry-After)",
+		description:
+			"The upstream provider returned 529 (overloaded) without a Retry-After header; entering probe cooldown.",
+		suggestion:
+			"Cooldown defaults to 60s. Set `CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS` in your environment to change it.",
+		severity: "warning",
+	},
 };
 
 function getModelFallbackMeta(context?: ErrorContext): ErrorMeta {

--- a/packages/http-api/src/handlers/__tests__/accounts-integration.test.ts
+++ b/packages/http-api/src/handlers/__tests__/accounts-integration.test.ts
@@ -636,6 +636,61 @@ describe("Accounts Handler - Dashboard Usage Data Integration", () => {
 			expect(payload[0].rateLimitedAt).toBe(rateLimitedAt);
 		});
 
+		it("should expose upstream_529_overloaded_with_reset reason via API (allowlist coverage)", async () => {
+			const accountsHandler = createMockAccountsListHandler(
+				CACHE_FRESHNESS_THRESHOLD_MS,
+			);
+			const futureTimestamp = Date.now() + 86400000;
+			const rateLimitedAt = Date.now() - 30_000;
+
+			mockUsageCache.getAge = () => 30000;
+
+			mockQuery.all = () => [
+				{
+					id: "529-account-id",
+					name: "529 Account",
+					provider: "anthropic",
+					access_token: "sk-ant-test",
+					refresh_token: "refresh-token",
+					request_count: 0,
+					total_requests: 0,
+					last_used: null,
+					created_at: Date.now() - 86400000,
+					expires_at: Date.now() + 86400000,
+					rate_limited_until: futureTimestamp,
+					rate_limited_reason: "upstream_529_overloaded_with_reset",
+					rate_limited_at: rateLimitedAt,
+					rate_limit_reset: null,
+					rate_limit_status: null,
+					rate_limit_remaining: null,
+					session_start: null,
+					session_request_count: 0,
+					paused: 0,
+					priority: 0,
+					auto_fallback_enabled: 0,
+					auto_refresh_enabled: 0,
+					custom_endpoint: null,
+					model_mappings: null,
+					token_valid: 1,
+					rate_limited: 0,
+					session_info: null,
+				},
+			];
+
+			const response = await accountsHandler();
+			const payload = (await response.json()) as Array<{
+				rateLimitedUntil: number | null;
+				rateLimitedReason: string | null;
+				rateLimitedAt: number | null;
+			}>;
+
+			expect(response.ok).toBe(true);
+			expect(payload[0].rateLimitedReason).toBe(
+				"upstream_529_overloaded_with_reset",
+			);
+			expect(payload[0].rateLimitedAt).toBe(rateLimitedAt);
+		});
+
 		it("should return null rateLimitedReason and rateLimitedAt for accounts that are not rate-limited (issue #178)", async () => {
 			const accountsHandler = createMockAccountsListHandler(
 				CACHE_FRESHNESS_THRESHOLD_MS,

--- a/packages/http-api/src/handlers/accounts.ts
+++ b/packages/http-api/src/handlers/accounts.ts
@@ -50,6 +50,8 @@ const RATE_LIMIT_REASONS = new Set<RateLimitReason>([
 	"upstream_429_no_reset_probe_cooldown",
 	"model_fallback_429",
 	"all_models_exhausted_429",
+	"upstream_529_overloaded_with_reset",
+	"upstream_529_overloaded_no_reset",
 ]);
 
 function toRateLimitReason(v: string | null): RateLimitReason | null {

--- a/packages/openai-formats/src/__tests__/stream.test.ts
+++ b/packages/openai-formats/src/__tests__/stream.test.ts
@@ -196,7 +196,7 @@ describe("transformStreamingResponse — text responses", () => {
 		const events = parseSSEEvents(raw);
 		const msgDelta = events.find((e) => e.event === "message_delta");
 		expect(msgDelta).toBeDefined();
-		const parsed = JSON.parse(msgDelta!.data);
+		const parsed = JSON.parse(msgDelta?.data);
 		expect(parsed.delta.stop_reason).toBe("end_turn");
 	});
 
@@ -232,7 +232,7 @@ describe("transformStreamingResponse — text responses", () => {
 		const raw = await readStream(transformed.body!);
 		const events = parseSSEEvents(raw);
 		const msgDelta = events.find((e) => e.event === "message_delta");
-		const parsed = JSON.parse(msgDelta!.data);
+		const parsed = JSON.parse(msgDelta?.data);
 		expect(parsed.usage.input_tokens).toBe(20);
 		expect(parsed.usage.output_tokens).toBe(5);
 	});
@@ -305,8 +305,8 @@ describe("transformStreamingResponse — tool calls", () => {
 				JSON.parse(e.data!).content_block?.type === "tool_use",
 		);
 		expect(blockStart).toBeDefined();
-		expect(JSON.parse(blockStart!.data).content_block.name).toBe("search");
-		expect(JSON.parse(blockStart!.data).content_block.id).toBe("call_abc");
+		expect(JSON.parse(blockStart?.data).content_block.name).toBe("search");
+		expect(JSON.parse(blockStart?.data).content_block.id).toBe("call_abc");
 	});
 
 	it("buffers all argument chunks and emits a single input_json_delta at [DONE]", async () => {
@@ -356,7 +356,7 @@ describe("transformStreamingResponse — tool calls", () => {
 		);
 		// Should be exactly one buffered emission
 		expect(deltas).toHaveLength(1);
-		expect(JSON.parse(deltas[0]!.data).delta.partial_json).toBe('{"q":"bun"}');
+		expect(JSON.parse(deltas[0]?.data).delta.partial_json).toBe('{"q":"bun"}');
 	});
 
 	it("emits message_delta with stop_reason tool_use for tool calls", async () => {
@@ -387,7 +387,7 @@ describe("transformStreamingResponse — tool calls", () => {
 		const raw = await readStream(transformed.body!);
 		const events = parseSSEEvents(raw);
 		const msgDelta = events.find((e) => e.event === "message_delta");
-		expect(JSON.parse(msgDelta!.data).delta.stop_reason).toBe("tool_use");
+		expect(JSON.parse(msgDelta?.data).delta.stop_reason).toBe("tool_use");
 	});
 
 	it("handles multiple parallel tool calls (indexes 0 and 1)", async () => {
@@ -569,7 +569,7 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 				JSON.parse(e.data!).content_block?.type === "thinking",
 		);
 		expect(thinkingStart).toBeDefined();
-		expect(JSON.parse(thinkingStart!.data).index).toBe(0);
+		expect(JSON.parse(thinkingStart?.data).index).toBe(0);
 	});
 
 	it("emits content_block_delta with type thinking_delta for reasoning_content chunks", async () => {
@@ -689,7 +689,7 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 		expect(stops[0]?.i).toBeLessThan(textStart?.i);
 
 		// text block must be at index 1
-		expect(JSON.parse(textStart!.e.data).index).toBe(1);
+		expect(JSON.parse(textStart?.e.data).index).toBe(1);
 		expect(types).toContain("message_start");
 	});
 
@@ -724,7 +724,7 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 				JSON.parse(e.data!).content_block?.type === "text",
 		);
 		expect(textBlockStart).toBeDefined();
-		expect(JSON.parse(textBlockStart!.data).index).toBe(1);
+		expect(JSON.parse(textBlockStart?.data).index).toBe(1);
 
 		// text_delta should also be at index 1
 		const textDeltas = events.filter(
@@ -733,7 +733,7 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 				JSON.parse(e.data!).delta?.type === "text_delta",
 		);
 		expect(textDeltas.length).toBeGreaterThanOrEqual(1);
-		expect(JSON.parse(textDeltas[0]!.data).index).toBe(1);
+		expect(JSON.parse(textDeltas[0]?.data).index).toBe(1);
 	});
 
 	it("emits content_block_stop at index 1 on stream end when thinking+text both present", async () => {
@@ -807,7 +807,7 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 		// Thinking block must be closed exactly once and message terminated
 		const stops = events.filter((e) => e.event === "content_block_stop");
 		expect(stops).toHaveLength(1);
-		expect(JSON.parse(stops[0]!.data).index).toBe(0);
+		expect(JSON.parse(stops[0]?.data).index).toBe(0);
 		const types = events.map((e) => e.event);
 		expect(types).toContain("message_stop");
 	});
@@ -885,7 +885,7 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 		// thinking must be closed before tool opens
 		expect(thinkingStop).toBeLessThan(toolStart);
 		// tool block gets index 1 (thinking consumed 0)
-		expect(JSON.parse(events[toolStart]!.data).index).toBe(1);
+		expect(JSON.parse(events[toolStart]?.data).index).toBe(1);
 	});
 
 	it("closes text block before first tool_use block when text precedes tool_calls", async () => {
@@ -961,7 +961,7 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 		// text block (idx=0) must be closed before tool block opens
 		expect(textStopIdx).toBeLessThan(toolStartIdx);
 		// tool block gets index 1
-		expect(JSON.parse(events[toolStartIdx]!.data).index).toBe(1);
+		expect(JSON.parse(events[toolStartIdx]?.data).index).toBe(1);
 	});
 
 	it("closes text block before thinking block when content precedes reasoning_content", async () => {
@@ -1013,7 +1013,7 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 		// text block (index 0) closed before thinking block opens
 		expect(textStopIdx).toBeLessThan(thinkingStartIdx);
 		// thinking block gets index 1
-		expect(JSON.parse(events[thinkingStartIdx]!.data).index).toBe(1);
+		expect(JSON.parse(events[thinkingStartIdx]?.data).index).toBe(1);
 		// exactly 2 content_block_stop events: one for text (index 0), one for thinking (index 1)
 		const stops = events.filter((e) => e.event === "content_block_stop");
 		expect(stops).toHaveLength(2);
@@ -1056,8 +1056,8 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 		expect(textStartIdx).toBeGreaterThanOrEqual(0);
 		// thinking block (index 0) before text block (index 1)
 		expect(thinkingStartIdx).toBeLessThan(textStartIdx);
-		expect(JSON.parse(events[thinkingStartIdx]!.data).index).toBe(0);
-		expect(JSON.parse(events[textStartIdx]!.data).index).toBe(1);
+		expect(JSON.parse(events[thinkingStartIdx]?.data).index).toBe(0);
+		expect(JSON.parse(events[textStartIdx]?.data).index).toBe(1);
 
 		// thinking block closed before text block opens
 		const thinkingStopIdx = events.findIndex(
@@ -1089,7 +1089,7 @@ describe("transformStreamingResponse — model extraction", () => {
 		const raw = await readStream(transformed.body!);
 		const events = parseSSEEvents(raw);
 		const msgStart = events.find((e) => e.event === "message_start");
-		const parsed = JSON.parse(msgStart!.data);
+		const parsed = JSON.parse(msgStart?.data);
 		expect(parsed.message.model).toBe("claude-sonnet-4-5");
 	});
 });
@@ -1134,7 +1134,7 @@ describe("transformStreamingResponse — block index assignment", () => {
 				JSON.parse(e.data!).content_block?.type === "text",
 		);
 		expect(textStart).toBeDefined();
-		expect(JSON.parse(textStart!.data).index).toBe(0);
+		expect(JSON.parse(textStart?.data).index).toBe(0);
 
 		const textDeltas = events.filter(
 			(e) =>
@@ -1179,7 +1179,7 @@ describe("transformStreamingResponse — block index assignment", () => {
 				JSON.parse(e.data!).content_block?.type === "tool_use",
 		);
 		expect(toolStart).toBeDefined();
-		expect(JSON.parse(toolStart!.data).index).toBe(0);
+		expect(JSON.parse(toolStart?.data).index).toBe(0);
 	});
 
 	it("text then tool: text gets index 0, tool gets index 1 — no collision", async () => {
@@ -1233,8 +1233,8 @@ describe("transformStreamingResponse — block index assignment", () => {
 		expect(textStart).toBeDefined();
 		expect(toolStart).toBeDefined();
 
-		const textIdx = JSON.parse(textStart!.data).index;
-		const toolIdx = JSON.parse(toolStart!.data).index;
+		const textIdx = JSON.parse(textStart?.data).index;
+		const toolIdx = JSON.parse(toolStart?.data).index;
 
 		// Indices must be distinct — no collision
 		expect(textIdx).not.toBe(toolIdx);
@@ -1249,7 +1249,7 @@ describe("transformStreamingResponse — block index assignment", () => {
 				JSON.parse(e.data!).delta?.type === "input_json_delta",
 		);
 		expect(jsonDelta).toBeDefined();
-		expect(JSON.parse(jsonDelta!.data).index).toBe(toolIdx);
+		expect(JSON.parse(jsonDelta?.data).index).toBe(toolIdx);
 
 		// The content_block_stop for the tool must match too
 		const stops = events.filter((e) => e.event === "content_block_stop");

--- a/packages/openai-formats/src/__tests__/stream.test.ts
+++ b/packages/openai-formats/src/__tests__/stream.test.ts
@@ -196,7 +196,8 @@ describe("transformStreamingResponse — text responses", () => {
 		const events = parseSSEEvents(raw);
 		const msgDelta = events.find((e) => e.event === "message_delta");
 		expect(msgDelta).toBeDefined();
-		const parsed = JSON.parse(msgDelta?.data);
+		if (!msgDelta) throw new Error("expected message_delta event");
+		const parsed = JSON.parse(msgDelta.data);
 		expect(parsed.delta.stop_reason).toBe("end_turn");
 	});
 
@@ -232,7 +233,9 @@ describe("transformStreamingResponse — text responses", () => {
 		const raw = await readStream(transformed.body!);
 		const events = parseSSEEvents(raw);
 		const msgDelta = events.find((e) => e.event === "message_delta");
-		const parsed = JSON.parse(msgDelta?.data);
+		expect(msgDelta).toBeDefined();
+		if (!msgDelta) throw new Error("expected message_delta event");
+		const parsed = JSON.parse(msgDelta.data);
 		expect(parsed.usage.input_tokens).toBe(20);
 		expect(parsed.usage.output_tokens).toBe(5);
 	});
@@ -305,8 +308,10 @@ describe("transformStreamingResponse — tool calls", () => {
 				JSON.parse(e.data!).content_block?.type === "tool_use",
 		);
 		expect(blockStart).toBeDefined();
-		expect(JSON.parse(blockStart?.data).content_block.name).toBe("search");
-		expect(JSON.parse(blockStart?.data).content_block.id).toBe("call_abc");
+		if (!blockStart) throw new Error("expected block_start event");
+		const blockStartData = JSON.parse(blockStart.data);
+		expect(blockStartData.content_block.name).toBe("search");
+		expect(blockStartData.content_block.id).toBe("call_abc");
 	});
 
 	it("buffers all argument chunks and emits a single input_json_delta at [DONE]", async () => {
@@ -356,7 +361,10 @@ describe("transformStreamingResponse — tool calls", () => {
 		);
 		// Should be exactly one buffered emission
 		expect(deltas).toHaveLength(1);
-		expect(JSON.parse(deltas[0]?.data).delta.partial_json).toBe('{"q":"bun"}');
+		const delta0 = deltas[0];
+		expect(delta0).toBeDefined();
+		if (!delta0) throw new Error("expected input_json_delta event");
+		expect(JSON.parse(delta0.data).delta.partial_json).toBe('{"q":"bun"}');
 	});
 
 	it("emits message_delta with stop_reason tool_use for tool calls", async () => {
@@ -387,7 +395,9 @@ describe("transformStreamingResponse — tool calls", () => {
 		const raw = await readStream(transformed.body!);
 		const events = parseSSEEvents(raw);
 		const msgDelta = events.find((e) => e.event === "message_delta");
-		expect(JSON.parse(msgDelta?.data).delta.stop_reason).toBe("tool_use");
+		expect(msgDelta).toBeDefined();
+		if (!msgDelta) throw new Error("expected message_delta event");
+		expect(JSON.parse(msgDelta.data).delta.stop_reason).toBe("tool_use");
 	});
 
 	it("handles multiple parallel tool calls (indexes 0 and 1)", async () => {
@@ -569,7 +579,8 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 				JSON.parse(e.data!).content_block?.type === "thinking",
 		);
 		expect(thinkingStart).toBeDefined();
-		expect(JSON.parse(thinkingStart?.data).index).toBe(0);
+		if (!thinkingStart) throw new Error("expected thinking block_start event");
+		expect(JSON.parse(thinkingStart.data).index).toBe(0);
 	});
 
 	it("emits content_block_delta with type thinking_delta for reasoning_content chunks", async () => {
@@ -724,7 +735,8 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 				JSON.parse(e.data!).content_block?.type === "text",
 		);
 		expect(textBlockStart).toBeDefined();
-		expect(JSON.parse(textBlockStart?.data).index).toBe(1);
+		if (!textBlockStart) throw new Error("expected text block_start event");
+		expect(JSON.parse(textBlockStart.data).index).toBe(1);
 
 		// text_delta should also be at index 1
 		const textDeltas = events.filter(
@@ -733,7 +745,10 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 				JSON.parse(e.data!).delta?.type === "text_delta",
 		);
 		expect(textDeltas.length).toBeGreaterThanOrEqual(1);
-		expect(JSON.parse(textDeltas[0]?.data).index).toBe(1);
+		const textDelta0 = textDeltas[0];
+		expect(textDelta0).toBeDefined();
+		if (!textDelta0) throw new Error("expected text_delta event");
+		expect(JSON.parse(textDelta0.data).index).toBe(1);
 	});
 
 	it("emits content_block_stop at index 1 on stream end when thinking+text both present", async () => {
@@ -807,7 +822,10 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 		// Thinking block must be closed exactly once and message terminated
 		const stops = events.filter((e) => e.event === "content_block_stop");
 		expect(stops).toHaveLength(1);
-		expect(JSON.parse(stops[0]?.data).index).toBe(0);
+		const stop0 = stops[0];
+		expect(stop0).toBeDefined();
+		if (!stop0) throw new Error("expected content_block_stop event");
+		expect(JSON.parse(stop0.data).index).toBe(0);
 		const types = events.map((e) => e.event);
 		expect(types).toContain("message_stop");
 	});
@@ -885,7 +903,11 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 		// thinking must be closed before tool opens
 		expect(thinkingStop).toBeLessThan(toolStart);
 		// tool block gets index 1 (thinking consumed 0)
-		expect(JSON.parse(events[toolStart]?.data).index).toBe(1);
+		const toolStartEvent = events[toolStart];
+		expect(toolStartEvent).toBeDefined();
+		if (!toolStartEvent)
+			throw new Error("expected tool_use block_start event at index");
+		expect(JSON.parse(toolStartEvent.data).index).toBe(1);
 	});
 
 	it("closes text block before first tool_use block when text precedes tool_calls", async () => {
@@ -961,7 +983,11 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 		// text block (idx=0) must be closed before tool block opens
 		expect(textStopIdx).toBeLessThan(toolStartIdx);
 		// tool block gets index 1
-		expect(JSON.parse(events[toolStartIdx]?.data).index).toBe(1);
+		const toolStartEvent2 = events[toolStartIdx];
+		expect(toolStartEvent2).toBeDefined();
+		if (!toolStartEvent2)
+			throw new Error("expected tool_use block_start event at index");
+		expect(JSON.parse(toolStartEvent2.data).index).toBe(1);
 	});
 
 	it("closes text block before thinking block when content precedes reasoning_content", async () => {
@@ -1013,7 +1039,11 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 		// text block (index 0) closed before thinking block opens
 		expect(textStopIdx).toBeLessThan(thinkingStartIdx);
 		// thinking block gets index 1
-		expect(JSON.parse(events[thinkingStartIdx]?.data).index).toBe(1);
+		const thinkingStartEvent = events[thinkingStartIdx];
+		expect(thinkingStartEvent).toBeDefined();
+		if (!thinkingStartEvent)
+			throw new Error("expected thinking block_start event at index");
+		expect(JSON.parse(thinkingStartEvent.data).index).toBe(1);
 		// exactly 2 content_block_stop events: one for text (index 0), one for thinking (index 1)
 		const stops = events.filter((e) => e.event === "content_block_stop");
 		expect(stops).toHaveLength(2);
@@ -1056,8 +1086,16 @@ describe("transformStreamingResponse — reasoning_content (thinking blocks)", (
 		expect(textStartIdx).toBeGreaterThanOrEqual(0);
 		// thinking block (index 0) before text block (index 1)
 		expect(thinkingStartIdx).toBeLessThan(textStartIdx);
-		expect(JSON.parse(events[thinkingStartIdx]?.data).index).toBe(0);
-		expect(JSON.parse(events[textStartIdx]?.data).index).toBe(1);
+		const thinkingStartEv = events[thinkingStartIdx];
+		expect(thinkingStartEv).toBeDefined();
+		if (!thinkingStartEv)
+			throw new Error("expected thinking block_start event at index");
+		const textStartEv = events[textStartIdx];
+		expect(textStartEv).toBeDefined();
+		if (!textStartEv)
+			throw new Error("expected text block_start event at index");
+		expect(JSON.parse(thinkingStartEv.data).index).toBe(0);
+		expect(JSON.parse(textStartEv.data).index).toBe(1);
 
 		// thinking block closed before text block opens
 		const thinkingStopIdx = events.findIndex(
@@ -1089,7 +1127,9 @@ describe("transformStreamingResponse — model extraction", () => {
 		const raw = await readStream(transformed.body!);
 		const events = parseSSEEvents(raw);
 		const msgStart = events.find((e) => e.event === "message_start");
-		const parsed = JSON.parse(msgStart?.data);
+		expect(msgStart).toBeDefined();
+		if (!msgStart) throw new Error("expected message_start event");
+		const parsed = JSON.parse(msgStart.data);
 		expect(parsed.message.model).toBe("claude-sonnet-4-5");
 	});
 });
@@ -1134,7 +1174,8 @@ describe("transformStreamingResponse — block index assignment", () => {
 				JSON.parse(e.data!).content_block?.type === "text",
 		);
 		expect(textStart).toBeDefined();
-		expect(JSON.parse(textStart?.data).index).toBe(0);
+		if (!textStart) throw new Error("expected text block_start event");
+		expect(JSON.parse(textStart.data).index).toBe(0);
 
 		const textDeltas = events.filter(
 			(e) =>
@@ -1179,7 +1220,8 @@ describe("transformStreamingResponse — block index assignment", () => {
 				JSON.parse(e.data!).content_block?.type === "tool_use",
 		);
 		expect(toolStart).toBeDefined();
-		expect(JSON.parse(toolStart?.data).index).toBe(0);
+		if (!toolStart) throw new Error("expected tool_use block_start event");
+		expect(JSON.parse(toolStart.data).index).toBe(0);
 	});
 
 	it("text then tool: text gets index 0, tool gets index 1 — no collision", async () => {
@@ -1232,9 +1274,11 @@ describe("transformStreamingResponse — block index assignment", () => {
 
 		expect(textStart).toBeDefined();
 		expect(toolStart).toBeDefined();
+		if (!textStart) throw new Error("expected text block_start event");
+		if (!toolStart) throw new Error("expected tool_use block_start event");
 
-		const textIdx = JSON.parse(textStart?.data).index;
-		const toolIdx = JSON.parse(toolStart?.data).index;
+		const textIdx = JSON.parse(textStart.data).index;
+		const toolIdx = JSON.parse(toolStart.data).index;
 
 		// Indices must be distinct — no collision
 		expect(textIdx).not.toBe(toolIdx);
@@ -1249,7 +1293,8 @@ describe("transformStreamingResponse — block index assignment", () => {
 				JSON.parse(e.data!).delta?.type === "input_json_delta",
 		);
 		expect(jsonDelta).toBeDefined();
-		expect(JSON.parse(jsonDelta?.data).index).toBe(toolIdx);
+		if (!jsonDelta) throw new Error("expected input_json_delta event");
+		expect(JSON.parse(jsonDelta.data).index).toBe(toolIdx);
 
 		// The content_block_stop for the tool must match too
 		const stops = events.filter((e) => e.event === "content_block_stop");

--- a/packages/providers/src/providers/anthropic/__tests__/streaming.test.ts
+++ b/packages/providers/src/providers/anthropic/__tests__/streaming.test.ts
@@ -147,6 +147,169 @@ describe("AnthropicProvider — streaming.test.ts", () => {
 			expect(result.isRateLimited).toBe(true);
 			expect(result.resetTime).toBe(unixSeconds * 1000);
 		});
+
+		// ─────────────────────────────────────────────
+		// 529 (overloaded_error) tests
+		// ─────────────────────────────────────────────
+
+		it("529 status with no rate-limit headers → isRateLimited:true and resetTime:undefined", () => {
+			const response = new Response(
+				'{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+				{
+					status: 529,
+					headers: { "content-type": "application/json" },
+				},
+			);
+
+			const result = provider.parseRateLimit(response);
+
+			expect(result.isRateLimited).toBe(true);
+			expect(result.resetTime).toBeUndefined();
+		});
+
+		it("529 status with anthropic-ratelimit-unified-status: allowed → isRateLimited:true (overload masks allowed)", () => {
+			const response = new Response(
+				'{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+				{
+					status: 529,
+					headers: {
+						"anthropic-ratelimit-unified-status": "allowed",
+					},
+				},
+			);
+
+			const result = provider.parseRateLimit(response);
+
+			// 529 overload should be treated as rate-limited even if status header says "allowed"
+			expect(result.isRateLimited).toBe(true);
+		});
+
+		it("529 status with retry-after as delta seconds → isRateLimited:true and resetTime ≈ now + N*1000", () => {
+			const deltaSeconds = 30;
+			const before = Date.now();
+			const response = new Response(null, {
+				status: 529,
+				headers: {
+					"retry-after": String(deltaSeconds),
+				},
+			});
+
+			const result = provider.parseRateLimit(response);
+			const after = Date.now();
+
+			expect(result.isRateLimited).toBe(true);
+			expect(result.resetTime).toBeGreaterThanOrEqual(
+				before + deltaSeconds * 1000,
+			);
+			expect(result.resetTime).toBeLessThanOrEqual(after + deltaSeconds * 1000);
+		});
+
+		it("529 status with retry-after as HTTP-date → isRateLimited:true and resetTime matches parsed date", () => {
+			// Use a date ~1 hour in the future
+			const futureDate = new Date(Date.now() + 3600 * 1000);
+			const httpDate = futureDate.toUTCString();
+			const response = new Response(null, {
+				status: 529,
+				headers: {
+					"retry-after": httpDate,
+				},
+			});
+
+			const result = provider.parseRateLimit(response);
+
+			expect(result.isRateLimited).toBe(true);
+			// Allow a 2-second tolerance for test execution time
+			expect(result.resetTime).toBeGreaterThanOrEqual(
+				futureDate.getTime() - 2000,
+			);
+			expect(result.resetTime).toBeLessThanOrEqual(futureDate.getTime() + 2000);
+		});
+
+		it("529 status with retry-after that is not a positive number falls back to x-ratelimit-reset (unix seconds)", () => {
+			// Use a future unix timestamp (now + 5 minutes) so clampResetTime accepts it.
+			const futureUnixSeconds = Math.floor((Date.now() + 5 * 60 * 1000) / 1000);
+			const response = new Response(null, {
+				status: 529,
+				headers: {
+					"retry-after": "not-a-date",
+					"x-ratelimit-reset": String(futureUnixSeconds),
+				},
+			});
+
+			const result = provider.parseRateLimit(response);
+
+			expect(result.isRateLimited).toBe(true);
+			expect(result.resetTime).toBeDefined();
+			expect(result.resetTime ?? 0).toBeGreaterThan(Date.now());
+			expect(result.resetTime ?? 0).toBeLessThanOrEqual(
+				futureUnixSeconds * 1000 + 1000,
+			);
+		});
+
+		it("non-429/529 status returns isRateLimited:false", () => {
+			const response = new Response(null, { status: 500 });
+
+			const result = provider.parseRateLimit(response);
+
+			expect(result.isRateLimited).toBe(false);
+		});
+
+		it("529 + retry-after '0' falls through with no usable resetTime", () => {
+			const response = new Response(null, {
+				status: 529,
+				headers: { "retry-after": "0" },
+			});
+			const result = provider.parseRateLimit(response);
+			expect(result.isRateLimited).toBe(true);
+			expect(result.resetTime).toBeUndefined();
+		});
+
+		it("529 + retry-after '-30' falls through with no usable resetTime", () => {
+			const response = new Response(null, {
+				status: 529,
+				headers: { "retry-after": "-30" },
+			});
+			const result = provider.parseRateLimit(response);
+			expect(result.isRateLimited).toBe(true);
+			expect(result.resetTime).toBeUndefined();
+		});
+
+		it("529 + retry-after as past HTTP-date falls through with no usable resetTime", () => {
+			const pastDate = new Date(Date.now() - 3600 * 1000);
+			const response = new Response(null, {
+				status: 529,
+				headers: { "retry-after": pastDate.toUTCString() },
+			});
+			const result = provider.parseRateLimit(response);
+			expect(result.isRateLimited).toBe(true);
+			expect(result.resetTime).toBeUndefined();
+		});
+
+		it("529 + retry-after 'Infinity' falls through with no usable resetTime", () => {
+			const response = new Response(null, {
+				status: 529,
+				headers: { "retry-after": "Infinity" },
+			});
+			const result = provider.parseRateLimit(response);
+			expect(result.isRateLimited).toBe(true);
+			expect(result.resetTime).toBeUndefined();
+		});
+
+		it("529 + retry-after '9999999999' is capped to now + 24h", () => {
+			const before = Date.now();
+			const response = new Response(null, {
+				status: 529,
+				headers: { "retry-after": "9999999999" },
+			});
+			const result = provider.parseRateLimit(response);
+			expect(result.isRateLimited).toBe(true);
+			const MAX = 24 * 60 * 60 * 1000;
+			expect(result.resetTime).toBeDefined();
+			expect(result.resetTime ?? 0).toBeLessThanOrEqual(
+				Date.now() + MAX + 1000,
+			);
+			expect(result.resetTime ?? 0).toBeGreaterThanOrEqual(before + MAX - 1000);
+		});
 	});
 
 	// ─────────────────────────────────────────────

--- a/packages/providers/src/providers/anthropic/__tests__/streaming.test.ts
+++ b/packages/providers/src/providers/anthropic/__tests__/streaming.test.ts
@@ -133,19 +133,88 @@ describe("AnthropicProvider — streaming.test.ts", () => {
 			expect(result.isRateLimited).toBe(true);
 		});
 
-		it("429 with x-ratelimit-reset header → uses that reset time converted to ms", () => {
-			const unixSeconds = 1_700_000_000;
+		it("429 with x-ratelimit-reset header → uses that reset time converted to ms (clamped)", () => {
+			// Use a future unix timestamp so clampResetTime accepts it.
+			const futureUnixSeconds = Math.floor((Date.now() + 5 * 60 * 1000) / 1000);
 			const response = new Response(null, {
 				status: 429,
 				headers: {
-					"x-ratelimit-reset": String(unixSeconds),
+					"x-ratelimit-reset": String(futureUnixSeconds),
 				},
 			});
 
 			const result = provider.parseRateLimit(response);
 
 			expect(result.isRateLimited).toBe(true);
-			expect(result.resetTime).toBe(unixSeconds * 1000);
+			// clampResetTime accepts in-range future values; reset time should match the header
+			expect(result.resetTime).toBe(futureUnixSeconds * 1000);
+		});
+
+		it("429 + x-ratelimit-reset: far-future (year 2286) is capped to now + 24h", () => {
+			// Unix timestamp 9_999_999_999 is year 2286 — hostile/accidentally large value.
+			// clampResetTime must cap it at now + MAX_RESET_MS (24h) to prevent the account
+			// being locked effectively forever.
+			const before = Date.now();
+			const response = new Response(null, {
+				status: 429,
+				headers: {
+					"x-ratelimit-reset": "9999999999",
+				},
+			});
+
+			const result = provider.parseRateLimit(response);
+
+			expect(result.isRateLimited).toBe(true);
+			const MAX = 24 * 60 * 60 * 1000;
+			expect(result.resetTime).toBeDefined();
+			// Must be capped at 24h from now (not the raw header value)
+			expect(result.resetTime ?? 0).toBeLessThanOrEqual(
+				Date.now() + MAX + 1000,
+			);
+			expect(result.resetTime ?? 0).toBeGreaterThanOrEqual(before + MAX - 1000);
+		});
+
+		it("429 + x-ratelimit-reset: past unix epoch falls back to now + 60s default", () => {
+			// A past reset timestamp should be rejected by clampResetTime, triggering the
+			// 60s default cooldown instead of keeping the account locked.
+			const before = Date.now();
+			const pastUnixSeconds = Math.floor((Date.now() - 60 * 1000) / 1000);
+			const response = new Response(null, {
+				status: 429,
+				headers: {
+					"x-ratelimit-reset": String(pastUnixSeconds),
+				},
+			});
+
+			const result = provider.parseRateLimit(response);
+
+			expect(result.isRateLimited).toBe(true);
+			// Past value → clampResetTime returns undefined → falls back to now + 60s
+			expect(result.resetTime).toBeDefined();
+			expect(result.resetTime ?? 0).toBeGreaterThanOrEqual(
+				before + 60_000 - 500,
+			);
+			expect(result.resetTime ?? 0).toBeLessThanOrEqual(
+				Date.now() + 60_000 + 500,
+			);
+		});
+
+		it("429 + no x-ratelimit-reset header still gets now + 60s default", () => {
+			// Regression: the dead `?? now429 + 60000` fallback has been replaced with a
+			// direct `now + DEFAULT_429_COOLDOWN_MS` assignment. Verify the 60s default still fires.
+			const before = Date.now();
+			const response = new Response(null, { status: 429 });
+
+			const result = provider.parseRateLimit(response);
+
+			expect(result.isRateLimited).toBe(true);
+			expect(result.resetTime).toBeDefined();
+			expect(result.resetTime ?? 0).toBeGreaterThanOrEqual(
+				before + 60_000 - 500,
+			);
+			expect(result.resetTime ?? 0).toBeLessThanOrEqual(
+				Date.now() + 60_000 + 500,
+			);
 		});
 
 		// ─────────────────────────────────────────────

--- a/packages/providers/src/providers/anthropic/provider.ts
+++ b/packages/providers/src/providers/anthropic/provider.ts
@@ -396,12 +396,14 @@ export class AnthropicProvider extends BaseProvider {
 
 		const now429 = Date.now();
 		const rateLimitReset = response.headers.get("x-ratelimit-reset");
-		// Use the x-ratelimit-reset header as-is (preserving existing behaviour).
-		// For the no-header default (now + 60s), the helper makes the cap intent
-		// explicit, though 60s is always within the 24h cap.
-		const resetTime = rateLimitReset
-			? parseInt(rateLimitReset, 10) * 1000
-			: (clampResetTime(now429 + 60000, now429) ?? now429 + 60000);
+		// Apply clampResetTime to both the upstream-provided reset header and the
+		// no-header default, matching the 529 path. Header values that are invalid,
+		// in the past, or beyond the 24h cap fall back to the 60s default.
+		const DEFAULT_429_COOLDOWN_MS = 60_000;
+		const parsedReset = rateLimitReset
+			? clampResetTime(parseInt(rateLimitReset, 10) * 1000, now429)
+			: undefined;
+		const resetTime = parsedReset ?? now429 + DEFAULT_429_COOLDOWN_MS;
 
 		return {
 			isRateLimited: true,

--- a/packages/providers/src/providers/anthropic/provider.ts
+++ b/packages/providers/src/providers/anthropic/provider.ts
@@ -18,6 +18,25 @@ const HARD_LIMIT_STATUSES = new Set([
 	"payment_required",
 ]);
 
+// Maximum allowed reset time: 24 hours from now.
+// Prevents a pathological Retry-After value from keeping an account
+// cooled down for days (or effectively forever with "Infinity").
+const MAX_RESET_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Clamp a candidate reset-time epoch-ms value.
+ *
+ * Returns:
+ *   - `undefined` if the input is NaN, not finite, or <= now (already in the past).
+ *   - `Math.min(input, now + MAX_RESET_MS)` otherwise — capped at 24 h from now.
+ */
+function clampResetTime(candidateMs: number, now: number): number | undefined {
+	if (!Number.isFinite(candidateMs) || candidateMs <= now) {
+		return undefined;
+	}
+	return Math.min(candidateMs, now + MAX_RESET_MS);
+}
+
 // Soft warning statuses that should not block account usage
 const _SOFT_WARNING_STATUSES = new Set(["allowed_warning", "queueing_soft"]);
 
@@ -275,18 +294,98 @@ export class AnthropicProvider extends BaseProvider {
 		);
 
 		if (statusHeader || resetHeader) {
-			const resetTime = resetHeader ? Number(resetHeader) * 1000 : undefined; // Convert to ms
+			const now = Date.now();
 			const remaining = remainingHeader ? Number(remainingHeader) : undefined;
 
-			// Only mark as rate limited for hard limit statuses or 429
+			// Only mark as rate limited for hard limit statuses, 429, or 529 (overloaded).
+			// A 529 is an overload even when the unified-status header says "allowed" —
+			// the overload condition takes precedence over the header value.
 			const isRateLimited =
-				HARD_LIMIT_STATUSES.has(statusHeader || "") || response.status === 429;
+				HARD_LIMIT_STATUSES.has(statusHeader || "") ||
+				response.status === 429 ||
+				response.status === 529;
 
+			// For 529 with a unified-reset header: clamp the reset time.
+			// If clamping rejects the value (past/NaN/infinite), fall through
+			// to the 529 block below to try Retry-After and x-ratelimit-reset.
+			if (response.status === 529 && resetHeader) {
+				const clamped = clampResetTime(Number(resetHeader) * 1000, now);
+				if (clamped === undefined) {
+					// Fall through to the 529 block for better header candidates.
+					// (handled below)
+				} else {
+					return {
+						isRateLimited,
+						resetTime: clamped,
+						statusHeader: statusHeader || undefined,
+						remaining,
+					};
+				}
+			} else if (response.status !== 529) {
+				// Non-529: use resetHeader as-is (existing behaviour for 429 / 200).
+				const resetTime = resetHeader ? Number(resetHeader) * 1000 : undefined;
+				return {
+					isRateLimited,
+					resetTime,
+					statusHeader: statusHeader || undefined,
+					remaining,
+				};
+			}
+			// 529 with no usable resetHeader — fall through to 529 block below.
+		}
+
+		// Handle 529 (overloaded_error) — try Retry-After, then x-ratelimit-reset
+		if (response.status === 529) {
+			const now = Date.now();
+			const retryAfterHeader = response.headers.get("retry-after");
+			if (retryAfterHeader) {
+				const parsed = Number(retryAfterHeader);
+				if (Number.isFinite(parsed) && parsed > 0) {
+					// Positive finite number → treat as delta-seconds
+					const clamped = clampResetTime(now + parsed * 1000, now);
+					if (clamped !== undefined) {
+						return {
+							isRateLimited: true,
+							resetTime: clamped,
+							statusHeader: undefined,
+							remaining: undefined,
+						};
+					}
+				}
+				// Try HTTP-date format
+				const dateMs = new Date(retryAfterHeader).getTime();
+				const clampedDate = clampResetTime(dateMs, now);
+				if (clampedDate !== undefined) {
+					return {
+						isRateLimited: true,
+						resetTime: clampedDate,
+						statusHeader: undefined,
+						remaining: undefined,
+					};
+				}
+			}
+
+			// Fall back to x-ratelimit-reset (unix epoch seconds → ms)
+			const rateLimitReset = response.headers.get("x-ratelimit-reset");
+			if (rateLimitReset) {
+				const resetMs = parseInt(rateLimitReset, 10) * 1000;
+				const clamped = clampResetTime(resetMs, now);
+				if (clamped !== undefined) {
+					return {
+						isRateLimited: true,
+						resetTime: clamped,
+						statusHeader: undefined,
+						remaining: undefined,
+					};
+				}
+			}
+
+			// No usable reset time — return without resetTime so the no-reset cooldown path fires
 			return {
-				isRateLimited,
-				resetTime,
-				statusHeader: statusHeader || undefined,
-				remaining,
+				isRateLimited: true,
+				resetTime: undefined,
+				statusHeader: undefined,
+				remaining: undefined,
 			};
 		}
 
@@ -295,10 +394,14 @@ export class AnthropicProvider extends BaseProvider {
 			return { isRateLimited: false };
 		}
 
+		const now429 = Date.now();
 		const rateLimitReset = response.headers.get("x-ratelimit-reset");
+		// Use the x-ratelimit-reset header as-is (preserving existing behaviour).
+		// For the no-header default (now + 60s), the helper makes the cap intent
+		// explicit, though 60s is always within the 24h cap.
 		const resetTime = rateLimitReset
 			? parseInt(rateLimitReset, 10) * 1000
-			: Date.now() + 60000; // Default to 1 minute
+			: (clampResetTime(now429 + 60000, now429) ?? now429 + 60000);
 
 		return {
 			isRateLimited: true,

--- a/packages/providers/src/providers/openai/__tests__/process-response.test.ts
+++ b/packages/providers/src/providers/openai/__tests__/process-response.test.ts
@@ -352,7 +352,7 @@ describe("processResponse – SSE (text/event-stream)", () => {
 
 		const messageStart = events.find((e) => e.event === "message_start");
 		expect(messageStart).toBeDefined();
-		const msgData = JSON.parse(messageStart!.data);
+		const msgData = JSON.parse(messageStart?.data);
 		expect(msgData.type).toBe("message_start");
 
 		const textDelta = events.find(
@@ -362,7 +362,7 @@ describe("processResponse – SSE (text/event-stream)", () => {
 				JSON.parse(e.data).delta?.type === "text_delta",
 		);
 		expect(textDelta).toBeDefined();
-		const deltaData = JSON.parse(textDelta!.data);
+		const deltaData = JSON.parse(textDelta?.data);
 		expect(deltaData.delta.text).toBe("Hello world");
 	});
 
@@ -422,7 +422,7 @@ describe("processResponse – SSE (text/event-stream)", () => {
 				JSON.parse(e.data).content_block?.type === "tool_use",
 		);
 		expect(blockStart).toBeDefined();
-		const blockData = JSON.parse(blockStart!.data);
+		const blockData = JSON.parse(blockStart?.data);
 		expect(blockData.content_block.name).toBe("search");
 
 		// Should have a content_block_delta with input_json_delta
@@ -433,7 +433,7 @@ describe("processResponse – SSE (text/event-stream)", () => {
 				JSON.parse(e.data).delta?.type === "input_json_delta",
 		);
 		expect(jsonDelta).toBeDefined();
-		const jsonDeltaData = JSON.parse(jsonDelta!.data);
+		const jsonDeltaData = JSON.parse(jsonDelta?.data);
 		expect(jsonDeltaData.delta.partial_json).toBe('{"q":"bun"}');
 	});
 });

--- a/packages/providers/src/providers/openai/__tests__/process-response.test.ts
+++ b/packages/providers/src/providers/openai/__tests__/process-response.test.ts
@@ -352,7 +352,8 @@ describe("processResponse – SSE (text/event-stream)", () => {
 
 		const messageStart = events.find((e) => e.event === "message_start");
 		expect(messageStart).toBeDefined();
-		const msgData = JSON.parse(messageStart?.data);
+		if (!messageStart) throw new Error("expected message_start event");
+		const msgData = JSON.parse(messageStart.data);
 		expect(msgData.type).toBe("message_start");
 
 		const textDelta = events.find(
@@ -362,7 +363,8 @@ describe("processResponse – SSE (text/event-stream)", () => {
 				JSON.parse(e.data).delta?.type === "text_delta",
 		);
 		expect(textDelta).toBeDefined();
-		const deltaData = JSON.parse(textDelta?.data);
+		if (!textDelta) throw new Error("expected text_delta event");
+		const deltaData = JSON.parse(textDelta.data);
 		expect(deltaData.delta.text).toBe("Hello world");
 	});
 
@@ -422,7 +424,8 @@ describe("processResponse – SSE (text/event-stream)", () => {
 				JSON.parse(e.data).content_block?.type === "tool_use",
 		);
 		expect(blockStart).toBeDefined();
-		const blockData = JSON.parse(blockStart?.data);
+		if (!blockStart) throw new Error("expected block_start event");
+		const blockData = JSON.parse(blockStart.data);
 		expect(blockData.content_block.name).toBe("search");
 
 		// Should have a content_block_delta with input_json_delta
@@ -433,7 +436,8 @@ describe("processResponse – SSE (text/event-stream)", () => {
 				JSON.parse(e.data).delta?.type === "input_json_delta",
 		);
 		expect(jsonDelta).toBeDefined();
-		const jsonDeltaData = JSON.parse(jsonDelta?.data);
+		if (!jsonDelta) throw new Error("expected input_json_delta event");
+		const jsonDeltaData = JSON.parse(jsonDelta.data);
 		expect(jsonDeltaData.delta.partial_json).toBe('{"q":"bun"}');
 	});
 });

--- a/packages/proxy/src/handlers/__tests__/proxy-operations-failover.test.ts
+++ b/packages/proxy/src/handlers/__tests__/proxy-operations-failover.test.ts
@@ -650,6 +650,51 @@ describe("proxyWithAccount — 529 failover", () => {
 		expect(result).toBeNull();
 	});
 
+	it("returns upstream 529 on the final account attempt instead of pool exhaustion", async () => {
+		globalThis.fetch = mock(
+			async () =>
+				new Response(
+					'{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+					{
+						status: 529,
+						headers: { "content-type": "application/json" },
+					},
+				),
+		);
+
+		const bodyBuffer = makeRequestBody();
+		const req = makeRequest(bodyBuffer);
+		const ctx = makeProxyContext();
+		const result = await proxyWithAccount(
+			req,
+			new URL("https://proxy.local/v1/messages"),
+			makeAccount({
+				provider: "anthropic",
+				api_key: "test-key",
+				access_token: null,
+			}),
+			makeRequestMeta(),
+			bodyBuffer,
+			() => undefined,
+			0,
+			ctx,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			true,
+		);
+
+		expect(result).not.toBeNull();
+		if (!result) throw new Error("Expected final 529 response");
+		expect(result.status).toBe(529);
+		const body = (await result.json()) as {
+			error: { type: string; message: string };
+		};
+		expect(body.error.type).toBe("overloaded_error");
+		expect(body.error.message).toBe("Overloaded");
+	});
+
 	it("isModelUnavailableError returns false for 529 overloaded responses", async () => {
 		const response = new Response(
 			'{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',

--- a/packages/proxy/src/handlers/__tests__/proxy-operations-failover.test.ts
+++ b/packages/proxy/src/handlers/__tests__/proxy-operations-failover.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import type { Account, RequestMeta } from "@better-ccflare/types";
-import { proxyWithAccount } from "../proxy-operations";
+import { isModelUnavailableError, proxyWithAccount } from "../proxy-operations";
 import type { ProxyContext } from "../proxy-types";
 
 // Minimal Account fixture for openai-compatible provider
@@ -590,6 +590,72 @@ describe("getModelList — model_fallbacks merge", () => {
 			"qwen/qwen3.6-plus:free",
 			"meta-llama/llama-3.3-70b:free",
 		]);
+	});
+});
+
+describe("proxyWithAccount — 529 failover", () => {
+	let originalFetch: typeof globalThis.fetch;
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("returns null (failover) when upstream returns 529 and provider parseRateLimit says isRateLimited:true", async () => {
+		globalThis.fetch = mock(
+			async () =>
+				new Response(
+					'{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+					{
+						status: 529,
+						headers: { "content-type": "application/json" },
+					},
+				),
+		);
+
+		const bodyBuffer = makeRequestBody();
+		const req = makeRequest(bodyBuffer);
+
+		// Override the proxy context to have a provider that treats 529 as rate-limited
+		// (matching the Anthropic provider's parseRateLimit behaviour for 529).
+		const ctx = makeProxyContext();
+		(ctx as { provider: typeof ctx.provider }).provider = {
+			...ctx.provider,
+			parseRateLimit: (r: Response) => ({
+				isRateLimited: r.status === 529 || r.status === 429,
+				resetTime: r.status === 529 ? Date.now() + 60_000 : undefined,
+				statusHeader: undefined,
+				remaining: undefined,
+			}),
+		} as typeof ctx.provider;
+
+		const result = await proxyWithAccount(
+			req,
+			new URL("https://proxy.local/v1/messages"),
+			makeAccount({
+				provider: "anthropic",
+				api_key: "test-key",
+				access_token: null,
+			}),
+			makeRequestMeta(),
+			bodyBuffer,
+			() => undefined,
+			0,
+			ctx,
+		);
+
+		expect(result).toBeNull();
+	});
+
+	it("isModelUnavailableError returns false for 529 overloaded responses", async () => {
+		const response = new Response(
+			'{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+			{ status: 529, headers: { "content-type": "application/json" } },
+		);
+		expect(await isModelUnavailableError(response)).toBe(false);
 	});
 });
 

--- a/packages/proxy/src/handlers/__tests__/response-handler-midstream.test.ts
+++ b/packages/proxy/src/handlers/__tests__/response-handler-midstream.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Mid-stream overloaded_error test.
+ *
+ * Tests that when an SSE stream contains an overloaded_error frame mid-stream,
+ * the account gets marked rate-limited with reason "upstream_529_overloaded_with_reset".
+ *
+ * Note: Mid-stream detection cannot rescue the current response — the stream
+ * headers were already sent to the client. It only prevents future requests
+ * from being routed to the overloaded account until the cooldown expires.
+ */
+import { describe, expect, it } from "bun:test";
+import type { Account } from "@better-ccflare/types";
+import type { ProxyContext } from "../proxy-types";
+import { handleRateLimitResponse } from "../response-processor";
+import { createSseRateLimitSniffer } from "../sse-rate-limit-sniffer";
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "acct-mid-1",
+		name: "mid-stream-test",
+		provider: "anthropic",
+		api_key: null,
+		refresh_token: "rt",
+		access_token: "at",
+		expires_at: Date.now() + 3_600_000,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: Date.now(),
+		rate_limited_until: null,
+		rate_limited_reason: null,
+		rate_limited_at: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		peak_hours_pause_enabled: false,
+		custom_endpoint: null,
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		billing_type: null,
+		pause_reason: null,
+		refresh_token_issued_at: null,
+		...overrides,
+	};
+}
+
+function makeCtxWithReason() {
+	const calls = {
+		markRateLimited: [] as Array<{
+			accountId: string;
+			resetTime: number;
+			reason: string;
+		}>,
+		enqueueCount: 0,
+	};
+
+	const ctx = {
+		provider: {
+			name: "anthropic",
+			isStreamingResponse: () => true,
+			parseRateLimit: () => ({
+				isRateLimited: true,
+				resetTime: undefined,
+				statusHeader: undefined,
+				remaining: undefined,
+			}),
+			parseUsage: undefined,
+			extractUsageInfo: undefined,
+		},
+		dbOps: {
+			markAccountRateLimited: (
+				accountId: string,
+				resetTime: number,
+				reason: string,
+			) => {
+				calls.markRateLimited.push({ accountId, resetTime, reason });
+			},
+			updateAccountUsage: () => {},
+			updateAccountRateLimitMeta: () => {},
+			getAdapter: () => ({
+				get: async () => ({ rate_limited_until: null }),
+				run: async () => {},
+			}),
+			updateRequestUsage: async () => {},
+		},
+		asyncWriter: {
+			enqueue: (job: () => void | Promise<void>) => {
+				calls.enqueueCount++;
+				void job();
+			},
+		},
+	} as unknown as ProxyContext;
+
+	return { ctx, calls };
+}
+
+describe("handleRateLimitResponse — mid-stream 529 overload", () => {
+	it("marks account with reason='upstream_529_overloaded_with_reset' when called with status 529 and resetTime", () => {
+		// This simulates what response-handler.ts does when rateLimitSniffer fires
+		// for an overloaded_error frame mid-stream (firedReason === "overloaded_error").
+		// The handler passes status=529 so the reason is correctly mapped.
+		const account = makeAccount();
+		const resetTime = Date.now() + 60_000;
+		const { ctx, calls } = makeCtxWithReason();
+
+		// handleRateLimitResponse with status=529 should use "upstream_529_overloaded_with_reset"
+		handleRateLimitResponse(
+			account,
+			{ isRateLimited: true, resetTime },
+			ctx,
+			529,
+		);
+
+		expect(calls.markRateLimited).toHaveLength(1);
+		expect(calls.markRateLimited[0]?.reason).toBe(
+			"upstream_529_overloaded_with_reset",
+		);
+		expect(calls.markRateLimited[0]?.resetTime).toBe(resetTime);
+		expect(account.rate_limited_until).toBe(resetTime);
+	});
+
+	it("marks account with reason='upstream_429_with_reset' when called with status 429 and resetTime", () => {
+		// rate_limit_error -> status 429 -> reason "upstream_429_with_reset"
+		const account = makeAccount();
+		const resetTime = Date.now() + 60_000;
+		const { ctx, calls } = makeCtxWithReason();
+
+		handleRateLimitResponse(
+			account,
+			{ isRateLimited: true, resetTime },
+			ctx,
+			429,
+		);
+
+		expect(calls.markRateLimited).toHaveLength(1);
+		expect(calls.markRateLimited[0]?.reason).toBe("upstream_429_with_reset");
+	});
+
+	it("does not mark when resetTime is absent (no-reset path is handled by caller)", () => {
+		// handleRateLimitResponse only applies cooldown when resetTime is provided.
+		// The no-reset path (upstream_529_overloaded_no_reset) goes through processProxyResponse.
+		const account = makeAccount();
+		const { ctx, calls } = makeCtxWithReason();
+
+		handleRateLimitResponse(account, { isRateLimited: true }, ctx, 529);
+
+		// handleRateLimitResponse returns early when no resetTime
+		expect(calls.markRateLimited).toHaveLength(0);
+		expect(account.rate_limited_until).toBeNull();
+	});
+});
+
+describe("production sniffer integration — overloaded_error mid-stream", () => {
+	it("sniffer fires on mid-stream overloaded_error and maps to 529 reason", () => {
+		const sniffer = createSseRateLimitSniffer({ provider: "anthropic" });
+		const encode = (s: string) => new TextEncoder().encode(s);
+		const frame = encode(
+			'event: error\ndata: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}\n\n',
+		);
+		expect(sniffer.feed(frame)).toBe(true);
+		expect(sniffer.firedReason).toBe("overloaded_error");
+		// The mapping used by response-handler.ts:
+		const status = sniffer.firedReason === "overloaded_error" ? 529 : 429;
+		expect(status).toBe(529);
+	});
+
+	it("sniffer with non-Anthropic provider does NOT fire on overloaded_error", () => {
+		const sniffer = createSseRateLimitSniffer({
+			provider: "openai-compatible",
+		});
+		const encode = (s: string) => new TextEncoder().encode(s);
+		const frame = encode(
+			'event: error\ndata: {"type":"error","error":{"type":"overloaded_error"}}\n\n',
+		);
+		expect(sniffer.feed(frame)).toBe(false);
+	});
+});

--- a/packages/proxy/src/handlers/__tests__/response-processor.test.ts
+++ b/packages/proxy/src/handlers/__tests__/response-processor.test.ts
@@ -355,6 +355,80 @@ describe("handleRateLimitResponse — in-memory cooldown mutation", () => {
 	});
 });
 
+describe("processProxyResponse — 529 overload reason", () => {
+	it("passes reason='upstream_529_overloaded_with_reset' on 529 with resetTime", async () => {
+		const account = makeAccount();
+		const resetTime = Date.now() + 30 * 60_000;
+		const { ctx, calls } = makeCtxWithReason({
+			isStream: false,
+			rateLimited: true,
+			resetTime,
+		});
+		const response = new Response(
+			'{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+			{
+				status: 529,
+				headers: { "content-type": "application/json" },
+			},
+		);
+
+		await processProxyResponse(response, account, ctx);
+
+		expect(calls.markRateLimited).toHaveLength(1);
+		expect(calls.markRateLimited[0]?.reason).toBe(
+			"upstream_529_overloaded_with_reset",
+		);
+	});
+
+	it("passes reason='upstream_529_overloaded_no_reset' on 529 without resetTime", async () => {
+		const account = makeAccount();
+		const { ctx, calls } = makeCtxWithReason({
+			isStream: false,
+			rateLimited: true,
+			resetTime: undefined,
+		});
+		const response = new Response(
+			'{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+			{
+				status: 529,
+				headers: { "content-type": "application/json" },
+			},
+		);
+
+		await processProxyResponse(response, account, ctx);
+
+		expect(calls.markRateLimited).toHaveLength(1);
+		expect(calls.markRateLimited[0]?.reason).toBe(
+			"upstream_529_overloaded_no_reset",
+		);
+	});
+
+	it("skips cooldown but logs status code for keepalive 529 requests", async () => {
+		const account = makeAccount();
+		const resetTime = Date.now() + 30 * 60_000;
+		const { ctx, calls } = makeCtxWithReason({
+			isStream: false,
+			rateLimited: true,
+			resetTime,
+		});
+		const response = new Response(
+			'{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+			{
+				status: 529,
+				headers: { "content-type": "application/json" },
+			},
+		);
+		const requestMeta = {
+			headers: new Headers({ "x-better-ccflare-keepalive": "true" }),
+		};
+
+		await processProxyResponse(response, account, ctx, undefined, requestMeta);
+
+		// Keepalive requests skip cooldown marking
+		expect(calls.markRateLimited).toHaveLength(0);
+	});
+});
+
 describe("processProxyResponse — in-memory cooldown mutation", () => {
 	it("sets account.rate_limited_until on 429 with resetTime", async () => {
 		const account = makeAccount();

--- a/packages/proxy/src/handlers/__tests__/sse-rate-limit-sniffer.test.ts
+++ b/packages/proxy/src/handlers/__tests__/sse-rate-limit-sniffer.test.ts
@@ -5,7 +5,7 @@ const encode = (s: string) => new TextEncoder().encode(s);
 
 describe("SseRateLimitSniffer", () => {
 	it("detects a complete rate-limit error frame in a single chunk", () => {
-		const sniffer = createSseRateLimitSniffer();
+		const sniffer = createSseRateLimitSniffer({ provider: "anthropic" });
 		const frame = encode(
 			'event: error\ndata: {"type":"error","error":{"type":"rate_limit_error","message":"Rate limited"}}\n\n',
 		);
@@ -13,7 +13,7 @@ describe("SseRateLimitSniffer", () => {
 	});
 
 	it("detects a rate-limit error frame split across multiple chunks", () => {
-		const sniffer = createSseRateLimitSniffer();
+		const sniffer = createSseRateLimitSniffer({ provider: "anthropic" });
 
 		// Chunk 1: partial event + partial data (the marker is split)
 		expect(
@@ -28,24 +28,56 @@ describe("SseRateLimitSniffer", () => {
 		).toBe(true);
 	});
 
-	it("ignores overloaded_error frames", () => {
-		const sniffer = createSseRateLimitSniffer();
+	it("fires once for overloaded_error frames", () => {
+		const sniffer = createSseRateLimitSniffer({ provider: "anthropic" });
 		const frame = encode(
 			'event: error\ndata: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}\n\n',
 		);
-		expect(sniffer.feed(frame)).toBe(false);
+		expect(sniffer.feed(frame)).toBe(true);
+		expect(sniffer.firedReason).toBe("overloaded_error");
 	});
 
 	it("ignores api_error frames", () => {
-		const sniffer = createSseRateLimitSniffer();
+		const sniffer = createSseRateLimitSniffer({ provider: "anthropic" });
 		const frame = encode(
 			'event: error\ndata: {"type":"error","error":{"type":"api_error","message":"Server error"}}\n\n',
 		);
 		expect(sniffer.feed(frame)).toBe(false);
+		expect(sniffer.firedReason).toBeNull();
+	});
+
+	it("rate_limit_error sets firedReason to 'rate_limit_error'", () => {
+		const sniffer = createSseRateLimitSniffer({ provider: "anthropic" });
+		const frame = encode(
+			'event: error\ndata: {"type":"error","error":{"type":"rate_limit_error","message":"Rate limited"}}\n\n',
+		);
+		expect(sniffer.feed(frame)).toBe(true);
+		expect(sniffer.firedReason).toBe("rate_limit_error");
+	});
+
+	it("overloaded_error subsequent frame returns false (one-shot)", () => {
+		const sniffer = createSseRateLimitSniffer({ provider: "anthropic" });
+		// First overloaded frame fires
+		expect(
+			sniffer.feed(
+				encode(
+					'event: error\ndata: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}\n\n',
+				),
+			),
+		).toBe(true);
+
+		// Second overloaded frame does NOT fire — one-shot semantics
+		expect(
+			sniffer.feed(
+				encode(
+					'event: error\ndata: {"type":"error","error":{"type":"overloaded_error","message":"Still overloaded"}}\n\n',
+				),
+			),
+		).toBe(false);
 	});
 
 	it("ignores regular content chunks", () => {
-		const sniffer = createSseRateLimitSniffer();
+		const sniffer = createSseRateLimitSniffer({ provider: "anthropic" });
 		const chunks = [
 			'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}\n\n',
 			'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" world"}}\n\n',
@@ -57,7 +89,7 @@ describe("SseRateLimitSniffer", () => {
 	});
 
 	it("fires only once even if the buffer still matches on subsequent feeds", () => {
-		const sniffer = createSseRateLimitSniffer();
+		const sniffer = createSseRateLimitSniffer({ provider: "anthropic" });
 
 		// First rate-limit frame fires
 		expect(
@@ -79,15 +111,17 @@ describe("SseRateLimitSniffer", () => {
 	});
 
 	it("handles empty chunks gracefully", () => {
-		const sniffer = createSseRateLimitSniffer();
+		const sniffer = createSseRateLimitSniffer({ provider: "anthropic" });
 		expect(sniffer.feed(encode(""))).toBe(false);
 		expect(sniffer.feed(new Uint8Array(0))).toBe(false);
 	});
 
 	it("does not grow memory unboundedly for long non-matching streams", () => {
-		const sniffer = createSseRateLimitSniffer();
-		// Feed 200KB of content without a rate-limit marker
-		const bigChunk = encode("a".repeat(1024));
+		const sniffer = createSseRateLimitSniffer({ provider: "anthropic" });
+		// Feed 200KB of content without a rate-limit marker.
+		// Each chunk ends with a newline (realistic SSE data lines are newline-terminated)
+		// so the subsequent `event: error` chunk is treated as starting on a new line.
+		const bigChunk = encode(`${"a".repeat(1023)}\n`);
 		for (let i = 0; i < 200; i++) {
 			expect(sniffer.feed(bigChunk)).toBe(false);
 		}
@@ -96,17 +130,48 @@ describe("SseRateLimitSniffer", () => {
 		expect(
 			sniffer.feed(
 				encode(
-					'data: {"type":"error","error":{"type":"rate_limit_error","message":"Late"}}\n\n',
+					'event: error\ndata: {"type":"error","error":{"type":"rate_limit_error","message":"Late"}}\n\n',
 				),
 			),
 		).toBe(true);
 	});
 
 	it("detects marker with extra whitespace in JSON", () => {
-		const sniffer = createSseRateLimitSniffer();
+		const sniffer = createSseRateLimitSniffer({ provider: "anthropic" });
 		const frame = encode(
 			'event: error\ndata: {"type" : "error", "error": {"type" :  "rate_limit_error"}}\n\n',
 		);
 		expect(sniffer.feed(frame)).toBe(true);
+	});
+
+	it("claude-oauth provider fires on overloaded_error (Anthropic-shape)", () => {
+		const sniffer = createSseRateLimitSniffer({ provider: "claude-oauth" });
+		const frame = encode(
+			'event: error\ndata: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}\n\n',
+		);
+		expect(sniffer.feed(frame)).toBe(true);
+		expect(sniffer.firedReason).toBe("overloaded_error");
+	});
+
+	it("non-Anthropic provider does NOT fire on overloaded_error", () => {
+		const sniffer = createSseRateLimitSniffer({
+			provider: "openai-compatible",
+		});
+		const frame = encode(
+			'event: error\ndata: {"type":"error","error":{"type":"overloaded_error"}}\n\n',
+		);
+		expect(sniffer.feed(frame)).toBe(false);
+		expect(sniffer.firedReason).toBeNull();
+	});
+
+	it("non-Anthropic provider still fires on rate_limit_error", () => {
+		const sniffer = createSseRateLimitSniffer({
+			provider: "openai-compatible",
+		});
+		const frame = encode(
+			'event: error\ndata: {"type":"error","error":{"type":"rate_limit_error","message":"Rate limited"}}\n\n',
+		);
+		expect(sniffer.feed(frame)).toBe(true);
+		expect(sniffer.firedReason).toBe("rate_limit_error");
 	});
 });

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -327,7 +327,9 @@ async function isCacheControlRejectionError(
  * Covers Anthropic (not_found_error), OpenAI-compat (model_not_found),
  * generic messages, and Bedrock (ResourceNotFoundException).
  */
-async function isModelUnavailableError(response: Response): Promise<boolean> {
+export async function isModelUnavailableError(
+	response: Response,
+): Promise<boolean> {
 	if (
 		response.status !== 404 &&
 		response.status !== 400 &&

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -481,6 +481,7 @@ export async function proxyWithAccount(
 	apiKeyId?: string | null,
 	apiKeyName?: string | null,
 	requestBodyContext?: RequestBodyContext | null,
+	returnRateLimitedResponseOnExhaustion = false,
 ): Promise<Response | null> {
 	try {
 		if (
@@ -963,8 +964,12 @@ export async function proxyWithAccount(
 		}
 
 		// Check for rate limit using account-specific provider
+		const responseForRateLimitCheck =
+			returnRateLimitedResponseOnExhaustion && response.status === 529
+				? response.clone()
+				: response;
 		const isRateLimited = await processProxyResponse(
-			response,
+			responseForRateLimitCheck,
 			account,
 			{
 				...ctx,
@@ -974,6 +979,31 @@ export async function proxyWithAccount(
 			requestMeta,
 		);
 		if (isRateLimited) {
+			if (returnRateLimitedResponseOnExhaustion && response.status === 529) {
+				log.warn(
+					`Account ${account.name} returned final 529 overload response — forwarding upstream response instead of pool_exhausted`,
+				);
+				return forwardToClient(
+					{
+						requestId: requestMeta.id,
+						method: req.method,
+						path: url.pathname,
+						account,
+						requestHeaders: req.headers,
+						requestBody: effectiveBodyBuffer,
+						project: requestMeta.project,
+						response,
+						timestamp: requestMeta.timestamp,
+						retryAttempt: 0,
+						failoverAttempts,
+						agentUsed: requestMeta.agentUsed,
+						comboName: requestMeta.comboName,
+						apiKeyId,
+						apiKeyName,
+					},
+					{ ...ctx, provider },
+				);
+			}
 			return null; // Signal to try next account
 		}
 

--- a/packages/proxy/src/handlers/response-processor.ts
+++ b/packages/proxy/src/handlers/response-processor.ts
@@ -15,16 +15,21 @@ const log = new Logger("ResponseProcessor");
  * @param account - The rate-limited account
  * @param rateLimitInfo - Parsed rate limit information
  * @param ctx - The proxy context
+ * @param status - HTTP status code of the triggering response (429 or 529). Defaults to 429.
  */
 export function handleRateLimitResponse(
 	account: Account,
 	rateLimitInfo: ReturnType<Provider["parseRateLimit"]>,
 	ctx: ProxyContext,
+	status = 429,
 ): void {
 	if (!rateLimitInfo.resetTime) return;
 
 	const resetTime = rateLimitInfo.resetTime;
-	const reason: RateLimitReason = "upstream_429_with_reset";
+	const reason: RateLimitReason =
+		status === 529
+			? "upstream_529_overloaded_with_reset"
+			: "upstream_429_with_reset";
 	account.rate_limited_until = resetTime;
 	ctx.asyncWriter.enqueue(() => {
 		log.warn(
@@ -280,10 +285,10 @@ export async function processProxyResponse(
 			requestMeta?.headers?.get("x-better-ccflare-keepalive") === "true";
 		if (isKeepalive) {
 			log.warn(
-				`Keepalive replay for ${account.name} got 429 — skipping cooldown (synthetic burst, not a real per-account rate limit)`,
+				`Keepalive replay for ${account.name} got ${response.status} — skipping cooldown (synthetic burst, not a real per-account rate limit)`,
 			);
 		} else if (rateLimitInfo.resetTime) {
-			handleRateLimitResponse(account, rateLimitInfo, ctx);
+			handleRateLimitResponse(account, rateLimitInfo, ctx, response.status);
 		} else {
 			// Mark as rate-limited even without reset time. Use a short
 			// probe-friendly cooldown (default 60s, override via
@@ -300,7 +305,10 @@ export async function processProxyResponse(
 			const cooldownUntil = Date.now() + cooldownMs;
 			account.rate_limited_until = cooldownUntil;
 			ctx.asyncWriter.enqueue(() => {
-				const reason: RateLimitReason = "upstream_429_no_reset_probe_cooldown";
+				const reason: RateLimitReason =
+					response.status === 529
+						? "upstream_529_overloaded_no_reset"
+						: "upstream_429_no_reset_probe_cooldown";
 				log.warn(
 					`[ccflare] account=${account.name} cooldown_applied reason=${reason} until=${new Date(cooldownUntil).toISOString()}`,
 				);

--- a/packages/proxy/src/handlers/sse-rate-limit-sniffer.ts
+++ b/packages/proxy/src/handlers/sse-rate-limit-sniffer.ts
@@ -1,7 +1,7 @@
 /**
  * SSE rate-limit sniffer — observes mid-stream `event: error` frames that
- * carry a `"type": "rate_limit_error"` payload and fires a one-shot signal
- * so the main thread can mark the account rate-limited.
+ * carry a `"type": "rate_limit_error"` or `"type": "overloaded_error"` payload
+ * and fires a one-shot signal so the main thread can mark the account rate-limited.
  *
  * Why this exists: the top-level `!isStream` guard in `response-processor.ts`
  * was removed so streaming 429 responses with `text/event-stream` bodies do
@@ -14,19 +14,21 @@
  *
  * Design choices:
  *
- * 1. **Substring regex, not a full SSE parser.** A proper parser would
- *    buffer per-line, track `event:` / `data:` pairs, and JSON.parse the
- *    payload. For a single one-shot signal, that's over-engineered. The
- *    regex `"type"\s*:\s*"rate_limit_error"` matches the Anthropic error
- *    envelope directly; false positives require Claude to literally
- *    transcribe that exact quoted key-value pair into content, which is
- *    vanishingly rare and non-catastrophic (the consequence is one account
- *    marked rate-limited for 5h, recoverable on the next successful call).
+ * 1. **Line-anchored regex requiring `event: error`.** The pattern requires
+ *    the SSE frame to start with `event: error` (at the start of the buffer
+ *    or after a line boundary) before matching the JSON type field. This
+ *    prevents false positives from content that contains the quoted key-value
+ *    pair literally inside a normal message body.
  *
- * 2. **Only `rate_limit_error`.** `overloaded_error` and `api_error` have
- *    different failover semantics — overload is transient and typically
- *    global, api_error is request-scoped. Marking an account rate-limited
- *    on those would cause spurious failovers.
+ * 2. **`rate_limit_error` and `overloaded_error` (Anthropic-shape providers
+ *    only).** Both trigger a short probe cooldown so the account is bypassed
+ *    while the overload persists. `overloaded_error` is only enabled for
+ *    Anthropic and claude-oauth providers — other OpenAI-compatible providers
+ *    do not emit this error type in the same SSE envelope and we should not
+ *    misfire on their content. `api_error` is always excluded — it is
+ *    request-scoped (server bug, not a quota/capacity issue) and marking an
+ *    account for an api_error would cause spurious failovers on transient
+ *    server faults.
  *
  * 3. **Bounded rolling buffer (16KB).** Most SSE frames are <1KB, and the
  *    error envelope is <500 bytes. A 16KB window is generous enough to
@@ -37,27 +39,62 @@
  *    main thread never double-marks an account within a single request.
  */
 
-const RATE_LIMIT_MARKER = /"type"\s*:\s*"rate_limit_error"/;
+// Providers that emit `overloaded_error` in the Anthropic SSE error envelope.
+const ANTHROPIC_SHAPE_PROVIDERS = new Set(["anthropic", "claude-oauth"]);
+
 const MAX_BUFFER_BYTES = 16 * 1024;
 
 export interface SseRateLimitSniffer {
 	/**
 	 * Feed an outgoing stream chunk. Returns `true` exactly once — on the
-	 * first chunk where the rolling buffer contains a rate-limit error
-	 * marker — and `false` on every subsequent call.
+	 * first chunk where the rolling buffer contains a rate-limit or overload
+	 * error marker — and `false` on every subsequent call.
 	 */
 	feed(chunk: Uint8Array): boolean;
+
+	/**
+	 * The error type that caused the sniffer to fire. Set to the matched
+	 * error type string on the first `feed()` call that returns `true`.
+	 * Remains `null` if the sniffer has not fired yet.
+	 */
+	firedReason: "rate_limit_error" | "overloaded_error" | null;
+}
+
+export interface SseRateLimitSnifferOptions {
+	/** Provider name (e.g. "anthropic", "claude-oauth", "openai-compatible"). */
+	provider: string;
 }
 
 /**
  * Create a stateful sniffer. One instance per streaming request.
+ *
+ * Pass `{ provider }` to enable provider-specific error detection.
+ * `overloaded_error` is only matched for Anthropic-shape providers
+ * ("anthropic", "claude-oauth"); all other providers only match
+ * `rate_limit_error`.
  */
-export function createSseRateLimitSniffer(): SseRateLimitSniffer {
+export function createSseRateLimitSniffer(
+	opts: SseRateLimitSnifferOptions,
+): SseRateLimitSniffer {
+	const isAnthropicShape = ANTHROPIC_SHAPE_PROVIDERS.has(opts.provider);
+	const typePattern = isAnthropicShape
+		? "rate_limit_error|overloaded_error"
+		: "rate_limit_error";
+
+	// Line-anchored: require `event: error` at start of buffer or after a line
+	// boundary before matching the JSON type field in the subsequent ≤500 bytes.
+	// match[1] = line-anchor group, match[2] = captured error type.
+	const RATE_LIMIT_MARKER = new RegExp(
+		`(^|\\r?\\n)event:\\s*error[\\s\\S]{0,500}?"type"\\s*:\\s*"(${typePattern})"`,
+	);
+
 	const decoder = new TextDecoder("utf-8", { fatal: false });
 	let buffer = "";
 	let fired = false;
 
-	return {
+	const sniffer: SseRateLimitSniffer = {
+		firedReason: null,
+
 		feed(chunk: Uint8Array): boolean {
 			if (fired) return false;
 
@@ -65,13 +102,21 @@ export function createSseRateLimitSniffer(): SseRateLimitSniffer {
 
 			// Keep the buffer bounded. We trim from the front to preserve
 			// the most recent bytes, which is where an in-progress error
-			// frame would be accumulating.
+			// frame would be accumulating. Prepend a synthetic newline so
+			// the line-anchor `(^|\r?\n)` still matches `event: error` at
+			// the trimmed boundary.
 			if (buffer.length > MAX_BUFFER_BYTES) {
-				buffer = buffer.slice(buffer.length - MAX_BUFFER_BYTES);
+				buffer = `\n${buffer.slice(buffer.length - MAX_BUFFER_BYTES)}`;
 			}
 
-			if (RATE_LIMIT_MARKER.test(buffer)) {
+			const match = RATE_LIMIT_MARKER.exec(buffer);
+			if (match) {
 				fired = true;
+				// match[2] is the first capture group inside the typePattern alternation
+				// (match[1] is the line-anchor group).
+				sniffer.firedReason = match[2] as
+					| "rate_limit_error"
+					| "overloaded_error";
 				// Release the buffer; we won't need it again.
 				buffer = "";
 				return true;
@@ -80,4 +125,6 @@ export function createSseRateLimitSniffer(): SseRateLimitSniffer {
 			return false;
 		},
 	};
+
+	return sniffer;
 }

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -450,6 +450,7 @@ export async function handleProxy(
 			apiKeyId,
 			apiKeyName,
 			requestBodyContext,
+			!filteredComboInfo?.comboName && i === accounts.length - 1,
 		);
 
 		if (response) {
@@ -502,6 +503,7 @@ export async function handleProxy(
 					apiKeyId,
 					apiKeyName,
 					requestBodyContext,
+					i === fallbackAccounts.length - 1,
 				);
 
 				if (response) {

--- a/packages/proxy/src/response-handler.ts
+++ b/packages/proxy/src/response-handler.ts
@@ -219,7 +219,9 @@ export async function forwardToClient(
 		// Mid-stream rate-limit detection for issue #114 Fix 1.2. Only
 		// create a sniffer when we know which account to mark — anonymous
 		// or unauthenticated requests can't be failed over.
-		const rateLimitSniffer = account ? createSseRateLimitSniffer() : null;
+		const rateLimitSniffer = account
+			? createSseRateLimitSniffer({ provider: account.provider })
+			: null;
 
 		(async () => {
 			// Configurable via env vars to support long agentic workloads where
@@ -300,6 +302,14 @@ export async function forwardToClient(
 							// Mid-stream rate-limit detection. The sniffer
 							// fires exactly once; after that feed() is a no-op.
 							if (account && rateLimitSniffer?.feed(value)) {
+								// Map firedReason to a synthetic status code so the
+								// audit trail uses the correct RateLimitReason:
+								//   "overloaded_error" → 529 → upstream_529_overloaded_with_reset
+								//   "rate_limit_error" → 429 → upstream_429_with_reset
+								const midStreamStatus =
+									rateLimitSniffer.firedReason === "overloaded_error"
+										? 529
+										: 429;
 								handleRateLimitResponse(
 									account,
 									{
@@ -307,6 +317,7 @@ export async function forwardToClient(
 										resetTime: Date.now() + getMidStreamRateLimitCooldownMs(),
 									},
 									ctx,
+									midStreamStatus,
 								);
 							}
 						}

--- a/packages/types/src/account.ts
+++ b/packages/types/src/account.ts
@@ -7,7 +7,11 @@ export type RateLimitReason =
 	| "upstream_429_no_reset_default_5h"
 	| "upstream_429_no_reset_probe_cooldown"
 	| "model_fallback_429"
-	| "all_models_exhausted_429";
+	| "all_models_exhausted_429"
+	/** Anthropic 529 overloaded_error with a Retry-After reset time. */
+	| "upstream_529_overloaded_with_reset"
+	/** Anthropic 529 overloaded_error with no Retry-After header; probe cooldown applied. */
+	| "upstream_529_overloaded_no_reset";
 
 // Usage data types for Anthropic accounts
 export interface UsageWindowData {


### PR DESCRIPTION
## Summary

  Repeated Anthropic `529 overloaded_error` responses were being forwarded to the client instead of marking the account temporarily unavailable, so any configured
  fallback providers (e.g. OpenAI-compatible accounts) were never selected during an outage.

  This treats 529 as a transient cooldown signal through the existing `rate_limited_until` mechanism, so other accounts/providers take over for a short window
  before Anthropic is retried with the existing exponential backoff. No new schema, no new background machinery — just plumbing 529 into the path 429 already
  follows.

  ## Behavior

  - `AnthropicProvider.parseRateLimit` treats `response.status === 529` as rate-limited.
  - For 529 with no unified-rate-limit headers, it parses `Retry-After` (both delta-seconds and HTTP-date) and falls back to `x-ratelimit-reset`. If neither is
  usable, it leaves `resetTime` undefined and the existing no-reset probe cooldown (default 60s) kicks in.
  - For 529 with Anthropic unified-rate-limit headers (`anthropic-ratelimit-unified-status: allowed`, etc.), the unified-reset is used when usable; otherwise it
  falls through to the Retry-After parser.
  - A shared `clampResetTime` helper applies `Number.isFinite`, rejects past/zero values, and caps reset times to 24h so a hostile or malformed upstream header
  can't permanently disable an account.
  - The SSE rate-limit sniffer fires on mid-stream `event: error` frames carrying `"type":"overloaded_error"` for Anthropic-shape providers only (`anthropic` /
  `claude-oauth`); other providers retain `rate_limit_error` detection only. The marker regex is line-anchored to require the `event: error` envelope, reducing
  false positives from content that mentions the literal string.
  - Two new `RateLimitReason` values (`upstream_529_overloaded_with_reset`, `upstream_529_overloaded_no_reset`) surface accurate audit attribution and dashboard
  error metadata. The accounts API allowlist is updated to expose them.
  - `handleRateLimitResponse` accepts an originating HTTP status so the audit reason reflects 529 vs 429 correctly. Keepalive replays log the actual status code.
  - `isModelUnavailableError` is exported and tested directly to confirm 529 does NOT trigger model-fallback retries (only account failover).

  ## Test plan

  - [x] `bun test packages/providers/src/providers/anthropic/__tests__/streaming.test.ts` — 529 with/without unified headers, Retry-After delta-seconds + HTTP-date
   + past HTTP-date, `"0"` / `"-30"` / `"Infinity"` reject, `9999999999` 24h cap
  - [x] `bun test packages/proxy/src/handlers/__tests__/response-processor.test.ts` — 529 reason wiring, keepalive 529 skip
  - [x] `bun test packages/proxy/src/handlers/__tests__/proxy-operations-failover.test.ts` — 529 fails over to next account; `isModelUnavailableError(529)` returns
   false
  - [x] `bun test packages/proxy/src/handlers/__tests__/sse-rate-limit-sniffer.test.ts` — overloaded_error fires for Anthropic providers, does NOT fire for 
  `openai-compatible`, rate_limit_error still fires for all
  - [x] `bun test packages/proxy/src/handlers/__tests__/response-handler-midstream.test.ts` — production sniffer integration: overloaded_error → status 529 →
  `upstream_529_overloaded_with_reset` reason
  - [x] `bun test packages/dashboard-web/src/components/overview/system-status/__tests__/errorCodeMeta.test.ts` — new entries
  - [x] `bun test packages/http-api/src/handlers/__tests__/accounts-integration.test.ts` — new reasons survive API serialization
  - [x] `bun run typecheck` clean
  - [x] `bun run lint` no new errors
  - [x] `bun run format` no-op
