### PR TITLE
feat: cache efficiency insights endpoint and dashboard tab

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,7 +68,9 @@ export {
 } from "./models";
 export {
 	estimateCostUSD,
+	getModelRates,
 	initializeNanoGPTPricingIfAccountsExist,
+	type ModelRates,
 	resetNanoGPTPricingCacheForTest,
 	setPricingLogger,
 	type TokenBreakdown,

--- a/packages/core/src/pricing.test.ts
+++ b/packages/core/src/pricing.test.ts
@@ -5,8 +5,10 @@ import {
 	estimateCostUSD,
 	fetchNanoGPTPricingData,
 	getCachedNanoGPTPricing,
+	getModelRates,
 	initializeNanoGPTPricingRefresh,
 	resetNanoGPTPricingCacheForTest,
+	setPricingLogger,
 	stopNanoGPTPricingRefresh,
 	type TokenBreakdown,
 } from "./pricing";
@@ -317,5 +319,116 @@ describe("NanoGPT Pricing", () => {
 			"nanogpt",
 		);
 		expect(initializeRefreshSpy).not.toHaveBeenCalled();
+	});
+});
+
+describe("getModelRates", () => {
+	let originalOffline: string | undefined;
+	let originalFetch: typeof global.fetch;
+
+	beforeEach(() => {
+		resetNanoGPTPricingCacheForTest();
+		originalOffline = process.env.CF_PRICING_OFFLINE;
+		process.env.CF_PRICING_OFFLINE = "1";
+		originalFetch = global.fetch;
+		// Block the NanoGPT fetch so only bundled pricing is used
+		global.fetch = vi.fn().mockRejectedValue(new Error("offline"));
+	});
+
+	afterEach(() => {
+		if (originalOffline === undefined) {
+			delete process.env.CF_PRICING_OFFLINE;
+		} else {
+			process.env.CF_PRICING_OFFLINE = originalOffline;
+		}
+		global.fetch = originalFetch;
+		resetNanoGPTPricingCacheForTest();
+		vi.restoreAllMocks();
+	});
+
+	it("should return full rates for a bundled model with cache pricing", async () => {
+		const rates = await getModelRates("claude-sonnet-4-20250514");
+
+		expect(rates).toEqual({
+			input: 3,
+			output: 15,
+			cacheRead: 0.3,
+			cacheWrite: 3.75,
+		});
+	});
+
+	it("should return null for an unknown model without throwing", async () => {
+		const rates = await getModelRates("totally-unknown-model-xyz");
+
+		expect(rates).toBeNull();
+	});
+
+	it("should return null cache rates for a bundled model without cache pricing", async () => {
+		const rates = await getModelRates("MiniMax-M2");
+
+		expect(rates).toEqual({
+			input: 0.3,
+			output: 1.2,
+			cacheRead: null,
+			cacheWrite: null,
+		});
+	});
+
+	it("should return null and warn when the catalogue has malformed cost data", async () => {
+		// Inject a malformed model via the NanoGPT merge path: pricing values
+		// flow straight into cost.input/cost.output without validation.
+		global.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				object: "list",
+				data: [
+					{
+						id: "malformed-cost-model",
+						name: "Malformed Cost Model",
+						pricing: {
+							prompt: "not-a-number",
+							completion: Number.NaN,
+							currency: "USD",
+							unit: "per_million_tokens",
+						},
+					},
+				],
+			}),
+		} as unknown as Response);
+
+		const warnLogger = { warn: vi.fn(), debug: vi.fn() };
+		setPricingLogger(warnLogger);
+
+		const rates = await getModelRates("malformed-cost-model");
+
+		expect(rates).toBeNull();
+		expect(warnLogger.warn).toHaveBeenCalledWith(
+			"Price for model %s not found - cache savings reported as unknown",
+			"malformed-cost-model",
+		);
+	});
+
+	it("should still warn when estimateCostUSD warned first for the same model", async () => {
+		const warnLogger = { warn: vi.fn(), debug: vi.fn() };
+		setPricingLogger(warnLogger);
+
+		// estimateCostUSD warns first via warnOnce (cost set to 0)
+		const cost = await estimateCostUSD("unknown-model-warn-dedup", {
+			inputTokens: 100,
+		});
+		expect(cost).toBe(0);
+		expect(warnLogger.warn).toHaveBeenCalledWith(
+			"Price for model %s not found - cost set to 0 (reason: %s)",
+			"unknown-model-warn-dedup",
+			expect.any(String),
+		);
+
+		// getModelRates must still emit its own distinct warning
+		const rates = await getModelRates("unknown-model-warn-dedup");
+		expect(rates).toBeNull();
+		expect(warnLogger.warn).toHaveBeenCalledWith(
+			"Price for model %s not found - cache savings reported as unknown",
+			"unknown-model-warn-dedup",
+		);
 	});
 });

--- a/packages/core/src/pricing.ts
+++ b/packages/core/src/pricing.ts
@@ -219,6 +219,7 @@ class PriceCatalogue {
 	private priceData: ApiResponse | null = null;
 	private lastFetch = 0;
 	private warnedModels = new Set<string>();
+	private warnedRatesUnknownModels = new Set<string>();
 	private logger: Logger | null = null;
 
 	private constructor() {}
@@ -510,6 +511,19 @@ class PriceCatalogue {
 			}
 		}
 	}
+
+	/**
+	 * Warn once that a model has no usable rates. Unlike warnOnce, the message
+	 * reflects that cache savings are reported as unknown rather than 0.
+	 */
+	warnRatesUnknownOnce(modelId: string): void {
+		if (this.warnedRatesUnknownModels.has(modelId)) return;
+		this.warnedRatesUnknownModels.add(modelId);
+		this.logger?.warn(
+			"Price for model %s not found - cache savings reported as unknown",
+			modelId,
+		);
+	}
 }
 
 /**
@@ -724,6 +738,22 @@ export function setPricingLogger(logger: Logger): void {
 }
 
 /**
+ * Find a model definition in the pricing catalogue across all providers
+ */
+async function findModel(modelId: string): Promise<ModelDef | null> {
+	const pricing = await PriceCatalogue.get().getPricing();
+
+	// Search all providers for the model
+	for (const provider of Object.values(pricing)) {
+		if (provider.models?.[modelId]) {
+			return provider.models[modelId];
+		}
+	}
+
+	return null;
+}
+
+/**
  * Get the cost rate for a specific model and token type
  * @returns Cost in dollars per token (NOT per million)
  * @throws If model or cost type is unknown
@@ -732,35 +762,65 @@ async function getCostRate(
 	modelId: string,
 	kind: "input" | "output" | "cache_read" | "cache_write",
 ): Promise<number> {
-	const catalogue = PriceCatalogue.get();
-	const pricing = await catalogue.getPricing();
-
-	// Search all providers for the model
-	for (const provider of Object.values(pricing)) {
-		if (provider.models?.[modelId]) {
-			const model = provider.models[modelId];
-			if (!model.cost) {
-				throw new Error(`Model ${modelId} has no cost information`);
-			}
-
-			const costKey =
-				kind === "cache_read" || kind === "cache_write"
-					? kind
-					: kind === "input"
-						? "input"
-						: "output";
-			const costPerMillion = model.cost[costKey];
-
-			if (costPerMillion === undefined) {
-				throw new Error(`Model ${modelId} has no ${kind} cost`);
-			}
-
-			// Convert from per-million to per-token
-			return costPerMillion / 1_000_000;
-		}
+	const model = await findModel(modelId);
+	if (!model) {
+		throw new Error(`Model ${modelId} not found in pricing catalogue`);
+	}
+	if (!model.cost) {
+		throw new Error(`Model ${modelId} has no cost information`);
 	}
 
-	throw new Error(`Model ${modelId} not found in pricing catalogue`);
+	const costPerMillion = model.cost[kind];
+
+	if (costPerMillion === undefined) {
+		throw new Error(`Model ${modelId} has no ${kind} cost`);
+	}
+
+	// Convert from per-million to per-token
+	return costPerMillion / 1_000_000;
+}
+
+export interface ModelRates {
+	input: number; // $ per 1M tokens
+	output: number; // $ per 1M tokens
+	cacheRead: number | null;
+	cacheWrite: number | null;
+}
+
+/**
+ * Get the per-model pricing rates in dollars per 1M tokens
+ * @returns Rates for the model, or null if the model is unknown
+ */
+export async function getModelRates(
+	modelId: string,
+): Promise<ModelRates | null> {
+	const model = await findModel(modelId);
+	const cost = model?.cost;
+	if (
+		!cost ||
+		typeof cost.input !== "number" ||
+		!Number.isFinite(cost.input) ||
+		typeof cost.output !== "number" ||
+		!Number.isFinite(cost.output)
+	) {
+		// Missing or malformed catalogue data (remote catalogues are not
+		// validated) - treat as unknown pricing rather than emitting NaN.
+		PriceCatalogue.get().warnRatesUnknownOnce(modelId);
+		return null;
+	}
+
+	return {
+		input: cost.input,
+		output: cost.output,
+		cacheRead:
+			typeof cost.cache_read === "number" && Number.isFinite(cost.cache_read)
+				? cost.cache_read
+				: null,
+		cacheWrite:
+			typeof cost.cache_write === "number" && Number.isFinite(cost.cache_write)
+				? cost.cache_write
+				: null,
+	};
 }
 
 /**

--- a/packages/core/src/pricing.ts
+++ b/packages/core/src/pricing.ts
@@ -516,13 +516,48 @@ class PriceCatalogue {
 	 * Warn once that a model has no usable rates. Unlike warnOnce, the message
 	 * reflects that cache savings are reported as unknown rather than 0.
 	 */
-	warnRatesUnknownOnce(modelId: string): void {
+	private warnRatesUnknownOnce(modelId: string): void {
 		if (this.warnedRatesUnknownModels.has(modelId)) return;
 		this.warnedRatesUnknownModels.add(modelId);
 		this.logger?.warn(
 			"Price for model %s not found - cache savings reported as unknown",
 			modelId,
 		);
+	}
+
+	/**
+	 * Get the per-model pricing rates in dollars per 1M tokens.
+	 * @returns Rates for the model, or null if the model is unknown
+	 */
+	async getModelRates(modelId: string): Promise<ModelRates | null> {
+		const model = await findModel(modelId);
+		const cost = model?.cost;
+		if (
+			!cost ||
+			typeof cost.input !== "number" ||
+			!Number.isFinite(cost.input) ||
+			typeof cost.output !== "number" ||
+			!Number.isFinite(cost.output)
+		) {
+			// Missing or malformed catalogue data (remote catalogues are not
+			// validated) - treat as unknown pricing rather than emitting NaN.
+			this.warnRatesUnknownOnce(modelId);
+			return null;
+		}
+
+		return {
+			input: cost.input,
+			output: cost.output,
+			cacheRead:
+				typeof cost.cache_read === "number" && Number.isFinite(cost.cache_read)
+					? cost.cache_read
+					: null,
+			cacheWrite:
+				typeof cost.cache_write === "number" &&
+				Number.isFinite(cost.cache_write)
+					? cost.cache_write
+					: null,
+		};
 	}
 }
 
@@ -794,33 +829,7 @@ export interface ModelRates {
 export async function getModelRates(
 	modelId: string,
 ): Promise<ModelRates | null> {
-	const model = await findModel(modelId);
-	const cost = model?.cost;
-	if (
-		!cost ||
-		typeof cost.input !== "number" ||
-		!Number.isFinite(cost.input) ||
-		typeof cost.output !== "number" ||
-		!Number.isFinite(cost.output)
-	) {
-		// Missing or malformed catalogue data (remote catalogues are not
-		// validated) - treat as unknown pricing rather than emitting NaN.
-		PriceCatalogue.get().warnRatesUnknownOnce(modelId);
-		return null;
-	}
-
-	return {
-		input: cost.input,
-		output: cost.output,
-		cacheRead:
-			typeof cost.cache_read === "number" && Number.isFinite(cost.cache_read)
-				? cost.cache_read
-				: null,
-		cacheWrite:
-			typeof cost.cache_write === "number" && Number.isFinite(cost.cache_write)
-				? cost.cache_write
-				: null,
-	};
+	return PriceCatalogue.get().getModelRates(modelId);
 }
 
 /**

--- a/packages/dashboard-web/src/App.tsx
+++ b/packages/dashboard-web/src/App.tsx
@@ -29,6 +29,11 @@ const LazyAnalyticsTab = lazy(() =>
 		default: module.LazyAnalytics,
 	})),
 );
+const LazyInsightsTab = lazy(() =>
+	import("./components/InsightsTab").then((module) => ({
+		default: module.InsightsTab,
+	})),
+);
 const LoadingSkeleton = () => (
 	<div className="space-y-6 p-6">
 		<div className="animate-pulse">
@@ -77,6 +82,16 @@ export function App() {
 				subtitle: "Deep dive into your usage patterns and trends",
 			},
 			{
+				path: "/insights",
+				element: (
+					<Suspense fallback={<LoadingSkeleton />}>
+						<LazyInsightsTab />
+					</Suspense>
+				),
+				title: "Insights",
+				subtitle: "Cache efficiency and estimated cost savings",
+			},
+			{
 				path: "/requests",
 				element: <RequestsTab />,
 				title: "Request History",
@@ -114,9 +129,9 @@ export function App() {
 			},
 		];
 
-		// Add combos route if feature is enabled
+		// Add combos route if feature is enabled (after Accounts, matching the nav)
 		if (showCombos) {
-			baseRoutes.splice(4, 0, {
+			baseRoutes.splice(5, 0, {
 				path: "/combos",
 				element: <CombosTab />,
 				title: "Combos Management",

--- a/packages/dashboard-web/src/api.ts
+++ b/packages/dashboard-web/src/api.ts
@@ -9,6 +9,7 @@ import type {
 	AgentUpdatePayload,
 	AgentWorkspace,
 	AnalyticsResponse,
+	CacheInsightsResponse,
 	Combo,
 	ComboFamilyAssignment,
 	ComboSlot,
@@ -959,6 +960,21 @@ class API extends HttpClient {
 
 			throw error;
 		}
+	}
+
+	async getCacheInsights(
+		range = "24h",
+		threshold?: number,
+	): Promise<CacheInsightsResponse> {
+		const params = new URLSearchParams({ range });
+
+		if (threshold !== undefined) {
+			params.append("threshold", String(threshold));
+		}
+
+		return this.get<CacheInsightsResponse>(
+			`/api/insights/cache?${params.toString()}`,
+		);
 	}
 
 	// Batch analytics requests for improved performance

--- a/packages/dashboard-web/src/components/InsightsTab.tsx
+++ b/packages/dashboard-web/src/components/InsightsTab.tsx
@@ -1,0 +1,43 @@
+import { AlertTriangle } from "lucide-react";
+import React, { useState } from "react";
+import type { TimeRange } from "../constants";
+import { useCacheInsights } from "../hooks/queries";
+import { CacheEfficiencyView } from "./insights/CacheEfficiencyView";
+import { TimeRangeSelector } from "./overview/TimeRangeSelector";
+import { Card, CardContent } from "./ui/card";
+
+export const InsightsTab = React.memo(() => {
+	const [timeRange, setTimeRange] = useState<TimeRange>("24h");
+
+	// Fetch cache insights with automatic refetch on range changes
+	const { data, isLoading: loading, isError } = useCacheInsights(timeRange);
+
+	return (
+		<div className="space-y-6">
+			{/* Controls */}
+			<div className="flex flex-col sm:flex-row gap-4 justify-between">
+				<TimeRangeSelector
+					value={timeRange}
+					onChange={(value) => setTimeRange(value as TimeRange)}
+				/>
+			</div>
+
+			{isError ? (
+				<Card>
+					<CardContent className="p-6">
+						<div className="flex items-center gap-2 text-destructive">
+							<AlertTriangle className="h-5 w-5" />
+							<span>Failed to load cache insights. Please try again.</span>
+						</div>
+					</CardContent>
+				</Card>
+			) : (
+				<CacheEfficiencyView
+					data={data}
+					loading={loading}
+					timeRange={timeRange}
+				/>
+			)}
+		</div>
+	);
+});

