### PR TITLE
feat: persist analytics view controls in the URL (+ localStorage)

### DIFF
--- a/packages/dashboard-web/src/components/AnalyticsTab.tsx
+++ b/packages/dashboard-web/src/components/AnalyticsTab.tsx
@@ -1,12 +1,11 @@
 import { format } from "date-fns";
 import React, { useCallback, useMemo, useState } from "react";
-import type { TimeRange } from "../constants";
 import { useAnalytics } from "../hooks/queries";
+import { useAnalyticsUrlState } from "../hooks/useAnalyticsUrlState";
 import {
 	AnalyticsControls,
 	CumulativeGrowthChart,
 	CumulativeTokenComposition,
-	type FilterState,
 	MainMetricsChart,
 	ModelAnalytics,
 	PerformanceIndicatorsChart,
@@ -15,17 +14,19 @@ import {
 } from "./analytics";
 
 export const AnalyticsTab = React.memo(() => {
-	const [timeRange, setTimeRange] = useState<TimeRange>("1h");
-	const [selectedMetric, setSelectedMetric] = useState("requests");
+	const {
+		timeRange,
+		setTimeRange,
+		selectedMetric,
+		setSelectedMetric,
+		viewMode,
+		setViewMode,
+		modelBreakdown,
+		setModelBreakdown,
+		filters,
+		setFilters,
+	} = useAnalyticsUrlState();
 	const [filterOpen, setFilterOpen] = useState(false);
-	const [viewMode, setViewMode] = useState<"normal" | "cumulative">("normal");
-	const [modelBreakdown, setModelBreakdown] = useState(false);
-	const [filters, setFilters] = useState<FilterState>({
-		accounts: [],
-		models: [],
-		apiKeys: [],
-		status: "all",
-	});
 
 	// Fetch analytics data with automatic refetch on dependency changes
 	const { data: analytics, isLoading: loading } = useAnalytics(
@@ -214,13 +215,7 @@ export const AnalyticsTab = React.memo(() => {
 				timeRange={timeRange}
 				setTimeRange={setTimeRange}
 				viewMode={viewMode}
-				setViewMode={(mode) => {
-					setViewMode(mode);
-					// Disable per-model breakdown when switching to cumulative
-					if (mode === "cumulative") {
-						setModelBreakdown(false);
-					}
-				}}
+				setViewMode={setViewMode}
 				filters={filters}
 				setFilters={setFilters}
 				availableAccounts={availableAccounts}

--- a/packages/dashboard-web/src/hooks/useAnalyticsUrlState.ts
+++ b/packages/dashboard-web/src/hooks/useAnalyticsUrlState.ts
@@ -3,6 +3,7 @@ import { useSearchParams } from "react-router-dom";
 import type { FilterState } from "../components/analytics/AnalyticsFilters";
 import type { TimeRange } from "../constants";
 import {
+	type AnalyticsMetric,
 	type AnalyticsUrlState,
 	decodeAnalyticsState,
 	encodeAnalyticsState,
@@ -34,7 +35,7 @@ function writeStoredState(state: AnalyticsUrlState): void {
 
 export interface UseAnalyticsUrlState {
 	timeRange: TimeRange;
-	selectedMetric: string;
+	selectedMetric: AnalyticsMetric;
 	viewMode: "normal" | "cumulative";
 	modelBreakdown: boolean;
 	filters: FilterState;
@@ -108,9 +109,23 @@ export function useAnalyticsUrlState(): UseAnalyticsUrlState {
 		(range: TimeRange) => setField("timeRange", range),
 		[setField],
 	);
+	// Accepts a raw string (the Radix Select emits `string`); normalizeState
+	// validates it against METRIC_VALUES, so the stored value stays a valid
+	// AnalyticsMetric. Inlined rather than routed through the strictly-typed
+	// setField so the unvalidated input doesn't need an unsafe cast.
 	const setSelectedMetric = useCallback(
-		(metric: string) => setField("selectedMetric", metric),
-		[setField],
+		(metric: string) =>
+			setSearchParams(
+				(prev) =>
+					encodeAnalyticsState(
+						normalizeState({
+							...decodeAnalyticsState(prev),
+							selectedMetric: metric,
+						}),
+					),
+				{ replace: true },
+			),
+		[setSearchParams],
 	);
 	const setViewMode = useCallback(
 		(mode: "normal" | "cumulative") => setField("viewMode", mode),

--- a/packages/dashboard-web/src/hooks/useAnalyticsUrlState.ts
+++ b/packages/dashboard-web/src/hooks/useAnalyticsUrlState.ts
@@ -60,11 +60,16 @@ export function useAnalyticsUrlState(): UseAnalyticsUrlState {
 	);
 
 	// On first mount, if the URL has no analytics params, seed it from the saved
-	// preference using replace (no new history entry). `skipMirror` stops the
-	// persistence effect below from clobbering the saved value with defaults
-	// during the pre-seed render.
+	// preference using replace (no new history entry). The `didSeed` guard makes
+	// this run exactly once: without it, re-running when `searchParams` changes
+	// would re-seed the stored value and fight the user when they reset a control
+	// back to its default. `skipMirror` stops the persistence effect below from
+	// clobbering the saved value with defaults during the pre-seed render.
+	const didSeed = useRef(false);
 	const skipMirror = useRef(false);
 	useEffect(() => {
+		if (didSeed.current) return;
+		didSeed.current = true;
 		if (hasAnalyticsParams(searchParams)) return;
 		const stored = readStoredState();
 		if (!stored) return;
@@ -72,9 +77,7 @@ export function useAnalyticsUrlState(): UseAnalyticsUrlState {
 		if (seeded.toString() === "") return;
 		skipMirror.current = true;
 		setSearchParams(seeded, { replace: true });
-		// Run once on mount; we intentionally read params/setter without resubscribing.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [setSearchParams, searchParams]);
+	}, [searchParams, setSearchParams]);
 
 	// Mirror the active state to localStorage so the next visit can restore it.
 	useEffect(() => {

--- a/packages/dashboard-web/src/hooks/useAnalyticsUrlState.ts
+++ b/packages/dashboard-web/src/hooks/useAnalyticsUrlState.ts
@@ -74,7 +74,7 @@ export function useAnalyticsUrlState(): UseAnalyticsUrlState {
 		setSearchParams(seeded, { replace: true });
 		// Run once on mount; we intentionally read params/setter without resubscribing.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+	}, [setSearchParams, searchParams]);
 
 	// Mirror the active state to localStorage so the next visit can restore it.
 	useEffect(() => {
@@ -86,7 +86,10 @@ export function useAnalyticsUrlState(): UseAnalyticsUrlState {
 	}, [state]);
 
 	const setField = useCallback(
-		<K extends keyof AnalyticsUrlState>(key: K, value: AnalyticsUrlState[K]) => {
+		<K extends keyof AnalyticsUrlState>(
+			key: K,
+			value: AnalyticsUrlState[K],
+		) => {
 			setSearchParams(
 				(prev) =>
 					encodeAnalyticsState(

--- a/packages/dashboard-web/src/hooks/useAnalyticsUrlState.ts
+++ b/packages/dashboard-web/src/hooks/useAnalyticsUrlState.ts
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useSearchParams } from "react-router-dom";
+import type { FilterState } from "../components/analytics/AnalyticsFilters";
+import type { TimeRange } from "../constants";
+import {
+	type AnalyticsUrlState,
+	decodeAnalyticsState,
+	encodeAnalyticsState,
+	hasAnalyticsParams,
+	normalizeState,
+} from "../lib/analytics-url-state";
+
+const STORAGE_KEY = "better-ccflare:analytics-state";
+
+function readStoredState(): AnalyticsUrlState | null {
+	if (typeof window === "undefined") return null;
+	try {
+		const raw = window.localStorage.getItem(STORAGE_KEY);
+		if (!raw) return null;
+		return normalizeState(JSON.parse(raw));
+	} catch {
+		return null;
+	}
+}
+
+function writeStoredState(state: AnalyticsUrlState): void {
+	if (typeof window === "undefined") return;
+	try {
+		window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+	} catch {
+		// ignore — storage unavailable / quota; the URL still holds the state
+	}
+}
+
+export interface UseAnalyticsUrlState {
+	timeRange: TimeRange;
+	selectedMetric: string;
+	viewMode: "normal" | "cumulative";
+	modelBreakdown: boolean;
+	filters: FilterState;
+	setTimeRange: (range: TimeRange) => void;
+	setSelectedMetric: (metric: string) => void;
+	setViewMode: (mode: "normal" | "cumulative") => void;
+	setModelBreakdown: (value: boolean) => void;
+	setFilters: (filters: FilterState) => void;
+}
+
+/**
+ * Syncs the Analytics page view controls with the URL query string (single
+ * source of truth) and localStorage (seed/backup). Drop-in for the 5 useState
+ * calls AnalyticsTab previously held.
+ */
+export function useAnalyticsUrlState(): UseAnalyticsUrlState {
+	const [searchParams, setSearchParams] = useSearchParams();
+
+	// The URL is the single source of truth for analytics view state.
+	const state = useMemo(
+		() => decodeAnalyticsState(searchParams),
+		[searchParams],
+	);
+
+	// On first mount, if the URL has no analytics params, seed it from the saved
+	// preference using replace (no new history entry). `skipMirror` stops the
+	// persistence effect below from clobbering the saved value with defaults
+	// during the pre-seed render.
+	const skipMirror = useRef(false);
+	useEffect(() => {
+		if (hasAnalyticsParams(searchParams)) return;
+		const stored = readStoredState();
+		if (!stored) return;
+		const seeded = encodeAnalyticsState(stored);
+		if (seeded.toString() === "") return;
+		skipMirror.current = true;
+		setSearchParams(seeded, { replace: true });
+		// Run once on mount; we intentionally read params/setter without resubscribing.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	// Mirror the active state to localStorage so the next visit can restore it.
+	useEffect(() => {
+		if (skipMirror.current) {
+			skipMirror.current = false;
+			return;
+		}
+		writeStoredState(state);
+	}, [state]);
+
+	const setField = useCallback(
+		<K extends keyof AnalyticsUrlState>(key: K, value: AnalyticsUrlState[K]) => {
+			setSearchParams(
+				(prev) =>
+					encodeAnalyticsState(
+						normalizeState({ ...decodeAnalyticsState(prev), [key]: value }),
+					),
+				{ replace: true },
+			);
+		},
+		[setSearchParams],
+	);
+
+	const setTimeRange = useCallback(
+		(range: TimeRange) => setField("timeRange", range),
+		[setField],
+	);
+	const setSelectedMetric = useCallback(
+		(metric: string) => setField("selectedMetric", metric),
+		[setField],
+	);
+	const setViewMode = useCallback(
+		(mode: "normal" | "cumulative") => setField("viewMode", mode),
+		[setField],
+	);
+	const setModelBreakdown = useCallback(
+		(value: boolean) => setField("modelBreakdown", value),
+		[setField],
+	);
+	const setFilters = useCallback(
+		(filters: FilterState) => setField("filters", filters),
+		[setField],
+	);
+
+	return {
+		timeRange: state.timeRange,
+		selectedMetric: state.selectedMetric,
+		viewMode: state.viewMode,
+		modelBreakdown: state.modelBreakdown,
+		filters: state.filters,
+		setTimeRange,
+		setSelectedMetric,
+		setViewMode,
+		setModelBreakdown,
+		setFilters,
+	};
+}

--- a/packages/dashboard-web/src/lib/__tests__/analytics-url-state.test.ts
+++ b/packages/dashboard-web/src/lib/__tests__/analytics-url-state.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "bun:test";
+import {
+	type AnalyticsUrlState,
+	DEFAULT_ANALYTICS_STATE,
+	decodeAnalyticsState,
+	encodeAnalyticsState,
+	hasAnalyticsParams,
+	normalizeState,
+} from "../analytics-url-state";
+
+describe("encodeAnalyticsState", () => {
+	it("emits no params for the default state", () => {
+		expect(encodeAnalyticsState(DEFAULT_ANALYTICS_STATE).toString()).toBe("");
+	});
+
+	it("omits values equal to their default but includes the rest", () => {
+		const params = encodeAnalyticsState({
+			...DEFAULT_ANALYTICS_STATE,
+			viewMode: "cumulative",
+			timeRange: "24h",
+			selectedMetric: "cost",
+		});
+		expect(params.get("view")).toBe("cumulative");
+		expect(params.get("range")).toBe("24h");
+		expect(params.get("metric")).toBe("cost");
+		expect(params.has("breakdown")).toBe(false);
+		expect(params.has("status")).toBe(false);
+	});
+
+	it("encodes filter arrays as repeated params and status when not 'all'", () => {
+		const params = encodeAnalyticsState({
+			...DEFAULT_ANALYTICS_STATE,
+			filters: {
+				accounts: ["a", "b"],
+				models: ["m1"],
+				apiKeys: ["k1"],
+				status: "error",
+			},
+		});
+		expect(params.getAll("accounts")).toEqual(["a", "b"]);
+		expect(params.getAll("models")).toEqual(["m1"]);
+		expect(params.getAll("keys")).toEqual(["k1"]);
+		expect(params.get("status")).toBe("error");
+	});
+
+	it("never emits breakdown when view is cumulative", () => {
+		const params = encodeAnalyticsState({
+			...DEFAULT_ANALYTICS_STATE,
+			viewMode: "cumulative",
+			modelBreakdown: true,
+		});
+		expect(params.has("breakdown")).toBe(false);
+	});
+});
+
+describe("decodeAnalyticsState", () => {
+	it("returns defaults for empty params", () => {
+		expect(decodeAnalyticsState(new URLSearchParams())).toEqual(
+			DEFAULT_ANALYTICS_STATE,
+		);
+	});
+
+	it("round-trips a representative state", () => {
+		const state: AnalyticsUrlState = {
+			viewMode: "normal",
+			timeRange: "7d",
+			selectedMetric: "tokensPerSecond",
+			modelBreakdown: true,
+			filters: {
+				accounts: ["acc-1"],
+				models: ["z-ai/glm-4.5-air:free"],
+				apiKeys: [],
+				status: "success",
+			},
+		};
+		expect(decodeAnalyticsState(encodeAnalyticsState(state))).toEqual(state);
+	});
+
+	it("falls back to defaults for invalid scalar values", () => {
+		const params = new URLSearchParams("view=bogus&range=99y&metric=foo&status=maybe");
+		expect(decodeAnalyticsState(params)).toEqual(DEFAULT_ANALYTICS_STATE);
+	});
+
+	it("forces modelBreakdown off when view is cumulative", () => {
+		const state = decodeAnalyticsState(
+			new URLSearchParams("view=cumulative&breakdown=true"),
+		);
+		expect(state.viewMode).toBe("cumulative");
+		expect(state.modelBreakdown).toBe(false);
+	});
+
+	it("parses breakdown=true in normal view", () => {
+		const state = decodeAnalyticsState(new URLSearchParams("breakdown=true"));
+		expect(state.modelBreakdown).toBe(true);
+	});
+});
+
+describe("normalizeState", () => {
+	it("coerces garbage input to the default state", () => {
+		expect(normalizeState(null)).toEqual(DEFAULT_ANALYTICS_STATE);
+		expect(normalizeState({ viewMode: 123, filters: "nope" })).toEqual(
+			DEFAULT_ANALYTICS_STATE,
+		);
+	});
+
+	it("keeps valid values and drops non-string filter entries", () => {
+		expect(
+			normalizeState({
+				viewMode: "cumulative",
+				timeRange: "7d",
+				selectedMetric: "cost",
+				modelBreakdown: true,
+				filters: {
+					accounts: ["a", 5, null],
+					models: [],
+					apiKeys: ["k"],
+					status: "error",
+				},
+			}),
+		).toEqual({
+			viewMode: "cumulative",
+			timeRange: "7d",
+			selectedMetric: "cost",
+			modelBreakdown: false,
+			filters: { accounts: ["a"], models: [], apiKeys: ["k"], status: "error" },
+		});
+	});
+});
+
+describe("hasAnalyticsParams", () => {
+	it("is false for empty or unrecognized params", () => {
+		expect(hasAnalyticsParams(new URLSearchParams())).toBe(false);
+		expect(hasAnalyticsParams(new URLSearchParams("foo=bar"))).toBe(false);
+	});
+
+	it("is true when a recognized param is present", () => {
+		expect(hasAnalyticsParams(new URLSearchParams("view=cumulative"))).toBe(true);
+		expect(hasAnalyticsParams(new URLSearchParams("accounts=a"))).toBe(true);
+	});
+});

--- a/packages/dashboard-web/src/lib/__tests__/analytics-url-state.test.ts
+++ b/packages/dashboard-web/src/lib/__tests__/analytics-url-state.test.ts
@@ -77,7 +77,9 @@ describe("decodeAnalyticsState", () => {
 	});
 
 	it("falls back to defaults for invalid scalar values", () => {
-		const params = new URLSearchParams("view=bogus&range=99y&metric=foo&status=maybe");
+		const params = new URLSearchParams(
+			"view=bogus&range=99y&metric=foo&status=maybe",
+		);
 		expect(decodeAnalyticsState(params)).toEqual(DEFAULT_ANALYTICS_STATE);
 	});
 
@@ -134,7 +136,9 @@ describe("hasAnalyticsParams", () => {
 	});
 
 	it("is true when a recognized param is present", () => {
-		expect(hasAnalyticsParams(new URLSearchParams("view=cumulative"))).toBe(true);
+		expect(hasAnalyticsParams(new URLSearchParams("view=cumulative"))).toBe(
+			true,
+		);
 		expect(hasAnalyticsParams(new URLSearchParams("accounts=a"))).toBe(true);
 	});
 });

--- a/packages/dashboard-web/src/lib/analytics-url-state.ts
+++ b/packages/dashboard-web/src/lib/analytics-url-state.ts
@@ -1,0 +1,125 @@
+import { TIME_RANGES, type TimeRange } from "@better-ccflare/ui-constants";
+import type { FilterState } from "../components/analytics/AnalyticsFilters";
+
+export type AnalyticsUrlState = {
+	viewMode: "normal" | "cumulative";
+	timeRange: TimeRange;
+	selectedMetric: string;
+	modelBreakdown: boolean;
+	filters: FilterState;
+};
+
+export const DEFAULT_ANALYTICS_STATE: AnalyticsUrlState = {
+	viewMode: "normal",
+	timeRange: "1h",
+	selectedMetric: "requests",
+	modelBreakdown: false,
+	filters: { accounts: [], models: [], apiKeys: [], status: "all" },
+};
+
+const VIEW_VALUES = ["normal", "cumulative"] as const;
+const METRIC_VALUES = [
+	"requests",
+	"tokens",
+	"cost",
+	"responseTime",
+	"tokensPerSecond",
+] as const;
+const STATUS_VALUES = ["all", "success", "error"] as const;
+const RANGE_VALUES = Object.keys(TIME_RANGES) as TimeRange[];
+
+// Query-string keys this feature owns. Used to decide URL-vs-storage hydration.
+const PARAM_KEYS = [
+	"view",
+	"range",
+	"metric",
+	"breakdown",
+	"accounts",
+	"models",
+	"keys",
+	"status",
+] as const;
+
+function oneOf<T extends string>(
+	value: unknown,
+	allowed: readonly T[],
+	fallback: T,
+): T {
+	return typeof value === "string" && (allowed as readonly string[]).includes(value)
+		? (value as T)
+		: fallback;
+}
+
+function asStringArray(value: unknown): string[] {
+	return Array.isArray(value)
+		? value.filter((item): item is string => typeof item === "string")
+		: [];
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+	return typeof value === "object" && value !== null
+		? (value as Record<string, unknown>)
+		: {};
+}
+
+/**
+ * Coerce arbitrary input (decoded URL params or parsed localStorage) into a
+ * valid AnalyticsUrlState. Invalid scalars fall back to their default, and the
+ * cumulative view always forces modelBreakdown off (the per-model toggle is
+ * hidden in cumulative mode).
+ */
+export function normalizeState(input: unknown): AnalyticsUrlState {
+	const raw = asRecord(input);
+	const filters = asRecord(raw.filters);
+	const viewMode = oneOf(raw.viewMode, VIEW_VALUES, "normal");
+	const breakdown = raw.modelBreakdown === true || raw.modelBreakdown === "true";
+	return {
+		viewMode,
+		timeRange: oneOf(raw.timeRange, RANGE_VALUES, "1h"),
+		selectedMetric: oneOf(raw.selectedMetric, METRIC_VALUES, "requests"),
+		modelBreakdown: viewMode === "cumulative" ? false : breakdown,
+		filters: {
+			accounts: asStringArray(filters.accounts),
+			models: asStringArray(filters.models),
+			apiKeys: asStringArray(filters.apiKeys),
+			status: oneOf(filters.status, STATUS_VALUES, "all"),
+		},
+	};
+}
+
+/** Serialize state to query params, omitting anything equal to its default. */
+export function encodeAnalyticsState(state: AnalyticsUrlState): URLSearchParams {
+	const params = new URLSearchParams();
+	if (state.viewMode !== "normal") params.set("view", state.viewMode);
+	if (state.timeRange !== "1h") params.set("range", state.timeRange);
+	if (state.selectedMetric !== "requests")
+		params.set("metric", state.selectedMetric);
+	if (state.modelBreakdown && state.viewMode !== "cumulative")
+		params.set("breakdown", "true");
+	for (const account of state.filters.accounts) params.append("accounts", account);
+	for (const model of state.filters.models) params.append("models", model);
+	for (const key of state.filters.apiKeys) params.append("keys", key);
+	if (state.filters.status !== "all") params.set("status", state.filters.status);
+	return params;
+}
+
+/** Parse query params back into a validated, normalized state. */
+export function decodeAnalyticsState(params: URLSearchParams): AnalyticsUrlState {
+	return normalizeState({
+		viewMode: params.get("view") ?? undefined,
+		timeRange: params.get("range") ?? undefined,
+		selectedMetric: params.get("metric") ?? undefined,
+		modelBreakdown: params.get("breakdown") ?? undefined,
+		filters: {
+			accounts: params.getAll("accounts"),
+			models: params.getAll("models"),
+			apiKeys: params.getAll("keys"),
+			status: params.get("status") ?? undefined,
+		},
+	});
+}
+
+/** True if the URL carries any param this feature owns. */
+export function hasAnalyticsParams(params: URLSearchParams): boolean {
+	return PARAM_KEYS.some((key) => params.has(key));
+}

--- a/packages/dashboard-web/src/lib/analytics-url-state.ts
+++ b/packages/dashboard-web/src/lib/analytics-url-state.ts
@@ -4,7 +4,7 @@ import type { FilterState } from "../components/analytics/AnalyticsFilters";
 export type AnalyticsUrlState = {
 	viewMode: "normal" | "cumulative";
 	timeRange: TimeRange;
-	selectedMetric: string;
+	selectedMetric: AnalyticsMetric;
 	modelBreakdown: boolean;
 	filters: FilterState;
 };
@@ -25,8 +25,17 @@ const METRIC_VALUES = [
 	"responseTime",
 	"tokensPerSecond",
 ] as const;
+
+/**
+ * The set of metrics the analytics chart can display — the single source of
+ * truth for `selectedMetric`. Typing the field as this union (rather than a
+ * bare `string`) means a metric added to `METRIC_VALUES` is reflected at every
+ * consumer, instead of silently falling back to "requests" when decoded.
+ */
+export type AnalyticsMetric = (typeof METRIC_VALUES)[number];
+
 const STATUS_VALUES = ["all", "success", "error"] as const;
-const RANGE_VALUES = Object.keys(TIME_RANGES) as TimeRange[];
+const RANGE_VALUES = Object.keys(TIME_RANGES) as readonly TimeRange[];
 
 // Query-string keys this feature owns. Used to decide URL-vs-storage hydration.
 const PARAM_KEYS = [

--- a/packages/dashboard-web/src/lib/analytics-url-state.ts
+++ b/packages/dashboard-web/src/lib/analytics-url-state.ts
@@ -45,7 +45,8 @@ function oneOf<T extends string>(
 	allowed: readonly T[],
 	fallback: T,
 ): T {
-	return typeof value === "string" && (allowed as readonly string[]).includes(value)
+	return typeof value === "string" &&
+		(allowed as readonly string[]).includes(value)
 		? (value as T)
 		: fallback;
 }
@@ -72,7 +73,8 @@ export function normalizeState(input: unknown): AnalyticsUrlState {
 	const raw = asRecord(input);
 	const filters = asRecord(raw.filters);
 	const viewMode = oneOf(raw.viewMode, VIEW_VALUES, "normal");
-	const breakdown = raw.modelBreakdown === true || raw.modelBreakdown === "true";
+	const breakdown =
+		raw.modelBreakdown === true || raw.modelBreakdown === "true";
 	return {
 		viewMode,
 		timeRange: oneOf(raw.timeRange, RANGE_VALUES, "1h"),
@@ -88,7 +90,9 @@ export function normalizeState(input: unknown): AnalyticsUrlState {
 }
 
 /** Serialize state to query params, omitting anything equal to its default. */
-export function encodeAnalyticsState(state: AnalyticsUrlState): URLSearchParams {
+export function encodeAnalyticsState(
+	state: AnalyticsUrlState,
+): URLSearchParams {
 	const params = new URLSearchParams();
 	if (state.viewMode !== "normal") params.set("view", state.viewMode);
 	if (state.timeRange !== "1h") params.set("range", state.timeRange);
@@ -96,15 +100,19 @@ export function encodeAnalyticsState(state: AnalyticsUrlState): URLSearchParams 
 		params.set("metric", state.selectedMetric);
 	if (state.modelBreakdown && state.viewMode !== "cumulative")
 		params.set("breakdown", "true");
-	for (const account of state.filters.accounts) params.append("accounts", account);
+	for (const account of state.filters.accounts)
+		params.append("accounts", account);
 	for (const model of state.filters.models) params.append("models", model);
 	for (const key of state.filters.apiKeys) params.append("keys", key);
-	if (state.filters.status !== "all") params.set("status", state.filters.status);
+	if (state.filters.status !== "all")
+		params.set("status", state.filters.status);
 	return params;
 }
 
 /** Parse query params back into a validated, normalized state. */
-export function decodeAnalyticsState(params: URLSearchParams): AnalyticsUrlState {
+export function decodeAnalyticsState(
+	params: URLSearchParams,
+): AnalyticsUrlState {
 	return normalizeState({
 		viewMode: params.get("view") ?? undefined,
 		timeRange: params.get("range") ?? undefined,


### PR DESCRIPTION
## What & why

The Analytics page's view controls were in-memory only, so reloading or sharing a link lost the selected view. This PR encodes those controls into the URL query string (shareable + reload-safe), with `localStorage` as a backup that restores the last selection on a fresh visit.

For example, clicking **Cumulative** now produces `/analytics?view=cumulative`, and that view survives a reload, back/forward, and a shared link.

## Scope

All persistable controls on the Analytics page are synced:

| Param | Values | Default (omitted from URL) |
|---|---|---|
| `view` | `normal` \| `cumulative` | `normal` |
| `range` | `1h` \| `6h` \| `24h` \| `7d` \| `30d` | `1h` |
| `metric` | `requests` \| `tokens` \| `cost` \| `responseTime` \| `tokensPerSecond` | `requests` |
| `breakdown` | `true` | `false` |
| `accounts` / `models` / `keys` | repeated param per selection | empty |
| `status` | `success` \| `error` | `all` |

`keys` maps to the API-key filter. The transient filter-popover open/close state is intentionally not persisted. Params equal to their default are omitted, so the default view stays a clean `/analytics`.

## Behavior

- **The URL is the single source of truth.** `localStorage` (`better-ccflare:analytics-state`) is a seed/backup only.
- On load: if the URL carries any recognized param, it wins (and is mirrored to `localStorage`). Otherwise, if a saved preference exists, the URL is seeded from it via history `replace`. Otherwise, defaults.
- All URL writes use `{ replace: true }`, so toggling controls doesn't pollute back-button history.
- Defensive decoding: invalid / hand-edited scalar values fall back to their default; the `view=cumulative ⇒ modelBreakdown=false` coupling (the per-model toggle is hidden in cumulative mode) is enforced centrally in `normalizeState`.
- **No backend change** — `useAnalytics(...)` already threads these values through its React Query key.

## Implementation

- `packages/dashboard-web/src/lib/analytics-url-state.ts` — pure, dependency-free serialization (`encodeAnalyticsState` / `decodeAnalyticsState` / `normalizeState` / `hasAnalyticsParams`), fully unit-tested.
- `packages/dashboard-web/src/hooks/useAnalyticsUrlState.ts` — wires `useSearchParams` + `localStorage`; a drop-in for the five `useState` calls `AnalyticsTab` previously held. A `didSeed` ref guarantees the one-time seed-from-storage runs exactly once (so resetting a control back to its default doesn't get re-seeded), and a `skipMirror` ref prevents the pre-seed render from clobbering a saved value with defaults.
- `packages/dashboard-web/src/components/AnalyticsTab.tsx` — uses the hook; the old inline `setViewMode` wrapper is removed since the cumulative coupling now lives in `normalizeState`.

## Testing

- 13 new unit tests for the serialization module (`bun test`): round-trip fidelity, defaults omitted, invalid-scalar fallback, cumulative coupling, filter-array encoding, and `normalizeState` coercion of garbage / stored input.
- The full `packages/dashboard-web` suite passes with no regressions.
- `bun run build:dashboard` succeeds.

The hook's effect glue (URL ⇄ `localStorage` sync) is covered by typecheck and manual behavioral testing — the repo has no jsdom/RTL harness for an effect-level test, so the bulk of the logic intentionally lives in the pure, well-tested module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
