### PR TITLE
feat: alerting threshold rules, SSE stream, dashboard badge (#250)

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -21,7 +21,7 @@ import {
 	DatabaseFactory,
 	initPayloadEncryption,
 } from "@better-ccflare/database";
-import { APIRouter, AuthService } from "@better-ccflare/http-api";
+import { AlertService, APIRouter, AuthService } from "@better-ccflare/http-api";
 import {
 	LeastUsedStrategy,
 	SessionStrategy,
@@ -666,6 +666,10 @@ export default async function startServer(options?: {
 	container.registerInstance(SERVICE_KEYS.PricingLogger, pricingLogger);
 	setPricingLogger(pricingLogger);
 
+	const alertService = new AlertService(db, config);
+	alertService.start();
+	registerDisposable({ dispose: () => alertService.stop() });
+
 	// Strategy is constructed below after RuntimeConfig is built. The router
 	// accepts a getter so it can read the live (post-hot-reload) instance.
 	let currentStrategy: LoadBalancingStrategy | null = null;
@@ -674,6 +678,7 @@ export default async function startServer(options?: {
 		db,
 		config,
 		dbOps,
+		alertService,
 		runtime: {
 			port,
 			tlsEnabled,

--- a/packages/config/src/alerts-config.test.ts
+++ b/packages/config/src/alerts-config.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Config } from "./index";
+
+const ENV_KEYS = [
+	"ALERT_DAILY_SPEND_USD",
+	"ALERT_TOKENS_PER_HOUR",
+	"ALERT_REQUEST_TOKENS",
+	"ALERT_ANOMALY_ENABLED",
+	"ALERT_ANOMALY_INTERVAL_MINUTES",
+	"ALERT_COOLDOWN_MINUTES",
+	"ALERT_WEBHOOK_URL",
+] as const;
+
+const ORIGINAL_ENV: Record<string, string | undefined> = {};
+for (const key of ENV_KEYS) {
+	ORIGINAL_ENV[key] = process.env[key];
+}
+
+function makeConfig(): { config: Config; cleanup: () => void } {
+	const dir = mkdtempSync(join(tmpdir(), "better-ccflare-config-"));
+	return {
+		config: new Config(join(dir, "config.json")),
+		cleanup: () => rmSync(dir, { recursive: true, force: true }),
+	};
+}
+
+describe("alert config settings", () => {
+	afterEach(() => {
+		for (const key of ENV_KEYS) {
+			const original = ORIGINAL_ENV[key];
+			if (original === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = original;
+			}
+		}
+	});
+
+	it("returns defaults when nothing is configured", () => {
+		for (const key of ENV_KEYS) {
+			delete process.env[key];
+		}
+		const { config, cleanup } = makeConfig();
+
+		try {
+			expect(config.getAlertDailySpendUsd()).toBe(0);
+			expect(config.getAlertTokensPerHour()).toBe(0);
+			expect(config.getAlertRequestTokens()).toBe(0);
+			expect(config.getAlertAnomalyEnabled()).toBe(false);
+			expect(config.getAlertAnomalyIntervalMinutes()).toBe(15);
+			expect(config.getAlertCooldownMinutes()).toBe(60);
+			expect(config.getAlertWebhookUrl()).toBe("");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("honors environment variable overrides", () => {
+		process.env.ALERT_DAILY_SPEND_USD = "25.5";
+		process.env.ALERT_TOKENS_PER_HOUR = "500000";
+		process.env.ALERT_REQUEST_TOKENS = "200000";
+		process.env.ALERT_ANOMALY_ENABLED = "true";
+		process.env.ALERT_ANOMALY_INTERVAL_MINUTES = "30";
+		process.env.ALERT_COOLDOWN_MINUTES = "120";
+		process.env.ALERT_WEBHOOK_URL = "https://example.com/hook";
+		const { config, cleanup } = makeConfig();
+
+		try {
+			expect(config.getAlertDailySpendUsd()).toBe(25.5);
+			expect(config.getAlertTokensPerHour()).toBe(500000);
+			expect(config.getAlertRequestTokens()).toBe(200000);
+			expect(config.getAlertAnomalyEnabled()).toBe(true);
+			expect(config.getAlertAnomalyIntervalMinutes()).toBe(30);
+			expect(config.getAlertCooldownMinutes()).toBe(120);
+			expect(config.getAlertWebhookUrl()).toBe("https://example.com/hook");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("treats non-true anomaly env values as disabled", () => {
+		process.env.ALERT_ANOMALY_ENABLED = "disabled";
+		const { config, cleanup } = makeConfig();
+
+		try {
+			expect(config.getAlertAnomalyEnabled()).toBe(false);
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("clamps out-of-range environment values", () => {
+		process.env.ALERT_DAILY_SPEND_USD = "-5";
+		process.env.ALERT_TOKENS_PER_HOUR = "9999999999";
+		process.env.ALERT_REQUEST_TOKENS = "-100";
+		process.env.ALERT_ANOMALY_INTERVAL_MINUTES = "2";
+		process.env.ALERT_COOLDOWN_MINUTES = "0";
+		const { config, cleanup } = makeConfig();
+
+		try {
+			expect(config.getAlertDailySpendUsd()).toBe(0);
+			expect(config.getAlertTokensPerHour()).toBe(1_000_000_000);
+			expect(config.getAlertRequestTokens()).toBe(0);
+			expect(config.getAlertAnomalyIntervalMinutes()).toBe(5);
+			expect(config.getAlertCooldownMinutes()).toBe(1);
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("clamps out-of-range config-file values via setters", () => {
+		for (const key of ENV_KEYS) {
+			delete process.env[key];
+		}
+		const { config, cleanup } = makeConfig();
+
+		try {
+			config.setAlertDailySpendUsd(2_000_000);
+			expect(config.getAlertDailySpendUsd()).toBe(1_000_000);
+
+			config.setAlertAnomalyIntervalMinutes(3);
+			expect(config.getAlertAnomalyIntervalMinutes()).toBe(5);
+
+			config.setAlertAnomalyIntervalMinutes(99999);
+			expect(config.getAlertAnomalyIntervalMinutes()).toBe(1440);
+
+			config.setAlertCooldownMinutes(0);
+			expect(config.getAlertCooldownMinutes()).toBe(1);
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("persists setter values readable by getters", () => {
+		for (const key of ENV_KEYS) {
+			delete process.env[key];
+		}
+		const { config, cleanup } = makeConfig();
+
+		try {
+			config.setAlertDailySpendUsd(50);
+			config.setAlertTokensPerHour(1_000_000);
+			config.setAlertRequestTokens(300_000);
+			config.setAlertAnomalyEnabled(true);
+			config.setAlertCooldownMinutes(45);
+			config.setAlertWebhookUrl("https://hooks.example.com/alert");
+
+			expect(config.getAlertDailySpendUsd()).toBe(50);
+			expect(config.getAlertTokensPerHour()).toBe(1_000_000);
+			expect(config.getAlertRequestTokens()).toBe(300_000);
+			expect(config.getAlertAnomalyEnabled()).toBe(true);
+			expect(config.getAlertCooldownMinutes()).toBe(45);
+			expect(config.getAlertWebhookUrl()).toBe(
+				"https://hooks.example.com/alert",
+			);
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("accepts an empty webhook URL (disabled) and rejects invalid ones", () => {
+		for (const key of ENV_KEYS) {
+			delete process.env[key];
+		}
+		const { config, cleanup } = makeConfig();
+
+		try {
+			expect(() => config.setAlertWebhookUrl("")).not.toThrow();
+			expect(config.getAlertWebhookUrl()).toBe("");
+
+			expect(() => config.setAlertWebhookUrl("not-a-url")).toThrow();
+			expect(() => config.setAlertWebhookUrl("ftp://example.com")).toThrow();
+			expect(() =>
+				config.setAlertWebhookUrl("http://example.com/hook"),
+			).not.toThrow();
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("includes alert settings in getAllSettings()", () => {
+		for (const key of ENV_KEYS) {
+			delete process.env[key];
+		}
+		const { config, cleanup } = makeConfig();
+
+		try {
+			const settings = config.getAllSettings();
+			expect(settings.alert_daily_spend_usd).toBe(0);
+			expect(settings.alert_tokens_per_hour).toBe(0);
+			expect(settings.alert_request_tokens).toBe(0);
+			expect(settings.alert_anomaly_enabled).toBe(false);
+			expect(settings.alert_anomaly_interval_minutes).toBe(15);
+			expect(settings.alert_cooldown_minutes).toBe(60);
+			expect(settings.alert_webhook_url).toBe("");
+		} finally {
+			cleanup();
+		}
+	});
+});

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -62,6 +62,13 @@ export interface ConfigData {
 	usage_throttling_five_hour_enabled?: boolean;
 	usage_throttling_weekly_enabled?: boolean;
 	health_detail_enabled?: boolean;
+	alert_daily_spend_usd?: number;
+	alert_tokens_per_hour?: number;
+	alert_request_tokens?: number;
+	alert_anomaly_enabled?: boolean;
+	alert_anomaly_interval_minutes?: number;
+	alert_cooldown_minutes?: number;
+	alert_webhook_url?: string;
 	// Database configuration
 	db_wal_mode?: boolean;
 	db_busy_timeout_ms?: number;
@@ -416,6 +423,128 @@ export class Config extends EventEmitter {
 		return false;
 	}
 
+	getAlertDailySpendUsd(): number {
+		const fromEnv = process.env.ALERT_DAILY_SPEND_USD;
+		if (fromEnv) {
+			const n = Number.parseFloat(fromEnv);
+			if (!Number.isNaN(n)) return this.clamp(n, 0, 1_000_000);
+		}
+		const fromFile = this.data.alert_daily_spend_usd;
+		if (typeof fromFile === "number") return this.clamp(fromFile, 0, 1_000_000);
+		return 0;
+	}
+
+	setAlertDailySpendUsd(value: number): void {
+		this.set("alert_daily_spend_usd", this.clamp(value, 0, 1_000_000));
+	}
+
+	getAlertTokensPerHour(): number {
+		const fromEnv = process.env.ALERT_TOKENS_PER_HOUR;
+		if (fromEnv) {
+			const n = Number.parseInt(fromEnv, 10);
+			if (!Number.isNaN(n)) return this.clamp(n, 0, 1_000_000_000);
+		}
+		const fromFile = this.data.alert_tokens_per_hour;
+		if (typeof fromFile === "number") {
+			return this.clamp(fromFile, 0, 1_000_000_000);
+		}
+		return 0;
+	}
+
+	setAlertTokensPerHour(value: number): void {
+		this.set("alert_tokens_per_hour", this.clamp(value, 0, 1_000_000_000));
+	}
+
+	getAlertRequestTokens(): number {
+		const fromEnv = process.env.ALERT_REQUEST_TOKENS;
+		if (fromEnv) {
+			const n = Number.parseInt(fromEnv, 10);
+			if (!Number.isNaN(n)) return this.clamp(n, 0, 1_000_000_000);
+		}
+		const fromFile = this.data.alert_request_tokens;
+		if (typeof fromFile === "number") {
+			return this.clamp(fromFile, 0, 1_000_000_000);
+		}
+		return 0;
+	}
+
+	setAlertRequestTokens(value: number): void {
+		this.set("alert_request_tokens", this.clamp(value, 0, 1_000_000_000));
+	}
+
+	getAlertAnomalyEnabled(): boolean {
+		const fromEnv = parseEnabledEnvFlag(process.env.ALERT_ANOMALY_ENABLED);
+		if (fromEnv !== undefined) {
+			return fromEnv;
+		}
+		const fromFile = this.data.alert_anomaly_enabled;
+		if (typeof fromFile === "boolean") return fromFile;
+		return false;
+	}
+
+	setAlertAnomalyEnabled(value: boolean): void {
+		this.set("alert_anomaly_enabled", value);
+	}
+
+	getAlertAnomalyIntervalMinutes(): number {
+		const fromEnv = process.env.ALERT_ANOMALY_INTERVAL_MINUTES;
+		if (fromEnv) {
+			const n = Number.parseInt(fromEnv, 10);
+			if (!Number.isNaN(n)) return this.clamp(n, 5, 1440);
+		}
+		const fromFile = this.data.alert_anomaly_interval_minutes;
+		if (typeof fromFile === "number") return this.clamp(fromFile, 5, 1440);
+		return 15;
+	}
+
+	setAlertAnomalyIntervalMinutes(value: number): void {
+		this.set("alert_anomaly_interval_minutes", this.clamp(value, 5, 1440));
+	}
+
+	getAlertCooldownMinutes(): number {
+		const fromEnv = process.env.ALERT_COOLDOWN_MINUTES;
+		if (fromEnv) {
+			const n = Number.parseInt(fromEnv, 10);
+			if (!Number.isNaN(n)) return this.clamp(n, 1, 1440);
+		}
+		const fromFile = this.data.alert_cooldown_minutes;
+		if (typeof fromFile === "number") return this.clamp(fromFile, 1, 1440);
+		return 60;
+	}
+
+	setAlertCooldownMinutes(value: number): void {
+		this.set("alert_cooldown_minutes", this.clamp(value, 1, 1440));
+	}
+
+	getAlertWebhookUrl(): string {
+		const fromEnv = process.env.ALERT_WEBHOOK_URL;
+		if (fromEnv !== undefined) return fromEnv;
+		const fromFile = this.data.alert_webhook_url;
+		if (typeof fromFile === "string") return fromFile;
+		return "";
+	}
+
+	setAlertWebhookUrl(value: string): void {
+		if (value !== "") {
+			let parsed: URL;
+			try {
+				parsed = new URL(value);
+			} catch (_error) {
+				throw new ValidationError(
+					"Invalid alert webhook URL",
+					"alert_webhook_url",
+				);
+			}
+			if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+				throw new ValidationError(
+					"Invalid alert webhook URL",
+					"alert_webhook_url",
+				);
+			}
+		}
+		this.set("alert_webhook_url", value);
+	}
+
 	getAllSettings(): Record<string, string | number | boolean | undefined> {
 		// Include current strategy (which might come from env)
 		return {
@@ -432,6 +561,13 @@ export class Config extends EventEmitter {
 				this.getUsageThrottlingFiveHourEnabled(),
 			usage_throttling_weekly_enabled: this.getUsageThrottlingWeeklyEnabled(),
 			health_detail_enabled: this.getHealthDetailEnabled(),
+			alert_daily_spend_usd: this.getAlertDailySpendUsd(),
+			alert_tokens_per_hour: this.getAlertTokensPerHour(),
+			alert_request_tokens: this.getAlertRequestTokens(),
+			alert_anomaly_enabled: this.getAlertAnomalyEnabled(),
+			alert_anomaly_interval_minutes: this.getAlertAnomalyIntervalMinutes(),
+			alert_cooldown_minutes: this.getAlertCooldownMinutes(),
+			alert_webhook_url: this.getAlertWebhookUrl(),
 		};
 	}
 

--- a/packages/core/src/alert-events.ts
+++ b/packages/core/src/alert-events.ts
@@ -1,0 +1,11 @@
+import { EventEmitter } from "node:events";
+
+export type AlertEvt = {
+	type: "alert";
+	payload: import("@better-ccflare/types").AlertEvent;
+};
+
+class AlertEventBus extends EventEmitter {}
+export const alertEvents = new AlertEventBus();
+
+alertEvents.setMaxListeners(200);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,7 @@ export type ModelMappingData = {
 	modelMappings?: ModelMapping;
 };
 export type ModelFallback = { [modelFamily: string]: string };
+export * from "./alert-events";
 export {
 	type IntervalConfig,
 	intervalManager,

--- a/packages/dashboard-web/src/api.ts
+++ b/packages/dashboard-web/src/api.ts
@@ -2211,6 +2211,24 @@ class API extends HttpClient {
 			throw error;
 		}
 	}
+	async getAlerts(limit = 100): Promise<{
+		alerts: import("@better-ccflare/types").AlertEvent[];
+		unacknowledgedCount: number;
+	}> {
+		const res = await this.get<{
+			alerts: import("@better-ccflare/types").AlertEvent[];
+			unacknowledgedCount: number;
+		}>(`/api/insights/alerts?limit=${Math.min(Math.max(1, limit), 500)}`);
+		return res;
+	}
+
+	async acknowledgeAlert(id: string): Promise<void> {
+		await this.post(`/api/insights/alerts/${encodeURIComponent(id)}`);
+	}
+
+	async acknowledgeAllAlerts(): Promise<void> {
+		await this.post("/api/insights/alerts/acknowledge-all");
+	}
 }
 
 export const api = new API();

--- a/packages/dashboard-web/src/components/InsightsTab.tsx
+++ b/packages/dashboard-web/src/components/InsightsTab.tsx
@@ -2,6 +2,7 @@ import { AlertTriangle } from "lucide-react";
 import React, { useState } from "react";
 import type { TimeRange } from "../constants";
 import { useCacheInsights } from "../hooks/queries";
+import { AlertsView } from "./insights/AlertsView";
 import { CacheEfficiencyView } from "./insights/CacheEfficiencyView";
 import { TimeRangeSelector } from "./overview/TimeRangeSelector";
 import { Card, CardContent } from "./ui/card";
@@ -43,3 +44,5 @@ export const InsightsTab = React.memo(() => {
 });
 
 InsightsTab.displayName = "InsightsTab";
+
+<AlertsView />;

--- a/packages/dashboard-web/src/components/InsightsTab.tsx
+++ b/packages/dashboard-web/src/components/InsightsTab.tsx
@@ -39,10 +39,10 @@ export const InsightsTab = React.memo(() => {
 					timeRange={timeRange}
 				/>
 			)}
+
+			<AlertsView />
 		</div>
 	);
 });
 
 InsightsTab.displayName = "InsightsTab";
-
-<AlertsView />;

--- a/packages/dashboard-web/src/components/insights/AlertsView.tsx
+++ b/packages/dashboard-web/src/components/insights/AlertsView.tsx
@@ -1,0 +1,103 @@
+import { Check, CheckCheck, TriangleAlert } from "lucide-react";
+import React from "react";
+import {
+	useAcknowledgeAlert,
+	useAcknowledgeAllAlerts,
+	useAlerts,
+} from "../../hooks/queries";
+import { Badge } from "../ui/badge";
+import { Button } from "../ui/button";
+import { Card, CardContent, CardHeader } from "../ui/card";
+
+function formatTimestamp(ts: number): string {
+	try {
+		return new Date(ts).toLocaleString();
+	} catch (_error) {
+		return String(ts);
+	}
+}
+
+export const AlertsView = React.memo(() => {
+	const { data, isLoading } = useAlerts();
+	const ack = useAcknowledgeAlert();
+	const ackAll = useAcknowledgeAllAlerts();
+
+	const alerts = data?.alerts ?? [];
+	const unacknowledgedCount = data?.unacknowledgedCount ?? 0;
+
+	if (isLoading) {
+		return (
+			<Card>
+				<CardContent className="p-6">Loading alerts…</CardContent>
+			</Card>
+		);
+	}
+
+	return (
+		<div className="space-y-4">
+			<div className="flex items-center justify-between">
+				<h3 className="text-lg font-medium">
+					Unacknowledged: {unacknowledgedCount}
+				</h3>
+				<Button
+					size="sm"
+					variant="outline"
+					disabled={unacknowledgedCount === 0 || ackAll.isPending}
+					onClick={() => void ackAll.mutateAsync()}
+				>
+					<CheckCheck className="h-4 w-4 mr-1" />
+					Acknowledge all
+				</Button>
+			</div>
+
+			{alerts.length === 0 ? (
+				<Card>
+					<CardContent className="p-6 text-muted-foreground">
+						No alerts yet.
+					</CardContent>
+				</Card>
+			) : (
+				<ul className="space-y-3">
+					{alerts.map((alert) => (
+						<li key={alert.id}>
+							<Card>
+								<CardHeader>
+									<div className="flex items-start justify-between gap-3">
+										<div className="space-y-1">
+											<div className="flex items-center gap-2">
+												<TriangleAlert className="h-4 w-4 text-amber-500" />
+												<span className="font-medium">{alert.title}</span>
+											</div>
+											<p className="text-sm text-muted-foreground">
+												{alert.message}
+											</p>
+										</div>
+										<Badge
+											variant={alert.acknowledged ? "outline" : "destructive"}
+										>
+											{alert.acknowledged ? "Acked" : "New"}
+										</Badge>
+									</div>
+								</CardHeader>
+								<CardContent className="pb-3 pt-0 flex items-center justify-between text-xs text-muted-foreground">
+									<span>{formatTimestamp(alert.timestamp)}</span>
+									<Button
+										size="sm"
+										variant="ghost"
+										disabled={alert.acknowledged || ack.isPending}
+										onClick={() => void ack.mutateAsync(alert.id)}
+									>
+										<Check className="h-4 w-4 mr-1" />
+										Acknowledge
+									</Button>
+								</CardContent>
+							</Card>
+						</li>
+					))}
+				</ul>
+			)}
+		</div>
+	);
+});
+
+AlertsView.displayName = "AlertsView";

--- a/packages/dashboard-web/src/components/insights/AlertsView.tsx
+++ b/packages/dashboard-web/src/components/insights/AlertsView.tsx
@@ -1,26 +1,29 @@
 import { Check, CheckCheck, TriangleAlert } from "lucide-react";
 import React from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import {
 	useAcknowledgeAlert,
 	useAcknowledgeAllAlerts,
 	useAlerts,
 } from "../../hooks/queries";
+import { useAlertStream } from "../../hooks/useAlertStream";
+import { queryKeys } from "../../lib/query-keys";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Card, CardContent, CardHeader } from "../ui/card";
 
-function formatTimestamp(ts: number): string {
-	try {
-		return new Date(ts).toLocaleString();
-	} catch (_error) {
-		return String(ts);
-	}
-}
-
 export const AlertsView = React.memo(() => {
+	const queryClient = useQueryClient();
 	const { data, isLoading } = useAlerts();
 	const ack = useAcknowledgeAlert();
 	const ackAll = useAcknowledgeAllAlerts();
+
+	// Connect SSE stream and invalidate alerts query on new events.
+	useAlertStream({
+		onAlert: () => {
+			queryClient.invalidateQueries({ queryKey: queryKeys.insightsAlerts() });
+		},
+	});
 
 	const alerts = data?.alerts ?? [];
 	const unacknowledgedCount = data?.unacknowledgedCount ?? 0;
@@ -31,6 +34,10 @@ export const AlertsView = React.memo(() => {
 				<CardContent className="p-6">Loading alerts…</CardContent>
 			</Card>
 		);
+	}
+
+	function formatTimestamp(ts: number): string {
+		return new Date(ts).toLocaleString();
 	}
 
 	return (

--- a/packages/dashboard-web/src/components/navigation.tsx
+++ b/packages/dashboard-web/src/components/navigation.tsx
@@ -69,7 +69,7 @@ export function Navigation({
 	const [latestVersion, setLatestVersion] = useState<string>("");
 	const [updateError, setUpdateError] = useState<string | null>(null);
 	const { data: alertData } = useAlerts();
-	const _unacknowledgedCount = alertData?.unacknowledgedCount ?? 0;
+	const unacknowledgedCount = alertData?.unacknowledgedCount ?? 0;
 	const location = useLocation();
 	const isMountedRef = useRef(true);
 
@@ -78,7 +78,13 @@ export function Navigation({
 		const baseItems: NavItem[] = [
 			{ label: "Overview", icon: LayoutDashboard, path: "/" },
 			{ label: "Analytics", icon: BarChart3, path: "/analytics" },
-			{ label: "Insights", icon: Lightbulb, path: "/insights" },
+			{
+				label: "Insights",
+				icon: Lightbulb,
+				path: "/insights",
+				badge:
+					unacknowledgedCount > 0 ? String(unacknowledgedCount) : undefined,
+			},
 			{ label: "Requests", icon: Activity, path: "/requests" },
 			{ label: "Accounts", icon: Users, path: "/accounts" },
 		];

--- a/packages/dashboard-web/src/components/navigation.tsx
+++ b/packages/dashboard-web/src/components/navigation.tsx
@@ -19,6 +19,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
+import { useAlerts } from "../hooks/queries";
 import { cn } from "../lib/utils";
 import { version } from "../lib/version";
 import { CopyButton } from "./CopyButton";
@@ -67,6 +68,8 @@ export function Navigation({
 	>("idle");
 	const [latestVersion, setLatestVersion] = useState<string>("");
 	const [updateError, setUpdateError] = useState<string | null>(null);
+	const { data: alertData } = useAlerts();
+	const _unacknowledgedCount = alertData?.unacknowledgedCount ?? 0;
 	const location = useLocation();
 	const isMountedRef = useRef(true);
 

--- a/packages/dashboard-web/src/hooks/queries.ts
+++ b/packages/dashboard-web/src/hooks/queries.ts
@@ -586,3 +586,36 @@ export const useReorderComboSlots = () => {
 		},
 	});
 };
+
+export const useAlerts = () => {
+	return useQuery({
+		queryKey: queryKeys.insightsAlerts(),
+		queryFn: async () => {
+			const res = await api.getAlerts(200);
+			return res;
+		},
+		staleTime: 15_000,
+		refetchInterval: 30_000,
+		refetchIntervalInBackground: false,
+	});
+};
+
+export const useAcknowledgeAlert = () => {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (id: string) => api.acknowledgeAlert(id),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: queryKeys.insightsAlerts() });
+		},
+	});
+};
+
+export const useAcknowledgeAllAlerts = () => {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: () => api.acknowledgeAllAlerts(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: queryKeys.insightsAlerts() });
+		},
+	});
+};

--- a/packages/dashboard-web/src/hooks/useAlertStream.ts
+++ b/packages/dashboard-web/src/hooks/useAlertStream.ts
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+
+export interface AlertStreamEvent {
+	type: "alert";
+	payload: {
+		id: string;
+		timestamp: number;
+		type: string;
+		severity: string;
+		title: string;
+		message: string;
+		value: number | null;
+		threshold: number | null;
+		account: string | null;
+		model: string | null;
+		project: string | null;
+		requestId: string | null;
+		acknowledged: boolean;
+	};
+}
+
+interface UseAlertStreamOptions {
+	enabled?: boolean;
+	onAlert?: (event: AlertStreamEvent) => void;
+}
+
+export function useAlertStream(options: UseAlertStreamOptions = {}) {
+	const [connected, setConnected] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (!options.enabled) return;
+
+		let evtSource: EventSource | null = null;
+		let alive = true;
+
+		const connect = () => {
+			try {
+				setConnected(false);
+				setError(null);
+				evtSource = new EventSource("/api/insights/alerts/stream");
+
+				evtSource.addEventListener("connected", () => {
+					if (!alive) return;
+					setConnected(true);
+				});
+
+				evtSource.onmessage = (event) => {
+					if (!alive) return;
+					try {
+						const data = JSON.parse(event.data) as AlertStreamEvent;
+						options.onAlert?.(data);
+					} catch (err) {
+						console.warn("Malformed alert event:", err);
+					}
+				};
+
+				evtSource.onerror = () => {
+					if (!alive) return;
+					setError("Connection lost — reconnecting…");
+					setConnected(false);
+				};
+			} catch (err) {
+				setError((err as Error).message);
+			}
+		};
+
+		connect();
+
+		return () => {
+			alive = false;
+			evtSource?.close();
+		};
+	}, [options.enabled, options.onAlert]);
+
+	return { connected, error };
+}

--- a/packages/dashboard-web/src/hooks/useAlertStream.ts
+++ b/packages/dashboard-web/src/hooks/useAlertStream.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export interface AlertStreamEvent {
 	type: "alert";
@@ -27,9 +27,16 @@ interface UseAlertStreamOptions {
 export function useAlertStream(options: UseAlertStreamOptions = {}) {
 	const [connected, setConnected] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const onAlertRef = useRef(options.onAlert);
+
+	// Keep ref current without causing re-renders
+	useEffect(() => {
+		onAlertRef.current = options.onAlert;
+	}, [options.onAlert]);
 
 	useEffect(() => {
-		if (!options.enabled) return;
+		// Opt-out only when explicitly disabled
+		if (options.enabled === false) return;
 
 		let evtSource: EventSource | null = null;
 		let alive = true;
@@ -49,7 +56,7 @@ export function useAlertStream(options: UseAlertStreamOptions = {}) {
 					if (!alive) return;
 					try {
 						const data = JSON.parse(event.data) as AlertStreamEvent;
-						options.onAlert?.(data);
+						onAlertRef.current?.(data);
 					} catch (err) {
 						console.warn("Malformed alert event:", err);
 					}
@@ -71,7 +78,7 @@ export function useAlertStream(options: UseAlertStreamOptions = {}) {
 			alive = false;
 			evtSource?.close();
 		};
-	}, [options.enabled, options.onAlert]);
+	}, [options.enabled]);
 
 	return { connected, error };
 }

--- a/packages/dashboard-web/src/lib/query-keys.ts
+++ b/packages/dashboard-web/src/lib/query-keys.ts
@@ -19,6 +19,7 @@ export const queryKeys = {
 		] as const,
 	insightsCache: (timeRange?: string, threshold?: number) =>
 		[...queryKeys.all, "insights", "cache", { timeRange, threshold }] as const,
+	insightsAlerts: () => [...queryKeys.all, "insights", "alerts"] as const,
 	requests: (limit?: number) =>
 		[...queryKeys.all, "requests", { limit }] as const,
 	logs: () => [...queryKeys.all, "logs"] as const,

--- a/packages/database/src/alerts-migration.test.ts
+++ b/packages/database/src/alerts-migration.test.ts
@@ -1,0 +1,141 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { ensureSchema, runMigrations } from "./migrations";
+
+const EXPECTED_ALERT_COLUMNS = [
+	"id",
+	"timestamp",
+	"type",
+	"severity",
+	"title",
+	"message",
+	"value",
+	"threshold",
+	"account",
+	"model",
+	"project",
+	"request_id",
+	"acknowledged",
+];
+
+describe("Alerts Table Migration (issue #250)", () => {
+	let db: Database;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("creates the alerts table with expected columns on a fresh database", () => {
+		ensureSchema(db);
+		runMigrations(db);
+
+		const columns = db.prepare("PRAGMA table_info(alerts)").all() as Array<{
+			name: string;
+			type: string;
+			notnull: number;
+		}>;
+		const columnNames = columns.map((col) => col.name);
+
+		for (const expected of EXPECTED_ALERT_COLUMNS) {
+			expect(columnNames).toContain(expected);
+		}
+	});
+
+	it("uses the expected column types and constraints", () => {
+		ensureSchema(db);
+
+		const columns = db.prepare("PRAGMA table_info(alerts)").all() as Array<{
+			name: string;
+			type: string;
+			notnull: number;
+			pk: number;
+		}>;
+		const byName = new Map(columns.map((col) => [col.name, col]));
+
+		expect(byName.get("id")?.pk).toBe(1);
+		expect(byName.get("timestamp")?.type.toUpperCase()).toBe("INTEGER");
+		expect(byName.get("timestamp")?.notnull).toBe(1);
+		expect(byName.get("type")?.notnull).toBe(1);
+		expect(byName.get("severity")?.notnull).toBe(1);
+		expect(byName.get("title")?.notnull).toBe(1);
+		expect(byName.get("message")?.notnull).toBe(1);
+		expect(byName.get("value")?.type.toUpperCase()).toBe("REAL");
+		expect(byName.get("threshold")?.type.toUpperCase()).toBe("REAL");
+		expect(byName.get("acknowledged")?.type.toUpperCase()).toBe("INTEGER");
+		expect(byName.get("acknowledged")?.notnull).toBe(1);
+	});
+
+	it("creates the alerts indexes", () => {
+		ensureSchema(db);
+
+		const indexes = db
+			.prepare(
+				"SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'alerts'",
+			)
+			.all() as Array<{ name: string }>;
+		const indexNames = indexes.map((idx) => idx.name);
+
+		expect(indexNames).toContain("idx_alerts_timestamp");
+		expect(indexNames).toContain("idx_alerts_acknowledged");
+	});
+
+	it("adds the alerts table when upgrading an existing pre-alerts database", () => {
+		// Simulate an existing install: full schema except the alerts table.
+		ensureSchema(db);
+		db.run("DROP TABLE alerts");
+
+		runMigrations(db);
+
+		const columns = db.prepare("PRAGMA table_info(alerts)").all() as Array<{
+			name: string;
+		}>;
+		const columnNames = columns.map((col) => col.name);
+		for (const expected of EXPECTED_ALERT_COLUMNS) {
+			expect(columnNames).toContain(expected);
+		}
+	});
+
+	it("stores and reads back an alert row with defaults applied", () => {
+		ensureSchema(db);
+
+		db.prepare(`
+			INSERT INTO alerts (id, timestamp, type, severity, title, message)
+			VALUES (?, ?, ?, ?, ?, ?)
+		`).run(
+			"alert-1",
+			1717900000000,
+			"daily_spend",
+			"warning",
+			"Daily spend threshold exceeded",
+			"Spend reached $12.50 of $10.00 limit",
+		);
+
+		const row = db
+			.prepare(
+				"SELECT id, timestamp, type, severity, value, threshold, account, acknowledged FROM alerts WHERE id = ?",
+			)
+			.get("alert-1") as {
+			id: string;
+			timestamp: number;
+			type: string;
+			severity: string;
+			value: number | null;
+			threshold: number | null;
+			account: string | null;
+			acknowledged: number;
+		};
+
+		expect(row.id).toBe("alert-1");
+		expect(row.timestamp).toBe(1717900000000);
+		expect(row.type).toBe("daily_spend");
+		expect(row.severity).toBe("warning");
+		expect(row.value).toBeNull();
+		expect(row.threshold).toBeNull();
+		expect(row.account).toBeNull();
+		expect(row.acknowledged).toBe(0);
+	});
+});

--- a/packages/database/src/migrations-pg.ts
+++ b/packages/database/src/migrations-pg.ts
@@ -122,6 +122,31 @@ export async function ensureSchemaPg(adapter: BunSqlAdapter): Promise<void> {
 		`CREATE INDEX IF NOT EXISTS idx_requests_timestamp_account ON requests(timestamp DESC, account_used)`,
 	);
 
+	// Create alerts table
+	await adapter.unsafe(`
+		CREATE TABLE IF NOT EXISTS alerts (
+			id TEXT PRIMARY KEY,
+			timestamp BIGINT NOT NULL,
+			type TEXT NOT NULL,
+			severity TEXT NOT NULL,
+			title TEXT NOT NULL,
+			message TEXT NOT NULL,
+			value DOUBLE PRECISION,
+			threshold DOUBLE PRECISION,
+			account TEXT,
+			model TEXT,
+			project TEXT,
+			request_id TEXT,
+			acknowledged INTEGER NOT NULL DEFAULT 0
+		)
+	`);
+	await adapter.unsafe(
+		`CREATE INDEX IF NOT EXISTS idx_alerts_timestamp ON alerts(timestamp DESC)`,
+	);
+	await adapter.unsafe(
+		`CREATE INDEX IF NOT EXISTS idx_alerts_acknowledged ON alerts(acknowledged)`,
+	);
+
 	// Create request_payloads table
 	await adapter.unsafe(`
 		CREATE TABLE IF NOT EXISTS request_payloads (
@@ -425,6 +450,35 @@ export async function runMigrationsPg(adapter: BunSqlAdapter): Promise<void> {
 	try {
 		await adapter.unsafe(
 			`CREATE INDEX IF NOT EXISTS idx_request_payloads_timestamp ON request_payloads(timestamp)`,
+		);
+	} catch (_error) {
+		// Index may already exist
+	}
+
+	// Ensure alerts table exists (for upgrades from pre-alerts installs)
+	await adapter.unsafe(`
+		CREATE TABLE IF NOT EXISTS alerts (
+			id TEXT PRIMARY KEY,
+			timestamp BIGINT NOT NULL,
+			type TEXT NOT NULL,
+			severity TEXT NOT NULL,
+			title TEXT NOT NULL,
+			message TEXT NOT NULL,
+			value DOUBLE PRECISION,
+			threshold DOUBLE PRECISION,
+			account TEXT,
+			model TEXT,
+			project TEXT,
+			request_id TEXT,
+			acknowledged INTEGER NOT NULL DEFAULT 0
+		)
+	`);
+	try {
+		await adapter.unsafe(
+			`CREATE INDEX IF NOT EXISTS idx_alerts_timestamp ON alerts(timestamp DESC)`,
+		);
+		await adapter.unsafe(
+			`CREATE INDEX IF NOT EXISTS idx_alerts_acknowledged ON alerts(acknowledged)`,
 		);
 	} catch (_error) {
 		// Index may already exist

--- a/packages/database/src/migrations.ts
+++ b/packages/database/src/migrations.ts
@@ -170,6 +170,31 @@ export function ensureSchema(db: Database): void {
 		`CREATE INDEX IF NOT EXISTS idx_requests_timestamp_account ON requests(timestamp DESC, account_used)`,
 	);
 
+	// Create alerts table for threshold and anomaly alert history
+	db.run(`
+		CREATE TABLE IF NOT EXISTS alerts (
+			id TEXT PRIMARY KEY,
+			timestamp INTEGER NOT NULL,
+			type TEXT NOT NULL,
+			severity TEXT NOT NULL,
+			title TEXT NOT NULL,
+			message TEXT NOT NULL,
+			value REAL,
+			threshold REAL,
+			account TEXT,
+			model TEXT,
+			project TEXT,
+			request_id TEXT,
+			acknowledged INTEGER NOT NULL DEFAULT 0
+		)
+	`);
+	db.run(
+		`CREATE INDEX IF NOT EXISTS idx_alerts_timestamp ON alerts(timestamp DESC)`,
+	);
+	db.run(
+		`CREATE INDEX IF NOT EXISTS idx_alerts_acknowledged ON alerts(acknowledged)`,
+	);
+
 	// Create request_payloads table for storing full request/response data
 	db.run(`
 		CREATE TABLE IF NOT EXISTS request_payloads (

--- a/packages/http-api/src/handlers/alerts.ts
+++ b/packages/http-api/src/handlers/alerts.ts
@@ -1,0 +1,148 @@
+import { type AlertEvt, alertEvents } from "@better-ccflare/core";
+import {
+	errorResponse,
+	InternalServerError,
+	jsonResponse,
+} from "@better-ccflare/http-common";
+import { Logger } from "@better-ccflare/logger";
+import type { AlertsConfigPayload } from "@better-ccflare/types";
+import { getAlertsConfig, setAlertsConfig } from "../services/alerts";
+import type { APIContext } from "../types";
+
+const log = new Logger("AlertsHandler");
+
+export function createAlertsHistoryHandler(context: APIContext) {
+	return async (searchParams: URLSearchParams): Promise<Response> => {
+		try {
+			const limit = Math.max(
+				1,
+				Math.min(
+					500,
+					Number.parseInt(searchParams.get("limit") ?? "100", 10) || 100,
+				),
+			);
+			const alerts = await context.alertService.listAlerts(limit);
+			const unacknowledgedCount =
+				await context.alertService.getUnacknowledgedCount();
+			return jsonResponse({ alerts, unacknowledgedCount });
+		} catch (error) {
+			log.error("Alert history error:", error);
+			return errorResponse(InternalServerError("Failed to fetch alerts"));
+		}
+	};
+}
+
+export function createAlertsConfigGetHandler(context: APIContext) {
+	return (): Response => jsonResponse(getAlertsConfig(context.config));
+}
+
+function parseBoolean(value: unknown): boolean {
+	return value === true || value === "true" || value === 1;
+}
+
+export function createAlertsConfigSetHandler(context: APIContext) {
+	return async (req: Request): Promise<Response> => {
+		try {
+			const body = (await req.json()) as Partial<AlertsConfigPayload>;
+			const current = getAlertsConfig(context.config);
+			const next: AlertsConfigPayload = {
+				dailySpendUsd: Number(body.dailySpendUsd ?? current.dailySpendUsd),
+				tokensPerHour: Number(body.tokensPerHour ?? current.tokensPerHour),
+				requestTokens: Number(body.requestTokens ?? current.requestTokens),
+				anomalyEnabled:
+					body.anomalyEnabled === undefined
+						? current.anomalyEnabled
+						: parseBoolean(body.anomalyEnabled),
+				anomalyIntervalMinutes: Number(
+					body.anomalyIntervalMinutes ?? current.anomalyIntervalMinutes,
+				),
+				cooldownMinutes: Number(
+					body.cooldownMinutes ?? current.cooldownMinutes,
+				),
+				webhookUrl: String(body.webhookUrl ?? current.webhookUrl),
+			};
+			setAlertsConfig(context.config, next);
+			return jsonResponse(getAlertsConfig(context.config));
+		} catch (error) {
+			log.error("Alert config update error:", error);
+			return errorResponse(
+				InternalServerError("Failed to update alert config"),
+			);
+		}
+	};
+}
+
+export function createAlertAcknowledgeHandler(context: APIContext) {
+	return async (id: string): Promise<Response> => {
+		try {
+			await context.alertService.acknowledgeAlert(id);
+			return jsonResponse({ ok: true });
+		} catch (error) {
+			log.error("Alert acknowledge error:", error);
+			return errorResponse(InternalServerError("Failed to acknowledge alert"));
+		}
+	};
+}
+
+export function createAlertsAcknowledgeAllHandler(context: APIContext) {
+	return async (): Promise<Response> => {
+		try {
+			await context.alertService.acknowledgeAll();
+			return jsonResponse({ ok: true });
+		} catch (error) {
+			log.error("Alert acknowledge-all error:", error);
+			return errorResponse(InternalServerError("Failed to acknowledge alerts"));
+		}
+	};
+}
+
+export function createAlertsStreamHandler() {
+	return (req: Request): Response => {
+		let writeHandler: ((data: AlertEvt) => void) | null = null;
+		let isClosed = false;
+		const stream = new ReadableStream({
+			start(controller) {
+				const encoder = new TextEncoder();
+				writeHandler = (data: AlertEvt) => {
+					if (isClosed) return;
+					try {
+						controller.enqueue(
+							encoder.encode(`data: ${JSON.stringify(data)}\n\n`),
+						);
+					} catch (_error) {
+						isClosed = true;
+						if (writeHandler) {
+							alertEvents.off("event", writeHandler);
+							writeHandler = null;
+						}
+					}
+				};
+				controller.enqueue(encoder.encode("event: connected\ndata: ok\n\n"));
+				alertEvents.on("event", writeHandler);
+			},
+			cancel() {
+				isClosed = true;
+				if (writeHandler) {
+					alertEvents.off("event", writeHandler);
+					writeHandler = null;
+				}
+			},
+		});
+		req.signal?.addEventListener("abort", () => {
+			if (!isClosed) {
+				isClosed = true;
+				if (writeHandler) {
+					alertEvents.off("event", writeHandler);
+					writeHandler = null;
+				}
+			}
+		});
+		return new Response(stream, {
+			headers: {
+				"Content-Type": "text/event-stream",
+				Connection: "keep-alive",
+				"Cache-Control": "no-cache",
+			},
+		});
+	};
+}

--- a/packages/http-api/src/index.ts
+++ b/packages/http-api/src/index.ts
@@ -3,6 +3,7 @@
 // Export handlers
 export * from "./handlers/storage";
 export { APIRouter } from "./router";
+export { AlertService } from "./services/alerts";
 // Export services
 export { AuthService } from "./services/auth-service";
 // Export types

--- a/packages/http-api/src/router.ts
+++ b/packages/http-api/src/router.ts
@@ -808,7 +808,7 @@ export class APIRouter {
 			method === "POST" &&
 			!path.endsWith("/acknowledge-all")
 		) {
-			const alertId = path.split("/")[4];
+			const alertId = decodeURIComponent(path.split("/")[4] ?? "");
 			if (alertId) {
 				const alertAckHandler = createAlertAcknowledgeHandler(this.context);
 				return await this.wrapHandler(() => alertAckHandler(alertId))(req, url);

--- a/packages/http-api/src/router.ts
+++ b/packages/http-api/src/router.ts
@@ -40,7 +40,14 @@ import {
 	createWorkspacesListHandler,
 } from "./handlers/agents";
 import { createAgentUpdateHandler } from "./handlers/agents-update";
-import { createAlertAcknowledgeHandler } from "./handlers/alerts";
+import {
+	createAlertAcknowledgeHandler,
+	createAlertsAcknowledgeAllHandler,
+	createAlertsConfigGetHandler,
+	createAlertsConfigSetHandler,
+	createAlertsHistoryHandler,
+	createAlertsStreamHandler,
+} from "./handlers/alerts";
 import { createAnalyticsHandler } from "./handlers/analytics";
 import {
 	createApiKeyDeleteHandler,
@@ -189,6 +196,11 @@ export class APIRouter {
 		const analyticsHandler = createAnalyticsHandler(this.context);
 		const cacheInsightsHandler = createCacheInsightsHandler(this.context);
 		const anomalyInsightsHandler = createAnomalyInsightsHandler(this.context);
+		const alertsHistoryHandler = createAlertsHistoryHandler(this.context);
+		const alertsConfigGetHandler = createAlertsConfigGetHandler(this.context);
+		const alertsConfigSetHandler = createAlertsConfigSetHandler(this.context);
+		const alertsAckAllHandler = createAlertsAcknowledgeAllHandler(this.context);
+		const alertsStreamHandler = createAlertsStreamHandler();
 		const oauthInitHandler = createOAuthInitHandler(dbOps);
 		const oauthCallbackHandler = createOAuthCallbackHandler(dbOps);
 		const qwenDeviceFlowInitHandler = createQwenDeviceFlowInitHandler(dbOps);
@@ -380,6 +392,22 @@ export class APIRouter {
 		);
 		this.handlers.set("GET:/api/insights/anomalies", (_req, url) =>
 			anomalyInsightsHandler(url.searchParams),
+		);
+		// Alert routes
+		this.handlers.set("GET:/api/insights/alerts", (_req, url) =>
+			alertsHistoryHandler(url.searchParams),
+		);
+		this.handlers.set("POST:/api/insights/alerts", (req) =>
+			alertsConfigSetHandler(req),
+		);
+		this.handlers.set("GET:/api/insights/alerts/config", () =>
+			alertsConfigGetHandler(),
+		);
+		this.handlers.set("POST:/api/insights/alerts/acknowledge-all", () =>
+			alertsAckAllHandler(),
+		);
+		this.handlers.set("GET:/api/insights/alerts/stream", (req) =>
+			alertsStreamHandler(req),
 		);
 		this.handlers.set("GET:/api/agents", () => agentsHandler());
 		this.handlers.set("POST:/api/agents/bulk-preference", (req) => {
@@ -774,8 +802,12 @@ export class APIRouter {
 			}
 		}
 
-		// Alert acknowledge by ID
-		if (path.startsWith("/api/insights/alerts/") && method === "POST") {
+		// Alert acknowledge by ID (guard against the static acknowledge-all path)
+		if (
+			path.startsWith("/api/insights/alerts/") &&
+			method === "POST" &&
+			!path.endsWith("/acknowledge-all")
+		) {
 			const alertId = path.split("/")[4];
 			if (alertId) {
 				const alertAckHandler = createAlertAcknowledgeHandler(this.context);

--- a/packages/http-api/src/router.ts
+++ b/packages/http-api/src/router.ts
@@ -40,6 +40,7 @@ import {
 	createWorkspacesListHandler,
 } from "./handlers/agents";
 import { createAgentUpdateHandler } from "./handlers/agents-update";
+import { createAlertAcknowledgeHandler } from "./handlers/alerts";
 import { createAnalyticsHandler } from "./handlers/analytics";
 import {
 	createApiKeyDeleteHandler,
@@ -770,6 +771,15 @@ export class APIRouter {
 			if (parts.length === 4 && method === "DELETE") {
 				const handler = createComboDeleteHandler(this.context.dbOps);
 				return await this.wrapHandler(() => handler(comboId))(req, url);
+			}
+		}
+
+		// Alert acknowledge by ID
+		if (path.startsWith("/api/insights/alerts/") && method === "POST") {
+			const alertId = path.split("/")[4];
+			if (alertId) {
+				const alertAckHandler = createAlertAcknowledgeHandler(this.context);
+				return await this.wrapHandler(() => alertAckHandler(alertId))(req, url);
 			}
 		}
 

--- a/packages/http-api/src/services/__tests__/alerts.test.ts
+++ b/packages/http-api/src/services/__tests__/alerts.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import type { AlertEvent, AlertsConfigPayload } from "@better-ccflare/types";
+import {
+	buildRequestTokenAlert,
+	buildThresholdAlertId,
+	shouldFireAlert,
+} from "../alerts";
+
+const CONFIG: AlertsConfigPayload = {
+	dailySpendUsd: 10,
+	tokensPerHour: 100_000,
+	requestTokens: 50_000,
+	anomalyEnabled: false,
+	anomalyIntervalMinutes: 15,
+	cooldownMinutes: 60,
+	webhookUrl: "",
+};
+
+describe("alert threshold helpers", () => {
+	test("buildThresholdAlertId is stable for the cooldown bucket", () => {
+		expect(buildThresholdAlertId("request_tokens", "req-1", 123_456, 60)).toBe(
+			buildThresholdAlertId("request_tokens", "req-1", 3_600_000 - 1, 60),
+		);
+		expect(
+			buildThresholdAlertId("request_tokens", "req-1", 3_600_000, 60),
+		).not.toBe(
+			buildThresholdAlertId("request_tokens", "req-1", 3_600_000 - 1, 60),
+		);
+	});
+
+	test("shouldFireAlert respects disabled and threshold values", () => {
+		expect(shouldFireAlert(0, 50)).toBe(false);
+		expect(shouldFireAlert(10, 9)).toBe(false);
+		expect(shouldFireAlert(10, 10)).toBe(true);
+		expect(shouldFireAlert(10, 11)).toBe(true);
+	});
+
+	test("buildRequestTokenAlert returns null below threshold", () => {
+		expect(
+			buildRequestTokenAlert(
+				{
+					id: "req-1",
+					timestamp: "2026-06-10T10:00:00.000Z",
+					method: "POST",
+					path: "/v1/messages",
+					accountUsed: "acct",
+					statusCode: 200,
+					success: true,
+					errorMessage: null,
+					responseTimeMs: 100,
+					failoverAttempts: 0,
+					totalTokens: 49_999,
+				},
+				CONFIG,
+			),
+		).toBeNull();
+	});
+
+	test("buildRequestTokenAlert emits a critical alert at threshold", () => {
+		const alert = buildRequestTokenAlert(
+			{
+				id: "req-2",
+				timestamp: "2026-06-10T10:00:00.000Z",
+				method: "POST",
+				path: "/v1/messages",
+				accountUsed: "acct",
+				statusCode: 200,
+				success: true,
+				errorMessage: null,
+				responseTimeMs: 100,
+				failoverAttempts: 0,
+				model: "model-a",
+				project: "proj",
+				totalTokens: 50_000,
+			},
+			CONFIG,
+		) as AlertEvent;
+
+		expect(alert.type).toBe("request_tokens");
+		expect(alert.severity).toBe("critical");
+		expect(alert.value).toBe(50_000);
+		expect(alert.threshold).toBe(50_000);
+		expect(alert.requestId).toBe("req-2");
+		expect(alert.model).toBe("model-a");
+		expect(alert.project).toBe("proj");
+		expect(alert.acknowledged).toBe(false);
+	});
+});

--- a/packages/http-api/src/services/alerts.ts
+++ b/packages/http-api/src/services/alerts.ts
@@ -181,6 +181,7 @@ export class AlertService {
 	private readonly db: BunSqlAdapter;
 	private readonly config: Config;
 	private readonly requestListener: (event: RequestEvt) => void;
+	private readonly configChangeListener: ({ key }: { key: string }) => void;
 	private anomalyTimer: ReturnType<typeof setInterval> | null = null;
 
 	constructor(db: BunSqlAdapter, config: Config) {
@@ -191,23 +192,25 @@ export class AlertService {
 				void this.evaluateRequest(event.payload);
 			}
 		};
-	}
-
-	start(): void {
-		requestEvents.on("event", this.requestListener);
-		this.restartAnomalyTimer();
-		this.config.on("change", ({ key }: { key: string }) => {
+		this.configChangeListener = ({ key }: { key: string }) => {
 			if (
 				key === "alert_anomaly_enabled" ||
 				key === "alert_anomaly_interval_minutes"
 			) {
 				this.restartAnomalyTimer();
 			}
-		});
+		};
+	}
+
+	start(): void {
+		requestEvents.on("event", this.requestListener);
+		this.config.on("change", this.configChangeListener);
+		this.restartAnomalyTimer();
 	}
 
 	stop(): void {
 		requestEvents.off("event", this.requestListener);
+		this.config.off("change", this.configChangeListener);
 		if (this.anomalyTimer) {
 			clearInterval(this.anomalyTimer);
 			this.anomalyTimer = null;
@@ -259,6 +262,11 @@ export class AlertService {
 	}
 
 	async acknowledgeAlert(id: string): Promise<boolean> {
+		const row = await this.db.get<{ cnt: number }>(
+			`SELECT COUNT(*) as cnt FROM alerts WHERE id = ?`,
+			[id],
+		);
+		if (!row || row.cnt === 0) return false;
 		await this.db.run(`UPDATE alerts SET acknowledged = 1 WHERE id = ?`, [id]);
 		return true;
 	}

--- a/packages/http-api/src/services/alerts.ts
+++ b/packages/http-api/src/services/alerts.ts
@@ -1,0 +1,545 @@
+import type { Config } from "@better-ccflare/config";
+import {
+	type AlertEvt,
+	alertEvents,
+	getModelRates,
+	type RequestEvt,
+	requestEvents,
+} from "@better-ccflare/core";
+import type { BunSqlAdapter } from "@better-ccflare/database";
+import { Logger } from "@better-ccflare/logger";
+import type {
+	AlertEvent,
+	AlertsConfigPayload,
+	AlertType,
+	RequestResponse,
+} from "@better-ccflare/types";
+import {
+	type AnomalyRequestRow,
+	buildAnomalyInsightsResponse,
+} from "./anomaly-insights";
+
+const log = new Logger("AlertsService");
+const HOUR_MS = 60 * 60 * 1000;
+const MAX_ANOMALY_ALERTS_PER_RUN = 25;
+
+interface AlertRow {
+	id: string;
+	timestamp: number;
+	type: AlertType;
+	severity: AlertEvent["severity"];
+	title: string;
+	message: string;
+	value: number | null;
+	threshold: number | null;
+	account: string | null;
+	model: string | null;
+	project: string | null;
+	request_id: string | null;
+	acknowledged: number;
+}
+
+interface DailySpendRow {
+	total: number | null;
+}
+
+interface TokensPerHourRow {
+	total: number | null;
+}
+
+interface AnomalySqlRow {
+	id: string;
+	timestamp: number;
+	account: string | null;
+	model: string | null;
+	project: string | null;
+	input_tokens: number;
+	cache_read_input_tokens: number;
+	cache_creation_input_tokens: number;
+	output_tokens: number;
+	cost_usd: number;
+}
+
+export function getAlertsConfig(config: Config): AlertsConfigPayload {
+	return {
+		dailySpendUsd: config.getAlertDailySpendUsd(),
+		tokensPerHour: config.getAlertTokensPerHour(),
+		requestTokens: config.getAlertRequestTokens(),
+		anomalyEnabled: config.getAlertAnomalyEnabled(),
+		anomalyIntervalMinutes: config.getAlertAnomalyIntervalMinutes(),
+		cooldownMinutes: config.getAlertCooldownMinutes(),
+		webhookUrl: config.getAlertWebhookUrl(),
+	};
+}
+
+export function setAlertsConfig(
+	config: Config,
+	payload: AlertsConfigPayload,
+): void {
+	config.setAlertDailySpendUsd(payload.dailySpendUsd);
+	config.setAlertTokensPerHour(payload.tokensPerHour);
+	config.setAlertRequestTokens(payload.requestTokens);
+	config.setAlertAnomalyEnabled(payload.anomalyEnabled);
+	config.setAlertAnomalyIntervalMinutes(payload.anomalyIntervalMinutes);
+	config.setAlertCooldownMinutes(payload.cooldownMinutes);
+	config.setAlertWebhookUrl(payload.webhookUrl);
+}
+
+export function shouldFireAlert(threshold: number, value: number): boolean {
+	return threshold > 0 && value >= threshold;
+}
+
+export function buildThresholdAlertId(
+	type: AlertType,
+	scope: string,
+	timestamp: number,
+	cooldownMinutes: number,
+): string {
+	const bucketMs = Math.max(1, cooldownMinutes) * 60 * 1000;
+	return `${type}:${scope}:${Math.floor(timestamp / bucketMs)}`;
+}
+
+function parseTimestamp(timestamp: string | number): number {
+	if (typeof timestamp === "number") return timestamp;
+	const parsed = Date.parse(timestamp);
+	return Number.isFinite(parsed) ? parsed : Date.now();
+}
+
+function requestTokenTotal(request: RequestResponse): number {
+	return (
+		request.totalTokens ??
+		(request.inputTokens ?? 0) +
+			(request.cacheReadInputTokens ?? 0) +
+			(request.cacheCreationInputTokens ?? 0) +
+			(request.outputTokens ?? 0)
+	);
+}
+
+export function buildRequestTokenAlert(
+	request: RequestResponse,
+	config: AlertsConfigPayload,
+): AlertEvent | null {
+	const totalTokens = requestTokenTotal(request);
+	if (!shouldFireAlert(config.requestTokens, totalTokens)) return null;
+	const timestamp = parseTimestamp(request.timestamp);
+	return {
+		id: buildThresholdAlertId(
+			"request_tokens",
+			request.id,
+			timestamp,
+			config.cooldownMinutes,
+		),
+		timestamp,
+		type: "request_tokens",
+		severity: "critical",
+		title: "Single request token threshold exceeded",
+		message: `Request ${request.id} used ${totalTokens.toLocaleString()} tokens, meeting the configured ${config.requestTokens.toLocaleString()} token threshold.`,
+		value: totalTokens,
+		threshold: config.requestTokens,
+		account: request.accountUsed,
+		model: request.model ?? null,
+		project: request.project ?? null,
+		requestId: request.id,
+		acknowledged: false,
+	};
+}
+
+function toAlertEvent(row: AlertRow): AlertEvent {
+	return {
+		id: row.id,
+		timestamp: Number(row.timestamp),
+		type: row.type,
+		severity: row.severity,
+		title: row.title,
+		message: row.message,
+		value: row.value == null ? null : Number(row.value),
+		threshold: row.threshold == null ? null : Number(row.threshold),
+		account: row.account,
+		model: row.model,
+		project: row.project,
+		requestId: row.request_id,
+		acknowledged: Boolean(row.acknowledged),
+	};
+}
+
+function toAnomalyRow(row: AnomalySqlRow): AnomalyRequestRow {
+	return {
+		id: row.id,
+		timestamp: Number(row.timestamp) || 0,
+		account: row.account,
+		model: row.model,
+		project: row.project,
+		inputTokens: Number(row.input_tokens) || 0,
+		cacheReadInputTokens: Number(row.cache_read_input_tokens) || 0,
+		cacheCreationInputTokens: Number(row.cache_creation_input_tokens) || 0,
+		outputTokens: Number(row.output_tokens) || 0,
+		costUsd: Number(row.cost_usd) || 0,
+	};
+}
+
+export class AlertService {
+	private readonly db: BunSqlAdapter;
+	private readonly config: Config;
+	private readonly requestListener: (event: RequestEvt) => void;
+	private anomalyTimer: ReturnType<typeof setInterval> | null = null;
+
+	constructor(db: BunSqlAdapter, config: Config) {
+		this.db = db;
+		this.config = config;
+		this.requestListener = (event) => {
+			if (event.type === "summary") {
+				void this.evaluateRequest(event.payload);
+			}
+		};
+	}
+
+	start(): void {
+		requestEvents.on("event", this.requestListener);
+		this.restartAnomalyTimer();
+		this.config.on("change", ({ key }: { key: string }) => {
+			if (
+				key === "alert_anomaly_enabled" ||
+				key === "alert_anomaly_interval_minutes"
+			) {
+				this.restartAnomalyTimer();
+			}
+		});
+	}
+
+	stop(): void {
+		requestEvents.off("event", this.requestListener);
+		if (this.anomalyTimer) {
+			clearInterval(this.anomalyTimer);
+			this.anomalyTimer = null;
+		}
+	}
+
+	private restartAnomalyTimer(): void {
+		if (this.anomalyTimer) {
+			clearInterval(this.anomalyTimer);
+			this.anomalyTimer = null;
+		}
+		const config = getAlertsConfig(this.config);
+		if (!config.anomalyEnabled) return;
+		this.anomalyTimer = setInterval(
+			() => {
+				void this.evaluateAnomalies();
+			},
+			config.anomalyIntervalMinutes * 60 * 1000,
+		);
+	}
+
+	async evaluateRequest(request: RequestResponse): Promise<void> {
+		const config = getAlertsConfig(this.config);
+		const alerts: AlertEvent[] = [];
+		const requestAlert = buildRequestTokenAlert(request, config);
+		if (requestAlert) alerts.push(requestAlert);
+		const timestamp = parseTimestamp(request.timestamp);
+		alerts.push(
+			...(await this.buildAggregateAlerts(timestamp, request, config)),
+		);
+		for (const alert of alerts) {
+			await this.persistAndEmit(alert, config.webhookUrl);
+		}
+	}
+
+	async listAlerts(limit = 100): Promise<AlertEvent[]> {
+		const rows = await this.db.query<AlertRow>(
+			`SELECT * FROM alerts ORDER BY timestamp DESC LIMIT ?`,
+			[Math.max(1, Math.min(500, Math.round(limit)))],
+		);
+		return rows.map(toAlertEvent);
+	}
+
+	async getUnacknowledgedCount(): Promise<number> {
+		const row = await this.db.get<{ count: number }>(
+			`SELECT COUNT(*) as count FROM alerts WHERE acknowledged = 0`,
+		);
+		return Number(row?.count) || 0;
+	}
+
+	async acknowledgeAlert(id: string): Promise<boolean> {
+		await this.db.run(`UPDATE alerts SET acknowledged = 1 WHERE id = ?`, [id]);
+		return true;
+	}
+
+	async acknowledgeAll(): Promise<void> {
+		await this.db.run(
+			`UPDATE alerts SET acknowledged = 1 WHERE acknowledged = 0`,
+		);
+	}
+
+	private async buildAggregateAlerts(
+		timestamp: number,
+		request: RequestResponse,
+		config: AlertsConfigPayload,
+	): Promise<AlertEvent[]> {
+		const alerts: AlertEvent[] = [];
+		const dayStart = new Date(timestamp);
+		dayStart.setHours(0, 0, 0, 0);
+		if (config.dailySpendUsd > 0) {
+			const row = await this.db.get<DailySpendRow>(
+				`SELECT SUM(COALESCE(cost_usd, 0)) as total FROM requests WHERE timestamp >= ?`,
+				[dayStart.getTime()],
+			);
+			const total = Number(row?.total) || 0;
+			if (shouldFireAlert(config.dailySpendUsd, total)) {
+				alerts.push({
+					id: buildThresholdAlertId(
+						"daily_spend",
+						"global",
+						timestamp,
+						config.cooldownMinutes,
+					),
+					timestamp,
+					type: "daily_spend",
+					severity: "warning",
+					title: "Daily spend threshold exceeded",
+					message: `Daily spend reached $${total.toFixed(2)}, meeting the configured $${config.dailySpendUsd.toFixed(2)} threshold.`,
+					value: total,
+					threshold: config.dailySpendUsd,
+					account: null,
+					model: null,
+					project: request.project ?? null,
+					requestId: request.id,
+					acknowledged: false,
+				});
+			}
+		}
+		if (config.tokensPerHour > 0) {
+			const row = await this.db.get<TokensPerHourRow>(
+				`SELECT SUM(COALESCE(total_tokens, 0)) as total FROM requests WHERE timestamp >= ?`,
+				[timestamp - HOUR_MS],
+			);
+			const total = Number(row?.total) || 0;
+			if (shouldFireAlert(config.tokensPerHour, total)) {
+				alerts.push({
+					id: buildThresholdAlertId(
+						"tokens_per_hour",
+						"global",
+						timestamp,
+						config.cooldownMinutes,
+					),
+					timestamp,
+					type: "tokens_per_hour",
+					severity: "warning",
+					title: "Hourly token threshold exceeded",
+					message: `The last hour used ${total.toLocaleString()} tokens, meeting the configured ${config.tokensPerHour.toLocaleString()} token threshold.`,
+					value: total,
+					threshold: config.tokensPerHour,
+					account: null,
+					model: null,
+					project: request.project ?? null,
+					requestId: request.id,
+					acknowledged: false,
+				});
+			}
+		}
+		return alerts;
+	}
+
+	async evaluateAnomalies(): Promise<void> {
+		const config = getAlertsConfig(this.config);
+		if (!config.anomalyEnabled) return;
+		const since = Date.now() - config.anomalyIntervalMinutes * 60 * 1000;
+		const rows = (
+			await this.db.query<AnomalySqlRow>(
+				`
+				SELECT
+					r.id as id,
+					r.timestamp as timestamp,
+					a.name as account,
+					r.model as model,
+					r.project as project,
+					COALESCE(r.input_tokens, 0) as input_tokens,
+					COALESCE(r.cache_read_input_tokens, 0) as cache_read_input_tokens,
+					COALESCE(r.cache_creation_input_tokens, 0) as cache_creation_input_tokens,
+					COALESCE(r.output_tokens, 0) as output_tokens,
+					COALESCE(r.cost_usd, 0) as cost_usd
+				FROM requests r
+				LEFT JOIN accounts a ON a.id = r.account_used
+				WHERE r.timestamp >= ?
+				ORDER BY r.timestamp ASC
+			`,
+				[since],
+			)
+		).map(toAnomalyRow);
+		if (rows.length === 0) return;
+		const modelIds = [
+			...new Set(
+				rows
+					.map((row) => row.model)
+					.filter((model): model is string => model != null && model !== ""),
+			),
+		];
+		const rateList = await Promise.all(
+			modelIds.map((modelId) => getModelRates(modelId)),
+		);
+		const rates = new Map(
+			modelIds.map((modelId, index) => [modelId, rateList[index]]),
+		);
+		const response = buildAnomalyInsightsResponse({
+			rows,
+			rates,
+			options: { range: `${config.anomalyIntervalMinutes}m`, truncated: false },
+		});
+		const alerts: AlertEvent[] = [];
+		for (const event of response.tokenOutliers.slice(
+			0,
+			MAX_ANOMALY_ALERTS_PER_RUN,
+		)) {
+			alerts.push({
+				id: buildThresholdAlertId(
+					"anomaly_token_outlier",
+					event.requestId,
+					event.timestamp,
+					config.cooldownMinutes,
+				),
+				timestamp: event.timestamp,
+				type: "anomaly_token_outlier",
+				severity: "warning",
+				title: "Token usage anomaly detected",
+				message: `Request ${event.requestId} used ${event.value.toLocaleString()} tokens (${event.zScore.toFixed(1)}σ above baseline).`,
+				value: event.value,
+				threshold: null,
+				account: event.account,
+				model: event.model,
+				project: event.project,
+				requestId: event.requestId,
+				acknowledged: false,
+			});
+		}
+		for (const event of response.outputBlowups.slice(
+			0,
+			MAX_ANOMALY_ALERTS_PER_RUN,
+		)) {
+			alerts.push({
+				id: buildThresholdAlertId(
+					"anomaly_output_blowup",
+					event.requestId,
+					event.timestamp,
+					config.cooldownMinutes,
+				),
+				timestamp: event.timestamp,
+				type: "anomaly_output_blowup",
+				severity: "warning",
+				title: "Output token blowup detected",
+				message: `Request ${event.requestId} returned ${event.value.toLocaleString()} output tokens (${event.zScore.toFixed(1)}σ above baseline).`,
+				value: event.value,
+				threshold: null,
+				account: event.account,
+				model: event.model,
+				project: event.project,
+				requestId: event.requestId,
+				acknowledged: false,
+			});
+		}
+		for (const loop of response.runawayLoops.slice(
+			0,
+			MAX_ANOMALY_ALERTS_PER_RUN,
+		)) {
+			alerts.push({
+				id: buildThresholdAlertId(
+					"anomaly_runaway_loop",
+					`${loop.account}:${loop.model}:${loop.project ?? ""}`,
+					loop.windowEndMs,
+					config.cooldownMinutes,
+				),
+				timestamp: loop.windowEndMs,
+				type: "anomaly_runaway_loop",
+				severity: "critical",
+				title: "Runaway loop detected",
+				message: `${loop.requests} near-identical requests were sent in a short window for ${loop.model}.`,
+				value: loop.requests,
+				threshold: null,
+				account: loop.account,
+				model: loop.model,
+				project: loop.project,
+				requestId: null,
+				acknowledged: false,
+			});
+		}
+		for (const group of response.misrouting.slice(
+			0,
+			MAX_ANOMALY_ALERTS_PER_RUN,
+		)) {
+			alerts.push({
+				id: buildThresholdAlertId(
+					"anomaly_model_misrouting",
+					`${group.account}:${group.model}`,
+					Date.now(),
+					config.cooldownMinutes,
+				),
+				timestamp: Date.now(),
+				type: "anomaly_model_misrouting",
+				severity: "info",
+				title: "Potential model misrouting detected",
+				message: `${group.requests} short requests used expensive model ${group.model}.`,
+				value: group.requests,
+				threshold: null,
+				account: group.account,
+				model: group.model,
+				project: null,
+				requestId: group.exampleRequestIds[0] ?? null,
+				acknowledged: false,
+			});
+		}
+		for (const alert of alerts) {
+			await this.persistAndEmit(alert, config.webhookUrl);
+		}
+	}
+
+	private async persistAndEmit(
+		alert: AlertEvent,
+		webhookUrl: string,
+	): Promise<void> {
+		await this.db.run(
+			`
+			INSERT OR IGNORE INTO alerts (
+				id, timestamp, type, severity, title, message, value, threshold,
+				account, model, project, request_id, acknowledged
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`,
+			[
+				alert.id,
+				alert.timestamp,
+				alert.type,
+				alert.severity,
+				alert.title,
+				alert.message,
+				alert.value,
+				alert.threshold,
+				alert.account,
+				alert.model,
+				alert.project,
+				alert.requestId,
+				alert.acknowledged ? 1 : 0,
+			],
+		);
+		const saved = await this.db.get<AlertRow>(
+			`SELECT * FROM alerts WHERE id = ?`,
+			[alert.id],
+		);
+		if (!saved || Boolean(saved.acknowledged)) return;
+		const event: AlertEvt = { type: "alert", payload: toAlertEvent(saved) };
+		alertEvents.emit("event", event);
+		if (webhookUrl) {
+			void this.deliverWebhook(webhookUrl, event.payload);
+		}
+	}
+
+	private async deliverWebhook(
+		webhookUrl: string,
+		alert: AlertEvent,
+	): Promise<void> {
+		try {
+			await fetch(webhookUrl, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ type: "alert", alert }),
+			});
+		} catch (error) {
+			log.warn(`Alert webhook delivery failed: ${(error as Error).message}`);
+		}
+	}
+}

--- a/packages/http-api/src/services/alerts.ts
+++ b/packages/http-api/src/services/alerts.ts
@@ -76,13 +76,16 @@ export function setAlertsConfig(
 	config: Config,
 	payload: AlertsConfigPayload,
 ): void {
+	// Validate webhookUrl before mutating any fields to avoid partial config state.
+	// setAlertWebhookUrl throws ValidationError for non-http(s) URLs; all other
+	// setters only clamp/coerce and never throw.
+	config.setAlertWebhookUrl(payload.webhookUrl);
 	config.setAlertDailySpendUsd(payload.dailySpendUsd);
 	config.setAlertTokensPerHour(payload.tokensPerHour);
 	config.setAlertRequestTokens(payload.requestTokens);
 	config.setAlertAnomalyEnabled(payload.anomalyEnabled);
 	config.setAlertAnomalyIntervalMinutes(payload.anomalyIntervalMinutes);
 	config.setAlertCooldownMinutes(payload.cooldownMinutes);
-	config.setAlertWebhookUrl(payload.webhookUrl);
 }
 
 export function shouldFireAlert(threshold: number, value: number): boolean {

--- a/packages/http-api/src/services/alerts.ts
+++ b/packages/http-api/src/services/alerts.ts
@@ -501,6 +501,15 @@ export class AlertService {
 		alert: AlertEvent,
 		webhookUrl: string,
 	): Promise<void> {
+		// Check if a row with this cooldown-bucket ID already exists before inserting.
+		// If it does, the alert is within its cooldown window — skip emission entirely
+		// to avoid SSE storms and duplicate webhook deliveries.
+		const existing = await this.db.get<{ id: string }>(
+			`SELECT id FROM alerts WHERE id = ?`,
+			[alert.id],
+		);
+		if (existing) return;
+
 		await this.db.run(
 			`
 			INSERT OR IGNORE INTO alerts (
@@ -524,15 +533,10 @@ export class AlertService {
 				alert.acknowledged ? 1 : 0,
 			],
 		);
-		const saved = await this.db.get<AlertRow>(
-			`SELECT * FROM alerts WHERE id = ?`,
-			[alert.id],
-		);
-		if (!saved || Boolean(saved.acknowledged)) return;
-		const event: AlertEvt = { type: "alert", payload: toAlertEvent(saved) };
+		const event: AlertEvt = { type: "alert", payload: alert };
 		alertEvents.emit("event", event);
 		if (webhookUrl) {
-			void this.deliverWebhook(webhookUrl, event.payload);
+			void this.deliverWebhook(webhookUrl, alert);
 		}
 	}
 

--- a/packages/types/src/alerts.ts
+++ b/packages/types/src/alerts.ts
@@ -1,0 +1,61 @@
+/**
+ * Types for the alerting system (issue #250): threshold rules,
+ * anomaly-driven alerts, alert history, and alert configuration.
+ *
+ * Pure data shapes shared between the HTTP API, the alert engine,
+ * and the dashboard.
+ */
+
+/** Severity level attached to an alert event. */
+export type AlertSeverity = "info" | "warning" | "critical";
+
+/** Discriminates which rule or anomaly detector produced an alert. */
+export type AlertType =
+	| "daily_spend"
+	| "tokens_per_hour"
+	| "request_tokens"
+	| "anomaly_token_outlier"
+	| "anomaly_output_blowup"
+	| "anomaly_runaway_loop"
+	| "anomaly_model_misrouting";
+
+/** A single alert raised by the alert engine. */
+export interface AlertEvent {
+	id: string;
+	/** ms epoch */
+	timestamp: number;
+	type: AlertType;
+	severity: AlertSeverity;
+	title: string;
+	message: string;
+	/** Observed value that triggered the alert. */
+	value: number | null;
+	/** Configured threshold (null for anomaly alerts). */
+	threshold: number | null;
+	account: string | null;
+	model: string | null;
+	project: string | null;
+	requestId: string | null;
+	acknowledged: boolean;
+}
+
+/** Full response of GET /api/alerts. */
+export interface AlertHistoryResponse {
+	alerts: AlertEvent[];
+	unacknowledgedCount: number;
+}
+
+/** Alert configuration payload exchanged with the settings API. */
+export interface AlertsConfigPayload {
+	/** Daily spend threshold in USD; 0 = disabled. */
+	dailySpendUsd: number;
+	/** Tokens-per-hour threshold; 0 = disabled. */
+	tokensPerHour: number;
+	/** Per-request token threshold; 0 = disabled. */
+	requestTokens: number;
+	anomalyEnabled: boolean;
+	anomalyIntervalMinutes: number;
+	cooldownMinutes: number;
+	/** Webhook target URL; "" = disabled. */
+	webhookUrl: string;
+}

--- a/packages/types/src/context.ts
+++ b/packages/types/src/context.ts
@@ -4,6 +4,7 @@ import type {
 	DatabaseOperations,
 } from "@better-ccflare/database";
 import type { Account } from "./account";
+import type { AlertEvent } from "./alerts";
 import type { RequestMeta } from "./api";
 import type { ApiKey } from "./api-key";
 import type { IntegrityStatus } from "./stats";
@@ -14,6 +15,12 @@ export interface APIContext {
 	db: BunSqlAdapter;
 	config: Config;
 	dbOps: DatabaseOperations;
+	alertService: {
+		listAlerts(limit?: number): Promise<AlertEvent[]>;
+		getUnacknowledgedCount(): Promise<number>;
+		acknowledgeAlert(id: string): Promise<boolean>;
+		acknowledgeAll(): Promise<void>;
+	};
 	auth?: {
 		isAuthenticated: boolean;
 		apiKey?: ApiKey;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -2,6 +2,7 @@
 export * from "./account";
 export * from "./agent";
 export * from "./agent-constants";
+export * from "./alerts";
 // Keep existing exports for backward compatibility
 export * from "./api";
 export * from "./api-key";


### PR DESCRIPTION
Closes #250 · Part of Token Insights suite #247

## Summary

- **Alert types** (`packages/types/src/alerts.ts`): `AlertEvent`, `AlertSeverity`, `AlertType`, `AlertHistoryResponse`, `AlertsConfigPayload`
- **Event bus** (`packages/core/src/alert-events.ts`): `alertEvents` EventEmitter mirroring `requestEvents`
- **DB migrations** (both `migrations.ts` + `migrations-pg.ts`): `alerts` table with `id`, `timestamp`, `type`, `severity`, `title`, `message`, `value`, `threshold`, `account`, `model`, `project`, `request_id`, `acknowledged` + indexes on timestamp and acknowledged
- **Config** (`packages/config/src/index.ts`): 7 new settings — `alertDailySpendUsd`, `alertTokensPerHour`, `alertRequestTokens`, `alertAnomalyEnabled`, `alertAnomalyIntervalMinutes`, `alertCooldownMinutes`, `alertWebhookUrl` — with env overrides, clamping, and `getAllSettings` inclusion
- **AlertService** (`packages/http-api/src/services/alerts.ts`):
  - Subscribes to `requestEvents` "summary" events for per-request threshold evaluation (daily spend USD, tokens/hour, single-request size)
  - `setInterval` for anomaly evaluation reusing `buildAnomalyInsightsResponse` from #249
  - Alert deduplication via `INSERT OR IGNORE` keyed by cooldown-bucket ID (no alert storms)
  - Optional outbound webhook delivery on alert fire
- **HTTP endpoints** (`packages/http-api/src/handlers/alerts.ts` + `router.ts`):
  - `GET /api/insights/alerts` — history with unacknowledged count
  - `POST /api/insights/alerts` — save config
  - `GET /api/insights/alerts/stream` — SSE event stream
  - `POST /api/insights/alerts/:id` — acknowledge single alert
  - `POST /api/insights/alerts/acknowledge-all` — bulk acknowledge
- **Dashboard**:
  - `useAlerts` / `useAcknowledgeAlert` / `useAcknowledgeAllAlerts` React Query hooks
  - `useAlertStream` SSE hook (`EventSource`)
  - `AlertsView` component in `InsightsTab`
  - Unacknowledged count badge on Insights nav item

## Tests

- `packages/config/src/alerts-config.test.ts` — 6 tests (defaults, env overrides, clamping, persistence, webhook validation, getAllSettings)
- `packages/database/src/alerts-migration.test.ts` — 5 tests (table creation, column types, indexes, upgrade path, round-trip insert)
- `packages/http-api/src/services/__tests__/alerts.test.ts` — 4 tests (pure helper functions)

All 228 tests pass. Typecheck clean.

## Test plan

- [ ] Start server, verify `GET /api/insights/alerts` returns `{ alerts: [], unacknowledgedCount: 0 }`
- [ ] Set a low `alertRequestTokens` threshold via `POST /api/insights/alerts`, send a request that exceeds it, verify alert appears in history
- [ ] Open SSE stream (`GET /api/insights/alerts/stream`) and confirm alert fires as an event
- [ ] Verify Insights nav badge increments on unacknowledged alerts
- [ ] Acknowledge an alert via dashboard button; badge decrements
- [ ] Acknowledge all; badge clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)