### PR TITLE
fix: strip content-encoding when forwarding upstream model-not-found errors

### DIFF
--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -4,6 +4,7 @@ import {
 	ProviderError,
 	TIME_CONSTANTS,
 } from "@better-ccflare/core";
+import { withSanitizedProxyHeaders } from "@better-ccflare/http-common";
 import { Logger } from "@better-ccflare/logger";
 import { stripCacheControlFromOpenAIRequest } from "@better-ccflare/openai-formats";
 import { getProvider, usageCache } from "@better-ccflare/providers";
@@ -783,7 +784,12 @@ export async function proxyWithAccount(
 						);
 						return null;
 					}
-					return rawResponse;
+					// Model-not-found (404/400) is forwarded to the client so it can
+					// surface the real error. Strip content-encoding/content-length
+					// first: Bun's fetch already decompressed the body, so leaving the
+					// upstream `content-encoding: gzip` header makes the client try to
+					// gunzip plaintext → "Decompression error: ZlibError".
+					return withSanitizedProxyHeaders(rawResponse);
 				}
 
 				for (let i = 1; i < modelList.length; i++) {


### PR DESCRIPTION
## Problem

Bun-based clients pointed at ccflare print a red **`Decompression error: ZlibError`** on startup (reproduced reliably with interactive Claude Code).

## Root cause

At startup the client sends a warmup `POST /v1/messages?beta=true` using an internal model alias (e.g. `claude-opus-4-8[1m]`). The upstream Anthropic API returns a gzip-encoded **404 `not_found_error`** for that model.

ccflare runs on Bun, whose `fetch` **auto-decompresses** the response body — so `rawResponse.body` is already plaintext while `rawResponse.headers` still carries `content-encoding: gzip` (and the upstream `content-length`).

In `proxyWithAccount` (`packages/proxy/src/handlers/proxy-operations.ts`), the model-unavailable branch forwards genuine 404/400 model errors to the client. When no model fallback is configured it did:

```ts
return rawResponse;
```

This returns the upstream response **directly**, bypassing `forwardToClient` → `withSanitizedProxyHeaders` (and even the `taggedRawResponse`/`processResponse` path). Every other forward path strips compression headers after Bun's auto-decompression; this one didn't.

Result: the client receives `content-encoding: gzip` over a plaintext body, tries to gunzip it, and throws `ZlibError`.

I confirmed this end-to-end with a raw passthrough sniffer between the client and ccflare:

```
[POST] /v1/messages?beta=true -> 404  content-encoding: gzip  content-length: 134
body (134B, NOT gzip): {"type":"error","error":{"type":"not_found_error","message":"model: claude-opus-4-8[1m]"}, ...}
```

## Fix

Sanitize the headers before returning, matching every other forward path:

```ts
return withSanitizedProxyHeaders(rawResponse);
```

One-line behavioral change (+ import). The 404 body still reaches the client unchanged — only the stale `content-encoding`/`content-length`/`transfer-encoding` headers are dropped, which is exactly what `withSanitizedProxyHeaders` exists for.

## Verification

- `bun run typecheck` passes.
- Reproduced before / confirmed gone after by launching **real Claude Code** (not a scripted curl, per the repo's Anthropic-account testing rule) against a local instance built from this branch on port 8081: `Decompression error: ZlibError` count went from present → **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)