### PR TITLE
Update base64 decoding to return UTF-8 string

### DIFF
--- a/packages/dashboard-web/src/components/RequestDetailsModal.tsx
+++ b/packages/dashboard-web/src/components/RequestDetailsModal.tsx
@@ -74,7 +74,9 @@ export function RequestDetailsModal({
 			if (str === "[streamed]") {
 				return "[Streaming data not captured]";
 			}
-			return atob(str);
+			const binary = atob(str);
+      		const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+      		return new TextDecoder("utf-8").decode(bytes);
 		} catch (error) {
 			console.error("Failed to decode base64:", error, "Input:", str);
 			return `Failed to decode: ${str}`;


### PR DESCRIPTION
When performing base64 decoding, non-ASCII characters in the body will be displayed as garbled text.
Like this:
<img width="400" height="244" alt="image" src="https://github.com/user-attachments/assets/9a1b702c-86a0-4d52-9c84-0ace949bbd0f" />

Repair by specifying UTF-8 decoding