--- a/packages/dashboard-web/src/components/InsightsTab.tsx
+++ b/packages/dashboard-web/src/components/InsightsTab.tsx
@@ -41,3 +41,5 @@ export const InsightsTab = React.memo(() => {
 		</div>
 	);
 });
+
+InsightsTab.displayName = "InsightsTab";

--- a/packages/dashboard-web/src/components/insights/CacheEfficiencyView.tsx
+++ b/packages/dashboard-web/src/components/insights/CacheEfficiencyView.tsx
@@ -208,7 +208,9 @@ export function CacheEfficiencyView({
 
 				<Card>
 					<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-						<CardTitle className="text-sm font-medium">Actual Cost</CardTitle>
+						<CardTitle className="text-sm font-medium">
+							Cache Token Cost
+						</CardTitle>
 						<DollarSign className="h-4 w-4 text-muted-foreground" />
 					</CardHeader>
 					<CardContent>
@@ -216,8 +218,8 @@ export function CacheEfficiencyView({
 							{formatCost(totals?.actualCacheCostUsd ?? 0)}
 						</div>
 						<p className="text-xs text-muted-foreground">
-							vs {formatCost(totals?.counterfactualCostUsd ?? 0)} without
-							caching
+							Cache read/write tokens only, vs{" "}
+							{formatCost(totals?.counterfactualCostUsd ?? 0)} without caching
 						</p>
 					</CardContent>
 				</Card>

--- a/packages/dashboard-web/src/components/insights/CacheEfficiencyView.tsx
+++ b/packages/dashboard-web/src/components/insights/CacheEfficiencyView.tsx
@@ -1,0 +1,312 @@
+import type {
+	CacheInsightsResponse,
+	CacheInsightsRow,
+} from "@better-ccflare/types";
+import {
+	formatCost,
+	formatNumber,
+	formatPercentage,
+	formatTokens,
+} from "@better-ccflare/ui-common";
+import {
+	Activity,
+	AlertTriangle,
+	DollarSign,
+	Percent,
+	PiggyBank,
+} from "lucide-react";
+import type { TimeRange } from "../../constants";
+import { BasePieChart } from "../charts";
+import { Badge } from "../ui/badge";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "../ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
+
+interface CacheEfficiencyViewProps {
+	data?: CacheInsightsResponse;
+	loading?: boolean;
+	timeRange: TimeRange;
+}
+
+/** Format a USD amount that may legitimately be negative. */
+function formatSignedCost(value: number): string {
+	return value < 0 ? `-${formatCost(-value)}` : formatCost(value);
+}
+
+function savingsColorClass(value: number): string {
+	if (value < 0) return "text-destructive";
+	if (value > 0) return "text-green-500";
+	return "";
+}
+
+interface BreakdownTableProps {
+	rows: CacheInsightsRow[];
+	nameLabel: string;
+}
+
+function BreakdownTable({ rows, nameLabel }: BreakdownTableProps) {
+	if (rows.length === 0) {
+		return (
+			<p className="text-sm text-muted-foreground py-4">
+				No data for this period
+			</p>
+		);
+	}
+
+	return (
+		<div className="overflow-x-auto">
+			<table
+				aria-label={`Cache efficiency by ${nameLabel.toLowerCase()}`}
+				className="w-full text-sm"
+			>
+				<thead className="bg-muted/50">
+					<tr>
+						<th scope="col" className="text-left px-3 py-2">
+							{nameLabel}
+						</th>
+						<th scope="col" className="text-right px-3 py-2">
+							Requests
+						</th>
+						<th scope="col" className="text-right px-3 py-2">
+							Hit Rate
+						</th>
+						<th scope="col" className="text-right px-3 py-2">
+							Savings
+						</th>
+					</tr>
+				</thead>
+				<tbody>
+					{rows.map((row) => (
+						<tr key={row.key} className="border-t">
+							<td className="px-3 py-2">
+								<div className="flex items-center gap-2">
+									<span className="text-muted-foreground break-all">
+										{row.key}
+									</span>
+									{row.flagged && (
+										<Badge variant="warning" className="whitespace-nowrap">
+											<AlertTriangle className="h-3 w-3 mr-1" />
+											Low cache hit
+										</Badge>
+									)}
+								</div>
+							</td>
+							<td className="px-3 py-2 text-right">
+								{formatNumber(row.requests)}
+							</td>
+							<td className="px-3 py-2 text-right">
+								{formatPercentage(row.cacheHitRate)}
+							</td>
+							<td className="px-3 py-2 text-right">
+								{row.pricingKnown && row.savingsUsd !== null ? (
+									<span className={savingsColorClass(row.savingsUsd)}>
+										{formatSignedCost(row.savingsUsd)}
+									</span>
+								) : (
+									<span
+										className="text-muted-foreground"
+										title="No pricing data for this model"
+									>
+										—
+									</span>
+								)}
+							</td>
+						</tr>
+					))}
+				</tbody>
+			</table>
+		</div>
+	);
+}
+
+export function CacheEfficiencyView({
+	data,
+	loading = false,
+	timeRange,
+}: CacheEfficiencyViewProps) {
+	const totals = data?.totals;
+
+	const tokenComposition = [
+		{
+			name: "Uncached Input",
+			value: totals?.uncachedInputTokens ?? 0,
+		},
+		{
+			name: "Cache Read",
+			value: totals?.cacheReadInputTokens ?? 0,
+		},
+		{
+			name: "Cache Creation",
+			value: totals?.cacheCreationInputTokens ?? 0,
+		},
+	].filter((item) => item.value > 0);
+
+	const totalInputTokens =
+		(totals?.uncachedInputTokens ?? 0) +
+		(totals?.cacheReadInputTokens ?? 0) +
+		(totals?.cacheCreationInputTokens ?? 0);
+
+	return (
+		<div className="space-y-6">
+			{/* Summary Cards */}
+			<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+				<Card>
+					<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+						<CardTitle className="text-sm font-medium">Cache Savings</CardTitle>
+						<PiggyBank className="h-4 w-4 text-muted-foreground" />
+					</CardHeader>
+					<CardContent>
+						<div
+							className={`text-2xl font-bold ${savingsColorClass(totals?.savingsUsd ?? 0)}`}
+						>
+							{formatSignedCost(totals?.savingsUsd ?? 0)}
+						</div>
+						<p className="text-xs text-muted-foreground">
+							Estimated vs. running uncached in the last {timeRange}
+						</p>
+					</CardContent>
+				</Card>
+
+				<Card>
+					<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+						<CardTitle className="text-sm font-medium">
+							Cache Hit Rate
+						</CardTitle>
+						<Percent className="h-4 w-4 text-muted-foreground" />
+					</CardHeader>
+					<CardContent>
+						<div className="text-2xl font-bold">
+							{formatPercentage(totals?.cacheHitRate ?? 0)}
+						</div>
+						<p className="text-xs text-muted-foreground">
+							Cache reads as share of input tokens
+						</p>
+					</CardContent>
+				</Card>
+
+				<Card>
+					<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+						<CardTitle className="text-sm font-medium">
+							Total Requests
+						</CardTitle>
+						<Activity className="h-4 w-4 text-muted-foreground" />
+					</CardHeader>
+					<CardContent>
+						<div className="text-2xl font-bold">
+							{formatNumber(totals?.requests ?? 0)}
+						</div>
+						<p className="text-xs text-muted-foreground">
+							Requests analyzed in the last {timeRange}
+						</p>
+					</CardContent>
+				</Card>
+
+				<Card>
+					<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+						<CardTitle className="text-sm font-medium">Actual Cost</CardTitle>
+						<DollarSign className="h-4 w-4 text-muted-foreground" />
+					</CardHeader>
+					<CardContent>
+						<div className="text-2xl font-bold">
+							{formatCost(totals?.actualCacheCostUsd ?? 0)}
+						</div>
+						<p className="text-xs text-muted-foreground">
+							vs {formatCost(totals?.counterfactualCostUsd ?? 0)} without
+							caching
+						</p>
+					</CardContent>
+				</Card>
+			</div>
+
+			{/* Token Composition + Breakdown */}
+			<div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+				<Card>
+					<CardHeader>
+						<CardTitle>Input Token Composition</CardTitle>
+						<CardDescription>
+							Uncached vs. cached input tokens in the last {timeRange}
+						</CardDescription>
+					</CardHeader>
+					<CardContent>
+						<BasePieChart
+							data={tokenComposition}
+							loading={loading}
+							height="small"
+							innerRadius={60}
+							outerRadius={80}
+							paddingAngle={5}
+							tooltipStyle="success"
+							tooltipFormatter={(value, name) => [
+								`${formatTokens(value as number)} tokens`,
+								name ?? "",
+							]}
+							showLegend
+						/>
+						<div className="mt-4 pt-4 border-t">
+							<div className="flex items-center justify-between text-sm">
+								<span className="font-medium">Total Input Tokens</span>
+								<span className="font-bold">
+									{formatTokens(totalInputTokens)}
+								</span>
+							</div>
+						</div>
+					</CardContent>
+				</Card>
+
+				<Card>
+					<CardHeader>
+						<CardTitle>Cache Efficiency Breakdown</CardTitle>
+						<CardDescription>
+							Hit rate and estimated savings per dimension
+						</CardDescription>
+					</CardHeader>
+					<CardContent>
+						<Tabs defaultValue="model" className="space-y-4">
+							<TabsList className="grid w-full grid-cols-3">
+								<TabsTrigger value="model">By Model</TabsTrigger>
+								<TabsTrigger value="account">By Account</TabsTrigger>
+								<TabsTrigger value="project">By Project</TabsTrigger>
+							</TabsList>
+							<TabsContent value="model">
+								<BreakdownTable rows={data?.byModel ?? []} nameLabel="Model" />
+							</TabsContent>
+							<TabsContent value="account">
+								<BreakdownTable
+									rows={data?.byAccount ?? []}
+									nameLabel="Account"
+								/>
+							</TabsContent>
+							<TabsContent value="project">
+								<BreakdownTable
+									rows={data?.byProject ?? []}
+									nameLabel="Project"
+								/>
+							</TabsContent>
+						</Tabs>
+					</CardContent>
+				</Card>
+			</div>
+
+			{/* Footnotes */}
+			<div className="space-y-1">
+				{totals && totals.unknownPricingModels.length > 0 && (
+					<p className="text-xs text-muted-foreground">
+						<AlertTriangle className="h-3 w-3 inline mr-1" />
+						No pricing data for: {totals.unknownPricingModels.join(", ")}.
+						Savings exclude this traffic.
+					</p>
+				)}
+				<p className="text-xs text-muted-foreground">
+					Savings on plan-billed (subscription) traffic are notional — they
+					reflect what the same usage would cost at API rates, not money
+					actually spent.
+				</p>
+			</div>
+		</div>
+	);
+}

--- a/packages/dashboard-web/src/components/navigation.tsx
+++ b/packages/dashboard-web/src/components/navigation.tsx
@@ -7,6 +7,7 @@ import {
 	GitBranch,
 	Key,
 	LayoutDashboard,
+	Lightbulb,
 	LogOut,
 	Menu,
 	RefreshCw,
@@ -41,6 +42,7 @@ interface NavItem {
 const _navItems: NavItem[] = [
 	{ label: "Overview", icon: LayoutDashboard, path: "/" },
 	{ label: "Analytics", icon: BarChart3, path: "/analytics" },
+	{ label: "Insights", icon: Lightbulb, path: "/insights" },
 	{ label: "Requests", icon: Activity, path: "/requests" },
 	{ label: "Accounts", icon: Users, path: "/accounts" },
 	// { label: "Combos", icon: Zap, path: "/combos" },
@@ -73,6 +75,7 @@ export function Navigation({
 		const baseItems: NavItem[] = [
 			{ label: "Overview", icon: LayoutDashboard, path: "/" },
 			{ label: "Analytics", icon: BarChart3, path: "/analytics" },
+			{ label: "Insights", icon: Lightbulb, path: "/insights" },
 			{ label: "Requests", icon: Activity, path: "/requests" },
 			{ label: "Accounts", icon: Users, path: "/accounts" },
 		];

--- a/packages/dashboard-web/src/hooks/queries.ts
+++ b/packages/dashboard-web/src/hooks/queries.ts
@@ -216,6 +216,18 @@ export const useAnalytics = (
 	});
 };
 
+export const useCacheInsights = (timeRange: string, threshold?: number) => {
+	return useQuery({
+		queryKey: queryKeys.insightsCache(timeRange, threshold),
+		queryFn: () => api.getCacheInsights(timeRange, threshold),
+		staleTime: 45000,
+		refetchInterval: 60000,
+		refetchIntervalInBackground: false,
+		gcTime: 15 * 60 * 1000,
+		enabled: !!timeRange,
+	});
+};
+
 export const useRequests = (limit: number, _refetchInterval?: number) => {
 	return useQuery({
 		queryKey: queryKeys.requests(limit),

--- a/packages/dashboard-web/src/lib/query-keys.ts
+++ b/packages/dashboard-web/src/lib/query-keys.ts
@@ -17,6 +17,8 @@ export const queryKeys = {
 			"analytics",
 			{ timeRange, filters, viewMode, modelBreakdown },
 		] as const,
+	insightsCache: (timeRange?: string, threshold?: number) =>
+		[...queryKeys.all, "insights", "cache", { timeRange, threshold }] as const,
 	requests: (limit?: number) =>
 		[...queryKeys.all, "requests", { limit }] as const,
 	logs: () => [...queryKeys.all, "logs"] as const,

--- a/packages/http-api/src/handlers/__tests__/insights-cache.test.ts
+++ b/packages/http-api/src/handlers/__tests__/insights-cache.test.ts
@@ -1,0 +1,446 @@
+import { Database } from "bun:sqlite";
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+} from "bun:test";
+import { resetNanoGPTPricingCacheForTest } from "@better-ccflare/core";
+import {
+	BunSqlAdapter,
+	ensureSchema,
+	runMigrations,
+} from "@better-ccflare/database";
+import type { APIContext } from "../../types";
+import { createCacheInsightsHandler } from "../insights";
+
+// Bundled pricing for claude-sonnet-4-20250514 ($ per 1M tokens)
+const SONNET = "claude-sonnet-4-20250514";
+const SONNET_INPUT = 3;
+const SONNET_CACHE_READ = 0.3;
+const SONNET_CACHE_WRITE = 3.75;
+const MILLION = 1_000_000;
+
+// ---------------------------------------------------------------------------
+// Pricing isolation: force bundled pricing only (no models.dev / NanoGPT
+// network fetches) for every test in this file.
+// ---------------------------------------------------------------------------
+
+let originalOffline: string | undefined;
+let originalFetch: typeof globalThis.fetch;
+
+beforeAll(() => {
+	resetNanoGPTPricingCacheForTest();
+	originalOffline = process.env.CF_PRICING_OFFLINE;
+	process.env.CF_PRICING_OFFLINE = "1";
+	originalFetch = globalThis.fetch;
+	globalThis.fetch = (() =>
+		Promise.reject(new Error("offline"))) as unknown as typeof fetch;
+});
+
+afterAll(() => {
+	if (originalOffline === undefined) {
+		delete process.env.CF_PRICING_OFFLINE;
+	} else {
+		process.env.CF_PRICING_OFFLINE = originalOffline;
+	}
+	globalThis.fetch = originalFetch;
+	resetNanoGPTPricingCacheForTest();
+});
+
+// ---------------------------------------------------------------------------
+// Mock-adapter tests
+// ---------------------------------------------------------------------------
+
+type SqlRow = {
+	dimension_key: string | null;
+	model: string | null;
+	requests: number;
+	uncached_input_tokens: number;
+	cache_read_input_tokens: number;
+	cache_creation_input_tokens: number;
+};
+
+function createMockContext(
+	accountRows: SqlRow[],
+	projectRows: SqlRow[],
+): APIContext {
+	const mockDb = {
+		// First query (account x model) carries the accounts LEFT JOIN;
+		// second query (project x model) does not.
+		query: async (sql: string) =>
+			sql.includes("LEFT JOIN accounts") ? accountRows : projectRows,
+	};
+
+	return {
+		db: {} as APIContext["db"],
+		config: {} as APIContext["config"],
+		dbOps: {
+			getAdapter: () => mockDb,
+		} as unknown as APIContext["dbOps"],
+	};
+}
+
+const sonnetAccountRow: SqlRow = {
+	dimension_key: "acct-A",
+	model: SONNET,
+	requests: 12,
+	uncached_input_tokens: 1_000_000,
+	cache_read_input_tokens: 2_000_000,
+	cache_creation_input_tokens: 400_000,
+};
+
+const sonnetProjectRow: SqlRow = { ...sonnetAccountRow, dimension_key: "proj" };
+
+describe("cache insights handler (mock adapter)", () => {
+	it("returns meta/totals/byModel/byAccount/byProject with defaults surfaced in meta", async () => {
+		const context = createMockContext([sonnetAccountRow], [sonnetProjectRow]);
+		const response = await createCacheInsightsHandler(context)(
+			new URLSearchParams(),
+		);
+		expect(response.status).toBe(200);
+		const data = await response.json();
+
+		expect(data.meta).toEqual({
+			range: "24h",
+			thresholdPercent: 50,
+			minRequestsForFlag: 10,
+		});
+		expect(Array.isArray(data.byModel)).toBe(true);
+		expect(Array.isArray(data.byAccount)).toBe(true);
+		expect(Array.isArray(data.byProject)).toBe(true);
+
+		// Hand-computed dollars for the sonnet volume:
+		// actual = 2M * 0.3/1M + 0.4M * 3.75/1M = 0.6 + 1.5 = 2.1
+		// counterfactual = 2.4M * 3/1M = 7.2 ; savings = 5.1
+		expect(data.totals.requests).toBe(12);
+		expect(data.totals.actualCacheCostUsd).toBeCloseTo(2.1, 10);
+		expect(data.totals.counterfactualCostUsd).toBeCloseTo(7.2, 10);
+		expect(data.totals.savingsUsd).toBeCloseTo(5.1, 10);
+		expect(data.totals.unknownPricingModels).toEqual([]);
+
+		expect(data.byAccount[0].key).toBe("acct-A");
+		expect(data.byAccount[0].pricingKnown).toBe(true);
+		expect(data.byAccount[0].savingsUsd).toBeCloseTo(5.1, 10);
+		expect(data.byModel[0].key).toBe(SONNET);
+		expect(data.byProject[0].key).toBe("proj");
+	});
+
+	it("echoes the range param in meta", async () => {
+		const context = createMockContext([sonnetAccountRow], [sonnetProjectRow]);
+		const response = await createCacheInsightsHandler(context)(
+			new URLSearchParams("range=7d"),
+		);
+		const data = await response.json();
+		expect(data.meta.range).toBe("7d");
+	});
+
+	it("reports the effective range in meta when the range param is unknown", async () => {
+		const context = createMockContext([sonnetAccountRow], [sonnetProjectRow]);
+		const response = await createCacheInsightsHandler(context)(
+			new URLSearchParams("range=bogus"),
+		);
+		const data = await response.json();
+		// "bogus" falls back to the 24h window, and meta must reflect that.
+		expect(data.meta.range).toBe("24h");
+	});
+
+	it("respects the threshold param and applies it to flagging", async () => {
+		const context = createMockContext([sonnetAccountRow], [sonnetProjectRow]);
+
+		// Row hit rate = 2M * 100 / 3.4M ~ 58.8% with 12 requests (>= 10).
+		const lowThreshold = await (
+			await createCacheInsightsHandler(context)(
+				new URLSearchParams("threshold=30"),
+			)
+		).json();
+		expect(lowThreshold.meta.thresholdPercent).toBe(30);
+		expect(lowThreshold.byAccount[0].flagged).toBe(false);
+
+		const highThreshold = await (
+			await createCacheInsightsHandler(context)(
+				new URLSearchParams("threshold=80"),
+			)
+		).json();
+		expect(highThreshold.meta.thresholdPercent).toBe(80);
+		expect(highThreshold.byAccount[0].flagged).toBe(true);
+	});
+
+	it("clamps the threshold param to 0-100", async () => {
+		const context = createMockContext([sonnetAccountRow], [sonnetProjectRow]);
+
+		const over = await (
+			await createCacheInsightsHandler(context)(
+				new URLSearchParams("threshold=150"),
+			)
+		).json();
+		expect(over.meta.thresholdPercent).toBe(100);
+
+		const under = await (
+			await createCacheInsightsHandler(context)(
+				new URLSearchParams("threshold=-20"),
+			)
+		).json();
+		expect(under.meta.thresholdPercent).toBe(0);
+	});
+
+	it("falls back to the default threshold for non-numeric input", async () => {
+		const context = createMockContext([sonnetAccountRow], [sonnetProjectRow]);
+		const data = await (
+			await createCacheInsightsHandler(context)(
+				new URLSearchParams("threshold=abc"),
+			)
+		).json();
+		expect(data.meta.thresholdPercent).toBe(50);
+	});
+
+	it("reports unknown models with null costs and lists them in totals", async () => {
+		const unknownRow: SqlRow = {
+			dimension_key: "acct-A",
+			model: "totally-unknown-model-xyz",
+			requests: 3,
+			uncached_input_tokens: 100,
+			cache_read_input_tokens: 50,
+			cache_creation_input_tokens: 0,
+		};
+		const context = createMockContext(
+			[unknownRow],
+			[{ ...unknownRow, dimension_key: null }],
+		);
+		const data = await (
+			await createCacheInsightsHandler(context)(new URLSearchParams())
+		).json();
+
+		expect(data.byModel[0].key).toBe("totally-unknown-model-xyz");
+		expect(data.byModel[0].pricingKnown).toBe(false);
+		expect(data.byModel[0].actualCacheCostUsd).toBeNull();
+		expect(data.byModel[0].counterfactualCostUsd).toBeNull();
+		expect(data.byModel[0].savingsUsd).toBeNull();
+		expect(data.totals.unknownPricingModels).toEqual([
+			"totally-unknown-model-xyz",
+		]);
+		// A null dimension key is reported under "Unknown"
+		expect(data.byProject[0].key).toBe("Unknown");
+	});
+
+	it("returns a 500 error response when the query fails", async () => {
+		const context = {
+			db: {} as APIContext["db"],
+			config: {} as APIContext["config"],
+			dbOps: {
+				getAdapter: () => ({
+					query: async () => {
+						throw new Error("boom");
+					},
+				}),
+			} as unknown as APIContext["dbOps"],
+		};
+		const response = await createCacheInsightsHandler(context)(
+			new URLSearchParams(),
+		);
+		expect(response.status).toBe(500);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Integration test: real in-memory SQLite
+// ---------------------------------------------------------------------------
+
+describe("cache insights handler (SQLite integration)", () => {
+	let db: Database;
+	let context: APIContext;
+
+	function insertRequest(opts: {
+		id: string;
+		timestamp: number;
+		accountUsed: string | null;
+		model: string | null;
+		inputTokens: number;
+		cacheReadTokens: number;
+		cacheCreationTokens: number;
+		project: string | null;
+	}): void {
+		db.run(
+			`INSERT INTO requests
+				(id, timestamp, method, path, account_used, status_code, success,
+				 response_time_ms, failover_attempts, model, input_tokens,
+				 cache_read_input_tokens, cache_creation_input_tokens, project)
+			 VALUES (?, ?, 'POST', '/v1/messages', ?, 200, 1, 100, 0, ?, ?, ?, ?, ?)`,
+			[
+				opts.id,
+				opts.timestamp,
+				opts.accountUsed,
+				opts.model,
+				opts.inputTokens,
+				opts.cacheReadTokens,
+				opts.cacheCreationTokens,
+				opts.project,
+			],
+		);
+	}
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		ensureSchema(db);
+		runMigrations(db);
+
+		db.run(
+			"INSERT INTO accounts (id, name, created_at) VALUES ('a1', 'acct-A', ?)",
+			[Date.now()],
+		);
+
+		const now = Date.now();
+		// r1: sonnet, project proj-x
+		insertRequest({
+			id: "r1",
+			timestamp: now - 1000,
+			accountUsed: "a1",
+			model: SONNET,
+			inputTokens: 1_000_000,
+			cacheReadTokens: 2_000_000,
+			cacheCreationTokens: 400_000,
+			project: "proj-x",
+		});
+		// r2: sonnet, NULL project
+		insertRequest({
+			id: "r2",
+			timestamp: now - 1000,
+			accountUsed: "a1",
+			model: SONNET,
+			inputTokens: 500_000,
+			cacheReadTokens: 0,
+			cacheCreationTokens: 0,
+			project: null,
+		});
+		// r3: NULL model, NULL account, NULL project -> "Unknown" everywhere
+		insertRequest({
+			id: "r3",
+			timestamp: now - 1000,
+			accountUsed: null,
+			model: null,
+			inputTokens: 100,
+			cacheReadTokens: 50,
+			cacheCreationTokens: 0,
+			project: null,
+		});
+		// r4: outside the default 24h range -> must be excluded
+		insertRequest({
+			id: "r4",
+			timestamp: now - 2 * 24 * 60 * 60 * 1000,
+			accountUsed: "a1",
+			model: SONNET,
+			inputTokens: 999_999,
+			cacheReadTokens: 999_999,
+			cacheCreationTokens: 999_999,
+			project: "proj-x",
+		});
+
+		const adapter = new BunSqlAdapter(db);
+		context = {
+			db: adapter,
+			config: {} as APIContext["config"],
+			dbOps: {
+				getAdapter: () => adapter,
+			} as unknown as APIContext["dbOps"],
+		};
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("computes exact hand-computed savings, hit rates and Unknown handling", async () => {
+		const response = await createCacheInsightsHandler(context)(
+			new URLSearchParams(),
+		);
+		expect(response.status).toBe(200);
+		const data = await response.json();
+
+		// Hand-computed for the sonnet volume of r1+r2:
+		// uncached 1.5M, cacheRead 2M, cacheCreation 0.4M
+		const sonnetActual =
+			(2_000_000 * SONNET_CACHE_READ) / MILLION +
+			(400_000 * SONNET_CACHE_WRITE) / MILLION; // 0.6 + 1.5 = 2.1
+		const sonnetCounterfactual = (2_400_000 * SONNET_INPUT) / MILLION; // 7.2
+		const sonnetSavings = sonnetCounterfactual - sonnetActual; // 5.1
+
+		// --- totals (r1+r2+r3; r4 excluded by the 24h window) ---
+		expect(data.totals.requests).toBe(3);
+		expect(data.totals.uncachedInputTokens).toBe(1_500_100);
+		expect(data.totals.cacheReadInputTokens).toBe(2_000_050);
+		expect(data.totals.cacheCreationInputTokens).toBe(400_000);
+		expect(data.totals.cacheHitRate).toBeCloseTo(
+			(2_000_050 * 100) / 3_900_150,
+			10,
+		);
+		expect(data.totals.actualCacheCostUsd).toBeCloseTo(sonnetActual, 10);
+		expect(data.totals.counterfactualCostUsd).toBeCloseTo(
+			sonnetCounterfactual,
+			10,
+		);
+		expect(data.totals.savingsUsd).toBeCloseTo(sonnetSavings, 10);
+		expect(data.totals.unknownPricingModels).toEqual(["Unknown"]);
+
+		// --- byModel: sonnet first (savings desc), Unknown (null costs) last ---
+		expect(data.byModel.map((r: { key: string }) => r.key)).toEqual([
+			SONNET,
+			"Unknown",
+		]);
+		const modelRow = data.byModel[0];
+		expect(modelRow.requests).toBe(2);
+		expect(modelRow.cacheHitRate).toBeCloseTo(
+			(2_000_000 * 100) / 3_900_000,
+			10,
+		);
+		expect(modelRow.actualCacheCostUsd).toBeCloseTo(sonnetActual, 10);
+		expect(modelRow.counterfactualCostUsd).toBeCloseTo(
+			sonnetCounterfactual,
+			10,
+		);
+		expect(modelRow.savingsUsd).toBeCloseTo(sonnetSavings, 10);
+		expect(modelRow.pricingKnown).toBe(true);
+		expect(data.byModel[1].pricingKnown).toBe(false);
+		expect(data.byModel[1].savingsUsd).toBeNull();
+
+		// --- byAccount: acct-A (priced), Unknown (r3, unpriced) ---
+		expect(data.byAccount.map((r: { key: string }) => r.key)).toEqual([
+			"acct-A",
+			"Unknown",
+		]);
+		expect(data.byAccount[0].requests).toBe(2);
+		expect(data.byAccount[0].savingsUsd).toBeCloseTo(sonnetSavings, 10);
+		expect(data.byAccount[1].requests).toBe(1);
+		expect(data.byAccount[1].savingsUsd).toBeNull();
+
+		// --- byProject: proj-x (r1), Unknown (r2 + r3 -> unpriced due to r3) ---
+		expect(data.byProject.map((r: { key: string }) => r.key)).toEqual([
+			"proj-x",
+			"Unknown",
+		]);
+		const projRow = data.byProject[0];
+		expect(projRow.requests).toBe(1);
+		expect(projRow.uncachedInputTokens).toBe(1_000_000);
+		expect(projRow.cacheHitRate).toBeCloseTo((2_000_000 * 100) / 3_400_000, 10);
+		expect(projRow.savingsUsd).toBeCloseTo(sonnetSavings, 10);
+		const unknownProj = data.byProject[1];
+		expect(unknownProj.requests).toBe(2);
+		expect(unknownProj.pricingKnown).toBe(false);
+		expect(unknownProj.savingsUsd).toBeNull();
+	});
+
+	it("applies the shared account filter", async () => {
+		const response = await createCacheInsightsHandler(context)(
+			new URLSearchParams("accounts=acct-A"),
+		);
+		const data = await response.json();
+
+		// r3 (NULL account) is excluded by the filter
+		expect(data.totals.requests).toBe(2);
+		expect(data.byAccount).toHaveLength(1);
+		expect(data.byAccount[0].key).toBe("acct-A");
+		expect(data.totals.unknownPricingModels).toEqual([]);
+	});
+});

--- a/packages/http-api/src/handlers/analytics.ts
+++ b/packages/http-api/src/handlers/analytics.ts
@@ -6,6 +6,7 @@ import {
 import { Logger } from "@better-ccflare/logger";
 import { NO_ACCOUNT_ID } from "@better-ccflare/types";
 import type { AnalyticsResponse, APIContext } from "../types";
+import { buildRequestFilters, getRangeConfig } from "../utils/query-filters";
 
 const log = new Logger("AnalyticsHandler");
 
@@ -23,53 +24,6 @@ export function effectiveBurnRateDays(
 	return Math.min(windowDays, Math.max(1, days));
 }
 
-interface BucketConfig {
-	bucketMs: number;
-	displayName: string;
-}
-
-function getRangeConfig(range: string): {
-	startMs: number;
-	bucket: BucketConfig;
-} {
-	const now = Date.now();
-	const hour = 60 * 60 * 1000;
-	const day = 24 * hour;
-
-	switch (range) {
-		case "1h":
-			return {
-				startMs: now - hour,
-				bucket: { bucketMs: 60 * 1000, displayName: "1m" },
-			};
-		case "6h":
-			return {
-				startMs: now - 6 * hour,
-				bucket: { bucketMs: 5 * 60 * 1000, displayName: "5m" },
-			};
-		case "24h":
-			return {
-				startMs: now - day,
-				bucket: { bucketMs: hour, displayName: "1h" },
-			};
-		case "7d":
-			return {
-				startMs: now - 7 * day,
-				bucket: { bucketMs: hour, displayName: "1h" },
-			};
-		case "30d":
-			return {
-				startMs: now - 30 * day,
-				bucket: { bucketMs: day, displayName: "1d" },
-			};
-		default:
-			return {
-				startMs: now - day,
-				bucket: { bucketMs: hour, displayName: "1h" },
-			};
-	}
-}
-
 export function createAnalyticsHandler(context: APIContext) {
 	return async (params: URLSearchParams): Promise<Response> => {
 		const db = context.dbOps.getAdapter();
@@ -78,52 +32,12 @@ export function createAnalyticsHandler(context: APIContext) {
 		const mode = params.get("mode") ?? "normal";
 		const isCumulative = mode === "cumulative";
 
-		// Extract filters
-		const accountsFilter =
-			params.get("accounts")?.split(",").filter(Boolean) || [];
-		const modelsFilter = params.get("models")?.split(",").filter(Boolean) || [];
-		const apiKeysFilter =
-			params.get("apiKeys")?.split(",").filter(Boolean) || [];
-		const statusFilter = params.get("status") || "all";
-
-		// Build filter conditions
-		const conditions: string[] = ["timestamp > ?"];
-		const queryParams: (string | number)[] = [startMs];
-
-		if (accountsFilter.length > 0) {
-			// Handle account filter - map account names to IDs via join
-			const placeholders = accountsFilter.map(() => "?").join(",");
-			conditions.push(`(
-				r.account_used IN (SELECT id FROM accounts WHERE name IN (${placeholders}))
-				OR (r.account_used = ? AND ? IN (${placeholders}))
-			)`);
-			queryParams.push(
-				...accountsFilter,
-				NO_ACCOUNT_ID,
-				NO_ACCOUNT_ID,
-				...accountsFilter,
-			);
-		}
-
-		if (modelsFilter.length > 0) {
-			const placeholders = modelsFilter.map(() => "?").join(",");
-			conditions.push(`model IN (${placeholders})`);
-			queryParams.push(...modelsFilter);
-		}
-
-		if (apiKeysFilter.length > 0) {
-			const placeholders = apiKeysFilter.map(() => "?").join(",");
-			conditions.push(`api_key_name IN (${placeholders})`);
-			queryParams.push(...apiKeysFilter);
-		}
-
-		if (statusFilter === "success") {
-			conditions.push("success = TRUE");
-		} else if (statusFilter === "error") {
-			conditions.push("success = FALSE");
-		}
-
-		const whereClause = conditions.join(" AND ");
+		// Build the shared range/filter WHERE clause (timestamp window,
+		// accounts, models, apiKeys, status)
+		const { whereClause, params: queryParams } = buildRequestFilters(
+			params,
+			startMs,
+		);
 
 		try {
 			// Check if we need per-model time series

--- a/packages/http-api/src/handlers/insights.ts
+++ b/packages/http-api/src/handlers/insights.ts
@@ -1,0 +1,139 @@
+import { getModelRates, type ModelRates } from "@better-ccflare/core";
+import {
+	errorResponse,
+	InternalServerError,
+	jsonResponse,
+} from "@better-ccflare/http-common";
+import { Logger } from "@better-ccflare/logger";
+import {
+	buildCacheInsightsResponse,
+	DEFAULT_THRESHOLD_PERCENT,
+	type GroupedTokenRow,
+} from "../services/cache-insights";
+import type { APIContext } from "../types";
+import { buildRequestFilters, getRangeConfig } from "../utils/query-filters";
+
+const log = new Logger("InsightsHandler");
+
+/** Raw GROUP BY row shape shared by both insights queries. */
+interface GroupedTokenSqlRow {
+	dimension_key: string | null;
+	model: string | null;
+	requests: number;
+	uncached_input_tokens: number;
+	cache_read_input_tokens: number;
+	cache_creation_input_tokens: number;
+}
+
+function toGroupedTokenRow(row: GroupedTokenSqlRow): GroupedTokenRow {
+	return {
+		dimensionKey: row.dimension_key,
+		model: row.model,
+		requests: Number(row.requests) || 0,
+		uncachedInputTokens: Number(row.uncached_input_tokens) || 0,
+		cacheReadInputTokens: Number(row.cache_read_input_tokens) || 0,
+		cacheCreationInputTokens: Number(row.cache_creation_input_tokens) || 0,
+	};
+}
+
+/** Parse the threshold query param: float, default 50, clamped to 0-100. */
+function parseThresholdPercent(raw: string | null): number {
+	if (raw === null) return DEFAULT_THRESHOLD_PERCENT;
+	const parsed = Number.parseFloat(raw);
+	if (!Number.isFinite(parsed)) return DEFAULT_THRESHOLD_PERCENT;
+	return Math.min(100, Math.max(0, parsed));
+}
+
+/**
+ * GET /api/insights/cache — cache efficiency insights.
+ *
+ * Aggregates token sums per (account, model) and (project, model) over the
+ * requested range/filters, prices the cache volume via the pricing catalogue,
+ * and returns hit rates, dollar savings and low-hit-rate flags.
+ */
+export function createCacheInsightsHandler(context: APIContext) {
+	return async (searchParams: URLSearchParams): Promise<Response> => {
+		const db = context.dbOps.getAdapter();
+		// Normalize the raw query param so meta.range reflects the window used.
+		const { startMs, range } = getRangeConfig(
+			searchParams.get("range") ?? "24h",
+		);
+		const { whereClause, params: queryParams } = buildRequestFilters(
+			searchParams,
+			startMs,
+		);
+		const thresholdPercent = parseThresholdPercent(
+			searchParams.get("threshold"),
+		);
+
+		try {
+			// account x model (also the source for byModel and totals)
+			const accountModelSqlRows = await db.query<GroupedTokenSqlRow>(
+				`
+				SELECT
+					COALESCE(a.name, 'Unknown') as dimension_key,
+					r.model as model,
+					COUNT(*) as requests,
+					SUM(COALESCE(r.input_tokens, 0)) as uncached_input_tokens,
+					SUM(COALESCE(r.cache_read_input_tokens, 0)) as cache_read_input_tokens,
+					SUM(COALESCE(r.cache_creation_input_tokens, 0)) as cache_creation_input_tokens
+				FROM requests r
+				LEFT JOIN accounts a ON a.id = r.account_used
+				WHERE ${whereClause}
+				GROUP BY COALESCE(a.name, 'Unknown'), r.model
+			`,
+				queryParams,
+			);
+
+			// project x model
+			const projectModelSqlRows = await db.query<GroupedTokenSqlRow>(
+				`
+				SELECT
+					COALESCE(r.project, 'Unknown') as dimension_key,
+					r.model as model,
+					COUNT(*) as requests,
+					SUM(COALESCE(r.input_tokens, 0)) as uncached_input_tokens,
+					SUM(COALESCE(r.cache_read_input_tokens, 0)) as cache_read_input_tokens,
+					SUM(COALESCE(r.cache_creation_input_tokens, 0)) as cache_creation_input_tokens
+				FROM requests r
+				WHERE ${whereClause}
+				GROUP BY COALESCE(r.project, 'Unknown'), r.model
+			`,
+				queryParams,
+			);
+
+			const accountModelRows = accountModelSqlRows.map(toGroupedTokenRow);
+			const projectModelRows = projectModelSqlRows.map(toGroupedTokenRow);
+
+			// Price each distinct model id once; null/empty models are handled by
+			// the service as "Unknown" and never priced.
+			const modelIds = [
+				...new Set(
+					[...accountModelRows, ...projectModelRows]
+						.map((row) => row.model)
+						.filter((model): model is string => model != null && model !== ""),
+				),
+			];
+			const rateList = await Promise.all(
+				modelIds.map((modelId) => getModelRates(modelId)),
+			);
+			const rates = new Map<string, ModelRates | null>(
+				modelIds.map((modelId, index) => [modelId, rateList[index] ?? null]),
+			);
+
+			return jsonResponse(
+				buildCacheInsightsResponse({
+					accountModelRows,
+					projectModelRows,
+					rates,
+					options: { range, thresholdPercent },
+				}),
+			);
+		} catch (error) {
+			log.error("Cache insights error:", error);
+			return errorResponse(
+				InternalServerError("Failed to fetch cache insights data"),
+			);
+		}
+	};
+}

--- a/packages/http-api/src/handlers/insights.ts
+++ b/packages/http-api/src/handlers/insights.ts
@@ -118,7 +118,7 @@ export function createCacheInsightsHandler(context: APIContext) {
 				modelIds.map((modelId) => getModelRates(modelId)),
 			);
 			const rates = new Map<string, ModelRates | null>(
-				modelIds.map((modelId, index) => [modelId, rateList[index] ?? null]),
+				modelIds.map((modelId, index) => [modelId, rateList[index]]),
 			);
 
 			return jsonResponse(

--- a/packages/http-api/src/router.ts
+++ b/packages/http-api/src/router.ts
@@ -71,6 +71,7 @@ import {
 } from "./handlers/debug";
 import { createFeaturesHandler } from "./handlers/features";
 import { createHealthHandler } from "./handlers/health";
+import { createCacheInsightsHandler } from "./handlers/insights";
 import { createLogsStreamHandler } from "./handlers/logs";
 import { createLogsHistoryHandler } from "./handlers/logs-history";
 import { createCleanupHandler } from "./handlers/maintenance";
@@ -182,6 +183,7 @@ export class APIRouter {
 		const logsStreamHandler = createLogsStreamHandler();
 		const logsHistoryHandler = createLogsHistoryHandler();
 		const analyticsHandler = createAnalyticsHandler(this.context);
+		const cacheInsightsHandler = createCacheInsightsHandler(this.context);
 		const oauthInitHandler = createOAuthInitHandler(dbOps);
 		const oauthCallbackHandler = createOAuthCallbackHandler(dbOps);
 		const qwenDeviceFlowInitHandler = createQwenDeviceFlowInitHandler(dbOps);
@@ -368,6 +370,9 @@ export class APIRouter {
 		this.handlers.set("GET:/api/analytics", (_req, url) => {
 			return analyticsHandler(url.searchParams);
 		});
+		this.handlers.set("GET:/api/insights/cache", (_req, url) =>
+			cacheInsightsHandler(url.searchParams),
+		);
 		this.handlers.set("GET:/api/agents", () => agentsHandler());
 		this.handlers.set("POST:/api/agents/bulk-preference", (req) => {
 			const bulkHandler = createBulkAgentPreferenceUpdateHandler(

--- a/packages/http-api/src/services/__tests__/cache-insights.test.ts
+++ b/packages/http-api/src/services/__tests__/cache-insights.test.ts
@@ -1,0 +1,555 @@
+import { describe, expect, test } from "bun:test";
+import type { ModelRates } from "@better-ccflare/core";
+import {
+	buildCacheInsightsResponse,
+	type CacheInsightsResponse,
+	computeCacheCosts,
+	computeCacheHitRate,
+	type GroupedTokenRow,
+	type TokenSums,
+} from "../cache-insights";
+
+/**
+ * Tests for the pure cache-savings math service.
+ *
+ * Rates are $ per 1M tokens. Reference rates loosely modeled on Claude Sonnet:
+ * input 3, output 15, cacheRead 0.3, cacheWrite 3.75.
+ */
+
+const SONNET_RATES: ModelRates = {
+	input: 3,
+	output: 15,
+	cacheRead: 0.3,
+	cacheWrite: 3.75,
+};
+
+function sums(partial: Partial<TokenSums> = {}): TokenSums {
+	return {
+		requests: 0,
+		uncachedInputTokens: 0,
+		cacheReadInputTokens: 0,
+		cacheCreationInputTokens: 0,
+		...partial,
+	};
+}
+
+function row(
+	dimensionKey: string | null,
+	model: string | null,
+	partial: Partial<TokenSums> = {},
+): GroupedTokenRow {
+	return { dimensionKey, model, ...sums(partial) };
+}
+
+function build(
+	accountModelRows: GroupedTokenRow[],
+	rates: Map<string, ModelRates | null>,
+	overrides: {
+		projectModelRows?: GroupedTokenRow[];
+		range?: string;
+		thresholdPercent?: number;
+		minRequestsForFlag?: number;
+	} = {},
+): CacheInsightsResponse {
+	return buildCacheInsightsResponse({
+		accountModelRows,
+		projectModelRows: overrides.projectModelRows ?? [],
+		rates,
+		options: {
+			range: overrides.range ?? "7d",
+			thresholdPercent: overrides.thresholdPercent,
+			minRequestsForFlag: overrides.minRequestsForFlag,
+		},
+	});
+}
+
+describe("computeCacheHitRate", () => {
+	test("returns 0 when the denominator is zero", () => {
+		expect(computeCacheHitRate(sums())).toBe(0);
+	});
+
+	test("returns 100 for pure cache-read traffic", () => {
+		expect(computeCacheHitRate(sums({ cacheReadInputTokens: 5_000 }))).toBe(
+			100,
+		);
+	});
+
+	test("matches the analytics.ts definition", () => {
+		// cache_read * 100 / (input + cache_read + cache_creation)
+		const rate = computeCacheHitRate(
+			sums({
+				uncachedInputTokens: 1_000_000,
+				cacheReadInputTokens: 10_000_000,
+				cacheCreationInputTokens: 2_000_000,
+			}),
+		);
+		expect(rate).toBeCloseTo((10_000_000 * 100) / 13_000_000, 10);
+	});
+});
+
+describe("computeCacheCosts", () => {
+	test("computes exact dollars including negative cache_creation contribution", () => {
+		const result = computeCacheCosts(
+			sums({
+				uncachedInputTokens: 1_000_000,
+				cacheReadInputTokens: 10_000_000,
+				cacheCreationInputTokens: 2_000_000,
+			}),
+			SONNET_RATES,
+		);
+		expect(result).not.toBeNull();
+		// actual = 10M * 0.3/1M + 2M * 3.75/1M = 3 + 7.5 = 10.5
+		expect(result?.actualCacheCostUsd).toBeCloseTo(10.5, 10);
+		// counterfactual = 12M * 3/1M = 36
+		expect(result?.counterfactualCostUsd).toBeCloseTo(36, 10);
+		// savings = 36 - 10.5 = 25.5
+		expect(result?.savingsUsd).toBeCloseTo(25.5, 10);
+	});
+
+	test("cache_creation dominating produces net negative savings", () => {
+		const result = computeCacheCosts(
+			sums({ cacheCreationInputTokens: 1_000_000 }),
+			SONNET_RATES,
+		);
+		// actual = 3.75, counterfactual = 3, savings = -0.75
+		expect(result?.actualCacheCostUsd).toBeCloseTo(3.75, 10);
+		expect(result?.counterfactualCostUsd).toBeCloseTo(3, 10);
+		expect(result?.savingsUsd).toBeCloseTo(-0.75, 10);
+	});
+
+	test("returns null for null rates (unknown model)", () => {
+		expect(
+			computeCacheCosts(sums({ cacheReadInputTokens: 100 }), null),
+		).toBeNull();
+	});
+
+	test("returns null when cacheWrite rate is null and cache_creation tokens > 0", () => {
+		const rates: ModelRates = { ...SONNET_RATES, cacheWrite: null };
+		expect(
+			computeCacheCosts(
+				sums({ cacheReadInputTokens: 100, cacheCreationInputTokens: 50 }),
+				rates,
+			),
+		).toBeNull();
+	});
+
+	test("null cacheWrite rate is irrelevant when cache_creation tokens are zero", () => {
+		const rates: ModelRates = { ...SONNET_RATES, cacheWrite: null };
+		const result = computeCacheCosts(
+			sums({ cacheReadInputTokens: 1_000_000 }),
+			rates,
+		);
+		expect(result).not.toBeNull();
+		expect(result?.actualCacheCostUsd).toBeCloseTo(0.3, 10);
+		expect(result?.counterfactualCostUsd).toBeCloseTo(3, 10);
+		expect(result?.savingsUsd).toBeCloseTo(2.7, 10);
+	});
+
+	test("returns null when cacheRead rate is null and cache_read tokens > 0", () => {
+		const rates: ModelRates = { ...SONNET_RATES, cacheRead: null };
+		expect(
+			computeCacheCosts(sums({ cacheReadInputTokens: 100 }), rates),
+		).toBeNull();
+	});
+});
+
+describe("buildCacheInsightsResponse", () => {
+	test("single account/model row: exact math, meta echo, totals", () => {
+		const rates = new Map<string, ModelRates | null>([
+			["claude-sonnet", SONNET_RATES],
+		]);
+		const response = build(
+			[
+				row("acc1", "claude-sonnet", {
+					requests: 100,
+					uncachedInputTokens: 1_000_000,
+					cacheReadInputTokens: 10_000_000,
+					cacheCreationInputTokens: 2_000_000,
+				}),
+			],
+			rates,
+			{ range: "30d" },
+		);
+
+		expect(response.meta).toEqual({
+			range: "30d",
+			thresholdPercent: 50,
+			minRequestsForFlag: 10,
+		});
+
+		expect(response.byAccount).toHaveLength(1);
+		const account = response.byAccount[0];
+		expect(account.key).toBe("acc1");
+		expect(account.requests).toBe(100);
+		expect(account.pricingKnown).toBe(true);
+		expect(account.actualCacheCostUsd).toBeCloseTo(10.5, 10);
+		expect(account.counterfactualCostUsd).toBeCloseTo(36, 10);
+		expect(account.savingsUsd).toBeCloseTo(25.5, 10);
+		expect(account.cacheHitRate).toBeCloseTo(
+			(10_000_000 * 100) / 13_000_000,
+			10,
+		);
+		// hit rate ~76.9% >= 50 threshold
+		expect(account.flagged).toBe(false);
+
+		expect(response.byModel).toHaveLength(1);
+		expect(response.byModel[0].key).toBe("claude-sonnet");
+		expect(response.byModel[0].savingsUsd).toBeCloseTo(25.5, 10);
+
+		expect(response.totals.requests).toBe(100);
+		expect(response.totals.uncachedInputTokens).toBe(1_000_000);
+		expect(response.totals.cacheReadInputTokens).toBe(10_000_000);
+		expect(response.totals.cacheCreationInputTokens).toBe(2_000_000);
+		expect(response.totals.actualCacheCostUsd).toBeCloseTo(10.5, 10);
+		expect(response.totals.counterfactualCostUsd).toBeCloseTo(36, 10);
+		expect(response.totals.savingsUsd).toBeCloseTo(25.5, 10);
+		expect(response.totals.cacheHitRate).toBeCloseTo(
+			(10_000_000 * 100) / 13_000_000,
+			10,
+		);
+		expect(response.totals.unknownPricingModels).toEqual([]);
+		expect(response.byProject).toEqual([]);
+	});
+
+	test("cache_creation-dominated model yields net negative savingsUsd", () => {
+		const rates = new Map<string, ModelRates | null>([
+			["claude-sonnet", SONNET_RATES],
+		]);
+		const response = build(
+			[
+				row("acc1", "claude-sonnet", {
+					requests: 5,
+					uncachedInputTokens: 100,
+					cacheCreationInputTokens: 1_000_000,
+				}),
+			],
+			rates,
+		);
+		expect(response.byModel[0].savingsUsd).toBeCloseTo(-0.75, 10);
+		expect(response.totals.savingsUsd).toBeCloseTo(-0.75, 10);
+	});
+
+	test("unknown model: null costs, pricingKnown=false, listed in unknownPricingModels, token totals still counted", () => {
+		const rates = new Map<string, ModelRates | null>([
+			["claude-sonnet", SONNET_RATES],
+			["mystery-model", null],
+		]);
+		const response = build(
+			[
+				row("acc1", "claude-sonnet", {
+					requests: 20,
+					uncachedInputTokens: 1_000_000,
+					cacheReadInputTokens: 10_000_000,
+					cacheCreationInputTokens: 2_000_000,
+				}),
+				row("acc1", "mystery-model", {
+					requests: 7,
+					uncachedInputTokens: 500,
+					cacheReadInputTokens: 1_500,
+					cacheCreationInputTokens: 250,
+				}),
+			],
+			rates,
+		);
+
+		const mystery = response.byModel.find((r) => r.key === "mystery-model");
+		expect(mystery).toBeDefined();
+		expect(mystery?.pricingKnown).toBe(false);
+		expect(mystery?.actualCacheCostUsd).toBeNull();
+		expect(mystery?.counterfactualCostUsd).toBeNull();
+		expect(mystery?.savingsUsd).toBeNull();
+
+		// account row aggregates a known and an unknown model -> pricingKnown=false, costs null
+		expect(response.byAccount).toHaveLength(1);
+		expect(response.byAccount[0].pricingKnown).toBe(false);
+		expect(response.byAccount[0].savingsUsd).toBeNull();
+
+		// token totals include the unknown model
+		expect(response.totals.requests).toBe(27);
+		expect(response.totals.uncachedInputTokens).toBe(1_000_500);
+		expect(response.totals.cacheReadInputTokens).toBe(10_001_500);
+		expect(response.totals.cacheCreationInputTokens).toBe(2_000_250);
+
+		// cost totals cover only the pricing-known volume
+		expect(response.totals.actualCacheCostUsd).toBeCloseTo(10.5, 10);
+		expect(response.totals.counterfactualCostUsd).toBeCloseTo(36, 10);
+		expect(response.totals.savingsUsd).toBeCloseTo(25.5, 10);
+
+		expect(response.totals.unknownPricingModels).toEqual(["mystery-model"]);
+	});
+
+	test("model missing from the rates map is treated as unknown", () => {
+		const response = build(
+			[row("acc1", "not-in-map", { requests: 1, cacheReadInputTokens: 100 })],
+			new Map(),
+		);
+		expect(response.byModel[0].pricingKnown).toBe(false);
+		expect(response.totals.unknownPricingModels).toEqual(["not-in-map"]);
+	});
+
+	test("null cacheWrite rate with cache_creation tokens > 0 -> pricingKnown=false", () => {
+		const rates = new Map<string, ModelRates | null>([
+			["no-write-rate", { ...SONNET_RATES, cacheWrite: null }],
+		]);
+		const response = build(
+			[
+				row("acc1", "no-write-rate", {
+					requests: 3,
+					cacheReadInputTokens: 1_000,
+					cacheCreationInputTokens: 1,
+				}),
+			],
+			rates,
+		);
+		expect(response.byModel[0].pricingKnown).toBe(false);
+		expect(response.byModel[0].savingsUsd).toBeNull();
+		expect(response.totals.unknownPricingModels).toEqual(["no-write-rate"]);
+	});
+
+	test("null cacheWrite rate with zero cache_creation tokens -> pricingKnown=true", () => {
+		const rates = new Map<string, ModelRates | null>([
+			["no-write-rate", { ...SONNET_RATES, cacheWrite: null }],
+		]);
+		const response = build(
+			[
+				row("acc1", "no-write-rate", {
+					requests: 3,
+					cacheReadInputTokens: 1_000_000,
+				}),
+			],
+			rates,
+		);
+		expect(response.byModel[0].pricingKnown).toBe(true);
+		expect(response.byModel[0].savingsUsd).toBeCloseTo(2.7, 10);
+		expect(response.totals.unknownPricingModels).toEqual([]);
+	});
+
+	test("hit-rate edge cases: zero denominator -> 0, pure cache-read -> 100", () => {
+		const rates = new Map<string, ModelRates | null>([
+			["claude-sonnet", SONNET_RATES],
+		]);
+		const response = build(
+			[
+				row("acc-zero", "claude-sonnet", { requests: 2 }),
+				row("acc-pure", "claude-sonnet", {
+					requests: 2,
+					cacheReadInputTokens: 1_000,
+				}),
+			],
+			rates,
+		);
+		const zero = response.byAccount.find((r) => r.key === "acc-zero");
+		const pure = response.byAccount.find((r) => r.key === "acc-pure");
+		expect(zero?.cacheHitRate).toBe(0);
+		expect(pure?.cacheHitRate).toBe(100);
+	});
+
+	test("flagging: below threshold with enough requests -> flagged; too few requests or above threshold -> not flagged", () => {
+		const rates = new Map<string, ModelRates | null>([
+			["claude-sonnet", SONNET_RATES],
+		]);
+		const response = build(
+			[
+				// 25% hit rate, 10 requests -> flagged (>= minRequests default 10)
+				row("acc-low-many", "claude-sonnet", {
+					requests: 10,
+					uncachedInputTokens: 750,
+					cacheReadInputTokens: 250,
+				}),
+				// 25% hit rate, 9 requests -> not flagged
+				row("acc-low-few", "claude-sonnet", {
+					requests: 9,
+					uncachedInputTokens: 750,
+					cacheReadInputTokens: 250,
+				}),
+				// 75% hit rate, 100 requests -> not flagged
+				row("acc-high", "claude-sonnet", {
+					requests: 100,
+					uncachedInputTokens: 250,
+					cacheReadInputTokens: 750,
+				}),
+			],
+			rates,
+		);
+		const byKey = new Map(response.byAccount.map((r) => [r.key, r]));
+		expect(byKey.get("acc-low-many")?.flagged).toBe(true);
+		expect(byKey.get("acc-low-few")?.flagged).toBe(false);
+		expect(byKey.get("acc-high")?.flagged).toBe(false);
+	});
+
+	test("flagging respects custom thresholdPercent and minRequestsForFlag", () => {
+		const rates = new Map<string, ModelRates | null>([
+			["claude-sonnet", SONNET_RATES],
+		]);
+		const response = build(
+			[
+				// 75% hit rate, 3 requests
+				row("acc1", "claude-sonnet", {
+					requests: 3,
+					uncachedInputTokens: 250,
+					cacheReadInputTokens: 750,
+				}),
+			],
+			rates,
+			{ thresholdPercent: 80, minRequestsForFlag: 2 },
+		);
+		expect(response.meta.thresholdPercent).toBe(80);
+		expect(response.meta.minRequestsForFlag).toBe(2);
+		expect(response.byAccount[0].flagged).toBe(true);
+	});
+
+	test("byModel aggregates the same model across accounts", () => {
+		const rates = new Map<string, ModelRates | null>([
+			["claude-sonnet", SONNET_RATES],
+		]);
+		const response = build(
+			[
+				row("acc1", "claude-sonnet", {
+					requests: 10,
+					uncachedInputTokens: 1_000_000,
+					cacheReadInputTokens: 4_000_000,
+					cacheCreationInputTokens: 1_000_000,
+				}),
+				row("acc2", "claude-sonnet", {
+					requests: 5,
+					uncachedInputTokens: 500_000,
+					cacheReadInputTokens: 6_000_000,
+					cacheCreationInputTokens: 1_000_000,
+				}),
+			],
+			rates,
+		);
+		expect(response.byAccount).toHaveLength(2);
+		expect(response.byModel).toHaveLength(1);
+		const model = response.byModel[0];
+		expect(model.key).toBe("claude-sonnet");
+		expect(model.requests).toBe(15);
+		expect(model.uncachedInputTokens).toBe(1_500_000);
+		expect(model.cacheReadInputTokens).toBe(10_000_000);
+		expect(model.cacheCreationInputTokens).toBe(2_000_000);
+		// actual = 10M*0.3/1M + 2M*3.75/1M = 3 + 7.5 = 10.5
+		expect(model.actualCacheCostUsd).toBeCloseTo(10.5, 10);
+		// counterfactual = 12M*3/1M = 36
+		expect(model.counterfactualCostUsd).toBeCloseTo(36, 10);
+		expect(model.savingsUsd).toBeCloseTo(25.5, 10);
+		expect(model.pricingKnown).toBe(true);
+	});
+
+	test("byProject aggregates project rows with Unknown key for null project", () => {
+		const rates = new Map<string, ModelRates | null>([
+			["claude-sonnet", SONNET_RATES],
+		]);
+		const response = build(
+			[
+				row("acc1", "claude-sonnet", {
+					requests: 4,
+					cacheReadInputTokens: 1_000_000,
+				}),
+			],
+			rates,
+			{
+				projectModelRows: [
+					row("proj-a", "claude-sonnet", {
+						requests: 3,
+						cacheReadInputTokens: 750_000,
+					}),
+					row(null, "claude-sonnet", {
+						requests: 1,
+						cacheReadInputTokens: 250_000,
+					}),
+				],
+			},
+		);
+		expect(response.byProject).toHaveLength(2);
+		const keys = response.byProject.map((r) => r.key).sort();
+		expect(keys).toEqual(["Unknown", "proj-a"]);
+		const unknown = response.byProject.find((r) => r.key === "Unknown");
+		// project key is unknown, but the model pricing is known
+		expect(unknown?.pricingKnown).toBe(true);
+		expect(unknown?.savingsUsd).toBeCloseTo((250_000 * (3 - 0.3)) / 1e6, 10);
+	});
+
+	test("null/empty model id maps to model key Unknown with pricingKnown=false", () => {
+		const rates = new Map<string, ModelRates | null>([
+			["claude-sonnet", SONNET_RATES],
+		]);
+		const response = build(
+			[
+				row("acc1", null, { requests: 2, cacheReadInputTokens: 100 }),
+				row("acc1", "", { requests: 3, cacheReadInputTokens: 200 }),
+				row("acc1", "claude-sonnet", {
+					requests: 1,
+					cacheReadInputTokens: 1_000,
+				}),
+			],
+			rates,
+		);
+		const unknown = response.byModel.find((r) => r.key === "Unknown");
+		expect(unknown).toBeDefined();
+		// null and empty model ids merge into one Unknown row
+		expect(unknown?.requests).toBe(5);
+		expect(unknown?.cacheReadInputTokens).toBe(300);
+		expect(unknown?.pricingKnown).toBe(false);
+		expect(unknown?.savingsUsd).toBeNull();
+		expect(response.totals.unknownPricingModels).toEqual(["Unknown"]);
+	});
+
+	test("rows sort by savingsUsd descending with nulls last, tie-break by key", () => {
+		const rates = new Map<string, ModelRates | null>([
+			["big-saver", SONNET_RATES],
+			["small-saver", SONNET_RATES],
+			["unknown-b", null],
+			["unknown-a", null],
+			["tie-b", SONNET_RATES],
+			["tie-a", SONNET_RATES],
+		]);
+		const response = build(
+			[
+				row("acc1", "small-saver", {
+					requests: 1,
+					cacheReadInputTokens: 1_000_000,
+				}),
+				row("acc1", "big-saver", {
+					requests: 1,
+					cacheReadInputTokens: 10_000_000,
+				}),
+				row("acc1", "unknown-b", { requests: 1, cacheReadInputTokens: 1 }),
+				row("acc1", "unknown-a", { requests: 1, cacheReadInputTokens: 1 }),
+				row("acc1", "tie-b", { requests: 1, cacheReadInputTokens: 500_000 }),
+				row("acc1", "tie-a", { requests: 1, cacheReadInputTokens: 500_000 }),
+			],
+			rates,
+		);
+		expect(response.byModel.map((r) => r.key)).toEqual([
+			"big-saver",
+			"small-saver",
+			"tie-a",
+			"tie-b",
+			"unknown-a",
+			"unknown-b",
+		]);
+		// unknownPricingModels is sorted
+		expect(response.totals.unknownPricingModels).toEqual([
+			"unknown-a",
+			"unknown-b",
+		]);
+	});
+
+	test("empty input produces zeroed totals and empty lists", () => {
+		const response = build([], new Map());
+		expect(response.byModel).toEqual([]);
+		expect(response.byAccount).toEqual([]);
+		expect(response.byProject).toEqual([]);
+		expect(response.totals).toEqual({
+			requests: 0,
+			uncachedInputTokens: 0,
+			cacheReadInputTokens: 0,
+			cacheCreationInputTokens: 0,
+			cacheHitRate: 0,
+			actualCacheCostUsd: 0,
+			counterfactualCostUsd: 0,
+			savingsUsd: 0,
+			unknownPricingModels: [],
+		});
+	});
+});

--- a/packages/http-api/src/services/cache-insights.ts
+++ b/packages/http-api/src/services/cache-insights.ts
@@ -294,7 +294,6 @@ export function buildCacheInsightsResponse(
 			}
 		}
 	};
-	collectUnknown(input.accountModelRows);
 	collectUnknown(input.projectModelRows);
 
 	for (const row of input.accountModelRows) {
@@ -302,8 +301,12 @@ export function buildCacheInsightsResponse(
 		totals.uncachedInputTokens += row.uncachedInputTokens;
 		totals.cacheReadInputTokens += row.cacheReadInputTokens;
 		totals.cacheCreationInputTokens += row.cacheCreationInputTokens;
+		// Single cost computation per row feeds both the unknown-models set
+		// and the totals accumulation.
 		const costs = computeCacheCosts(row, ratesForModel(row.model, input.rates));
-		if (costs !== null) {
+		if (costs === null) {
+			unknownModels.add(normalizeKey(row.model));
+		} else {
 			totals.actualCacheCostUsd += costs.actualCacheCostUsd;
 			totals.counterfactualCostUsd += costs.counterfactualCostUsd;
 		}

--- a/packages/http-api/src/services/cache-insights.ts
+++ b/packages/http-api/src/services/cache-insights.ts
@@ -1,0 +1,322 @@
+import type { ModelRates } from "@better-ccflare/core";
+import type {
+	CacheInsightsResponse,
+	CacheInsightsRow,
+} from "@better-ccflare/types";
+
+/**
+ * Pure cache-savings math for the cache insights endpoint.
+ *
+ * No DB access and no pricing-engine imports: model rates ($ per 1M tokens)
+ * are injected as plain data. The response shapes live in
+ * @better-ccflare/types and are re-exported here for convenience.
+ */
+
+export type {
+	CacheInsightsMeta,
+	CacheInsightsResponse,
+	CacheInsightsRow,
+	CacheInsightsTotals,
+} from "@better-ccflare/types";
+
+/** Token sums for a group of requests. */
+export interface TokenSums {
+	requests: number;
+	uncachedInputTokens: number;
+	cacheReadInputTokens: number;
+	cacheCreationInputTokens: number;
+}
+
+/**
+ * Token sums grouped by (dimensionKey, model), e.g. (account, model) or
+ * (project, model). A null/empty dimensionKey or model is reported under
+ * the key "Unknown".
+ */
+export interface GroupedTokenRow extends TokenSums {
+	dimensionKey: string | null;
+	model: string | null;
+}
+
+/** Cache cost breakdown in dollars for a single model's token volume. */
+export interface CacheCostBreakdown {
+	actualCacheCostUsd: number;
+	counterfactualCostUsd: number;
+	savingsUsd: number;
+}
+
+export interface CacheInsightsOptions {
+	range: string;
+	/** Hit-rate percentage below which a row is flagged. Default 50. */
+	thresholdPercent?: number;
+	/** Minimum requests before a row can be flagged. Default 10. */
+	minRequestsForFlag?: number;
+}
+
+export interface BuildCacheInsightsInput {
+	/** Token sums grouped by (account, model). Also the source for byModel and totals. */
+	accountModelRows: GroupedTokenRow[];
+	/** Token sums grouped by (project, model). */
+	projectModelRows: GroupedTokenRow[];
+	/** Rates per model id ($ per 1M tokens); null for unknown models. */
+	rates: Map<string, ModelRates | null>;
+	options: CacheInsightsOptions;
+}
+
+export const DEFAULT_THRESHOLD_PERCENT = 50;
+export const DEFAULT_MIN_REQUESTS_FOR_FLAG = 10;
+
+const UNKNOWN_KEY = "Unknown";
+const TOKENS_PER_MILLION = 1_000_000;
+
+/**
+ * Cache hit rate (0-100): cache_read * 100 / (uncached + cache_read + cache_creation).
+ * Returns 0 when the denominator is 0. Matches the analytics.ts SQL definition.
+ */
+export function computeCacheHitRate(sums: TokenSums): number {
+	const denominator =
+		sums.uncachedInputTokens +
+		sums.cacheReadInputTokens +
+		sums.cacheCreationInputTokens;
+	if (denominator === 0) return 0;
+	return (sums.cacheReadInputTokens * 100) / denominator;
+}
+
+/**
+ * Compute cache cost breakdown in dollars for one model's token volume.
+ *
+ * - actual = cacheRead * r.cacheRead/1M + cacheCreation * r.cacheWrite/1M
+ * - counterfactual = (cacheRead + cacheCreation) * r.input/1M
+ * - savings = counterfactual - actual (cacheWrite > input, so cache_creation
+ *   contributes NEGATIVE savings — intended)
+ *
+ * Returns null when the rates are unusable: rates are null (unknown model),
+ * or the cacheRead/cacheWrite rate is null while the corresponding token
+ * volume is > 0. A null rate with zero corresponding tokens is irrelevant.
+ */
+export function computeCacheCosts(
+	sums: TokenSums,
+	rates: ModelRates | null | undefined,
+): CacheCostBreakdown | null {
+	if (!rates) return null;
+	if (sums.cacheReadInputTokens > 0 && rates.cacheRead === null) return null;
+	if (sums.cacheCreationInputTokens > 0 && rates.cacheWrite === null) {
+		return null;
+	}
+
+	const actualCacheCostUsd =
+		(sums.cacheReadInputTokens * (rates.cacheRead ?? 0)) / TOKENS_PER_MILLION +
+		(sums.cacheCreationInputTokens * (rates.cacheWrite ?? 0)) /
+			TOKENS_PER_MILLION;
+	const counterfactualCostUsd =
+		((sums.cacheReadInputTokens + sums.cacheCreationInputTokens) *
+			rates.input) /
+		TOKENS_PER_MILLION;
+	return {
+		actualCacheCostUsd,
+		counterfactualCostUsd,
+		savingsUsd: counterfactualCostUsd - actualCacheCostUsd,
+	};
+}
+
+function normalizeKey(key: string | null | undefined): string {
+	return key == null || key === "" ? UNKNOWN_KEY : key;
+}
+
+interface RowAccumulator {
+	key: string;
+	requests: number;
+	uncachedInputTokens: number;
+	cacheReadInputTokens: number;
+	cacheCreationInputTokens: number;
+	actualCacheCostUsd: number;
+	counterfactualCostUsd: number;
+	pricingKnown: boolean;
+}
+
+/**
+ * Look up rates for a (possibly null/empty) model id. Unknown-keyed models
+ * never have usable rates.
+ */
+function ratesForModel(
+	model: string | null,
+	rates: Map<string, ModelRates | null>,
+): ModelRates | null {
+	const key = normalizeKey(model);
+	if (key === UNKNOWN_KEY) return null;
+	return rates.get(key) ?? null;
+}
+
+/**
+ * Aggregate grouped rows into CacheInsightsRows keyed by `keyOf(row)`.
+ * A row is pricingKnown only if every constituent model portion had usable
+ * rates; otherwise its cost fields are null.
+ */
+function aggregateRows(
+	rows: GroupedTokenRow[],
+	keyOf: (row: GroupedTokenRow) => string,
+	rates: Map<string, ModelRates | null>,
+	thresholdPercent: number,
+	minRequestsForFlag: number,
+): CacheInsightsRow[] {
+	const groups = new Map<string, RowAccumulator>();
+	for (const row of rows) {
+		const key = keyOf(row);
+		let acc = groups.get(key);
+		if (!acc) {
+			acc = {
+				key,
+				requests: 0,
+				uncachedInputTokens: 0,
+				cacheReadInputTokens: 0,
+				cacheCreationInputTokens: 0,
+				actualCacheCostUsd: 0,
+				counterfactualCostUsd: 0,
+				pricingKnown: true,
+			};
+			groups.set(key, acc);
+		}
+		acc.requests += row.requests;
+		acc.uncachedInputTokens += row.uncachedInputTokens;
+		acc.cacheReadInputTokens += row.cacheReadInputTokens;
+		acc.cacheCreationInputTokens += row.cacheCreationInputTokens;
+
+		const costs = computeCacheCosts(row, ratesForModel(row.model, rates));
+		if (costs === null) {
+			acc.pricingKnown = false;
+		} else {
+			acc.actualCacheCostUsd += costs.actualCacheCostUsd;
+			acc.counterfactualCostUsd += costs.counterfactualCostUsd;
+		}
+	}
+
+	const result: CacheInsightsRow[] = [];
+	for (const acc of groups.values()) {
+		const cacheHitRate = computeCacheHitRate(acc);
+		const actualCacheCostUsd = acc.pricingKnown ? acc.actualCacheCostUsd : null;
+		const counterfactualCostUsd = acc.pricingKnown
+			? acc.counterfactualCostUsd
+			: null;
+		result.push({
+			key: acc.key,
+			requests: acc.requests,
+			uncachedInputTokens: acc.uncachedInputTokens,
+			cacheReadInputTokens: acc.cacheReadInputTokens,
+			cacheCreationInputTokens: acc.cacheCreationInputTokens,
+			cacheHitRate,
+			actualCacheCostUsd,
+			counterfactualCostUsd,
+			savingsUsd:
+				counterfactualCostUsd !== null && actualCacheCostUsd !== null
+					? counterfactualCostUsd - actualCacheCostUsd
+					: null,
+			pricingKnown: acc.pricingKnown,
+			flagged:
+				cacheHitRate < thresholdPercent && acc.requests >= minRequestsForFlag,
+		});
+	}
+	return sortRows(result);
+}
+
+/** Sort by savingsUsd descending with nulls last; tie-break by key ascending. */
+function sortRows(rows: CacheInsightsRow[]): CacheInsightsRow[] {
+	return rows.sort((a, b) => {
+		if (a.savingsUsd === null && b.savingsUsd !== null) return 1;
+		if (a.savingsUsd !== null && b.savingsUsd === null) return -1;
+		if (
+			a.savingsUsd !== null &&
+			b.savingsUsd !== null &&
+			a.savingsUsd !== b.savingsUsd
+		) {
+			return b.savingsUsd - a.savingsUsd;
+		}
+		return a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
+	});
+}
+
+/**
+ * Assemble the full cache insights response from grouped token sums and
+ * injected model rates.
+ *
+ * - byAccount / byProject aggregate the respective input rows per dimension key.
+ * - byModel is derived by re-aggregating accountModelRows per model.
+ * - totals: token sums over ALL account/model rows; cost sums over
+ *   pricing-known volume only; unknownPricingModels lists distinct model ids
+ *   (sorted) whose rates were unusable for any input row.
+ */
+export function buildCacheInsightsResponse(
+	input: BuildCacheInsightsInput,
+): CacheInsightsResponse {
+	const thresholdPercent =
+		input.options.thresholdPercent ?? DEFAULT_THRESHOLD_PERCENT;
+	const minRequestsForFlag =
+		input.options.minRequestsForFlag ?? DEFAULT_MIN_REQUESTS_FOR_FLAG;
+
+	const byAccount = aggregateRows(
+		input.accountModelRows,
+		(row) => normalizeKey(row.dimensionKey),
+		input.rates,
+		thresholdPercent,
+		minRequestsForFlag,
+	);
+	const byProject = aggregateRows(
+		input.projectModelRows,
+		(row) => normalizeKey(row.dimensionKey),
+		input.rates,
+		thresholdPercent,
+		minRequestsForFlag,
+	);
+	const byModel = aggregateRows(
+		input.accountModelRows,
+		(row) => normalizeKey(row.model),
+		input.rates,
+		thresholdPercent,
+		minRequestsForFlag,
+	);
+
+	const totals = {
+		requests: 0,
+		uncachedInputTokens: 0,
+		cacheReadInputTokens: 0,
+		cacheCreationInputTokens: 0,
+		cacheHitRate: 0,
+		actualCacheCostUsd: 0,
+		counterfactualCostUsd: 0,
+		savingsUsd: 0,
+		unknownPricingModels: [] as string[],
+	};
+	const unknownModels = new Set<string>();
+	const collectUnknown = (rows: GroupedTokenRow[]) => {
+		for (const row of rows) {
+			if (
+				computeCacheCosts(row, ratesForModel(row.model, input.rates)) === null
+			) {
+				unknownModels.add(normalizeKey(row.model));
+			}
+		}
+	};
+	collectUnknown(input.accountModelRows);
+	collectUnknown(input.projectModelRows);
+
+	for (const row of input.accountModelRows) {
+		totals.requests += row.requests;
+		totals.uncachedInputTokens += row.uncachedInputTokens;
+		totals.cacheReadInputTokens += row.cacheReadInputTokens;
+		totals.cacheCreationInputTokens += row.cacheCreationInputTokens;
+		const costs = computeCacheCosts(row, ratesForModel(row.model, input.rates));
+		if (costs !== null) {
+			totals.actualCacheCostUsd += costs.actualCacheCostUsd;
+			totals.counterfactualCostUsd += costs.counterfactualCostUsd;
+		}
+	}
+	totals.savingsUsd = totals.counterfactualCostUsd - totals.actualCacheCostUsd;
+	totals.cacheHitRate = computeCacheHitRate(totals);
+	totals.unknownPricingModels = [...unknownModels].sort();
+
+	return {
+		meta: { range: input.options.range, thresholdPercent, minRequestsForFlag },
+		totals,
+		byModel,
+		byAccount,
+		byProject,
+	};
+}

--- a/packages/http-api/src/types.ts
+++ b/packages/http-api/src/types.ts
@@ -4,6 +4,8 @@ export type {
 	AccountResponse,
 	AnalyticsResponse,
 	APIContext,
+	CacheInsightsResponse,
+	CacheInsightsRow,
 	CleanupResponse,
 	ConfigResponse,
 	HealthResponse,

--- a/packages/http-api/src/utils/__tests__/query-filters.test.ts
+++ b/packages/http-api/src/utils/__tests__/query-filters.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "bun:test";
+// Side-effect import: load @better-ccflare/core before @better-ccflare/types.
+// types/agent.ts runtime-imports core while core/strategy.ts imports types, a
+// pre-existing cycle that crashes when types is the first module evaluated.
+import "@better-ccflare/core";
+import { NO_ACCOUNT_ID } from "@better-ccflare/types";
+import { buildRequestFilters, getRangeConfig } from "../query-filters";
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+/**
+ * getRangeConfig uses Date.now() internally, so startMs is asserted as a
+ * window: [before - offset, after - offset].
+ */
+function expectStartMsOffset(
+	range: string,
+	offsetMs: number,
+	expectedBucket: { bucketMs: number; displayName: string },
+	expectedRange: string = range,
+) {
+	const before = Date.now();
+	const { startMs, bucket, range: effectiveRange } = getRangeConfig(range);
+	const after = Date.now();
+
+	expect(startMs).toBeGreaterThanOrEqual(before - offsetMs);
+	expect(startMs).toBeLessThanOrEqual(after - offsetMs);
+	expect(bucket).toEqual(expectedBucket);
+	expect(effectiveRange).toBe(expectedRange);
+}
+
+describe("getRangeConfig", () => {
+	it("maps 1h to a 1-hour window with 1m buckets", () => {
+		expectStartMsOffset("1h", HOUR, { bucketMs: 60 * 1000, displayName: "1m" });
+	});
+
+	it("maps 6h to a 6-hour window with 5m buckets", () => {
+		expectStartMsOffset("6h", 6 * HOUR, {
+			bucketMs: 5 * 60 * 1000,
+			displayName: "5m",
+		});
+	});
+
+	it("maps 24h to a 1-day window with 1h buckets", () => {
+		expectStartMsOffset("24h", DAY, { bucketMs: HOUR, displayName: "1h" });
+	});
+
+	it("maps 7d to a 7-day window with 1h buckets", () => {
+		expectStartMsOffset("7d", 7 * DAY, { bucketMs: HOUR, displayName: "1h" });
+	});
+
+	it("maps 30d to a 30-day window with 1d buckets", () => {
+		expectStartMsOffset("30d", 30 * DAY, { bucketMs: DAY, displayName: "1d" });
+	});
+
+	it("falls back to the 24h window for unknown ranges", () => {
+		expectStartMsOffset(
+			"bogus",
+			DAY,
+			{ bucketMs: HOUR, displayName: "1h" },
+			"24h",
+		);
+	});
+});
+
+describe("buildRequestFilters", () => {
+	const START_MS = 1_700_000_000_000;
+
+	it("returns only the timestamp condition when no filters are present", () => {
+		const { whereClause, params } = buildRequestFilters(
+			new URLSearchParams(),
+			START_MS,
+		);
+		expect(whereClause).toBe("timestamp > ?");
+		expect(params).toEqual([START_MS]);
+	});
+
+	it("builds the accounts condition with name subquery and NO_ACCOUNT_ID escape hatch", () => {
+		const { whereClause, params } = buildRequestFilters(
+			new URLSearchParams("accounts=acct-1,acct-2"),
+			START_MS,
+		);
+
+		expect(whereClause).toContain("timestamp > ?");
+		expect(whereClause).toContain(
+			"r.account_used IN (SELECT id FROM accounts WHERE name IN (?,?))",
+		);
+		expect(whereClause).toContain("OR (r.account_used = ? AND ? IN (?,?))");
+		expect(params).toEqual([
+			START_MS,
+			"acct-1",
+			"acct-2",
+			NO_ACCOUNT_ID,
+			NO_ACCOUNT_ID,
+			"acct-1",
+			"acct-2",
+		]);
+	});
+
+	it("builds the models condition", () => {
+		const { whereClause, params } = buildRequestFilters(
+			new URLSearchParams("models=model-a,model-b"),
+			START_MS,
+		);
+		expect(whereClause).toContain("model IN (?,?)");
+		expect(params).toEqual([START_MS, "model-a", "model-b"]);
+	});
+
+	it("builds the apiKeys condition", () => {
+		const { whereClause, params } = buildRequestFilters(
+			new URLSearchParams("apiKeys=key-1"),
+			START_MS,
+		);
+		expect(whereClause).toContain("api_key_name IN (?)");
+		expect(params).toEqual([START_MS, "key-1"]);
+	});
+
+	it("builds the status condition for success", () => {
+		const { whereClause, params } = buildRequestFilters(
+			new URLSearchParams("status=success"),
+			START_MS,
+		);
+		expect(whereClause).toContain("success = TRUE");
+		expect(params).toEqual([START_MS]);
+	});
+
+	it("builds the status condition for error", () => {
+		const { whereClause, params } = buildRequestFilters(
+			new URLSearchParams("status=error"),
+			START_MS,
+		);
+		expect(whereClause).toContain("success = FALSE");
+		expect(params).toEqual([START_MS]);
+	});
+
+	it("adds no status condition for status=all", () => {
+		const { whereClause } = buildRequestFilters(
+			new URLSearchParams("status=all"),
+			START_MS,
+		);
+		expect(whereClause).not.toContain("success =");
+	});
+
+	it("ignores empty filter values", () => {
+		const { whereClause, params } = buildRequestFilters(
+			new URLSearchParams("accounts=&models=&apiKeys="),
+			START_MS,
+		);
+		expect(whereClause).toBe("timestamp > ?");
+		expect(params).toEqual([START_MS]);
+	});
+
+	it("drops empty segments inside comma lists", () => {
+		const { whereClause, params } = buildRequestFilters(
+			new URLSearchParams("models=model-a,,model-b,"),
+			START_MS,
+		);
+		expect(whereClause).toContain("model IN (?,?)");
+		expect(params).toEqual([START_MS, "model-a", "model-b"]);
+	});
+
+	it("combines all filters with AND in timestamp/accounts/models/apiKeys/status order", () => {
+		const { whereClause, params } = buildRequestFilters(
+			new URLSearchParams(
+				"accounts=acct-1&models=model-a&apiKeys=key-1&status=error",
+			),
+			START_MS,
+		);
+
+		const tsIdx = whereClause.indexOf("timestamp > ?");
+		const acctIdx = whereClause.indexOf("r.account_used IN");
+		const modelIdx = whereClause.indexOf("model IN");
+		const keyIdx = whereClause.indexOf("api_key_name IN");
+		const statusIdx = whereClause.indexOf("success = FALSE");
+
+		expect(tsIdx).toBeGreaterThanOrEqual(0);
+		expect(acctIdx).toBeGreaterThan(tsIdx);
+		expect(modelIdx).toBeGreaterThan(acctIdx);
+		expect(keyIdx).toBeGreaterThan(modelIdx);
+		expect(statusIdx).toBeGreaterThan(keyIdx);
+
+		expect(params).toEqual([
+			START_MS,
+			"acct-1",
+			NO_ACCOUNT_ID,
+			NO_ACCOUNT_ID,
+			"acct-1",
+			"model-a",
+			"key-1",
+		]);
+	});
+});

--- a/packages/http-api/src/utils/query-filters.ts
+++ b/packages/http-api/src/utils/query-filters.ts
@@ -1,0 +1,137 @@
+import { NO_ACCOUNT_ID } from "@better-ccflare/types";
+
+/**
+ * Shared range + filter parsing for request-analytics style endpoints
+ * (/api/analytics, /api/insights/cache).
+ *
+ * Extracted verbatim from the analytics handler so both endpoints interpret
+ * `range`, `accounts`, `models`, `apiKeys` and `status` identically.
+ */
+
+export interface BucketConfig {
+	bucketMs: number;
+	displayName: string;
+}
+
+export interface RangeConfig {
+	startMs: number;
+	bucket: BucketConfig;
+	/** The effective range actually used (unknown inputs normalize to "24h"). */
+	range: string;
+}
+
+/**
+ * Map a range string (1h/6h/24h/7d/30d) to a window start (ms since epoch)
+ * and a time-series bucket size. Unknown ranges fall back to 24h, and the
+ * returned `range` reflects that effective value.
+ */
+export function getRangeConfig(range: string): RangeConfig {
+	const now = Date.now();
+	const hour = 60 * 60 * 1000;
+	const day = 24 * hour;
+
+	switch (range) {
+		case "1h":
+			return {
+				startMs: now - hour,
+				bucket: { bucketMs: 60 * 1000, displayName: "1m" },
+				range,
+			};
+		case "6h":
+			return {
+				startMs: now - 6 * hour,
+				bucket: { bucketMs: 5 * 60 * 1000, displayName: "5m" },
+				range,
+			};
+		case "24h":
+			return {
+				startMs: now - day,
+				bucket: { bucketMs: hour, displayName: "1h" },
+				range,
+			};
+		case "7d":
+			return {
+				startMs: now - 7 * day,
+				bucket: { bucketMs: hour, displayName: "1h" },
+				range,
+			};
+		case "30d":
+			return {
+				startMs: now - 30 * day,
+				bucket: { bucketMs: day, displayName: "1d" },
+				range,
+			};
+		default:
+			return {
+				startMs: now - day,
+				bucket: { bucketMs: hour, displayName: "1h" },
+				range: "24h",
+			};
+	}
+}
+
+export interface RequestFilterResult {
+	/** SQL conditions joined with AND; assumes the requests table is aliased `r`. */
+	whereClause: string;
+	/** Bind parameters matching the `?` placeholders in whereClause, in order. */
+	params: (string | number)[];
+}
+
+/**
+ * Build the WHERE clause + bind params for queries over the `requests` table
+ * (aliased `r`) from dashboard filter search params.
+ *
+ * Conditions, in order: timestamp window, accounts (names resolved to ids via
+ * subquery, plus the NO_ACCOUNT_ID sentinel escape hatch), models, apiKeys,
+ * status (success/error; anything else adds no condition).
+ */
+export function buildRequestFilters(
+	searchParams: URLSearchParams,
+	startMs: number,
+): RequestFilterResult {
+	const accountsFilter =
+		searchParams.get("accounts")?.split(",").filter(Boolean) || [];
+	const modelsFilter =
+		searchParams.get("models")?.split(",").filter(Boolean) || [];
+	const apiKeysFilter =
+		searchParams.get("apiKeys")?.split(",").filter(Boolean) || [];
+	const statusFilter = searchParams.get("status") || "all";
+
+	const conditions: string[] = ["timestamp > ?"];
+	const params: (string | number)[] = [startMs];
+
+	if (accountsFilter.length > 0) {
+		// Handle account filter - map account names to IDs via join
+		const placeholders = accountsFilter.map(() => "?").join(",");
+		conditions.push(`(
+				r.account_used IN (SELECT id FROM accounts WHERE name IN (${placeholders}))
+				OR (r.account_used = ? AND ? IN (${placeholders}))
+			)`);
+		params.push(
+			...accountsFilter,
+			NO_ACCOUNT_ID,
+			NO_ACCOUNT_ID,
+			...accountsFilter,
+		);
+	}
+
+	if (modelsFilter.length > 0) {
+		const placeholders = modelsFilter.map(() => "?").join(",");
+		conditions.push(`model IN (${placeholders})`);
+		params.push(...modelsFilter);
+	}
+
+	if (apiKeysFilter.length > 0) {
+		const placeholders = apiKeysFilter.map(() => "?").join(",");
+		conditions.push(`api_key_name IN (${placeholders})`);
+		params.push(...apiKeysFilter);
+	}
+
+	if (statusFilter === "success") {
+		conditions.push("success = TRUE");
+	} else if (statusFilter === "error") {
+		conditions.push("success = FALSE");
+	}
+
+	return { whereClause: conditions.join(" AND "), params };
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -9,6 +9,7 @@ export * from "./combo";
 export * from "./constants";
 export * from "./context";
 export * from "./conversation";
+export * from "./insights";
 export * from "./logging";
 export * from "./request";
 export * from "./stats";

--- a/packages/types/src/insights.ts
+++ b/packages/types/src/insights.ts
@@ -1,0 +1,62 @@
+/**
+ * Response types for the cache insights endpoint (/api/insights/cache).
+ *
+ * Pure data shapes shared between the HTTP API and the dashboard.
+ */
+
+/** Metadata echoed back with a cache insights response. */
+export interface CacheInsightsMeta {
+	range: string;
+	thresholdPercent: number;
+	minRequestsForFlag: number;
+}
+
+/**
+ * Aggregate totals across all rows of a cache insights response.
+ * Cost fields sum over pricing-known volume only.
+ */
+export interface CacheInsightsTotals {
+	requests: number;
+	uncachedInputTokens: number;
+	cacheReadInputTokens: number;
+	cacheCreationInputTokens: number;
+	cacheHitRate: number;
+	/** Sums over pricing-known volume only. */
+	actualCacheCostUsd: number;
+	counterfactualCostUsd: number;
+	savingsUsd: number;
+	/** Distinct model ids (sorted) whose rates were unusable. */
+	unknownPricingModels: string[];
+}
+
+/**
+ * One row of the cache insights response.
+ *
+ * Cost fields (actualCacheCostUsd, counterfactualCostUsd, savingsUsd) are
+ * null whenever pricingKnown is false — i.e. when ANY portion of the row's
+ * token volume belongs to a model whose rates were unusable (unknown model,
+ * or a null cacheRead/cacheWrite rate with non-zero corresponding tokens).
+ */
+export interface CacheInsightsRow {
+	key: string;
+	requests: number;
+	uncachedInputTokens: number;
+	cacheReadInputTokens: number;
+	cacheCreationInputTokens: number;
+	/** 0-100; cache_read * 100 / (uncached + cache_read + cache_creation), 0 when denominator is 0 */
+	cacheHitRate: number;
+	actualCacheCostUsd: number | null;
+	counterfactualCostUsd: number | null;
+	savingsUsd: number | null;
+	pricingKnown: boolean;
+	flagged: boolean;
+}
+
+/** Full response of GET /api/insights/cache. */
+export interface CacheInsightsResponse {
+	meta: CacheInsightsMeta;
+	totals: CacheInsightsTotals;
+	byModel: CacheInsightsRow[];
+	byAccount: CacheInsightsRow[];
+	byProject: CacheInsightsRow[];
+}


### PR DESCRIPTION
Implements #248, the first slice of the Token Insights tracking issue (#247).

## What's new

### Backend
- **`GET /api/insights/cache`** — read-only endpoint over existing request data (no schema changes):
  - cache_read vs cache_creation vs uncached input token breakdown per **model**, **account**, and **project**
  - cache hit rates (same definition as `/api/analytics`)
  - **cache savings in USD** vs the all-uncached counterfactual (cache_read billed at full input rate; cache_creation contributes negative savings since cache_write > input rate)
  - low cache-hit-ratio flagging: `threshold` query param (percent, default 50), with a min-10-requests guard against noise; defaults surfaced in `meta`
  - supports the same `range`/`accounts`/`models`/`apiKeys`/`status` params as `/api/analytics`
  - models without pricing data report `savingsUsd: null` and are listed in `totals.unknownPricingModels` instead of guessing
- New exported `getModelRates()` accessor in `packages/core/src/pricing.ts` (NaN-guarded against malformed remote catalogue data)
- Pure savings-math service (`packages/http-api/src/services/cache-insights.ts`) — rates injected, fully unit-tested
- Range/filter parsing extracted from the analytics handler into a shared `query-filters` util (behavior-preserving; analytics now imports it)

### Dashboard
- New **Insights** tab (`/insights`): savings / hit-rate / request / cost summary cards, input-token composition donut, per-dimension breakdown table (model / account / project tabs) with "Low cache hit" badges, unknown-pricing footnotes, and an error state on fetch failure

## Testing
- 51 new tests (pricing rates, savings math incl. negative-savings and unknown-pricing cases, filter extraction parity, handler tests with mock adapter + in-memory SQLite integration asserting hand-computed dollar values)
- Full suite green (1600+ tests), lint/typecheck/format clean
- Verified live on port 8081: endpoint totals match direct SQLite sums exactly; threshold and flagging behave as specified
- SQL is dialect-safe (COALESCE, bound `?` placeholders, full expressions in GROUP BY) and runs through the shared adapter, same as the analytics handler, for SQLite + PostgreSQL
- Greptile review: 4/5 confidence, "safe to merge"; both P2 findings addressed (per-path warn dedup in pricing, error state in the Insights tab)

Closes #248. Part of #247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)