### PR TITLE
feat: anomaly detection insights endpoint (#249)

### DIFF
--- a/packages/http-api/src/handlers/__tests__/insights.test.ts
+++ b/packages/http-api/src/handlers/__tests__/insights.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import type {
+	AnomalyInsightsResponse,
+	APIContext,
+} from "@better-ccflare/types";
+import { createAnomalyInsightsHandler, parseDetectorParam } from "../insights";
+
+/**
+ * Tests for the anomaly insights handler: query-param parsing/clamping and
+ * the row-scan truncation path. The DB adapter is faked (the handler only
+ * calls getAdapter().query); rows use a null model so no pricing lookups
+ * (network-backed) are triggered.
+ */
+
+function sqlRow(i: number, timestamp: number) {
+	return {
+		id: `req-${i}`,
+		timestamp,
+		account: "acc",
+		model: null,
+		project: null,
+		input_tokens: 100,
+		cache_read_input_tokens: 0,
+		cache_creation_input_tokens: 0,
+		output_tokens: 0,
+		cost_usd: 0,
+	};
+}
+
+function contextWithRows(rows: unknown[]): APIContext {
+	return {
+		dbOps: {
+			getAdapter: () => ({
+				query: async () => rows,
+			}),
+		},
+	} as unknown as APIContext;
+}
+
+describe("parseDetectorParam", () => {
+	test("falls back to the default when missing or unparseable", () => {
+		expect(parseDetectorParam(null, 3, 0.5, 10)).toBe(3);
+		expect(parseDetectorParam("abc", 3, 0.5, 10)).toBe(3);
+		expect(parseDetectorParam("", 3, 0.5, 10)).toBe(3);
+	});
+
+	test("parses valid floats", () => {
+		expect(parseDetectorParam("2.5", 3, 0.5, 10)).toBe(2.5);
+	});
+
+	test("clamps to the allowed range", () => {
+		expect(parseDetectorParam("0.1", 3, 0.5, 10)).toBe(0.5);
+		expect(parseDetectorParam("99", 3, 0.5, 10)).toBe(10);
+		expect(parseDetectorParam("-5", 3, 0.5, 10)).toBe(0.5);
+	});
+
+	test("rounds to an integer when requested, after clamping", () => {
+		expect(parseDetectorParam("5.7", 5, 1, 120, true)).toBe(6);
+		expect(parseDetectorParam("999", 50, 1, 500, true)).toBe(500);
+		expect(parseDetectorParam(null, 50, 1, 500, true)).toBe(50);
+	});
+});
+
+describe("createAnomalyInsightsHandler", () => {
+	test("echoes defaults in meta and reports scanned rows", async () => {
+		const handler = createAnomalyInsightsHandler(
+			contextWithRows([sqlRow(1, 2_000), sqlRow(2, 1_000)]),
+		);
+		const response = await handler(new URLSearchParams());
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as AnomalyInsightsResponse;
+		expect(body.meta.range).toBe("24h");
+		expect(body.meta.zScoreThreshold).toBe(3);
+		expect(body.meta.maxEventsPerDetector).toBe(50);
+		expect(body.meta.scannedRequests).toBe(2);
+		expect(body.meta.truncated).toBe(false);
+	});
+
+	test("falls back and clamps invalid query params", async () => {
+		const handler = createAnomalyInsightsHandler(contextWithRows([]));
+		const response = await handler(
+			new URLSearchParams(
+				"zScoreThreshold=abc&maxEventsPerDetector=99999&loopWindowMinutes=5.7&minBaselineRequests=-3&range=bogus",
+			),
+		);
+		const body = (await response.json()) as AnomalyInsightsResponse;
+		expect(body.meta.zScoreThreshold).toBe(3);
+		expect(body.meta.maxEventsPerDetector).toBe(500);
+		expect(body.meta.loopWindowMinutes).toBe(6);
+		expect(body.meta.minBaselineRequests).toBe(2);
+		// Unknown ranges normalize to 24h, mirroring the analytics endpoint.
+		expect(body.meta.range).toBe("24h");
+	});
+
+	test("marks the response truncated when the scan cap is exceeded", async () => {
+		// The handler fetches cap + 1 rows to detect truncation; simulate the
+		// DB returning exactly that.
+		const rows = Array.from({ length: 100_001 }, (_, i) => sqlRow(i, i));
+		const handler = createAnomalyInsightsHandler(contextWithRows(rows));
+		const response = await handler(new URLSearchParams());
+		const body = (await response.json()) as AnomalyInsightsResponse;
+		expect(body.meta.truncated).toBe(true);
+		expect(body.meta.scannedRequests).toBe(100_000);
+	});
+
+	test("returns 500 when the query fails", async () => {
+		const context = {
+			dbOps: {
+				getAdapter: () => ({
+					query: async () => {
+						throw new Error("boom");
+					},
+				}),
+			},
+		} as unknown as APIContext;
+		const handler = createAnomalyInsightsHandler(context);
+		const response = await handler(new URLSearchParams());
+		expect(response.status).toBe(500);
+	});
+});

--- a/packages/http-api/src/handlers/insights.ts
+++ b/packages/http-api/src/handlers/insights.ts
@@ -6,6 +6,19 @@ import {
 } from "@better-ccflare/http-common";
 import { Logger } from "@better-ccflare/logger";
 import {
+	type AnomalyRequestRow,
+	buildAnomalyInsightsResponse,
+	DEFAULT_LOOP_MIN_REQUESTS,
+	DEFAULT_LOOP_SIMILARITY_TOLERANCE,
+	DEFAULT_LOOP_WINDOW_MINUTES,
+	DEFAULT_MAX_EVENTS_PER_DETECTOR,
+	DEFAULT_MIN_BASELINE_REQUESTS,
+	DEFAULT_MISROUTING_MAX_TOTAL_TOKENS,
+	DEFAULT_MISROUTING_MIN_OUTPUT_RATE_USD,
+	DEFAULT_MISROUTING_MIN_REQUESTS,
+	DEFAULT_Z_SCORE_THRESHOLD,
+} from "../services/anomaly-insights";
+import {
 	buildCacheInsightsResponse,
 	DEFAULT_THRESHOLD_PERCENT,
 	type GroupedTokenRow,
@@ -133,6 +146,204 @@ export function createCacheInsightsHandler(context: APIContext) {
 			log.error("Cache insights error:", error);
 			return errorResponse(
 				InternalServerError("Failed to fetch cache insights data"),
+			);
+		}
+	};
+}
+
+/**
+ * Hard cap on rows fetched per anomalies request. With wide ranges on
+ * high-traffic instances the raw fetch would otherwise be unbounded; beyond
+ * the cap only the most recent rows are analyzed and meta.truncated is set.
+ */
+const MAX_ANOMALY_SCAN_ROWS = 100_000;
+
+/** Raw per-request row shape for the anomalies query. */
+interface AnomalyRequestSqlRow {
+	id: string;
+	timestamp: number;
+	account: string | null;
+	model: string | null;
+	project: string | null;
+	input_tokens: number;
+	cache_read_input_tokens: number;
+	cache_creation_input_tokens: number;
+	output_tokens: number;
+	cost_usd: number;
+}
+
+function toAnomalyRequestRow(row: AnomalyRequestSqlRow): AnomalyRequestRow {
+	return {
+		id: row.id,
+		timestamp: Number(row.timestamp) || 0,
+		account: row.account,
+		model: row.model,
+		project: row.project,
+		inputTokens: Number(row.input_tokens) || 0,
+		cacheReadInputTokens: Number(row.cache_read_input_tokens) || 0,
+		cacheCreationInputTokens: Number(row.cache_creation_input_tokens) || 0,
+		outputTokens: Number(row.output_tokens) || 0,
+		costUsd: Number(row.cost_usd) || 0,
+	};
+}
+
+/**
+ * Parse a numeric detector-threshold query param: fall back to the default
+ * when missing or unparseable, clamp to [min, max], optionally round to an
+ * integer (for count-like params).
+ */
+function parseDetectorParam(
+	raw: string | null,
+	fallback: number,
+	min: number,
+	max: number,
+	integer = false,
+): number {
+	const parsed = raw === null ? fallback : Number.parseFloat(raw);
+	const value = Number.isFinite(parsed) ? parsed : fallback;
+	const clamped = Math.min(max, Math.max(min, value));
+	return integer ? Math.round(clamped) : clamped;
+}
+
+/**
+ * GET /api/insights/anomalies — token anomaly detection.
+ *
+ * Fetches per-request rows over the requested range/filters in one batch
+ * query and runs the pure detectors from services/anomaly-insights:
+ * per-account/model baselines, token outliers, output blowups, runaway
+ * loops, and model misrouting. Detector thresholds are query params with
+ * sane defaults (see AnomalyInsightsOptions).
+ */
+export function createAnomalyInsightsHandler(context: APIContext) {
+	return async (searchParams: URLSearchParams): Promise<Response> => {
+		const db = context.dbOps.getAdapter();
+		const { startMs, range } = getRangeConfig(
+			searchParams.get("range") ?? "24h",
+		);
+		const { whereClause, params: queryParams } = buildRequestFilters(
+			searchParams,
+			startMs,
+		);
+
+		const options = {
+			range,
+			zScoreThreshold: parseDetectorParam(
+				searchParams.get("zScoreThreshold"),
+				DEFAULT_Z_SCORE_THRESHOLD,
+				0.5,
+				10,
+			),
+			minBaselineRequests: parseDetectorParam(
+				searchParams.get("minBaselineRequests"),
+				DEFAULT_MIN_BASELINE_REQUESTS,
+				2,
+				100_000,
+				true,
+			),
+			loopWindowMinutes: parseDetectorParam(
+				searchParams.get("loopWindowMinutes"),
+				DEFAULT_LOOP_WINDOW_MINUTES,
+				1,
+				120,
+				true,
+			),
+			loopMinRequests: parseDetectorParam(
+				searchParams.get("loopMinRequests"),
+				DEFAULT_LOOP_MIN_REQUESTS,
+				2,
+				10_000,
+				true,
+			),
+			loopSimilarityTolerance: parseDetectorParam(
+				searchParams.get("loopSimilarityTolerance"),
+				DEFAULT_LOOP_SIMILARITY_TOLERANCE,
+				0,
+				5,
+			),
+			misroutingMaxTotalTokens: parseDetectorParam(
+				searchParams.get("misroutingMaxTotalTokens"),
+				DEFAULT_MISROUTING_MAX_TOTAL_TOKENS,
+				1,
+				1_000_000,
+				true,
+			),
+			misroutingMinOutputRateUsd: parseDetectorParam(
+				searchParams.get("misroutingMinOutputRateUsd"),
+				DEFAULT_MISROUTING_MIN_OUTPUT_RATE_USD,
+				0,
+				10_000,
+			),
+			misroutingMinRequests: parseDetectorParam(
+				searchParams.get("misroutingMinRequests"),
+				DEFAULT_MISROUTING_MIN_REQUESTS,
+				1,
+				10_000,
+				true,
+			),
+			maxEventsPerDetector: parseDetectorParam(
+				searchParams.get("maxEventsPerDetector"),
+				DEFAULT_MAX_EVENTS_PER_DETECTOR,
+				1,
+				500,
+				true,
+			),
+		};
+
+		try {
+			// Safety cap on the batch fetch: scan at most the most recent
+			// MAX_ANOMALY_SCAN_ROWS rows (fetch one extra to detect truncation).
+			const sqlRows = await db.query<AnomalyRequestSqlRow>(
+				`
+				SELECT
+					r.id as id,
+					r.timestamp as timestamp,
+					a.name as account,
+					r.model as model,
+					r.project as project,
+					COALESCE(r.input_tokens, 0) as input_tokens,
+					COALESCE(r.cache_read_input_tokens, 0) as cache_read_input_tokens,
+					COALESCE(r.cache_creation_input_tokens, 0) as cache_creation_input_tokens,
+					COALESCE(r.output_tokens, 0) as output_tokens,
+					COALESCE(r.cost_usd, 0) as cost_usd
+				FROM requests r
+				LEFT JOIN accounts a ON a.id = r.account_used
+				WHERE ${whereClause}
+				ORDER BY r.timestamp DESC
+				LIMIT ${MAX_ANOMALY_SCAN_ROWS + 1}
+			`,
+				queryParams,
+			);
+			const truncated = sqlRows.length > MAX_ANOMALY_SCAN_ROWS;
+			const rows = sqlRows
+				.slice(0, MAX_ANOMALY_SCAN_ROWS)
+				.map(toAnomalyRequestRow)
+				.reverse();
+
+			const modelIds = [
+				...new Set(
+					rows
+						.map((row) => row.model)
+						.filter((model): model is string => model != null && model !== ""),
+				),
+			];
+			const rateList = await Promise.all(
+				modelIds.map((modelId) => getModelRates(modelId)),
+			);
+			const rates = new Map<string, ModelRates | null>(
+				modelIds.map((modelId, index) => [modelId, rateList[index]]),
+			);
+
+			return jsonResponse(
+				buildAnomalyInsightsResponse({
+					rows,
+					rates,
+					options: { ...options, truncated },
+				}),
+			);
+		} catch (error) {
+			log.error("Anomaly insights error:", error);
+			return errorResponse(
+				InternalServerError("Failed to fetch anomaly insights data"),
 			);
 		}
 	};

--- a/packages/http-api/src/handlers/insights.ts
+++ b/packages/http-api/src/handlers/insights.ts
@@ -190,9 +190,9 @@ function toAnomalyRequestRow(row: AnomalyRequestSqlRow): AnomalyRequestRow {
 /**
  * Parse a numeric detector-threshold query param: fall back to the default
  * when missing or unparseable, clamp to [min, max], optionally round to an
- * integer (for count-like params).
+ * integer (for count-like params). Exported for tests.
  */
-function parseDetectorParam(
+export function parseDetectorParam(
 	raw: string | null,
 	fallback: number,
 	min: number,
@@ -314,6 +314,9 @@ export function createAnomalyInsightsHandler(context: APIContext) {
 				queryParams,
 			);
 			const truncated = sqlRows.length > MAX_ANOMALY_SCAN_ROWS;
+			// Undo the DESC fetch order so detectors see chronological rows.
+			// Not load-bearing (the loop detector re-sorts per group), just
+			// keeps the row order deterministic and intuitive.
 			const rows = sqlRows
 				.slice(0, MAX_ANOMALY_SCAN_ROWS)
 				.map(toAnomalyRequestRow)

--- a/packages/http-api/src/router.ts
+++ b/packages/http-api/src/router.ts
@@ -71,7 +71,10 @@ import {
 } from "./handlers/debug";
 import { createFeaturesHandler } from "./handlers/features";
 import { createHealthHandler } from "./handlers/health";
-import { createCacheInsightsHandler } from "./handlers/insights";
+import {
+	createAnomalyInsightsHandler,
+	createCacheInsightsHandler,
+} from "./handlers/insights";
 import { createLogsStreamHandler } from "./handlers/logs";
 import { createLogsHistoryHandler } from "./handlers/logs-history";
 import { createCleanupHandler } from "./handlers/maintenance";
@@ -184,6 +187,7 @@ export class APIRouter {
 		const logsHistoryHandler = createLogsHistoryHandler();
 		const analyticsHandler = createAnalyticsHandler(this.context);
 		const cacheInsightsHandler = createCacheInsightsHandler(this.context);
+		const anomalyInsightsHandler = createAnomalyInsightsHandler(this.context);
 		const oauthInitHandler = createOAuthInitHandler(dbOps);
 		const oauthCallbackHandler = createOAuthCallbackHandler(dbOps);
 		const qwenDeviceFlowInitHandler = createQwenDeviceFlowInitHandler(dbOps);
@@ -372,6 +376,9 @@ export class APIRouter {
 		});
 		this.handlers.set("GET:/api/insights/cache", (_req, url) =>
 			cacheInsightsHandler(url.searchParams),
+		);
+		this.handlers.set("GET:/api/insights/anomalies", (_req, url) =>
+			anomalyInsightsHandler(url.searchParams),
 		);
 		this.handlers.set("GET:/api/agents", () => agentsHandler());
 		this.handlers.set("POST:/api/agents/bulk-preference", (req) => {

--- a/packages/http-api/src/services/__tests__/anomaly-insights.test.ts
+++ b/packages/http-api/src/services/__tests__/anomaly-insights.test.ts
@@ -214,8 +214,8 @@ describe("detectRunawayLoops", () => {
 		expect(loops[0].requests).toBe(12);
 		expect(loops[0].windowStartMs).toBe(0);
 		expect(loops[0].windowEndMs).toBe(110_000);
-		expect(loops[0].meanInputTokens).toBe(500);
-		expect(loops[0].inputTokenSpread).toBe(0);
+		expect(loops[0].meanRequestSideTokens).toBe(500);
+		expect(loops[0].requestSideTokenSpread).toBe(0);
 		// 12 requests over 110s
 		expect(loops[0].requestsPerMinute).toBeCloseTo((12 * 60_000) / 110_000, 6);
 	});
@@ -253,8 +253,33 @@ describe("detectRunawayLoops", () => {
 		);
 		const loops = detectRunawayLoops(rows, opts);
 		expect(loops).toHaveLength(1);
-		expect(loops[0].meanInputTokens).toBe(0);
-		expect(loops[0].inputTokenSpread).toBe(0);
+		expect(loops[0].meanRequestSideTokens).toBe(0);
+		expect(loops[0].requestSideTokenSpread).toBe(0);
+	});
+
+	test("reports adjacent bursts with different profiles as separate loops", () => {
+		// Burst A: 12 requests at 100 tokens (t = 0..110s). Burst B: 12
+		// requests at 10000 tokens (t = 120s..230s). Both fit inside one
+		// 5-minute window, so a post-merge similarity check would drop both;
+		// per-window qualification must report each burst on its own.
+		const rows = [
+			...Array.from({ length: 12 }, (_, i) =>
+				req({ timestamp: i * 10_000, inputTokens: 100 }),
+			),
+			...Array.from({ length: 12 }, (_, i) =>
+				req({ timestamp: 120_000 + i * 10_000, inputTokens: 10_000 }),
+			),
+		];
+		const loops = detectRunawayLoops(rows, opts);
+		expect(loops).toHaveLength(2);
+		const means = loops
+			.map((loop) => loop.meanRequestSideTokens)
+			.sort((a, b) => a - b);
+		expect(means).toEqual([100, 10_000]);
+		for (const loop of loops) {
+			expect(loop.requests).toBe(12);
+			expect(loop.requestSideTokenSpread).toBe(0);
+		}
 	});
 
 	test("merges overlapping qualifying windows into one sustained run", () => {

--- a/packages/http-api/src/services/__tests__/anomaly-insights.test.ts
+++ b/packages/http-api/src/services/__tests__/anomaly-insights.test.ts
@@ -1,0 +1,471 @@
+import { describe, expect, test } from "bun:test";
+import type { ModelRates } from "@better-ccflare/core";
+import {
+	type AnomalyRequestRow,
+	buildAnomalyInsightsResponse,
+	computeBaselines,
+	detectModelMisrouting,
+	detectRunawayLoops,
+	detectTokenOutliers,
+} from "../anomaly-insights";
+
+/**
+ * Tests for the pure anomaly-detection math service.
+ *
+ * Token values are chosen so means/stddevs are exact in floating point,
+ * e.g. nine requests at 100 tokens plus one at 1000 gives mean 190,
+ * stddev 270 and a z-score of exactly 3 for the spike.
+ */
+
+const OPUS_RATES: ModelRates = {
+	input: 15,
+	output: 75,
+	cacheRead: 1.5,
+	cacheWrite: 18.75,
+};
+
+const HAIKU_RATES: ModelRates = {
+	input: 1,
+	output: 4,
+	cacheRead: 0.1,
+	cacheWrite: 1.25,
+};
+
+let nextId = 0;
+
+function req(partial: Partial<AnomalyRequestRow> = {}): AnomalyRequestRow {
+	nextId += 1;
+	return {
+		id: `req-${nextId}`,
+		timestamp: 0,
+		account: "acc",
+		model: "claude-opus-4-8",
+		project: null,
+		inputTokens: 0,
+		cacheReadInputTokens: 0,
+		cacheCreationInputTokens: 0,
+		outputTokens: 0,
+		costUsd: 0,
+		...partial,
+	};
+}
+
+/** Nine requests totalling 100 tokens each plus one 1000-token spike. */
+function spikeRows(): AnomalyRequestRow[] {
+	const rows = Array.from({ length: 9 }, () => req({ inputTokens: 100 }));
+	rows.push(req({ id: "spike", inputTokens: 1000 }));
+	return rows;
+}
+
+describe("computeBaselines", () => {
+	test("computes mean and population stddev per account/model", () => {
+		const rows = [
+			...Array.from({ length: 5 }, () =>
+				req({ inputTokens: 90, outputTokens: 0 }),
+			),
+			...Array.from({ length: 5 }, () =>
+				req({ inputTokens: 110, outputTokens: 0 }),
+			),
+		];
+		const baselines = computeBaselines(rows, 10);
+		expect(baselines).toHaveLength(1);
+		expect(baselines[0].account).toBe("acc");
+		expect(baselines[0].model).toBe("claude-opus-4-8");
+		expect(baselines[0].requests).toBe(10);
+		expect(baselines[0].meanTotalTokens).toBe(100);
+		expect(baselines[0].stdDevTotalTokens).toBe(10);
+		expect(baselines[0].meanOutputTokens).toBe(0);
+		expect(baselines[0].stdDevOutputTokens).toBe(0);
+	});
+
+	test("total tokens sum input, cache read, cache creation and output", () => {
+		const rows = Array.from({ length: 10 }, () =>
+			req({
+				inputTokens: 10,
+				cacheReadInputTokens: 20,
+				cacheCreationInputTokens: 30,
+				outputTokens: 40,
+			}),
+		);
+		const baselines = computeBaselines(rows, 10);
+		expect(baselines[0].meanTotalTokens).toBe(100);
+	});
+
+	test("excludes zero-token rows from the baseline", () => {
+		const rows = [
+			...Array.from({ length: 10 }, () => req({ inputTokens: 100 })),
+			...Array.from({ length: 10 }, () => req()), // failed requests, no tokens
+		];
+		const baselines = computeBaselines(rows, 10);
+		expect(baselines).toHaveLength(1);
+		expect(baselines[0].requests).toBe(10);
+		expect(baselines[0].meanTotalTokens).toBe(100);
+	});
+
+	test("omits groups below minBaselineRequests", () => {
+		const rows = Array.from({ length: 9 }, () => req({ inputTokens: 100 }));
+		expect(computeBaselines(rows, 10)).toHaveLength(0);
+	});
+
+	test("groups separately per account and model, normalizing null to Unknown", () => {
+		const rows = [
+			...Array.from({ length: 3 }, () =>
+				req({ account: "a1", model: "m1", inputTokens: 100 }),
+			),
+			...Array.from({ length: 3 }, () =>
+				req({ account: "a1", model: "m2", inputTokens: 200 }),
+			),
+			...Array.from({ length: 3 }, () =>
+				req({ account: null, model: null, inputTokens: 300 }),
+			),
+		];
+		const baselines = computeBaselines(rows, 3);
+		expect(baselines).toHaveLength(3);
+		const unknown = baselines.find((b) => b.account === "Unknown");
+		expect(unknown?.model).toBe("Unknown");
+		expect(unknown?.meanTotalTokens).toBe(300);
+	});
+});
+
+describe("detectTokenOutliers", () => {
+	test("flags requests at or above the z-score threshold", () => {
+		const rows = spikeRows();
+		const baselines = computeBaselines(rows, 10);
+		const outliers = detectTokenOutliers(rows, baselines, 3, "total_tokens");
+		expect(outliers).toHaveLength(1);
+		expect(outliers[0].requestId).toBe("spike");
+		expect(outliers[0].metric).toBe("total_tokens");
+		expect(outliers[0].value).toBe(1000);
+		expect(outliers[0].baselineMean).toBe(190);
+		expect(outliers[0].baselineStdDev).toBe(270);
+		expect(outliers[0].zScore).toBe(3);
+	});
+
+	test("does not flag low-side outliers", () => {
+		// Nine 1000-token requests plus one at 100: the small one has z = -3.
+		const rows = Array.from({ length: 9 }, () => req({ inputTokens: 1000 }));
+		rows.push(req({ inputTokens: 100 }));
+		const baselines = computeBaselines(rows, 10);
+		expect(
+			detectTokenOutliers(rows, baselines, 3, "total_tokens"),
+		).toHaveLength(0);
+	});
+
+	test("returns nothing when the baseline has zero variance", () => {
+		const rows = Array.from({ length: 10 }, () => req({ inputTokens: 100 }));
+		const baselines = computeBaselines(rows, 10);
+		expect(
+			detectTokenOutliers(rows, baselines, 3, "total_tokens"),
+		).toHaveLength(0);
+	});
+
+	test("returns nothing for groups without a baseline", () => {
+		const rows = spikeRows();
+		expect(detectTokenOutliers(rows, [], 3, "total_tokens")).toHaveLength(0);
+	});
+
+	test("output_tokens metric detects output blowups independently", () => {
+		// Constant 200 total tokens, but one response with 100 output tokens
+		// against a baseline of 10: z = 3 on the output metric only.
+		const rows = Array.from({ length: 9 }, () =>
+			req({ inputTokens: 190, outputTokens: 10 }),
+		);
+		rows.push(req({ id: "blowup", inputTokens: 100, outputTokens: 100 }));
+		const baselines = computeBaselines(rows, 10);
+		expect(
+			detectTokenOutliers(rows, baselines, 3, "total_tokens"),
+		).toHaveLength(0);
+		const blowups = detectTokenOutliers(rows, baselines, 3, "output_tokens");
+		expect(blowups).toHaveLength(1);
+		expect(blowups[0].requestId).toBe("blowup");
+		expect(blowups[0].metric).toBe("output_tokens");
+		expect(blowups[0].zScore).toBe(3);
+	});
+
+	test("sorts outliers by z-score descending", () => {
+		const rows = [
+			...Array.from({ length: 18 }, () => req({ inputTokens: 100 })),
+			req({ id: "big", inputTokens: 1000 }),
+			req({ id: "bigger", inputTokens: 2000 }),
+		];
+		const baselines = computeBaselines(rows, 10);
+		// z(big) ~ 1.69, z(bigger) ~ 3.92 against mean 240, stddev ~448.8.
+		const outliers = detectTokenOutliers(rows, baselines, 1.5, "total_tokens");
+		expect(outliers.map((o) => o.requestId)).toEqual(["bigger", "big"]);
+	});
+});
+
+describe("detectRunawayLoops", () => {
+	const opts = {
+		windowMs: 5 * 60_000,
+		minRequests: 10,
+		similarityTolerance: 0.25,
+	};
+
+	test("flags a dense burst of near-identical requests", () => {
+		// 12 requests, one every 10s, identical token profile.
+		const rows = Array.from({ length: 12 }, (_, i) =>
+			req({ timestamp: i * 10_000, inputTokens: 500, project: "proj" }),
+		);
+		const loops = detectRunawayLoops(rows, opts);
+		expect(loops).toHaveLength(1);
+		expect(loops[0].account).toBe("acc");
+		expect(loops[0].project).toBe("proj");
+		expect(loops[0].requests).toBe(12);
+		expect(loops[0].windowStartMs).toBe(0);
+		expect(loops[0].windowEndMs).toBe(110_000);
+		expect(loops[0].meanInputTokens).toBe(500);
+		expect(loops[0].inputTokenSpread).toBe(0);
+		// 12 requests over 110s
+		expect(loops[0].requestsPerMinute).toBeCloseTo((12 * 60_000) / 110_000, 6);
+	});
+
+	test("does not flag sparse traffic", () => {
+		// One request every 10 minutes: never enough in any 5-minute window.
+		const rows = Array.from({ length: 12 }, (_, i) =>
+			req({ timestamp: i * 600_000, inputTokens: 500 }),
+		);
+		expect(detectRunawayLoops(rows, opts)).toHaveLength(0);
+	});
+
+	test("does not flag bursts with dissimilar token profiles", () => {
+		const rows = Array.from({ length: 12 }, (_, i) =>
+			req({ timestamp: i * 10_000, inputTokens: i % 2 === 0 ? 10 : 10_000 }),
+		);
+		expect(detectRunawayLoops(rows, opts)).toHaveLength(0);
+	});
+
+	test("splits groups by project", () => {
+		// 6 requests in each of two projects: neither reaches minRequests.
+		const rows = Array.from({ length: 12 }, (_, i) =>
+			req({
+				timestamp: i * 10_000,
+				inputTokens: 500,
+				project: i % 2 === 0 ? "p1" : "p2",
+			}),
+		);
+		expect(detectRunawayLoops(rows, opts)).toHaveLength(0);
+	});
+
+	test("flags repeated zero-token requests (e.g. failing retries)", () => {
+		const rows = Array.from({ length: 12 }, (_, i) =>
+			req({ timestamp: i * 5_000 }),
+		);
+		const loops = detectRunawayLoops(rows, opts);
+		expect(loops).toHaveLength(1);
+		expect(loops[0].meanInputTokens).toBe(0);
+		expect(loops[0].inputTokenSpread).toBe(0);
+	});
+
+	test("merges overlapping qualifying windows into one sustained run", () => {
+		// 30 requests, one every 30s (14.5 minutes total). Every 5-minute
+		// window holds 10-11 requests, so the run must merge into one group.
+		const rows = Array.from({ length: 30 }, (_, i) =>
+			req({ timestamp: i * 30_000, inputTokens: 500 }),
+		);
+		const loops = detectRunawayLoops(rows, opts);
+		expect(loops).toHaveLength(1);
+		expect(loops[0].requests).toBe(30);
+		expect(loops[0].windowStartMs).toBe(0);
+		expect(loops[0].windowEndMs).toBe(29 * 30_000);
+	});
+});
+
+describe("detectModelMisrouting", () => {
+	const rates = new Map<string, ModelRates | null>([
+		["claude-opus-4-8", OPUS_RATES],
+		["claude-haiku-4-5", HAIKU_RATES],
+		["mystery-model", null],
+	]);
+	const opts = {
+		maxTotalTokens: 500,
+		minOutputRateUsd: 25,
+		minRequests: 5,
+	};
+
+	test("flags small calls on expensive models", () => {
+		const rows = Array.from({ length: 5 }, (_, i) =>
+			req({
+				timestamp: i,
+				inputTokens: 80,
+				outputTokens: 20,
+				costUsd: 0.01,
+			}),
+		);
+		const groups = detectModelMisrouting(rows, rates, opts);
+		expect(groups).toHaveLength(1);
+		expect(groups[0].account).toBe("acc");
+		expect(groups[0].model).toBe("claude-opus-4-8");
+		expect(groups[0].requests).toBe(5);
+		expect(groups[0].meanTotalTokens).toBe(100);
+		expect(groups[0].outputRateUsd).toBe(75);
+		expect(groups[0].totalCostUsd).toBeCloseTo(0.05, 10);
+		expect(groups[0].exampleRequestIds).toHaveLength(5);
+	});
+
+	test("caps exampleRequestIds at five", () => {
+		const rows = Array.from({ length: 8 }, (_, i) =>
+			req({ timestamp: i, inputTokens: 100 }),
+		);
+		const groups = detectModelMisrouting(rows, rates, opts);
+		expect(groups[0].requests).toBe(8);
+		expect(groups[0].exampleRequestIds).toHaveLength(5);
+	});
+
+	test("ignores cheap models", () => {
+		const rows = Array.from({ length: 5 }, () =>
+			req({ model: "claude-haiku-4-5", inputTokens: 100 }),
+		);
+		expect(detectModelMisrouting(rows, rates, opts)).toHaveLength(0);
+	});
+
+	test("ignores models with unknown rates", () => {
+		const rows = Array.from({ length: 5 }, () =>
+			req({ model: "mystery-model", inputTokens: 100 }),
+		);
+		expect(detectModelMisrouting(rows, rates, opts)).toHaveLength(0);
+	});
+
+	test("ignores calls above the trivial-size threshold and zero-token rows", () => {
+		const rows = [
+			...Array.from({ length: 5 }, () => req({ inputTokens: 501 })),
+			...Array.from({ length: 5 }, () => req()),
+		];
+		expect(detectModelMisrouting(rows, rates, opts)).toHaveLength(0);
+	});
+
+	test("requires minRequests trivial calls before flagging", () => {
+		const rows = Array.from({ length: 4 }, () => req({ inputTokens: 100 }));
+		expect(detectModelMisrouting(rows, rates, opts)).toHaveLength(0);
+	});
+
+	test("sorts groups by total cost descending", () => {
+		const rows = [
+			...Array.from({ length: 5 }, () =>
+				req({ account: "cheap-acc", inputTokens: 100, costUsd: 0.01 }),
+			),
+			...Array.from({ length: 5 }, () =>
+				req({ account: "pricey-acc", inputTokens: 100, costUsd: 0.05 }),
+			),
+		];
+		const groups = detectModelMisrouting(rows, rates, opts);
+		expect(groups.map((g) => g.account)).toEqual(["pricey-acc", "cheap-acc"]);
+	});
+});
+
+describe("buildAnomalyInsightsResponse", () => {
+	const rates = new Map<string, ModelRates | null>([
+		["claude-opus-4-8", OPUS_RATES],
+	]);
+
+	test("echoes the effective options in meta", () => {
+		const response = buildAnomalyInsightsResponse({
+			rows: [],
+			rates,
+			options: { range: "7d" },
+		});
+		expect(response.meta).toEqual({
+			range: "7d",
+			zScoreThreshold: 3,
+			minBaselineRequests: 20,
+			loopWindowMinutes: 5,
+			loopMinRequests: 10,
+			loopSimilarityTolerance: 0.25,
+			misroutingMaxTotalTokens: 500,
+			misroutingMinOutputRateUsd: 25,
+			misroutingMinRequests: 5,
+			maxEventsPerDetector: 50,
+			scannedRequests: 0,
+			truncated: false,
+		});
+		expect(response.baselines).toHaveLength(0);
+		expect(response.tokenOutliers).toHaveLength(0);
+		expect(response.outputBlowups).toHaveLength(0);
+		expect(response.runawayLoops).toHaveLength(0);
+		expect(response.misrouting).toHaveLength(0);
+	});
+
+	test("reports scanned row count and truncation in meta", () => {
+		const rows = Array.from({ length: 3 }, () => req({ inputTokens: 100 }));
+		const response = buildAnomalyInsightsResponse({
+			rows,
+			rates,
+			options: { range: "30d", truncated: true },
+		});
+		expect(response.meta.scannedRequests).toBe(3);
+		expect(response.meta.truncated).toBe(true);
+	});
+
+	test("runs all detectors over the same rows", () => {
+		const rows: AnomalyRequestRow[] = [
+			// Baseline + total-token spike (also an output blowup). Totals stay
+			// above misroutingMaxTotalTokens so they don't trip that detector.
+			...Array.from({ length: 19 }, (_, i) =>
+				req({ timestamp: i * 600_000, inputTokens: 900, outputTokens: 100 }),
+			),
+			req({
+				id: "spike",
+				timestamp: 19 * 600_000,
+				inputTokens: 90_000,
+				outputTokens: 10_000,
+			}),
+			// Runaway loop burst on another account/project; the model has no
+			// known rates so the small calls don't count as misrouting.
+			...Array.from({ length: 12 }, (_, i) =>
+				req({
+					account: "loop-acc",
+					project: "loop-proj",
+					model: "loop-model",
+					timestamp: i * 10_000,
+					inputTokens: 50,
+				}),
+			),
+			// Misrouting: small opus calls on a third account.
+			...Array.from({ length: 5 }, (_, i) =>
+				req({
+					account: "tiny-acc",
+					timestamp: i,
+					inputTokens: 50,
+					outputTokens: 10,
+					costUsd: 0.02,
+				}),
+			),
+		];
+		const response = buildAnomalyInsightsResponse({
+			rows,
+			rates,
+			options: { range: "24h", minBaselineRequests: 20 },
+		});
+		expect(
+			response.baselines.some((b) => b.account === "acc" && b.requests === 20),
+		).toBe(true);
+		expect(response.tokenOutliers.map((o) => o.requestId)).toEqual(["spike"]);
+		expect(response.outputBlowups.map((o) => o.requestId)).toEqual(["spike"]);
+		expect(response.runawayLoops).toHaveLength(1);
+		expect(response.runawayLoops[0].account).toBe("loop-acc");
+		expect(response.misrouting).toHaveLength(1);
+		expect(response.misrouting[0].account).toBe("tiny-acc");
+	});
+
+	test("caps every detector list at maxEventsPerDetector", () => {
+		const rows: AnomalyRequestRow[] = [
+			...Array.from({ length: 18 }, () => req({ inputTokens: 100 })),
+			req({ id: "big", inputTokens: 1000 }),
+			req({ id: "bigger", inputTokens: 2000 }),
+		];
+		const response = buildAnomalyInsightsResponse({
+			rows,
+			rates,
+			options: {
+				range: "24h",
+				minBaselineRequests: 10,
+				// At 1.5 both "big" and "bigger" qualify; the cap keeps one.
+				zScoreThreshold: 1.5,
+				maxEventsPerDetector: 1,
+			},
+		});
+		expect(response.tokenOutliers).toHaveLength(1);
+		// The cap keeps the highest z-score.
+		expect(response.tokenOutliers[0].requestId).toBe("bigger");
+	});
+});

--- a/packages/http-api/src/services/anomaly-insights.ts
+++ b/packages/http-api/src/services/anomaly-insights.ts
@@ -249,8 +249,16 @@ export interface RunawayLoopOptions {
  * is similar (coefficient of variation <= similarityTolerance).
  *
  * All rows count, including zero-token ones — repeated failing retries are
- * exactly the signal. Overlapping qualifying windows merge into one
- * sustained run so a long loop is reported once, not per window position.
+ * exactly the signal.
+ *
+ * Both count and similarity are checked PER WINDOW (forward-maximal windows
+ * from each start row plus backward-maximal windows from each end row, so a
+ * burst adjacent to dissimilar traffic on either side is still found), and
+ * only then are overlapping qualifying windows merged, so a long loop is
+ * reported once. Two adjacent bursts with different profiles inside one
+ * window length therefore surface as two separate loops. A merged run's
+ * reported spread is computed over the whole run and can exceed the
+ * tolerance when the profile drifts across merged windows.
  *
  * Sorted by request count descending.
  */
@@ -272,47 +280,94 @@ export function detectRunawayLoops(
 	const loops: RunawayLoopGroup[] = [];
 	for (const group of groups.values()) {
 		group.sort((a, b) => a.timestamp - b.timestamp);
+		const n = group.length;
 
-		// Find qualifying windows with two pointers and merge overlapping
-		// index ranges into maximal runs.
-		const runs: Array<{ start: number; end: number }> = [];
-		let end = 0;
-		for (let start = 0; start < group.length; start++) {
-			if (end < start) end = start;
+		// Prefix sums of request-side tokens so any window's mean/stddev is
+		// O(1); token counts are small enough that the sum-of-squares form
+		// is numerically safe in doubles.
+		const prefixSum = new Float64Array(n + 1);
+		const prefixSumSquares = new Float64Array(n + 1);
+		for (let i = 0; i < n; i++) {
+			const tokens = requestSideTokens(group[i]);
+			prefixSum[i + 1] = prefixSum[i] + tokens;
+			prefixSumSquares[i + 1] = prefixSumSquares[i] + tokens * tokens;
+		}
+
+		const windowStats = (start: number, end: number) => {
+			const count = end - start + 1;
+			const mean = (prefixSum[end + 1] - prefixSum[start]) / count;
+			const variance = Math.max(
+				(prefixSumSquares[end + 1] - prefixSumSquares[start]) / count -
+					mean * mean,
+				0,
+			);
+			const stdDev = Math.sqrt(variance);
+			// All-zero-token windows (failing retries) are identical profiles.
+			return { mean, spread: mean > 0 ? stdDev / mean : 0 };
+		};
+
+		const qualifies = (start: number, end: number) =>
+			end - start + 1 >= options.minRequests &&
+			windowStats(start, end).spread <= options.similarityTolerance;
+
+		// Forward-maximal window for each start row, backward-maximal window
+		// for each end row (both two-pointer, so O(n) per group).
+		const ranges: Array<{ start: number; end: number }> = [];
+		let forwardEnd = 0;
+		for (let start = 0; start < n; start++) {
+			if (forwardEnd < start) forwardEnd = start;
 			while (
-				end + 1 < group.length &&
-				group[end + 1].timestamp - group[start].timestamp <= options.windowMs
+				forwardEnd + 1 < n &&
+				group[forwardEnd + 1].timestamp - group[start].timestamp <=
+					options.windowMs
 			) {
-				end++;
+				forwardEnd++;
 			}
-			if (end - start + 1 < options.minRequests) continue;
+			if (qualifies(start, forwardEnd)) {
+				ranges.push({ start, end: forwardEnd });
+			}
+		}
+		let backwardStart = 0;
+		for (let end = 0; end < n; end++) {
+			while (
+				group[end].timestamp - group[backwardStart].timestamp >
+				options.windowMs
+			) {
+				backwardStart++;
+			}
+			if (qualifies(backwardStart, end)) {
+				ranges.push({ start: backwardStart, end });
+			}
+		}
+
+		// Merge overlapping qualifying windows into maximal runs.
+		ranges.sort((a, b) => a.start - b.start || a.end - b.end);
+		const runs: Array<{ start: number; end: number }> = [];
+		for (const range of ranges) {
 			const last = runs[runs.length - 1];
-			if (last && start <= last.end) {
-				last.end = Math.max(last.end, end);
+			if (last && range.start <= last.end) {
+				last.end = Math.max(last.end, range.end);
 			} else {
-				runs.push({ start, end });
+				runs.push({ ...range });
 			}
 		}
 
 		for (const run of runs) {
-			const burst = group.slice(run.start, run.end + 1);
-			const { mean, stdDev } = meanAndStdDev(burst.map(requestSideTokens));
-			const spread = mean > 0 ? stdDev / mean : 0;
-			if (spread > options.similarityTolerance) continue;
-			const windowStartMs = burst[0].timestamp;
-			const windowEndMs = burst[burst.length - 1].timestamp;
+			const { mean, spread } = windowStats(run.start, run.end);
+			const windowStartMs = group[run.start].timestamp;
+			const windowEndMs = group[run.end].timestamp;
 			loops.push({
-				account: normalizeKey(burst[0].account),
-				model: normalizeKey(burst[0].model),
-				project: burst[0].project,
+				account: normalizeKey(group[run.start].account),
+				model: normalizeKey(group[run.start].model),
+				project: group[run.start].project,
 				windowStartMs,
 				windowEndMs,
-				requests: burst.length,
+				requests: run.end - run.start + 1,
 				requestsPerMinute:
-					(burst.length * 60_000) /
+					((run.end - run.start + 1) * 60_000) /
 					Math.max(windowEndMs - windowStartMs, 60_000),
-				meanInputTokens: mean,
-				inputTokenSpread: spread,
+				meanRequestSideTokens: mean,
+				requestSideTokenSpread: spread,
 			});
 		}
 	}
@@ -350,9 +405,10 @@ export function detectModelMisrouting(
 	for (const row of rows) {
 		const tokens = totalTokens(row);
 		if (tokens === 0 || tokens > options.maxTotalTokens) continue;
-		const model = normalizeKey(row.model);
-		if (model === UNKNOWN_KEY) continue;
-		const modelRates = rates.get(model);
+		// Look up rates with the raw model id — the rates map is keyed by the
+		// raw values, normalizeKey is only for display grouping.
+		if (row.model == null || row.model === "") continue;
+		const modelRates = rates.get(row.model);
 		if (!modelRates || modelRates.output < options.minOutputRateUsd) continue;
 		const key = baselineKey(row.account, row.model);
 		const group = groups.get(key);

--- a/packages/http-api/src/services/anomaly-insights.ts
+++ b/packages/http-api/src/services/anomaly-insights.ts
@@ -1,0 +1,468 @@
+import type { ModelRates } from "@better-ccflare/core";
+import type {
+	AnomalyBaseline,
+	AnomalyInsightsResponse,
+	ModelMisroutingGroup,
+	RunawayLoopGroup,
+	TokenOutlierEvent,
+	TokenOutlierMetric,
+} from "@better-ccflare/types";
+
+/**
+ * Pure anomaly-detection math for the anomaly insights endpoint.
+ *
+ * No DB access and no pricing-engine imports: per-request rows and model
+ * rates ($ per 1M tokens) are injected as plain data. The response shapes
+ * live in @better-ccflare/types and are re-exported here for convenience.
+ *
+ * Detectors (all batch, computed over the requested window):
+ * - baselines: mean/stddev of tokens per request per (account, model)
+ * - tokenOutliers / outputBlowups: requests >= zScoreThreshold stddevs
+ *   above their baseline mean (total tokens / output tokens respectively)
+ * - runawayLoops: dense bursts of near-identical requests per
+ *   (account, model, project)
+ * - misrouting: expensive models repeatedly used for trivially small calls
+ */
+
+export type {
+	AnomalyBaseline,
+	AnomalyInsightsMeta,
+	AnomalyInsightsResponse,
+	ModelMisroutingGroup,
+	RunawayLoopGroup,
+	TokenOutlierEvent,
+	TokenOutlierMetric,
+} from "@better-ccflare/types";
+
+/** One request row fetched from the requests table for anomaly analysis. */
+export interface AnomalyRequestRow {
+	id: string;
+	timestamp: number;
+	account: string | null;
+	model: string | null;
+	project: string | null;
+	inputTokens: number;
+	cacheReadInputTokens: number;
+	cacheCreationInputTokens: number;
+	outputTokens: number;
+	costUsd: number;
+}
+
+export interface AnomalyInsightsOptions {
+	range: string;
+	/** Flag requests >= this many stddevs above the baseline mean. Default 3. */
+	zScoreThreshold?: number;
+	/** Minimum token-bearing requests per (account, model) to form a baseline. Default 20. */
+	minBaselineRequests?: number;
+	/** Sliding window length for runaway-loop detection. Default 5. */
+	loopWindowMinutes?: number;
+	/** Minimum requests inside one window to qualify as a loop. Default 10. */
+	loopMinRequests?: number;
+	/** Max coefficient of variation of request-side tokens within a burst. Default 0.25. */
+	loopSimilarityTolerance?: number;
+	/** Calls at or below this many total tokens count as trivial. Default 500. */
+	misroutingMaxTotalTokens?: number;
+	/** A model is "expensive" when its output rate ($/1M) is at least this. Default 25. */
+	misroutingMinOutputRateUsd?: number;
+	/** Minimum trivial calls per (account, model) before flagging. Default 5. */
+	misroutingMinRequests?: number;
+	/** Cap applied to every list in the response. Default 50. */
+	maxEventsPerDetector?: number;
+	/** Whether the caller's row fetch hit its scan cap (echoed in meta). Default false. */
+	truncated?: boolean;
+}
+
+export interface BuildAnomalyInsightsInput {
+	rows: AnomalyRequestRow[];
+	/** Rates per model id ($ per 1M tokens); null for unknown models. */
+	rates: Map<string, ModelRates | null>;
+	options: AnomalyInsightsOptions;
+}
+
+export const DEFAULT_Z_SCORE_THRESHOLD = 3;
+export const DEFAULT_MIN_BASELINE_REQUESTS = 20;
+export const DEFAULT_LOOP_WINDOW_MINUTES = 5;
+export const DEFAULT_LOOP_MIN_REQUESTS = 10;
+export const DEFAULT_LOOP_SIMILARITY_TOLERANCE = 0.25;
+export const DEFAULT_MISROUTING_MAX_TOTAL_TOKENS = 500;
+export const DEFAULT_MISROUTING_MIN_OUTPUT_RATE_USD = 25;
+export const DEFAULT_MISROUTING_MIN_REQUESTS = 5;
+export const DEFAULT_MAX_EVENTS_PER_DETECTOR = 50;
+
+const UNKNOWN_KEY = "Unknown";
+const GROUP_KEY_SEPARATOR = "\u001f"; // unit separator: never appears in names, keys cannot collide
+const MAX_EXAMPLE_REQUEST_IDS = 5;
+
+function normalizeKey(key: string | null | undefined): string {
+	return key == null || key === "" ? UNKNOWN_KEY : key;
+}
+
+/** All token volume attributed to a request, prompt side and output side. */
+function totalTokens(row: AnomalyRequestRow): number {
+	return (
+		row.inputTokens +
+		row.cacheReadInputTokens +
+		row.cacheCreationInputTokens +
+		row.outputTokens
+	);
+}
+
+/** Request-side tokens only; the "shape" of the prompt for loop similarity. */
+function requestSideTokens(row: AnomalyRequestRow): number {
+	return (
+		row.inputTokens + row.cacheReadInputTokens + row.cacheCreationInputTokens
+	);
+}
+
+function meanAndStdDev(values: number[]): { mean: number; stdDev: number } {
+	if (values.length === 0) return { mean: 0, stdDev: 0 };
+	let sum = 0;
+	for (const value of values) sum += value;
+	const mean = sum / values.length;
+	let sumSquares = 0;
+	for (const value of values) {
+		const deviation = value - mean;
+		sumSquares += deviation * deviation;
+	}
+	// Population stddev: the window is the whole population we report on.
+	return { mean, stdDev: Math.sqrt(sumSquares / values.length) };
+}
+
+function baselineKey(account: string | null, model: string | null): string {
+	return `${normalizeKey(account)}${GROUP_KEY_SEPARATOR}${normalizeKey(model)}`;
+}
+
+/**
+ * Compute per-(account, model) token baselines over the window.
+ *
+ * Rows with zero total tokens (failed or empty requests) carry no token
+ * signal and are excluded so they don't drag means down. Groups with fewer
+ * than minBaselineRequests qualifying rows produce no baseline.
+ *
+ * Sorted by requests descending, then account/model ascending.
+ */
+export function computeBaselines(
+	rows: AnomalyRequestRow[],
+	minBaselineRequests: number,
+): AnomalyBaseline[] {
+	const groups = new Map<string, AnomalyRequestRow[]>();
+	for (const row of rows) {
+		if (totalTokens(row) === 0) continue;
+		const key = baselineKey(row.account, row.model);
+		const group = groups.get(key);
+		if (group) {
+			group.push(row);
+		} else {
+			groups.set(key, [row]);
+		}
+	}
+
+	const baselines: AnomalyBaseline[] = [];
+	for (const group of groups.values()) {
+		if (group.length < minBaselineRequests) continue;
+		const total = meanAndStdDev(group.map(totalTokens));
+		const output = meanAndStdDev(group.map((row) => row.outputTokens));
+		baselines.push({
+			account: normalizeKey(group[0].account),
+			model: normalizeKey(group[0].model),
+			requests: group.length,
+			meanTotalTokens: total.mean,
+			stdDevTotalTokens: total.stdDev,
+			meanOutputTokens: output.mean,
+			stdDevOutputTokens: output.stdDev,
+		});
+	}
+	return baselines.sort(
+		(a, b) =>
+			b.requests - a.requests ||
+			a.account.localeCompare(b.account) ||
+			a.model.localeCompare(b.model),
+	);
+}
+
+/**
+ * Flag requests whose token usage sits >= zScoreThreshold stddevs ABOVE
+ * their (account, model) baseline mean. Low-side deviations are not
+ * anomalies for cost purposes and are never reported. Groups without a
+ * baseline, or with zero variance, produce no outliers.
+ *
+ * Sorted by z-score descending.
+ */
+export function detectTokenOutliers(
+	rows: AnomalyRequestRow[],
+	baselines: AnomalyBaseline[],
+	zScoreThreshold: number,
+	metric: TokenOutlierMetric,
+): TokenOutlierEvent[] {
+	const baselineByKey = new Map<string, AnomalyBaseline>(
+		baselines.map((baseline) => [
+			`${baseline.account}${GROUP_KEY_SEPARATOR}${baseline.model}`,
+			baseline,
+		]),
+	);
+
+	const outliers: TokenOutlierEvent[] = [];
+	for (const row of rows) {
+		if (totalTokens(row) === 0) continue;
+		const baseline = baselineByKey.get(baselineKey(row.account, row.model));
+		if (!baseline) continue;
+		const mean =
+			metric === "total_tokens"
+				? baseline.meanTotalTokens
+				: baseline.meanOutputTokens;
+		const stdDev =
+			metric === "total_tokens"
+				? baseline.stdDevTotalTokens
+				: baseline.stdDevOutputTokens;
+		if (stdDev <= 0) continue;
+		const value =
+			metric === "total_tokens" ? totalTokens(row) : row.outputTokens;
+		const zScore = (value - mean) / stdDev;
+		if (zScore < zScoreThreshold) continue;
+		outliers.push({
+			requestId: row.id,
+			timestamp: row.timestamp,
+			account: normalizeKey(row.account),
+			model: normalizeKey(row.model),
+			project: row.project,
+			metric,
+			value,
+			baselineMean: mean,
+			baselineStdDev: stdDev,
+			zScore,
+		});
+	}
+	return outliers.sort(
+		(a, b) => b.zScore - a.zScore || a.requestId.localeCompare(b.requestId),
+	);
+}
+
+export interface RunawayLoopOptions {
+	windowMs: number;
+	minRequests: number;
+	similarityTolerance: number;
+}
+
+/**
+ * Detect runaway loops: bursts of >= minRequests requests within windowMs
+ * for one (account, model, project), where the request-side token profile
+ * is similar (coefficient of variation <= similarityTolerance).
+ *
+ * All rows count, including zero-token ones — repeated failing retries are
+ * exactly the signal. Overlapping qualifying windows merge into one
+ * sustained run so a long loop is reported once, not per window position.
+ *
+ * Sorted by request count descending.
+ */
+export function detectRunawayLoops(
+	rows: AnomalyRequestRow[],
+	options: RunawayLoopOptions,
+): RunawayLoopGroup[] {
+	const groups = new Map<string, AnomalyRequestRow[]>();
+	for (const row of rows) {
+		const key = `${baselineKey(row.account, row.model)}${GROUP_KEY_SEPARATOR}${normalizeKey(row.project)}`;
+		const group = groups.get(key);
+		if (group) {
+			group.push(row);
+		} else {
+			groups.set(key, [row]);
+		}
+	}
+
+	const loops: RunawayLoopGroup[] = [];
+	for (const group of groups.values()) {
+		group.sort((a, b) => a.timestamp - b.timestamp);
+
+		// Find qualifying windows with two pointers and merge overlapping
+		// index ranges into maximal runs.
+		const runs: Array<{ start: number; end: number }> = [];
+		let end = 0;
+		for (let start = 0; start < group.length; start++) {
+			if (end < start) end = start;
+			while (
+				end + 1 < group.length &&
+				group[end + 1].timestamp - group[start].timestamp <= options.windowMs
+			) {
+				end++;
+			}
+			if (end - start + 1 < options.minRequests) continue;
+			const last = runs[runs.length - 1];
+			if (last && start <= last.end) {
+				last.end = Math.max(last.end, end);
+			} else {
+				runs.push({ start, end });
+			}
+		}
+
+		for (const run of runs) {
+			const burst = group.slice(run.start, run.end + 1);
+			const { mean, stdDev } = meanAndStdDev(burst.map(requestSideTokens));
+			const spread = mean > 0 ? stdDev / mean : 0;
+			if (spread > options.similarityTolerance) continue;
+			const windowStartMs = burst[0].timestamp;
+			const windowEndMs = burst[burst.length - 1].timestamp;
+			loops.push({
+				account: normalizeKey(burst[0].account),
+				model: normalizeKey(burst[0].model),
+				project: burst[0].project,
+				windowStartMs,
+				windowEndMs,
+				requests: burst.length,
+				requestsPerMinute:
+					(burst.length * 60_000) /
+					Math.max(windowEndMs - windowStartMs, 60_000),
+				meanInputTokens: mean,
+				inputTokenSpread: spread,
+			});
+		}
+	}
+	return loops.sort(
+		(a, b) =>
+			b.requests - a.requests ||
+			a.windowStartMs - b.windowStartMs ||
+			a.account.localeCompare(b.account),
+	);
+}
+
+export interface ModelMisroutingOptions {
+	maxTotalTokens: number;
+	minOutputRateUsd: number;
+	minRequests: number;
+}
+
+/**
+ * Detect model misrouting: an expensive model (output rate >=
+ * minOutputRateUsd $/1M) repeatedly handling trivially small calls
+ * (0 < total tokens <= maxTotalTokens). Models with unknown rates are
+ * never flagged.
+ *
+ * Sorted by total logged cost descending.
+ */
+export function detectModelMisrouting(
+	rows: AnomalyRequestRow[],
+	rates: Map<string, ModelRates | null>,
+	options: ModelMisroutingOptions,
+): ModelMisroutingGroup[] {
+	const groups = new Map<
+		string,
+		{ rows: AnomalyRequestRow[]; outputRateUsd: number }
+	>();
+	for (const row of rows) {
+		const tokens = totalTokens(row);
+		if (tokens === 0 || tokens > options.maxTotalTokens) continue;
+		const model = normalizeKey(row.model);
+		if (model === UNKNOWN_KEY) continue;
+		const modelRates = rates.get(model);
+		if (!modelRates || modelRates.output < options.minOutputRateUsd) continue;
+		const key = baselineKey(row.account, row.model);
+		const group = groups.get(key);
+		if (group) {
+			group.rows.push(row);
+		} else {
+			groups.set(key, { rows: [row], outputRateUsd: modelRates.output });
+		}
+	}
+
+	const result: ModelMisroutingGroup[] = [];
+	for (const group of groups.values()) {
+		if (group.rows.length < options.minRequests) continue;
+		group.rows.sort((a, b) => a.timestamp - b.timestamp);
+		let tokenSum = 0;
+		let costSum = 0;
+		for (const row of group.rows) {
+			tokenSum += totalTokens(row);
+			costSum += row.costUsd;
+		}
+		result.push({
+			account: normalizeKey(group.rows[0].account),
+			model: normalizeKey(group.rows[0].model),
+			requests: group.rows.length,
+			meanTotalTokens: tokenSum / group.rows.length,
+			outputRateUsd: group.outputRateUsd,
+			totalCostUsd: costSum,
+			exampleRequestIds: group.rows
+				.slice(0, MAX_EXAMPLE_REQUEST_IDS)
+				.map((row) => row.id),
+		});
+	}
+	return result.sort(
+		(a, b) =>
+			b.totalCostUsd - a.totalCostUsd ||
+			b.requests - a.requests ||
+			a.account.localeCompare(b.account),
+	);
+}
+
+/**
+ * Run all detectors over one window of request rows and assemble the
+ * response. Every list is capped at maxEventsPerDetector (already sorted
+ * most-significant first by each detector).
+ */
+export function buildAnomalyInsightsResponse(
+	input: BuildAnomalyInsightsInput,
+): AnomalyInsightsResponse {
+	const { options } = input;
+	const zScoreThreshold = options.zScoreThreshold ?? DEFAULT_Z_SCORE_THRESHOLD;
+	const minBaselineRequests =
+		options.minBaselineRequests ?? DEFAULT_MIN_BASELINE_REQUESTS;
+	const loopWindowMinutes =
+		options.loopWindowMinutes ?? DEFAULT_LOOP_WINDOW_MINUTES;
+	const loopMinRequests = options.loopMinRequests ?? DEFAULT_LOOP_MIN_REQUESTS;
+	const loopSimilarityTolerance =
+		options.loopSimilarityTolerance ?? DEFAULT_LOOP_SIMILARITY_TOLERANCE;
+	const misroutingMaxTotalTokens =
+		options.misroutingMaxTotalTokens ?? DEFAULT_MISROUTING_MAX_TOTAL_TOKENS;
+	const misroutingMinOutputRateUsd =
+		options.misroutingMinOutputRateUsd ??
+		DEFAULT_MISROUTING_MIN_OUTPUT_RATE_USD;
+	const misroutingMinRequests =
+		options.misroutingMinRequests ?? DEFAULT_MISROUTING_MIN_REQUESTS;
+	const maxEventsPerDetector =
+		options.maxEventsPerDetector ?? DEFAULT_MAX_EVENTS_PER_DETECTOR;
+
+	const baselines = computeBaselines(input.rows, minBaselineRequests);
+	const tokenOutliers = detectTokenOutliers(
+		input.rows,
+		baselines,
+		zScoreThreshold,
+		"total_tokens",
+	);
+	const outputBlowups = detectTokenOutliers(
+		input.rows,
+		baselines,
+		zScoreThreshold,
+		"output_tokens",
+	);
+	const runawayLoops = detectRunawayLoops(input.rows, {
+		windowMs: loopWindowMinutes * 60_000,
+		minRequests: loopMinRequests,
+		similarityTolerance: loopSimilarityTolerance,
+	});
+	const misrouting = detectModelMisrouting(input.rows, input.rates, {
+		maxTotalTokens: misroutingMaxTotalTokens,
+		minOutputRateUsd: misroutingMinOutputRateUsd,
+		minRequests: misroutingMinRequests,
+	});
+
+	return {
+		meta: {
+			range: options.range,
+			zScoreThreshold,
+			minBaselineRequests,
+			loopWindowMinutes,
+			loopMinRequests,
+			loopSimilarityTolerance,
+			misroutingMaxTotalTokens,
+			misroutingMinOutputRateUsd,
+			misroutingMinRequests,
+			maxEventsPerDetector,
+			scannedRequests: input.rows.length,
+			truncated: options.truncated ?? false,
+		},
+		baselines: baselines.slice(0, maxEventsPerDetector),
+		tokenOutliers: tokenOutliers.slice(0, maxEventsPerDetector),
+		outputBlowups: outputBlowups.slice(0, maxEventsPerDetector),
+		runawayLoops: runawayLoops.slice(0, maxEventsPerDetector),
+		misrouting: misrouting.slice(0, maxEventsPerDetector),
+	};
+}

--- a/packages/types/src/insights.ts
+++ b/packages/types/src/insights.ts
@@ -135,9 +135,9 @@ export interface RunawayLoopGroup {
 	/** Request rate over the burst, floored at a one-minute span. */
 	requestsPerMinute: number;
 	/** Mean request-side tokens (input + cache read + cache creation). */
-	meanInputTokens: number;
+	meanRequestSideTokens: number;
 	/** Coefficient of variation of request-side tokens (0 = identical). */
-	inputTokenSpread: number;
+	requestSideTokenSpread: number;
 }
 
 /**

--- a/packages/types/src/insights.ts
+++ b/packages/types/src/insights.ts
@@ -60,3 +60,109 @@ export interface CacheInsightsResponse {
 	byAccount: CacheInsightsRow[];
 	byProject: CacheInsightsRow[];
 }
+
+/**
+ * Response types for the anomaly insights endpoint (/api/insights/anomalies).
+ */
+
+/** Which per-request token metric an outlier was detected on. */
+export type TokenOutlierMetric = "total_tokens" | "output_tokens";
+
+/** Effective detector thresholds echoed back with an anomalies response. */
+export interface AnomalyInsightsMeta {
+	range: string;
+	zScoreThreshold: number;
+	minBaselineRequests: number;
+	loopWindowMinutes: number;
+	loopMinRequests: number;
+	/** Max coefficient of variation of request-side tokens for a burst to count as a loop. */
+	loopSimilarityTolerance: number;
+	misroutingMaxTotalTokens: number;
+	misroutingMinOutputRateUsd: number;
+	misroutingMinRequests: number;
+	maxEventsPerDetector: number;
+	/** Number of request rows the detectors actually ran over. */
+	scannedRequests: number;
+	/** True when the window held more rows than the scan cap; only the most recent rows were analyzed. */
+	truncated: boolean;
+}
+
+/**
+ * Rolling token baseline for one (account, model) pair over the requested
+ * window. Only computed from requests with at least one token; groups with
+ * fewer than minBaselineRequests such requests have no baseline.
+ */
+export interface AnomalyBaseline {
+	account: string;
+	model: string;
+	requests: number;
+	meanTotalTokens: number;
+	stdDevTotalTokens: number;
+	meanOutputTokens: number;
+	stdDevOutputTokens: number;
+}
+
+/**
+ * A single request whose token usage sits at or above zScoreThreshold
+ * standard deviations over its (account, model) baseline mean. Low-side
+ * deviations are never reported.
+ */
+export interface TokenOutlierEvent {
+	requestId: string;
+	timestamp: number;
+	account: string;
+	model: string;
+	project: string | null;
+	metric: TokenOutlierMetric;
+	value: number;
+	baselineMean: number;
+	baselineStdDev: number;
+	zScore: number;
+}
+
+/**
+ * A sustained burst of near-identical requests (same account/model/project,
+ * similar request-side token profile) dense enough to look like a runaway
+ * agent loop.
+ */
+export interface RunawayLoopGroup {
+	account: string;
+	model: string;
+	project: string | null;
+	windowStartMs: number;
+	windowEndMs: number;
+	requests: number;
+	/** Request rate over the burst, floored at a one-minute span. */
+	requestsPerMinute: number;
+	/** Mean request-side tokens (input + cache read + cache creation). */
+	meanInputTokens: number;
+	/** Coefficient of variation of request-side tokens (0 = identical). */
+	inputTokenSpread: number;
+}
+
+/**
+ * An (account, model) pair where an expensive model handled repeated
+ * trivially small calls that a cheaper model could likely serve.
+ */
+export interface ModelMisroutingGroup {
+	account: string;
+	model: string;
+	requests: number;
+	meanTotalTokens: number;
+	/** The model's output rate ($ per 1M tokens) that classified it as expensive. */
+	outputRateUsd: number;
+	/** Sum of logged cost_usd over the flagged calls. */
+	totalCostUsd: number;
+	/** Up to five request ids illustrating the pattern. */
+	exampleRequestIds: string[];
+}
+
+/** Full response of GET /api/insights/anomalies. */
+export interface AnomalyInsightsResponse {
+	meta: AnomalyInsightsMeta;
+	baselines: AnomalyBaseline[];
+	tokenOutliers: TokenOutlierEvent[];
+	outputBlowups: TokenOutlierEvent[];
+	runawayLoops: RunawayLoopGroup[];
+	misrouting: ModelMisroutingGroup[];
+}


### PR DESCRIPTION
Implements #249 (part of the Token Insights epic #247).

## What

New read-only endpoint `GET /api/insights/anomalies` running four batch detectors over the `requests` table for the selected range/filters (shared `range`/`accounts`/`models`/`apiKeys`/`status` params from the analytics endpoints):

- **Rolling baselines** — mean/stddev of tokens per request per (account, model), computed over token-bearing requests only so failed/empty requests don't drag means down
- **Token outliers** — requests at or above `zScoreThreshold` (default 3) standard deviations over their baseline mean; low-side deviations are never reported
- **Output-token blowups** — the same z-score test applied to output tokens
- **Runaway loops** — bursts of ≥ `loopMinRequests` (default 10) requests within `loopWindowMinutes` (default 5) per (account, model, project) with a similar request-side token profile (coefficient of variation ≤ `loopSimilarityTolerance`, default 0.25); overlapping windows merge so a sustained loop is reported once
- **Model misrouting** — expensive models (output rate ≥ `misroutingMinOutputRateUsd` $/1M, default 25, priced via the models.dev catalogue) repeatedly serving trivially small calls (≤ `misroutingMaxTotalTokens` total tokens, default 500)

All detector thresholds are query params with sane defaults, clamped server-side. Statistics are computed in TypeScript over one batch SQL fetch (per the issue's implementation notes); the fetch is capped at the most recent 100k rows with `meta.truncated`/`meta.scannedRequests` reporting when the cap was hit.

## Structure

- `packages/http-api/src/services/anomaly-insights.ts` — pure detector math, no DB/pricing imports (mirrors `cache-insights.ts` from #253)
- `packages/http-api/src/handlers/insights.ts` — `createAnomalyInsightsHandler`: param parsing/clamping, batch query, rate lookup
- `packages/types/src/insights.ts` — response shapes shared with the dashboard for later slices
- 28 unit tests over the pure service

## Testing

- `bun test packages/http-api`: 237 pass
- Smoke-tested live on port 8081 against real history: baselines/blowups/loops detected with plausible values; invalid params fall back to defaults; oversized caps clamped
- `bun run lint && bun run typecheck && bun run format` clean
- Greptile review run pre-PR; both findings addressed (scan cap, integer loop window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)