### PR TITLE
fix: stop auto-refresh probing manually-paused accounts (respect pause_reason)

### DIFF
--- a/packages/proxy/src/__tests__/auto-refresh-manual-pause-guard.test.ts
+++ b/packages/proxy/src/__tests__/auto-refresh-manual-pause-guard.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Regression test: the auto-refresh probe-selection query must respect
+ * `pause_reason`, not just `auto_pause_on_overage_enabled`.
+ *
+ * Bug: a manually-paused account (pause_reason='manual') that also has the
+ * auto-pause-on-overage *capability* enabled (auto_pause_on_overage_enabled=1)
+ * was selected for probing every time its rate-limit window allowed it. Each
+ * probe is a real POST /v1/messages force-routed to that account; when the
+ * account is over a window limit it 429s, gets logged as model_fallback_429,
+ * and is put on a short cooldown — then re-probed the moment the cooldown
+ * expires. The result is an endless ~5-6 min loop of synthetic 429s against an
+ * account the user disabled by hand.
+ *
+ * The auto-resume guard in sendDummyMessage only un-pauses accounts where
+ * `auto_pause_on_overage_enabled=1 AND (pause_reason IS NULL OR pause_reason='overage')`,
+ * so any other paused account would be probed forever yet never resumed. The
+ * selection query must use the *same* criteria.
+ *
+ * Strategy: capture the SQL the scheduler issues (mock db), then execute that
+ * exact SQL against a real in-memory SQLite DB seeded with one account per
+ * pause scenario. This proves row-level filtering, not just string presence.
+ */
+import { Database } from "bun:sqlite";
+import { describe, expect, it, mock } from "bun:test";
+
+type QueryCall = { sql: string; params: unknown[] };
+
+function makeDb(queryResult: unknown[] = []) {
+	const queryCalls: QueryCall[] = [];
+	return {
+		query: mock(async (sql: string, params: unknown[]) => {
+			queryCalls.push({ sql, params });
+			return queryResult;
+		}),
+		run: mock(async () => {}),
+		queryCalls,
+	};
+}
+
+function makeProxyContext() {
+	return {
+		runtime: { port: 8080, clientId: "test-client" },
+		refreshInFlight: new Map(),
+	};
+}
+
+async function makeScheduler(db: ReturnType<typeof makeDb>) {
+	const { AutoRefreshScheduler } = await import("../auto-refresh-scheduler");
+	return new AutoRefreshScheduler(db as never, makeProxyContext() as never);
+}
+
+/**
+ * Run the scheduler's eligibility query once and return the captured SQL +
+ * params. The query returns [] from the mock, so no probes are sent.
+ */
+async function captureEligibilityQuery(): Promise<QueryCall> {
+	const db = makeDb([]);
+	const scheduler = await makeScheduler(db);
+	await (
+		scheduler as never as { checkAndRefresh(): Promise<void> }
+	).checkAndRefresh();
+
+	const mainQuery = db.queryCalls.find(
+		(c) =>
+			c.sql.includes("rate_limit_reset") &&
+			c.sql.includes("auto_refresh_enabled"),
+	);
+	if (!mainQuery) {
+		throw new Error("eligibility query not captured");
+	}
+	return mainQuery;
+}
+
+/**
+ * Minimal in-memory accounts table holding just the columns the eligibility
+ * query reads. Each row is an anthropic account with auto-refresh enabled and a
+ * NULL rate_limit_reset (so the reset-window clause matches) and a NULL
+ * rate_limited_until (so the cooldown guard passes) — isolating the
+ * paused/pause_reason behaviour under test.
+ */
+function seedDb(): Database {
+	const db = new Database(":memory:");
+	db.run(`
+		CREATE TABLE accounts (
+			id TEXT PRIMARY KEY,
+			name TEXT,
+			provider TEXT,
+			refresh_token TEXT,
+			access_token TEXT,
+			expires_at INTEGER,
+			rate_limit_reset INTEGER,
+			custom_endpoint TEXT,
+			paused INTEGER,
+			auto_pause_on_overage_enabled INTEGER,
+			pause_reason TEXT,
+			auto_refresh_enabled INTEGER,
+			rate_limited_until INTEGER
+		)
+	`);
+
+	const insert = db.prepare(`
+		INSERT INTO accounts
+			(id, name, provider, refresh_token, access_token, expires_at,
+			 rate_limit_reset, custom_endpoint, paused,
+			 auto_pause_on_overage_enabled, pause_reason, auto_refresh_enabled,
+			 rate_limited_until)
+		VALUES (?, ?, 'anthropic', 'rt', 'at', NULL, NULL, NULL, ?, ?, ?, 1, NULL)
+	`);
+
+	// name, paused, auto_pause_on_overage_enabled, pause_reason
+	const rows: Array<[string, number, number, string | null]> = [
+		["active", 0, 1, null], // not paused → eligible
+		["overage-paused", 1, 1, "overage"], // overage auto-pause → eligible (resumable)
+		["overage-null-reason", 1, 1, null], // overage pause, null reason → eligible (resumable)
+		["manual-overage-on", 1, 1, "manual"], // THE BUG: manual pause, feature on → MUST be excluded
+		["failure-threshold", 1, 1, "failure_threshold"], // auto-pause-fail → excluded
+		["manual-overage-off", 1, 0, "manual"], // manual pause, feature off → excluded (already was)
+	];
+	for (const [name, paused, overage, reason] of rows) {
+		insert.run(name, name, paused, overage, reason);
+	}
+	return db;
+}
+
+function selectedNames(query: QueryCall): Set<string> {
+	const db = seedDb();
+	try {
+		const now = Date.now();
+		// The query binds exactly three `now` placeholders ([now, now, now]).
+		const rows = db.query(query.sql).all(now, now, now) as Array<{
+			name: string;
+		}>;
+		return new Set(rows.map((r) => r.name));
+	} finally {
+		db.close();
+	}
+}
+
+describe("AutoRefreshScheduler — manual-pause probe guard", () => {
+	it("excludes manually-paused accounts even when auto_pause_on_overage_enabled=1", async () => {
+		const query = await captureEligibilityQuery();
+		const names = selectedNames(query);
+
+		// The regression: a manual pause with the overage *feature* enabled must
+		// NOT be probed, because the auto-resume guard would never un-pause it.
+		expect(names.has("manual-overage-on")).toBe(false);
+	});
+
+	it("excludes failure-threshold pauses", async () => {
+		const query = await captureEligibilityQuery();
+		const names = selectedNames(query);
+		expect(names.has("failure-threshold")).toBe(false);
+	});
+
+	it("still includes overage-paused accounts (so they auto-resume on window reset)", async () => {
+		const query = await captureEligibilityQuery();
+		const names = selectedNames(query);
+		expect(names.has("overage-paused")).toBe(true);
+		// A null pause_reason is treated as overage by the resume guard, so it
+		// must remain eligible too.
+		expect(names.has("overage-null-reason")).toBe(true);
+	});
+
+	it("still includes non-paused accounts and excludes feature-off manual pauses", async () => {
+		const query = await captureEligibilityQuery();
+		const names = selectedNames(query);
+		expect(names.has("active")).toBe(true);
+		expect(names.has("manual-overage-off")).toBe(false);
+	});
+
+	it("selection criteria match the auto-resume guard exactly", async () => {
+		// Paused rows the query selects must be precisely the rows the resume
+		// guard (auto_pause_on_overage_enabled=1 AND pause_reason IN (NULL,'overage'))
+		// would un-pause. Anything else is a probe that can never be resumed.
+		const query = await captureEligibilityQuery();
+		const names = selectedNames(query);
+		const pausedSelected = [
+			"overage-paused",
+			"overage-null-reason",
+			"manual-overage-on",
+			"failure-threshold",
+			"manual-overage-off",
+		].filter((n) => names.has(n));
+		expect(pausedSelected.sort()).toEqual(
+			["overage-null-reason", "overage-paused"].sort(),
+		);
+	});
+});

--- a/packages/proxy/src/__tests__/auto-refresh-manual-pause-guard.test.ts
+++ b/packages/proxy/src/__tests__/auto-refresh-manual-pause-guard.test.ts
@@ -21,7 +21,7 @@
  * pause scenario. This proves row-level filtering, not just string presence.
  */
 import { Database } from "bun:sqlite";
-import { describe, expect, it, mock } from "bun:test";
+import { beforeAll, describe, expect, it, mock } from "bun:test";
 
 type QueryCall = { sql: string; params: unknown[] };
 
@@ -114,6 +114,7 @@ function seedDb(): Database {
 		["overage-null-reason", 1, 1, null], // overage pause, null reason → eligible (resumable)
 		["manual-overage-on", 1, 1, "manual"], // THE BUG: manual pause, feature on → MUST be excluded
 		["failure-threshold", 1, 1, "failure_threshold"], // auto-pause-fail → excluded
+		["peak-hours-paused", 1, 1, "peak_hours"], // zai peak-hours auto-pause → excluded
 		["manual-overage-off", 1, 0, "manual"], // manual pause, feature off → excluded (already was)
 	];
 	for (const [name, paused, overage, reason] of rows) {
@@ -137,48 +138,55 @@ function selectedNames(query: QueryCall): Set<string> {
 }
 
 describe("AutoRefreshScheduler — manual-pause probe guard", () => {
-	it("excludes manually-paused accounts even when auto_pause_on_overage_enabled=1", async () => {
-		const query = await captureEligibilityQuery();
-		const names = selectedNames(query);
+	// The eligibility SQL is identical across every scenario, so capture it (and
+	// the set of accounts it selects) once rather than re-running the whole
+	// scheduler per test.
+	let names: Set<string>;
 
+	beforeAll(async () => {
+		const query = await captureEligibilityQuery();
+		names = selectedNames(query);
+	});
+
+	it("excludes manually-paused accounts even when auto_pause_on_overage_enabled=1", () => {
 		// The regression: a manual pause with the overage *feature* enabled must
 		// NOT be probed, because the auto-resume guard would never un-pause it.
 		expect(names.has("manual-overage-on")).toBe(false);
 	});
 
-	it("excludes failure-threshold pauses", async () => {
-		const query = await captureEligibilityQuery();
-		const names = selectedNames(query);
+	it("excludes failure-threshold pauses", () => {
 		expect(names.has("failure-threshold")).toBe(false);
 	});
 
-	it("still includes overage-paused accounts (so they auto-resume on window reset)", async () => {
-		const query = await captureEligibilityQuery();
-		const names = selectedNames(query);
+	it("excludes peak_hours pauses (zai peak-hours auto-pause)", () => {
+		// checkPeakHoursPause sets pause_reason='peak_hours' on zai accounts; such
+		// a pause is not overage, so it must never be probed even with the overage
+		// feature flag enabled.
+		expect(names.has("peak-hours-paused")).toBe(false);
+	});
+
+	it("still includes overage-paused accounts (so they auto-resume on window reset)", () => {
 		expect(names.has("overage-paused")).toBe(true);
 		// A null pause_reason is treated as overage by the resume guard, so it
 		// must remain eligible too.
 		expect(names.has("overage-null-reason")).toBe(true);
 	});
 
-	it("still includes non-paused accounts and excludes feature-off manual pauses", async () => {
-		const query = await captureEligibilityQuery();
-		const names = selectedNames(query);
+	it("still includes non-paused accounts and excludes feature-off manual pauses", () => {
 		expect(names.has("active")).toBe(true);
 		expect(names.has("manual-overage-off")).toBe(false);
 	});
 
-	it("selection criteria match the auto-resume guard exactly", async () => {
+	it("selection criteria match the auto-resume guard exactly", () => {
 		// Paused rows the query selects must be precisely the rows the resume
 		// guard (auto_pause_on_overage_enabled=1 AND pause_reason IN (NULL,'overage'))
 		// would un-pause. Anything else is a probe that can never be resumed.
-		const query = await captureEligibilityQuery();
-		const names = selectedNames(query);
 		const pausedSelected = [
 			"overage-paused",
 			"overage-null-reason",
 			"manual-overage-on",
 			"failure-threshold",
+			"peak-hours-paused",
 			"manual-overage-off",
 		].filter((n) => names.has(n));
 		expect(pausedSelected.sort()).toEqual(

--- a/packages/proxy/src/auto-refresh-scheduler.ts
+++ b/packages/proxy/src/auto-refresh-scheduler.ts
@@ -151,16 +151,22 @@ export class AutoRefreshScheduler {
 					AND (
 						rate_limited_until IS NULL OR rate_limited_until <= ?
 					)
-					-- Exclude accounts that are paused for reasons other than overage (e.g. manually
-					-- paused zai/codex accounts, or accounts paused by the failure-threshold guard).
-					-- auto_pause_on_overage_enabled defaults to 0 for zai/codex, so a manually-paused
-					-- account of those types is correctly excluded — there is no point refreshing a
-					-- broken/manually-paused endpoint.  Overage-paused accounts (paused=1 AND
-					-- auto_pause_on_overage_enabled=1) are intentionally included so the scheduler can
-					-- probe them and auto-resume after the usage window resets.
-					AND NOT (
-						COALESCE(paused, 0) = 1
-						AND COALESCE(auto_pause_on_overage_enabled, 0) = 0
+					-- Only probe a paused account if it was auto-paused due to billing
+					-- overage. The auto-resume guard in sendDummyMessage only un-pauses an
+					-- account when auto_pause_on_overage_enabled=1 AND pause_reason IN
+					-- (NULL, 'overage'); selecting any other paused account here would probe
+					-- it forever yet never resume it. So a manually-paused account
+					-- (pause_reason='manual') or one paused by the failure-threshold guard
+					-- (pause_reason='failure_threshold') is left completely alone — probing it
+					-- just burns quota and pollutes the request log with synthetic 429s for an
+					-- account the user (or the guard) intentionally disabled (issue #199, bug 1).
+					-- These criteria MUST stay in sync with the resume guard.
+					AND (
+						COALESCE(paused, 0) = 0
+						OR (
+							COALESCE(auto_pause_on_overage_enabled, 0) = 1
+							AND (pause_reason IS NULL OR pause_reason = 'overage')
+						)
 					)
 			`,
 				[now, now, now],

--- a/packages/proxy/src/handlers/__tests__/account-selector.test.ts
+++ b/packages/proxy/src/handlers/__tests__/account-selector.test.ts
@@ -447,6 +447,7 @@ describe("selectAccountsForRequest — auto-refresh bypass (overage-paused accou
 			name: "overage-paused",
 			paused: true,
 			auto_pause_on_overage_enabled: true,
+			pause_reason: "overage",
 		});
 		const activeAcc = makeAccount({ id: "acc-active", name: "active" });
 		const ctx: ProxyContext = {
@@ -499,6 +500,42 @@ describe("selectAccountsForRequest — auto-refresh bypass (overage-paused accou
 
 		const result = await selectAccountsForRequest(meta, ctx);
 		// Without bypass header the account is unavailable; falls back to strategy
+		expect(result).toHaveLength(1);
+		expect(result[0]?.id).toBe("acc-active");
+	});
+
+	it("blocks manually-paused overage-enabled account even with bypass-session header", async () => {
+		// A manual pause must win even when auto_pause_on_overage_enabled is set:
+		// the auto-resume guard would never un-pause it, so admitting it on a
+		// bypass-session force-route just produces an endless probe loop. Mirrors
+		// the scheduler eligibility query and the sendDummyMessage resume guard.
+		const manualPausedAcc = makeAccount({
+			id: "acc-manual",
+			name: "manual-paused",
+			paused: true,
+			auto_pause_on_overage_enabled: true,
+			pause_reason: "manual",
+		});
+		const activeAcc = makeAccount({ id: "acc-active", name: "active" });
+		const ctx: ProxyContext = {
+			strategy: { select: mock(() => [activeAcc]) },
+			dbOps: {
+				getAllAccounts: mock(async () => [manualPausedAcc, activeAcc]),
+				getActiveComboForFamily: mock(async () => null),
+			},
+			refreshInFlight: new Map(),
+			asyncWriter: { enqueue: mock(() => {}) },
+			usageWorker: { postMessage: mock(() => {}) },
+		} as unknown as ProxyContext;
+		const meta = makeRequestMeta({
+			headers: new Headers({
+				"x-better-ccflare-account-id": "acc-manual",
+				"x-better-ccflare-bypass-session": "true",
+			}),
+		});
+
+		const result = await selectAccountsForRequest(meta, ctx);
+		// Manual pause is not overage → not allowed through; falls back to strategy
 		expect(result).toHaveLength(1);
 		expect(result[0]?.id).toBe("acc-active");
 	});

--- a/packages/proxy/src/handlers/account-selector.ts
+++ b/packages/proxy/src/handlers/account-selector.ts
@@ -86,13 +86,19 @@ export async function selectAccountsForRequest(
 					// or to probe accounts that are rate-limited (to detect when the window has reset).
 					// For those requests we must allow through an overage-paused or rate-limited account
 					// so the scheduler can hit the real endpoint and trigger the window-reset + auto-resume logic.
-					// We still block accounts that were paused by the failure-threshold guard (those are
-					// paused because their endpoint is broken, not because of overage or rate-limiting).
+					// Only an overage pause qualifies: a manual pause (pause_reason='manual') or a
+					// failure-threshold / peak_hours pause must still win even when the overage feature
+					// flag is enabled, because the auto-resume guard would never un-pause those accounts.
+					// This mirrors the scheduler eligibility query and the sendDummyMessage resume guard
+					// (auto_pause_on_overage_enabled=1 AND pause_reason IN (NULL,'overage')).
 					const isAutoRefreshBypass =
 						meta.headers.get("x-better-ccflare-bypass-session") === "true";
 					const available = isAccountAvailable(forcedAccount);
 					const isOveragePaused =
-						forcedAccount.paused && forcedAccount.auto_pause_on_overage_enabled;
+						forcedAccount.paused &&
+						forcedAccount.auto_pause_on_overage_enabled &&
+						(!forcedAccount.pause_reason ||
+							forcedAccount.pause_reason === "overage");
 					const isRateLimited =
 						!available &&
 						!forcedAccount.paused &&


### PR DESCRIPTION
The auto-refresh scheduler sends a synthetic POST /v1/messages probe to accounts to reset their rate-limit window, then auto-resumes overage-paused accounts once the window clears. The eligibility query excluded paused accounts only when auto_pause_on_overage_enabled=0, ignoring pause_reason — but the auto-resume guard in sendDummyMessage only un-pauses accounts where pause_reason IS NULL OR pause_reason='overage'.

As a result a manually-paused account (pause_reason='manual') that also had the overage feature enabled was probed on every window, force-routed past its paused state, 429'd by Anthropic (logged as model_fallback_429), put on a short cooldown, and re-probed the moment it expired — an endless ~5-6 min loop of synthetic 429s against an account the user had disabled by hand, and which the resume guard would never un-pause.

Align the eligibility query with the resume guard: only probe a paused account when auto_pause_on_overage_enabled=1 AND pause_reason IN (NULL,'overage'). Manual and failure-threshold pauses are now left completely alone.

Adds a regression test that runs the scheduler's actual SQL against a seeded in-memory DB and asserts the selected paused rows exactly match what the resume guard would un-pause.