### PR TITLE
feat: context composition insights from stored payloads (#251)

### DIFF
--- a/packages/dashboard-web/src/api.ts
+++ b/packages/dashboard-web/src/api.ts
@@ -14,6 +14,7 @@ import type {
 	ComboFamilyAssignment,
 	ComboSlot,
 	ComboWithSlots,
+	ContextInsightsResponse,
 	LogEvent,
 	RequestPayload,
 	RequestResponse,
@@ -974,6 +975,14 @@ class API extends HttpClient {
 
 		return this.get<CacheInsightsResponse>(
 			`/api/insights/cache?${params.toString()}`,
+		);
+	}
+
+	async getContextInsights(range = "24h"): Promise<ContextInsightsResponse> {
+		const params = new URLSearchParams({ range });
+
+		return this.get<ContextInsightsResponse>(
+			`/api/insights/context?${params.toString()}`,
 		);
 	}
 

--- a/packages/dashboard-web/src/components/InsightsTab.tsx
+++ b/packages/dashboard-web/src/components/InsightsTab.tsx
@@ -1,9 +1,10 @@
 import { AlertTriangle } from "lucide-react";
 import React, { useState } from "react";
 import type { TimeRange } from "../constants";
-import { useCacheInsights } from "../hooks/queries";
+import { useCacheInsights, useContextInsights } from "../hooks/queries";
 import { AlertsView } from "./insights/AlertsView";
 import { CacheEfficiencyView } from "./insights/CacheEfficiencyView";
+import { ContextCompositionView } from "./insights/ContextCompositionView";
 import { TimeRangeSelector } from "./overview/TimeRangeSelector";
 import { Card, CardContent } from "./ui/card";
 
@@ -12,6 +13,11 @@ export const InsightsTab = React.memo(() => {
 
 	// Fetch cache insights with automatic refetch on range changes
 	const { data, isLoading: loading, isError } = useCacheInsights(timeRange);
+	const {
+		data: contextData,
+		isLoading: contextLoading,
+		isError: contextError,
+	} = useContextInsights(timeRange);
 
 	return (
 		<div className="space-y-6">
@@ -36,6 +42,23 @@ export const InsightsTab = React.memo(() => {
 				<CacheEfficiencyView
 					data={data}
 					loading={loading}
+					timeRange={timeRange}
+				/>
+			)}
+
+			{contextError ? (
+				<Card>
+					<CardContent className="p-6">
+						<div className="flex items-center gap-2 text-destructive">
+							<AlertTriangle className="h-5 w-5" />
+							<span>Failed to load context insights. Please try again.</span>
+						</div>
+					</CardContent>
+				</Card>
+			) : (
+				<ContextCompositionView
+					data={contextData}
+					loading={contextLoading}
 					timeRange={timeRange}
 				/>
 			)}

--- a/packages/dashboard-web/src/components/insights/ContextCompositionView.tsx
+++ b/packages/dashboard-web/src/components/insights/ContextCompositionView.tsx
@@ -43,13 +43,6 @@ interface ContextCompositionViewProps {
 	timeRange: TimeRange;
 }
 
-/** Mirrors the backend's char→token heuristic (see ContextInsightsMeta.estimateNote). */
-const CHARS_PER_TOKEN = 4;
-
-function estimateTokensFromChars(chars: number): number {
-	return Math.round(chars / CHARS_PER_TOKEN);
-}
-
 const CONTRIBUTOR_KIND_LABELS: Record<ContextContributorKind, string> = {
 	tool_result: "Tool Result",
 	text: "Text",
@@ -179,13 +172,13 @@ function PerRequestTable({ rows }: PerRequestTableProps) {
 							Project
 						</th>
 						<th scope="col" className="text-right px-3 py-2">
-							System
+							System (chars)
 						</th>
 						<th scope="col" className="text-right px-3 py-2">
-							Tools
+							Tools (chars)
 						</th>
 						<th scope="col" className="text-right px-3 py-2">
-							Messages
+							Messages (chars)
 						</th>
 						<th scope="col" className="text-right px-3 py-2">
 							Est. Context
@@ -217,13 +210,13 @@ function PerRequestTable({ rows }: PerRequestTableProps) {
 									</span>
 								</td>
 								<td className="px-3 py-2 text-right">
-									~{formatTokens(estimateTokensFromChars(row.systemChars))}
+									{formatNumber(row.systemChars)}
 								</td>
 								<td className="px-3 py-2 text-right">
-									~{formatTokens(estimateTokensFromChars(row.toolsChars))}
+									{formatNumber(row.toolsChars)}
 								</td>
 								<td className="px-3 py-2 text-right">
-									~{formatTokens(estimateTokensFromChars(row.messagesChars))}
+									{formatNumber(row.messagesChars)}
 								</td>
 								<td className="px-3 py-2 text-right">
 									~{formatTokens(row.estimatedContextTokens)}
@@ -287,9 +280,7 @@ export const ContextCompositionView = React.memo(
 
 		const recentRequests = useMemo(
 			() =>
-				[...(data?.composition.perRequest ?? [])]
-					.sort((a, b) => b.timestamp - a.timestamp)
-					.slice(0, PER_REQUEST_ROW_LIMIT),
+				(data?.composition.perRequest ?? []).slice(0, PER_REQUEST_ROW_LIMIT),
 			[data?.composition.perRequest],
 		);
 
@@ -333,8 +324,7 @@ export const ContextCompositionView = React.memo(
 								~{formatTokens(totals?.estimatedTokens.total ?? 0)}
 							</div>
 							<p className="text-xs text-muted-foreground">
-								Estimated tokens across analyzed payloads (~
-								{CHARS_PER_TOKEN} chars/token)
+								Estimated tokens across analyzed payloads (~ 4 chars/token)
 							</p>
 						</CardContent>
 					</Card>
@@ -375,41 +365,31 @@ export const ContextCompositionView = React.memo(
 					</Card>
 				</div>
 
-				{noPayloads ? (
+				{/* No-payloads notice — only for payload-dependent sections */}
+				{noPayloads && requestsInRange > 0 && (
 					<Card>
 						<CardContent className="p-6">
 							<div className="flex items-start gap-3">
 								<Database className="h-5 w-5 text-muted-foreground mt-0.5 shrink-0" />
 								<div className="space-y-1">
-									<p className="font-medium">
-										{requestsInRange === 0
-											? "No requests in this period"
-											: "No stored payloads to analyze"}
-									</p>
+									<p className="font-medium">No stored payloads to analyze</p>
 									<p className="text-sm text-muted-foreground">
-										{requestsInRange === 0 ? (
-											<>
-												No requests were recorded in the last {timeRange}, so
-												there is nothing to analyze yet. Try a wider time range.
-											</>
-										) : (
-											<>
-												Context composition is computed from stored request
-												payloads, but none of the{" "}
-												{formatNumber(requestsInRange)} requests in the last{" "}
-												{timeRange} have one. Enable payload storage (the{" "}
-												<code>store_payloads</code> config option) and new
-												requests will appear here. Note that payloads are
-												size-capped and cleaned up by retention, so coverage is
-												always partial.
-											</>
-										)}
+										Context composition is computed from stored request
+										payloads, but none of the {formatNumber(requestsInRange)}{" "}
+										requests in the last {timeRange} have one. Enable payload
+										storage (the <code>store_payloads</code> config option) and
+										new requests will appear here. Note that payloads are
+										size-capped and cleaned up by retention, so coverage is
+										always partial.
 									</p>
 								</div>
 							</div>
 						</CardContent>
 					</Card>
-				) : (
+				)}
+
+				{/* Payload-dependent sections: composition donuts + context details */}
+				{!noPayloads && (
 					<>
 						{/* Composition Donuts */}
 						<div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -431,9 +411,7 @@ export const ContextCompositionView = React.memo(
 										paddingAngle={5}
 										tooltipStyle="success"
 										tooltipFormatter={(value, name) => [
-											`~${formatTokens(
-												estimateTokensFromChars(value as number),
-											)} tokens (${formatNumber(value as number)} chars)`,
+											`${formatNumber(value as number)} chars`,
 											name ?? "",
 										]}
 										showLegend
@@ -503,79 +481,6 @@ export const ContextCompositionView = React.memo(
 							</Card>
 						</div>
 
-						{/* Growth Curve */}
-						<Card>
-							<CardHeader>
-								<div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-									<div>
-										<CardTitle>Context Growth</CardTitle>
-										<CardDescription>
-											Exact context tokens (input + cache read + cache creation)
-											per request over a session
-										</CardDescription>
-									</div>
-									{sessions.length > 0 && (
-										<Select
-											value={String(sessionIndex)}
-											onValueChange={setSelectedSession}
-										>
-											<SelectTrigger className="w-full sm:w-[340px]">
-												<SelectValue />
-											</SelectTrigger>
-											<SelectContent>
-												{sessions.map((session, index) => (
-													<SelectItem
-														key={`${session.project ?? "unknown"}-${session.startTimestamp}`}
-														value={String(index)}
-													>
-														{formatSessionLabel(session)}
-													</SelectItem>
-												))}
-											</SelectContent>
-										</Select>
-									)}
-								</div>
-							</CardHeader>
-							<CardContent>
-								<BaseLineChart
-									data={growthData}
-									loading={loading}
-									height="medium"
-									xAxisKey="time"
-									lines={[
-										{
-											dataKey: "contextTokens",
-											name: "Context tokens",
-											stroke: COLORS.primary,
-											dot: true,
-										},
-										{
-											dataKey: "outputTokens",
-											name: "Output tokens",
-											stroke: COLORS.blue,
-										},
-									]}
-									yAxisTickFormatter={(value) => formatTokens(Number(value))}
-									tooltipFormatter={(value, name) => [
-										`${formatTokens(value as number)} tokens`,
-										name ?? "",
-									]}
-									showLegend
-									emptyState={
-										<p className="text-sm text-muted-foreground">
-											No session data for this period
-										</p>
-									}
-								/>
-								{data?.growthCurve.truncated && (
-									<p className="mt-2 text-xs text-muted-foreground">
-										<AlertTriangle className="h-3 w-3 inline mr-1" />
-										Some sessions or points were trimmed by scan caps.
-									</p>
-								)}
-							</CardContent>
-						</Card>
-
 						{/* Contributors + Per-Request Tables */}
 						<Card>
 							<CardHeader>
@@ -612,6 +517,81 @@ export const ContextCompositionView = React.memo(
 							</CardContent>
 						</Card>
 					</>
+				)}
+
+				{/* Growth Curve — always shown, doesn't need payloads */}
+				{data && (
+					<Card>
+						<CardHeader>
+							<div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+								<div>
+									<CardTitle>Context Growth</CardTitle>
+									<CardDescription>
+										Exact context tokens (input + cache read + cache creation)
+										per request over a session
+									</CardDescription>
+								</div>
+								{sessions.length > 0 && (
+									<Select
+										value={String(sessionIndex)}
+										onValueChange={setSelectedSession}
+									>
+										<SelectTrigger className="w-full sm:w-[340px]">
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											{sessions.map((session, index) => (
+												<SelectItem
+													key={`${session.project ?? "unknown"}-${session.startTimestamp}`}
+													value={String(index)}
+												>
+													{formatSessionLabel(session)}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								)}
+							</div>
+						</CardHeader>
+						<CardContent>
+							<BaseLineChart
+								data={growthData}
+								loading={loading}
+								height="medium"
+								xAxisKey="time"
+								lines={[
+									{
+										dataKey: "contextTokens",
+										name: "Context tokens",
+										stroke: COLORS.primary,
+										dot: true,
+									},
+									{
+										dataKey: "outputTokens",
+										name: "Output tokens",
+										stroke: COLORS.blue,
+									},
+								]}
+								yAxisTickFormatter={(value) => formatTokens(Number(value))}
+								tooltipFormatter={(value, name) => [
+									`${formatTokens(value as number)} tokens`,
+									name ?? "",
+								]}
+								showLegend
+								emptyState={
+									<p className="text-sm text-muted-foreground">
+										No session data for this period
+									</p>
+								}
+							/>
+							{data?.growthCurve.truncated && (
+								<p className="mt-2 text-xs text-muted-foreground">
+									<AlertTriangle className="h-3 w-3 inline mr-1" />
+									Some sessions or points were trimmed by scan caps.
+								</p>
+							)}
+						</CardContent>
+					</Card>
 				)}
 
 				{/* Footnotes */}

--- a/packages/dashboard-web/src/components/insights/ContextCompositionView.tsx
+++ b/packages/dashboard-web/src/components/insights/ContextCompositionView.tsx
@@ -384,15 +384,29 @@ export const ContextCompositionView = React.memo(
 							<div className="flex items-start gap-3">
 								<Database className="h-5 w-5 text-muted-foreground mt-0.5 shrink-0" />
 								<div className="space-y-1">
-									<p className="font-medium">No stored payloads to analyze</p>
+									<p className="font-medium">
+										{requestsInRange === 0
+											? "No requests in this period"
+											: "No stored payloads to analyze"}
+									</p>
 									<p className="text-sm text-muted-foreground">
-										Context composition is computed from stored request
-										payloads, but none of the {formatNumber(requestsInRange)}{" "}
-										requests in the last {timeRange} have one. Enable payload
-										storage (the <code>store_payloads</code> config option) and
-										new requests will appear here. Note that payloads are
-										size-capped and cleaned up by retention, so coverage is
-										always partial.
+										{requestsInRange === 0 ? (
+											<>
+												No requests were recorded in the last {timeRange}, so
+												there is nothing to analyze yet. Try a wider time range.
+											</>
+										) : (
+											<>
+												Context composition is computed from stored request
+												payloads, but none of the{" "}
+												{formatNumber(requestsInRange)} requests in the last{" "}
+												{timeRange} have one. Enable payload storage (the{" "}
+												<code>store_payloads</code> config option) and new
+												requests will appear here. Note that payloads are
+												size-capped and cleaned up by retention, so coverage is
+												always partial.
+											</>
+										)}
 									</p>
 								</div>
 							</div>

--- a/packages/dashboard-web/src/components/insights/ContextCompositionView.tsx
+++ b/packages/dashboard-web/src/components/insights/ContextCompositionView.tsx
@@ -1,0 +1,633 @@
+import type {
+	ContextContributor,
+	ContextContributorKind,
+	ContextGrowthSession,
+	ContextInsightsResponse,
+	ContextRequestComposition,
+} from "@better-ccflare/types";
+import {
+	formatNumber,
+	formatPercentage,
+	formatTokens,
+} from "@better-ccflare/ui-common";
+import {
+	AlertTriangle,
+	Database,
+	FileSearch,
+	Layers,
+	TrendingUp,
+} from "lucide-react";
+import React, { useMemo, useState } from "react";
+import { COLORS, type TimeRange } from "../../constants";
+import { BaseLineChart, BasePieChart } from "../charts";
+import { Badge } from "../ui/badge";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "../ui/card";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "../ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
+
+interface ContextCompositionViewProps {
+	data?: ContextInsightsResponse;
+	loading?: boolean;
+	timeRange: TimeRange;
+}
+
+/** Mirrors the backend's char→token heuristic (see ContextInsightsMeta.estimateNote). */
+const CHARS_PER_TOKEN = 4;
+
+function estimateTokensFromChars(chars: number): number {
+	return Math.round(chars / CHARS_PER_TOKEN);
+}
+
+const CONTRIBUTOR_KIND_LABELS: Record<ContextContributorKind, string> = {
+	tool_result: "Tool Result",
+	text: "Text",
+	tool_use: "Tool Use",
+};
+
+const CONTRIBUTOR_KIND_VARIANTS: Record<
+	ContextContributorKind,
+	"default" | "secondary" | "outline"
+> = {
+	tool_result: "secondary",
+	text: "outline",
+	tool_use: "default",
+};
+
+function formatSessionLabel(session: ContextGrowthSession): string {
+	const start = new Date(session.startTimestamp).toLocaleString();
+	const end = new Date(session.endTimestamp).toLocaleTimeString();
+	return `${session.project ?? "Unknown"} — ${start} – ${end} (${session.requestCount} reqs)`;
+}
+
+interface ContributorsTableProps {
+	contributors: ContextContributor[];
+}
+
+function ContributorsTable({ contributors }: ContributorsTableProps) {
+	if (contributors.length === 0) {
+		return (
+			<p className="text-sm text-muted-foreground py-4">
+				No large content blocks found in the analyzed payloads
+			</p>
+		);
+	}
+
+	return (
+		<div className="overflow-x-auto">
+			<table
+				aria-label="Largest context contributors"
+				className="w-full text-sm"
+			>
+				<thead className="bg-muted/50">
+					<tr>
+						<th scope="col" className="text-left px-3 py-2">
+							Kind
+						</th>
+						<th scope="col" className="text-left px-3 py-2">
+							Content
+						</th>
+						<th scope="col" className="text-right px-3 py-2">
+							Size (est.)
+						</th>
+						<th scope="col" className="text-right px-3 py-2">
+							Occurrences
+						</th>
+						<th scope="col" className="text-right px-3 py-2">
+							Requests
+						</th>
+					</tr>
+				</thead>
+				<tbody>
+					{contributors.map((contributor) => (
+						<tr
+							key={`${contributor.kind}-${contributor.label}-${contributor.maxChars}`}
+							className="border-t"
+						>
+							<td className="px-3 py-2">
+								<Badge
+									variant={CONTRIBUTOR_KIND_VARIANTS[contributor.kind]}
+									className="whitespace-nowrap"
+								>
+									{CONTRIBUTOR_KIND_LABELS[contributor.kind]}
+								</Badge>
+							</td>
+							<td className="px-3 py-2">
+								<span className="text-muted-foreground break-all">
+									{contributor.label}
+								</span>
+							</td>
+							<td className="px-3 py-2 text-right whitespace-nowrap">
+								~{formatTokens(contributor.estimatedTokens)} tokens
+								<span className="text-muted-foreground">
+									{" "}
+									({formatNumber(contributor.maxChars)} chars)
+								</span>
+							</td>
+							<td className="px-3 py-2 text-right">
+								{formatNumber(contributor.occurrences)}
+							</td>
+							<td className="px-3 py-2 text-right">
+								{formatNumber(contributor.requestCount)}
+							</td>
+						</tr>
+					))}
+				</tbody>
+			</table>
+		</div>
+	);
+}
+
+interface PerRequestTableProps {
+	rows: ContextRequestComposition[];
+}
+
+const PER_REQUEST_ROW_LIMIT = 20;
+
+function PerRequestTable({ rows }: PerRequestTableProps) {
+	if (rows.length === 0) {
+		return (
+			<p className="text-sm text-muted-foreground py-4">
+				No analyzed requests for this period
+			</p>
+		);
+	}
+
+	return (
+		<div className="overflow-x-auto">
+			<table
+				aria-label="Analyzed request compositions"
+				className="w-full text-sm"
+			>
+				<thead className="bg-muted/50">
+					<tr>
+						<th scope="col" className="text-left px-3 py-2">
+							Time
+						</th>
+						<th scope="col" className="text-left px-3 py-2">
+							Model
+						</th>
+						<th scope="col" className="text-left px-3 py-2">
+							Project
+						</th>
+						<th scope="col" className="text-right px-3 py-2">
+							System
+						</th>
+						<th scope="col" className="text-right px-3 py-2">
+							Tools
+						</th>
+						<th scope="col" className="text-right px-3 py-2">
+							Messages
+						</th>
+						<th scope="col" className="text-right px-3 py-2">
+							Est. Context
+						</th>
+						<th scope="col" className="text-right px-3 py-2">
+							Actual Input
+						</th>
+					</tr>
+				</thead>
+				<tbody>
+					{rows.map((row) => {
+						const actualInputTokens =
+							row.inputTokens +
+							row.cacheReadInputTokens +
+							row.cacheCreationInputTokens;
+						return (
+							<tr key={row.id} className="border-t">
+								<td className="px-3 py-2 whitespace-nowrap">
+									{new Date(row.timestamp).toLocaleString()}
+								</td>
+								<td className="px-3 py-2">
+									<span className="text-muted-foreground break-all">
+										{row.model ?? "—"}
+									</span>
+								</td>
+								<td className="px-3 py-2">
+									<span className="text-muted-foreground break-all">
+										{row.project ?? "—"}
+									</span>
+								</td>
+								<td className="px-3 py-2 text-right">
+									~{formatTokens(estimateTokensFromChars(row.systemChars))}
+								</td>
+								<td className="px-3 py-2 text-right">
+									~{formatTokens(estimateTokensFromChars(row.toolsChars))}
+								</td>
+								<td className="px-3 py-2 text-right">
+									~{formatTokens(estimateTokensFromChars(row.messagesChars))}
+								</td>
+								<td className="px-3 py-2 text-right">
+									~{formatTokens(row.estimatedContextTokens)}
+								</td>
+								<td className="px-3 py-2 text-right">
+									{formatTokens(actualInputTokens)}
+								</td>
+							</tr>
+						);
+					})}
+				</tbody>
+			</table>
+		</div>
+	);
+}
+
+export const ContextCompositionView = React.memo(
+	({ data, loading = false, timeRange }: ContextCompositionViewProps) => {
+		const meta = data?.meta;
+		const totals = data?.composition.totals;
+		const tokenTotals = data?.composition.tokenTotals;
+
+		const sessions = useMemo(
+			() => data?.growthCurve.sessions ?? [],
+			[data?.growthCurve.sessions],
+		);
+
+		// Index into sessions; clamped below so a shrinking session list
+		// after a refetch can never point past the end.
+		const [selectedSession, setSelectedSession] = useState("0");
+		const sessionIndex = Math.min(
+			Math.max(Number.parseInt(selectedSession, 10) || 0, 0),
+			Math.max(sessions.length - 1, 0),
+		);
+		const activeSession = sessions[sessionIndex];
+
+		const growthData = useMemo(
+			() =>
+				(activeSession?.points ?? []).map((point) => ({
+					time: new Date(point.timestamp).toLocaleTimeString(),
+					contextTokens: point.contextTokens,
+					outputTokens: point.outputTokens,
+				})),
+			[activeSession],
+		);
+
+		const compositionData = [
+			{ name: "System", value: totals?.systemChars ?? 0 },
+			{ name: "Tools", value: totals?.toolsChars ?? 0 },
+			{ name: "Messages", value: totals?.messagesChars ?? 0 },
+		].filter((item) => item.value > 0);
+
+		const tokenMixData = [
+			{ name: "Uncached Input", value: tokenTotals?.uncachedInputTokens ?? 0 },
+			{ name: "Cache Read", value: tokenTotals?.cacheReadInputTokens ?? 0 },
+			{
+				name: "Cache Creation",
+				value: tokenTotals?.cacheCreationInputTokens ?? 0,
+			},
+		].filter((item) => item.value > 0);
+
+		const recentRequests = useMemo(
+			() =>
+				[...(data?.composition.perRequest ?? [])]
+					.sort((a, b) => b.timestamp - a.timestamp)
+					.slice(0, PER_REQUEST_ROW_LIMIT),
+			[data?.composition.perRequest],
+		);
+
+		const requestsInRange = meta?.payloadCoverage.requestsInRange ?? 0;
+		const requestsWithPayload = meta?.payloadCoverage.requestsWithPayload ?? 0;
+		const noPayloads = !!data && requestsWithPayload === 0;
+
+		return (
+			<div className="space-y-6">
+				{/* Coverage Summary Cards */}
+				<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+					<Card>
+						<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+							<CardTitle className="text-sm font-medium">
+								Requests Analyzed
+							</CardTitle>
+							<FileSearch className="h-4 w-4 text-muted-foreground" />
+						</CardHeader>
+						<CardContent>
+							<div className="text-2xl font-bold">
+								{formatNumber(meta?.parsedPayloads ?? 0)}{" "}
+								<span className="text-base font-normal text-muted-foreground">
+									of {formatNumber(requestsInRange)}
+								</span>
+							</div>
+							<p className="text-xs text-muted-foreground">
+								Requests with a parsed payload in the last {timeRange}
+							</p>
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+							<CardTitle className="text-sm font-medium">
+								Est. Context Size
+							</CardTitle>
+							<Layers className="h-4 w-4 text-muted-foreground" />
+						</CardHeader>
+						<CardContent>
+							<div className="text-2xl font-bold">
+								~{formatTokens(totals?.estimatedTokens.total ?? 0)}
+							</div>
+							<p className="text-xs text-muted-foreground">
+								Estimated tokens across analyzed payloads (~
+								{CHARS_PER_TOKEN} chars/token)
+							</p>
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+							<CardTitle className="text-sm font-medium">
+								Stored Payloads
+							</CardTitle>
+							<Database className="h-4 w-4 text-muted-foreground" />
+						</CardHeader>
+						<CardContent>
+							<div className="text-2xl font-bold">
+								{formatNumber(requestsWithPayload)}
+							</div>
+							<p className="text-xs text-muted-foreground">
+								{formatNumber(meta?.scannedPayloads ?? 0)} scanned
+								{meta?.truncated ? " (scan limit reached)" : ""}
+							</p>
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+							<CardTitle className="text-sm font-medium">
+								Growth Sessions
+							</CardTitle>
+							<TrendingUp className="h-4 w-4 text-muted-foreground" />
+						</CardHeader>
+						<CardContent>
+							<div className="text-2xl font-bold">
+								{formatNumber(sessions.length)}
+							</div>
+							<p className="text-xs text-muted-foreground">
+								Request runs grouped by project and time gap
+							</p>
+						</CardContent>
+					</Card>
+				</div>
+
+				{noPayloads ? (
+					<Card>
+						<CardContent className="p-6">
+							<div className="flex items-start gap-3">
+								<Database className="h-5 w-5 text-muted-foreground mt-0.5 shrink-0" />
+								<div className="space-y-1">
+									<p className="font-medium">No stored payloads to analyze</p>
+									<p className="text-sm text-muted-foreground">
+										Context composition is computed from stored request
+										payloads, but none of the {formatNumber(requestsInRange)}{" "}
+										requests in the last {timeRange} have one. Enable payload
+										storage (the <code>store_payloads</code> config option) and
+										new requests will appear here. Note that payloads are
+										size-capped and cleaned up by retention, so coverage is
+										always partial.
+									</p>
+								</div>
+							</div>
+						</CardContent>
+					</Card>
+				) : (
+					<>
+						{/* Composition Donuts */}
+						<div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+							<Card>
+								<CardHeader>
+									<CardTitle>Context Composition (Estimated)</CardTitle>
+									<CardDescription>
+										System prompt vs. tool definitions vs. messages, by
+										serialized size in the last {timeRange}
+									</CardDescription>
+								</CardHeader>
+								<CardContent>
+									<BasePieChart
+										data={compositionData}
+										loading={loading}
+										height="small"
+										innerRadius={60}
+										outerRadius={80}
+										paddingAngle={5}
+										tooltipStyle="success"
+										tooltipFormatter={(value, name) => [
+											`~${formatTokens(
+												estimateTokensFromChars(value as number),
+											)} tokens (${formatNumber(value as number)} chars)`,
+											name ?? "",
+										]}
+										showLegend
+									/>
+									<div className="mt-4 pt-4 border-t space-y-1 text-sm">
+										<div className="flex items-center justify-between">
+											<span className="text-muted-foreground">System</span>
+											<span>
+												~{formatTokens(totals?.estimatedTokens.system ?? 0)} (
+												{formatPercentage(totals?.percentages.system ?? 0)})
+											</span>
+										</div>
+										<div className="flex items-center justify-between">
+											<span className="text-muted-foreground">Tools</span>
+											<span>
+												~{formatTokens(totals?.estimatedTokens.tools ?? 0)} (
+												{formatPercentage(totals?.percentages.tools ?? 0)})
+											</span>
+										</div>
+										<div className="flex items-center justify-between">
+											<span className="text-muted-foreground">Messages</span>
+											<span>
+												~{formatTokens(totals?.estimatedTokens.messages ?? 0)} (
+												{formatPercentage(totals?.percentages.messages ?? 0)})
+											</span>
+										</div>
+									</div>
+								</CardContent>
+							</Card>
+
+							<Card>
+								<CardHeader>
+									<CardTitle>Input Token Mix (Exact)</CardTitle>
+									<CardDescription>
+										Exact token counts from the requests table for the analyzed
+										requests
+									</CardDescription>
+								</CardHeader>
+								<CardContent>
+									<BasePieChart
+										data={tokenMixData}
+										loading={loading}
+										height="small"
+										innerRadius={60}
+										outerRadius={80}
+										paddingAngle={5}
+										tooltipStyle="success"
+										tooltipFormatter={(value, name) => [
+											`${formatTokens(value as number)} tokens`,
+											name ?? "",
+										]}
+										showLegend
+									/>
+									<div className="mt-4 pt-4 border-t">
+										<div className="flex items-center justify-between text-sm">
+											<span className="font-medium">Total Input Tokens</span>
+											<span className="font-bold">
+												{formatTokens(
+													(tokenTotals?.uncachedInputTokens ?? 0) +
+														(tokenTotals?.cacheReadInputTokens ?? 0) +
+														(tokenTotals?.cacheCreationInputTokens ?? 0),
+												)}
+											</span>
+										</div>
+									</div>
+								</CardContent>
+							</Card>
+						</div>
+
+						{/* Growth Curve */}
+						<Card>
+							<CardHeader>
+								<div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+									<div>
+										<CardTitle>Context Growth</CardTitle>
+										<CardDescription>
+											Exact context tokens (input + cache read + cache creation)
+											per request over a session
+										</CardDescription>
+									</div>
+									{sessions.length > 0 && (
+										<Select
+											value={String(sessionIndex)}
+											onValueChange={setSelectedSession}
+										>
+											<SelectTrigger className="w-full sm:w-[340px]">
+												<SelectValue />
+											</SelectTrigger>
+											<SelectContent>
+												{sessions.map((session, index) => (
+													<SelectItem
+														key={`${session.project ?? "unknown"}-${session.startTimestamp}`}
+														value={String(index)}
+													>
+														{formatSessionLabel(session)}
+													</SelectItem>
+												))}
+											</SelectContent>
+										</Select>
+									)}
+								</div>
+							</CardHeader>
+							<CardContent>
+								<BaseLineChart
+									data={growthData}
+									loading={loading}
+									height="medium"
+									xAxisKey="time"
+									lines={[
+										{
+											dataKey: "contextTokens",
+											name: "Context tokens",
+											stroke: COLORS.primary,
+											dot: true,
+										},
+										{
+											dataKey: "outputTokens",
+											name: "Output tokens",
+											stroke: COLORS.blue,
+										},
+									]}
+									yAxisTickFormatter={(value) => formatTokens(Number(value))}
+									tooltipFormatter={(value, name) => [
+										`${formatTokens(value as number)} tokens`,
+										name ?? "",
+									]}
+									showLegend
+									emptyState={
+										<p className="text-sm text-muted-foreground">
+											No session data for this period
+										</p>
+									}
+								/>
+								{data?.growthCurve.truncated && (
+									<p className="mt-2 text-xs text-muted-foreground">
+										<AlertTriangle className="h-3 w-3 inline mr-1" />
+										Some sessions or points were trimmed by scan caps.
+									</p>
+								)}
+							</CardContent>
+						</Card>
+
+						{/* Contributors + Per-Request Tables */}
+						<Card>
+							<CardHeader>
+								<CardTitle>Context Details</CardTitle>
+								<CardDescription>
+									Largest repeated content blocks and per-request composition
+								</CardDescription>
+							</CardHeader>
+							<CardContent>
+								<Tabs defaultValue="contributors" className="space-y-4">
+									<TabsList className="grid w-full grid-cols-2">
+										<TabsTrigger value="contributors">
+											Top Contributors
+										</TabsTrigger>
+										<TabsTrigger value="requests">Recent Requests</TabsTrigger>
+									</TabsList>
+									<TabsContent value="contributors">
+										<ContributorsTable
+											contributors={data?.topContributors ?? []}
+										/>
+									</TabsContent>
+									<TabsContent value="requests">
+										<PerRequestTable rows={recentRequests} />
+										{(data?.composition.perRequest.length ?? 0) >
+											PER_REQUEST_ROW_LIMIT && (
+											<p className="mt-2 text-xs text-muted-foreground">
+												Showing the {PER_REQUEST_ROW_LIMIT} most recent of{" "}
+												{formatNumber(data?.composition.perRequest.length ?? 0)}{" "}
+												analyzed requests.
+											</p>
+										)}
+									</TabsContent>
+								</Tabs>
+							</CardContent>
+						</Card>
+					</>
+				)}
+
+				{/* Footnotes */}
+				<div className="space-y-1">
+					{meta && meta.unparseablePayloads > 0 && (
+						<p className="text-xs text-muted-foreground">
+							<AlertTriangle className="h-3 w-3 inline mr-1" />
+							{formatNumber(meta.unparseablePayloads)} stored payload
+							{meta.unparseablePayloads === 1 ? "" : "s"} could not be parsed
+							and {meta.unparseablePayloads === 1 ? "is" : "are"} excluded from
+							the composition figures.
+						</p>
+					)}
+					{meta?.truncated && (
+						<p className="text-xs text-muted-foreground">
+							<AlertTriangle className="h-3 w-3 inline mr-1" />
+							More payload-bearing requests existed than the scan limit; only
+							the most recent were analyzed.
+						</p>
+					)}
+					{meta?.estimateNote && (
+						<p className="text-xs text-muted-foreground">{meta.estimateNote}</p>
+					)}
+				</div>
+			</div>
+		);
+	},
+);
+
+ContextCompositionView.displayName = "ContextCompositionView";

--- a/packages/dashboard-web/src/components/insights/ContextCompositionView.tsx
+++ b/packages/dashboard-web/src/components/insights/ContextCompositionView.tsx
@@ -111,10 +111,7 @@ function ContributorsTable({ contributors }: ContributorsTableProps) {
 				</thead>
 				<tbody>
 					{contributors.map((contributor) => (
-						<tr
-							key={`${contributor.kind}-${contributor.label}-${contributor.maxChars}`}
-							className="border-t"
-						>
+						<tr key={contributor.hash} className="border-t">
 							<td className="px-3 py-2">
 								<Badge
 									variant={CONTRIBUTOR_KIND_VARIANTS[contributor.kind]}

--- a/packages/dashboard-web/src/hooks/queries.ts
+++ b/packages/dashboard-web/src/hooks/queries.ts
@@ -228,6 +228,18 @@ export const useCacheInsights = (timeRange: string, threshold?: number) => {
 	});
 };
 
+export const useContextInsights = (timeRange: string) => {
+	return useQuery({
+		queryKey: queryKeys.insightsContext(timeRange),
+		queryFn: () => api.getContextInsights(timeRange),
+		staleTime: 45000,
+		refetchInterval: 60000,
+		refetchIntervalInBackground: false,
+		gcTime: 15 * 60 * 1000,
+		enabled: !!timeRange,
+	});
+};
+
 export const useRequests = (limit: number, _refetchInterval?: number) => {
 	return useQuery({
 		queryKey: queryKeys.requests(limit),

--- a/packages/dashboard-web/src/lib/query-keys.ts
+++ b/packages/dashboard-web/src/lib/query-keys.ts
@@ -19,6 +19,8 @@ export const queryKeys = {
 		] as const,
 	insightsCache: (timeRange?: string, threshold?: number) =>
 		[...queryKeys.all, "insights", "cache", { timeRange, threshold }] as const,
+	insightsContext: (timeRange?: string) =>
+		[...queryKeys.all, "insights", "context", { timeRange }] as const,
 	insightsAlerts: () => [...queryKeys.all, "insights", "alerts"] as const,
 	requests: (limit?: number) =>
 		[...queryKeys.all, "requests", { limit }] as const,

--- a/packages/http-api/src/handlers/__tests__/insights-context.test.ts
+++ b/packages/http-api/src/handlers/__tests__/insights-context.test.ts
@@ -1,0 +1,475 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+	BunSqlAdapter,
+	ensureSchema,
+	runMigrations,
+} from "@better-ccflare/database";
+import type { APIContext } from "../../types";
+import { createContextInsightsHandler } from "../insights";
+
+/**
+ * Integration tests for GET /api/insights/context against a real in-memory
+ * SQLite database, seeding requests + request_payloads with realistic
+ * base64-wrapped Anthropic bodies.
+ */
+
+const SONNET = "claude-sonnet-4-20250514";
+
+/** Wrap a provider request body the way the proxy stores it. */
+function wrapBody(body: unknown): string {
+	return JSON.stringify({
+		request: {
+			headers: { "content-type": "application/json" },
+			body: Buffer.from(JSON.stringify(body), "utf-8").toString("base64"),
+		},
+		response: { status: 200, headers: {}, body: "" },
+		meta: { accountId: "a1", timestamp: 1, success: true, isStream: false },
+	});
+}
+
+const SYSTEM_PROMPT = "You are a helpful assistant with detailed instructions.";
+const TOOLS = [{ name: "Bash", input_schema: { type: "object" } }];
+const BIG_TOOL_OUTPUT = "tool output line\n".repeat(60); // > 512 chars
+
+/** Anthropic-format body used by most seeded payloads. */
+function anthropicBody(userText: string): unknown {
+	return {
+		model: SONNET,
+		system: SYSTEM_PROMPT,
+		tools: TOOLS,
+		messages: [
+			{ role: "user", content: userText },
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_use",
+						id: "toolu_1",
+						name: "Bash",
+						input: { cmd: "ls" },
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "toolu_1",
+						content: BIG_TOOL_OUTPUT,
+					},
+				],
+			},
+		],
+	};
+}
+
+/** Expected char breakdown for an anthropicBody payload. */
+function expectedChars(userText: string): {
+	system: number;
+	tools: number;
+	messages: number;
+} {
+	const body = anthropicBody(userText) as {
+		system: unknown;
+		tools: unknown;
+		messages: unknown;
+	};
+	return {
+		system: JSON.stringify(body.system).length,
+		tools: JSON.stringify(body.tools).length,
+		messages: JSON.stringify(body.messages).length,
+	};
+}
+
+describe("context insights handler (SQLite integration)", () => {
+	let db: Database;
+	let context: APIContext;
+	let now: number;
+
+	function insertRequest(opts: {
+		id: string;
+		timestamp: number;
+		accountUsed?: string | null;
+		model?: string | null;
+		project?: string | null;
+		inputTokens?: number;
+		cacheReadTokens?: number;
+		cacheCreationTokens?: number;
+		outputTokens?: number;
+	}): void {
+		db.run(
+			`INSERT INTO requests
+				(id, timestamp, method, path, account_used, status_code, success,
+				 response_time_ms, failover_attempts, model, input_tokens,
+				 cache_read_input_tokens, cache_creation_input_tokens, output_tokens,
+				 project)
+			 VALUES (?, ?, 'POST', '/v1/messages', ?, 200, 1, 100, 0, ?, ?, ?, ?, ?, ?)`,
+			[
+				opts.id,
+				opts.timestamp,
+				opts.accountUsed ?? "a1",
+				opts.model ?? SONNET,
+				opts.inputTokens ?? 0,
+				opts.cacheReadTokens ?? 0,
+				opts.cacheCreationTokens ?? 0,
+				opts.outputTokens ?? 0,
+				opts.project ?? null,
+			],
+		);
+	}
+
+	function insertPayload(id: string, json: string, timestamp: number): void {
+		db.run(
+			"INSERT INTO request_payloads (id, json, timestamp) VALUES (?, ?, ?)",
+			[id, json, timestamp],
+		);
+	}
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		ensureSchema(db);
+		runMigrations(db);
+
+		db.run(
+			"INSERT INTO accounts (id, name, created_at) VALUES ('a1', 'acct-A', ?)",
+			[Date.now()],
+		);
+		db.run(
+			"INSERT INTO accounts (id, name, created_at) VALUES ('a2', 'acct-B', ?)",
+			[Date.now()],
+		);
+
+		now = Date.now();
+
+		const adapter = new BunSqlAdapter(db);
+		context = {
+			db: adapter,
+			config: {} as APIContext["config"],
+			dbOps: {
+				getAdapter: () => adapter,
+				// Mirrors RequestRepository.getPayload: parsed wrapper or null
+				// when the row is missing or its json is malformed.
+				getRequestPayload: async (id: string) => {
+					const rows = await adapter.query<{ json: string }>(
+						"SELECT json FROM request_payloads WHERE id = ?",
+						[id],
+					);
+					if (!rows[0]) return null;
+					try {
+						return JSON.parse(rows[0].json);
+					} catch {
+						return null;
+					}
+				},
+			} as unknown as APIContext["dbOps"],
+		};
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("reports coverage, composition sums and exact token totals", async () => {
+		// r1 + r2 have payloads; r3 has none (coverage gap); r4 is out of range.
+		insertRequest({
+			id: "r1",
+			timestamp: now - 3_000,
+			inputTokens: 100,
+			cacheReadTokens: 1_000,
+			cacheCreationTokens: 10,
+			outputTokens: 50,
+			project: "proj-x",
+		});
+		insertPayload("r1", wrapBody(anthropicBody("first request")), now - 3_000);
+		insertRequest({
+			id: "r2",
+			timestamp: now - 2_000,
+			inputTokens: 200,
+			cacheReadTokens: 2_000,
+			cacheCreationTokens: 20,
+			outputTokens: 60,
+			project: "proj-x",
+		});
+		insertPayload("r2", wrapBody(anthropicBody("second request")), now - 2_000);
+		insertRequest({ id: "r3", timestamp: now - 1_000, inputTokens: 999 });
+		insertRequest({ id: "r4", timestamp: now - 2 * 24 * 60 * 60 * 1000 });
+		insertPayload("r4", wrapBody(anthropicBody("old")), now);
+
+		const response = await createContextInsightsHandler(context)(
+			new URLSearchParams(),
+		);
+		expect(response.status).toBe(200);
+		const data = await response.json();
+
+		expect(data.meta.range).toBe("24h");
+		expect(data.meta.payloadCoverage).toEqual({
+			requestsInRange: 3,
+			requestsWithPayload: 2,
+		});
+		expect(data.meta.scannedPayloads).toBe(2);
+		expect(data.meta.parsedPayloads).toBe(2);
+		expect(data.meta.unparseablePayloads).toBe(0);
+		expect(data.meta.truncated).toBe(false);
+		expect(typeof data.meta.estimateNote).toBe("string");
+		expect(data.meta.estimateNote).toContain("~4 chars/token");
+
+		// Hand-computed char sums over r1 + r2.
+		const c1 = expectedChars("first request");
+		const c2 = expectedChars("second request");
+		expect(data.composition.totals.systemChars).toBe(c1.system + c2.system);
+		expect(data.composition.totals.toolsChars).toBe(c1.tools + c2.tools);
+		expect(data.composition.totals.messagesChars).toBe(
+			c1.messages + c2.messages,
+		);
+
+		// Exact token sums over the parsed requests (r3 excluded: no payload).
+		expect(data.composition.tokenTotals).toEqual({
+			uncachedInputTokens: 300,
+			cacheReadInputTokens: 3_000,
+			cacheCreationInputTokens: 30,
+		});
+
+		// perRequest: most recent first, with account name resolved.
+		expect(
+			data.composition.perRequest.map((r: { id: string }) => r.id),
+		).toEqual(["r2", "r1"]);
+		expect(data.composition.perRequest[0].account).toBe("acct-A");
+		expect(data.composition.perRequest[0].project).toBe("proj-x");
+
+		// The large tool_result appears in both requests with the same content,
+		// so it groups into one contributor seen twice.
+		const toolResult = data.topContributors.find(
+			(c: { kind: string }) => c.kind === "tool_result",
+		);
+		expect(toolResult).toBeDefined();
+		expect(toolResult.label).toBe("Bash");
+		expect(toolResult.occurrences).toBe(2);
+		expect(toolResult.requestCount).toBe(2);
+	});
+
+	it("counts unparseable payloads without failing the request", async () => {
+		insertRequest({ id: "ok", timestamp: now - 2_000 });
+		insertPayload("ok", wrapBody(anthropicBody("fine")), now - 2_000);
+		// Wrapper parses but the body is invalid base64 garbage.
+		insertRequest({ id: "bad-body", timestamp: now - 1_500 });
+		insertPayload(
+			"bad-body",
+			JSON.stringify({ request: { headers: {}, body: "!!!not-base64!!!" } }),
+			now - 1_500,
+		);
+		// The json column itself is not JSON (e.g. encrypted at rest).
+		insertRequest({ id: "bad-json", timestamp: now - 1_000 });
+		insertPayload("bad-json", "enc:deadbeef", now - 1_000);
+
+		const response = await createContextInsightsHandler(context)(
+			new URLSearchParams(),
+		);
+		expect(response.status).toBe(200);
+		const data = await response.json();
+
+		expect(data.meta.scannedPayloads).toBe(3);
+		expect(data.meta.parsedPayloads).toBe(1);
+		expect(data.meta.unparseablePayloads).toBe(2);
+		expect(
+			data.composition.perRequest.map((r: { id: string }) => r.id),
+		).toEqual(["ok"]);
+	});
+
+	it("applies the scan limit and sets truncated, analyzing the most recent payloads", async () => {
+		for (let index = 0; index < 3; index++) {
+			const id = `r${index}`;
+			insertRequest({ id, timestamp: now - (3 - index) * 1_000 });
+			insertPayload(id, wrapBody(anthropicBody(`request ${index}`)), now);
+		}
+
+		const response = await createContextInsightsHandler(context)(
+			new URLSearchParams("limit=2"),
+		);
+		const data = await response.json();
+
+		expect(data.meta.scannedPayloads).toBe(2);
+		expect(data.meta.truncated).toBe(true);
+		// Most recent two: r2 then r1.
+		expect(
+			data.composition.perRequest.map((r: { id: string }) => r.id),
+		).toEqual(["r2", "r1"]);
+		// Coverage is unaffected by the scan limit.
+		expect(data.meta.payloadCoverage).toEqual({
+			requestsInRange: 3,
+			requestsWithPayload: 3,
+		});
+	});
+
+	it("clamps the limit param to the allowed range", async () => {
+		insertRequest({ id: "r1", timestamp: now - 1_000 });
+		insertPayload("r1", wrapBody(anthropicBody("hi")), now);
+
+		// limit=0 clamps to 1; nonsense falls back to the default — both succeed.
+		const zero = await createContextInsightsHandler(context)(
+			new URLSearchParams("limit=0"),
+		);
+		expect(zero.status).toBe(200);
+		const nonsense = await createContextInsightsHandler(context)(
+			new URLSearchParams("limit=abc"),
+		);
+		expect(nonsense.status).toBe(200);
+		const data = await nonsense.json();
+		expect(data.meta.scannedPayloads).toBe(1);
+	});
+
+	it("applies the shared account filter to coverage, payloads and growth", async () => {
+		insertRequest({ id: "mine", timestamp: now - 2_000, accountUsed: "a1" });
+		insertPayload("mine", wrapBody(anthropicBody("mine")), now);
+		insertRequest({ id: "theirs", timestamp: now - 1_000, accountUsed: "a2" });
+		insertPayload("theirs", wrapBody(anthropicBody("theirs")), now);
+
+		const response = await createContextInsightsHandler(context)(
+			new URLSearchParams("accounts=acct-A"),
+		);
+		const data = await response.json();
+
+		expect(data.meta.payloadCoverage).toEqual({
+			requestsInRange: 1,
+			requestsWithPayload: 1,
+		});
+		expect(
+			data.composition.perRequest.map((r: { id: string }) => r.id),
+		).toEqual(["mine"]);
+		const allPoints = data.growthCurve.sessions.flatMap(
+			(s: { points: Array<{ requestId: string }> }) => s.points,
+		);
+		expect(allPoints.map((p: { requestId: string }) => p.requestId)).toEqual([
+			"mine",
+		]);
+	});
+
+	it("builds growth sessions from exact token columns, split by gap and project", async () => {
+		const MINUTE = 60_000;
+		// proj-x: two close requests, then one past the 30-minute default gap.
+		insertRequest({
+			id: "x1",
+			timestamp: now - 120 * MINUTE,
+			project: "proj-x",
+			inputTokens: 10,
+			cacheReadTokens: 100,
+			cacheCreationTokens: 1,
+			outputTokens: 7,
+		});
+		insertRequest({
+			id: "x2",
+			timestamp: now - 115 * MINUTE,
+			project: "proj-x",
+			inputTokens: 20,
+			cacheReadTokens: 200,
+			cacheCreationTokens: 2,
+			outputTokens: 8,
+		});
+		insertRequest({
+			id: "x3",
+			timestamp: now - 60 * MINUTE,
+			project: "proj-x",
+			inputTokens: 30,
+			cacheReadTokens: 300,
+			cacheCreationTokens: 3,
+			outputTokens: 9,
+		});
+		// Different project inside the same window: its own session.
+		insertRequest({
+			id: "y1",
+			timestamp: now - 110 * MINUTE,
+			project: "proj-y",
+		});
+		// No payloads at all — the growth curve must not require them.
+
+		const response = await createContextInsightsHandler(context)(
+			new URLSearchParams(),
+		);
+		const data = await response.json();
+
+		expect(data.meta.parsedPayloads).toBe(0);
+		const sessions = data.growthCurve.sessions;
+		expect(sessions).toHaveLength(3);
+		// Most recent first by end timestamp: x3 alone (-60m), y1 (-110m),
+		// then x1+x2 (ends -115m).
+		expect(
+			sessions.map((s: { points: Array<{ requestId: string }> }) =>
+				s.points.map((p) => p.requestId),
+			),
+		).toEqual([["x3"], ["y1"], ["x1", "x2"]]);
+		const early = sessions[2];
+		expect(early.project).toBe("proj-x");
+		expect(early.requestCount).toBe(2);
+		expect(early.points[0].contextTokens).toBe(111); // 10 + 100 + 1
+		expect(early.points[0].outputTokens).toBe(7);
+		expect(data.growthCurve.truncated).toBe(false);
+	});
+
+	it("respects the sessionGapMinutes param", async () => {
+		const MINUTE = 60_000;
+		insertRequest({ id: "a", timestamp: now - 20 * MINUTE, project: "p" });
+		insertRequest({ id: "b", timestamp: now - 5 * MINUTE, project: "p" });
+
+		const wide = await (
+			await createContextInsightsHandler(context)(new URLSearchParams())
+		).json();
+		expect(wide.growthCurve.sessions).toHaveLength(1);
+
+		const narrow = await (
+			await createContextInsightsHandler(context)(
+				new URLSearchParams("sessionGapMinutes=10"),
+			)
+		).json();
+		expect(narrow.growthCurve.sessions).toHaveLength(2);
+	});
+
+	it("respects the topContributors param", async () => {
+		// Two distinct large text blocks in one payload.
+		const bigA = "alpha ".repeat(200);
+		const bigB = "beta ".repeat(300);
+		insertRequest({ id: "r1", timestamp: now - 1_000 });
+		insertPayload(
+			"r1",
+			wrapBody({
+				messages: [
+					{ role: "user", content: [{ type: "text", text: bigA }] },
+					{ role: "user", content: [{ type: "text", text: bigB }] },
+				],
+			}),
+			now,
+		);
+
+		const all = await (
+			await createContextInsightsHandler(context)(new URLSearchParams())
+		).json();
+		expect(all.topContributors).toHaveLength(2);
+
+		const capped = await (
+			await createContextInsightsHandler(context)(
+				new URLSearchParams("topContributors=1"),
+			)
+		).json();
+		expect(capped.topContributors).toHaveLength(1);
+		// Largest block wins.
+		expect(capped.topContributors[0].label.startsWith("beta")).toBe(true);
+	});
+
+	it("returns a 500 error response when the query fails", async () => {
+		const failing = {
+			db: {} as APIContext["db"],
+			config: {} as APIContext["config"],
+			dbOps: {
+				getAdapter: () => ({
+					query: async () => {
+						throw new Error("boom");
+					},
+				}),
+			} as unknown as APIContext["dbOps"],
+		};
+		const response = await createContextInsightsHandler(failing)(
+			new URLSearchParams(),
+		);
+		expect(response.status).toBe(500);
+	});
+});

--- a/packages/http-api/src/handlers/insights.ts
+++ b/packages/http-api/src/handlers/insights.ts
@@ -453,14 +453,6 @@ export function createContextInsightsHandler(context: APIContext) {
 			searchParams,
 			startMs,
 		);
-		// buildRequestFilters emits an unqualified `timestamp > ?` (fine for
-		// requests-only queries); the payload joins below need it qualified
-		// because request_payloads also has a timestamp column.
-		const qualifiedWhere = whereClause.replace(
-			"timestamp > ?",
-			"r.timestamp > ?",
-		);
-
 		const limit = parseDetectorParam(
 			searchParams.get("limit"),
 			DEFAULT_PAYLOAD_SCAN_LIMIT,
@@ -493,7 +485,7 @@ export function createContextInsightsHandler(context: APIContext) {
 					COUNT(rp.id) as requests_with_payload
 				FROM requests r
 				LEFT JOIN request_payloads rp ON rp.id = r.id
-				WHERE ${qualifiedWhere}
+				WHERE ${whereClause}
 			`,
 				queryParams,
 			);
@@ -520,7 +512,7 @@ export function createContextInsightsHandler(context: APIContext) {
 				FROM requests r
 				JOIN request_payloads rp ON rp.id = r.id
 				LEFT JOIN accounts a ON a.id = r.account_used
-				WHERE ${qualifiedWhere}
+				WHERE ${whereClause}
 				ORDER BY r.timestamp DESC
 				LIMIT ${limit + 1}
 			`,

--- a/packages/http-api/src/handlers/insights.ts
+++ b/packages/http-api/src/handlers/insights.ts
@@ -23,6 +23,18 @@ import {
 	DEFAULT_THRESHOLD_PERCENT,
 	type GroupedTokenRow,
 } from "../services/cache-insights";
+import {
+	analyzePayloadWrapper,
+	buildContextInsightsResponse,
+	type ContextGrowthRow,
+	type ContextRequestRow,
+	DEFAULT_PAYLOAD_SCAN_LIMIT,
+	DEFAULT_SESSION_GAP_MINUTES,
+	DEFAULT_TOP_CONTRIBUTORS,
+	MAX_PAYLOAD_SCAN_LIMIT,
+	MAX_TOP_CONTRIBUTORS,
+	type PayloadAnalysis,
+} from "../services/context-insights";
 import type { APIContext } from "../types";
 import { buildRequestFilters, getRangeConfig } from "../utils/query-filters";
 
@@ -347,6 +359,244 @@ export function createAnomalyInsightsHandler(context: APIContext) {
 			log.error("Anomaly insights error:", error);
 			return errorResponse(
 				InternalServerError("Failed to fetch anomaly insights data"),
+			);
+		}
+	};
+}
+
+/**
+ * Hard cap on rows fetched for the context growth curve. The growth query
+ * reads the requests table only (no payload join), so it may scan far more
+ * rows than the payload loop; beyond the cap only the most recent rows are
+ * used and growthCurve.truncated is set.
+ */
+const MAX_GROWTH_SCAN_ROWS = 20_000;
+
+/** Upper bound for the sessionGapMinutes query param (12 hours). */
+const MAX_SESSION_GAP_MINUTES = 720;
+
+/** Raw row shape for the payload coverage query. */
+interface ContextCoverageSqlRow {
+	requests_in_range: number;
+	requests_with_payload: number;
+}
+
+/** Raw per-request row shape for the context candidate query. */
+interface ContextRequestSqlRow {
+	id: string;
+	timestamp: number;
+	account: string | null;
+	model: string | null;
+	project: string | null;
+	input_tokens: number;
+	cache_read_input_tokens: number;
+	cache_creation_input_tokens: number;
+	output_tokens: number;
+}
+
+function toContextRequestRow(row: ContextRequestSqlRow): ContextRequestRow {
+	return {
+		id: row.id,
+		timestamp: Number(row.timestamp) || 0,
+		account: row.account,
+		model: row.model,
+		project: row.project,
+		inputTokens: Number(row.input_tokens) || 0,
+		cacheReadInputTokens: Number(row.cache_read_input_tokens) || 0,
+		cacheCreationInputTokens: Number(row.cache_creation_input_tokens) || 0,
+		outputTokens: Number(row.output_tokens) || 0,
+	};
+}
+
+/** Raw per-request row shape for the growth-curve query. */
+interface ContextGrowthSqlRow {
+	id: string;
+	timestamp: number;
+	project: string | null;
+	input_tokens: number;
+	cache_read_input_tokens: number;
+	cache_creation_input_tokens: number;
+	output_tokens: number;
+}
+
+function toContextGrowthRow(row: ContextGrowthSqlRow): ContextGrowthRow {
+	return {
+		id: row.id,
+		timestamp: Number(row.timestamp) || 0,
+		project: row.project,
+		inputTokens: Number(row.input_tokens) || 0,
+		cacheReadInputTokens: Number(row.cache_read_input_tokens) || 0,
+		cacheCreationInputTokens: Number(row.cache_creation_input_tokens) || 0,
+		outputTokens: Number(row.output_tokens) || 0,
+	};
+}
+
+/**
+ * GET /api/insights/context — context composition analysis from stored
+ * request payloads.
+ *
+ * Payload storage is optional (store_payloads) and retention-cleaned, so
+ * coverage is partial — meta.payloadCoverage reports requests in the window
+ * vs requests with a stored payload. To bound memory, candidate request ids
+ * are fetched metadata-only first, then each payload's json column is
+ * fetched, parsed, aggregated and discarded ONE ROW AT A TIME; the json
+ * column is never selected in a multi-row query. The growth curve uses only
+ * exact requests-table token columns (no payload parsing).
+ */
+export function createContextInsightsHandler(context: APIContext) {
+	return async (searchParams: URLSearchParams): Promise<Response> => {
+		const db = context.dbOps.getAdapter();
+		const { startMs, range } = getRangeConfig(
+			searchParams.get("range") ?? "24h",
+		);
+		const { whereClause, params: queryParams } = buildRequestFilters(
+			searchParams,
+			startMs,
+		);
+		// buildRequestFilters emits an unqualified `timestamp > ?` (fine for
+		// requests-only queries); the payload joins below need it qualified
+		// because request_payloads also has a timestamp column.
+		const qualifiedWhere = whereClause.replace(
+			"timestamp > ?",
+			"r.timestamp > ?",
+		);
+
+		const limit = parseDetectorParam(
+			searchParams.get("limit"),
+			DEFAULT_PAYLOAD_SCAN_LIMIT,
+			1,
+			MAX_PAYLOAD_SCAN_LIMIT,
+			true,
+		);
+		const topContributors = parseDetectorParam(
+			searchParams.get("topContributors"),
+			DEFAULT_TOP_CONTRIBUTORS,
+			1,
+			MAX_TOP_CONTRIBUTORS,
+			true,
+		);
+		const sessionGapMinutes = parseDetectorParam(
+			searchParams.get("sessionGapMinutes"),
+			DEFAULT_SESSION_GAP_MINUTES,
+			1,
+			MAX_SESSION_GAP_MINUTES,
+			true,
+		);
+
+		try {
+			// Coverage: how many requests in the window have a stored payload at
+			// all — payload storage is optional, so this can be far below 100%.
+			const coverageRows = await db.query<ContextCoverageSqlRow>(
+				`
+				SELECT
+					COUNT(*) as requests_in_range,
+					COUNT(rp.id) as requests_with_payload
+				FROM requests r
+				LEFT JOIN request_payloads rp ON rp.id = r.id
+				WHERE ${qualifiedWhere}
+			`,
+				queryParams,
+			);
+			const coverage = {
+				requestsInRange: Number(coverageRows[0]?.requests_in_range) || 0,
+				requestsWithPayload:
+					Number(coverageRows[0]?.requests_with_payload) || 0,
+			};
+
+			// Candidate ids: metadata-only (the json column is deliberately NOT
+			// selected here), most recent first, one extra row to detect truncation.
+			const candidateSqlRows = await db.query<ContextRequestSqlRow>(
+				`
+				SELECT
+					r.id as id,
+					r.timestamp as timestamp,
+					a.name as account,
+					r.model as model,
+					r.project as project,
+					COALESCE(r.input_tokens, 0) as input_tokens,
+					COALESCE(r.cache_read_input_tokens, 0) as cache_read_input_tokens,
+					COALESCE(r.cache_creation_input_tokens, 0) as cache_creation_input_tokens,
+					COALESCE(r.output_tokens, 0) as output_tokens
+				FROM requests r
+				JOIN request_payloads rp ON rp.id = r.id
+				LEFT JOIN accounts a ON a.id = r.account_used
+				WHERE ${qualifiedWhere}
+				ORDER BY r.timestamp DESC
+				LIMIT ${limit + 1}
+			`,
+				queryParams,
+			);
+			const truncated = candidateSqlRows.length > limit;
+			const candidates = candidateSqlRows
+				.slice(0, limit)
+				.map(toContextRequestRow);
+
+			// Sequential per-id loop keeps at most one payload in memory at a
+			// time. getRequestPayload handles at-rest decryption; rows that
+			// fail to decrypt or whose bodies don't parse (truncated 4MB-capped
+			// bodies, invalid base64) count as unparseable in meta rather than
+			// failing the request.
+			const analyses: Array<{
+				row: ContextRequestRow;
+				analysis: PayloadAnalysis | null;
+			}> = [];
+			for (const row of candidates) {
+				let payload: unknown = null;
+				try {
+					payload = await context.dbOps.getRequestPayload(row.id);
+				} catch (error) {
+					log.warn(`Failed to load payload ${row.id}:`, error);
+				}
+				analyses.push({
+					row,
+					analysis: payload === null ? null : analyzePayloadWrapper(payload),
+				});
+			}
+
+			// Growth curve: exact token columns over the whole window, no payload
+			// join. Fetch one extra row to detect truncation at the scan cap.
+			const growthSqlRows = await db.query<ContextGrowthSqlRow>(
+				`
+				SELECT
+					r.id as id,
+					r.timestamp as timestamp,
+					r.project as project,
+					COALESCE(r.input_tokens, 0) as input_tokens,
+					COALESCE(r.cache_read_input_tokens, 0) as cache_read_input_tokens,
+					COALESCE(r.cache_creation_input_tokens, 0) as cache_creation_input_tokens,
+					COALESCE(r.output_tokens, 0) as output_tokens
+				FROM requests r
+				WHERE ${whereClause}
+				ORDER BY r.timestamp DESC
+				LIMIT ${MAX_GROWTH_SCAN_ROWS + 1}
+			`,
+				queryParams,
+			);
+			const growthScanTruncated = growthSqlRows.length > MAX_GROWTH_SCAN_ROWS;
+			// Undo the DESC fetch order so session building sees chronological rows.
+			const growthRows = growthSqlRows
+				.slice(0, MAX_GROWTH_SCAN_ROWS)
+				.map(toContextGrowthRow)
+				.reverse();
+
+			return jsonResponse(
+				buildContextInsightsResponse({
+					analyses,
+					coverage,
+					growthRows,
+					options: {
+						range,
+						truncated,
+						growthScanTruncated,
+						topContributors,
+						sessionGapMinutes,
+					},
+				}),
+			);
+		} catch (error) {
+			log.error("Context insights error:", error);
+			return errorResponse(
+				InternalServerError("Failed to fetch context insights data"),
 			);
 		}
 	};

--- a/packages/http-api/src/router.ts
+++ b/packages/http-api/src/router.ts
@@ -82,6 +82,7 @@ import { createHealthHandler } from "./handlers/health";
 import {
 	createAnomalyInsightsHandler,
 	createCacheInsightsHandler,
+	createContextInsightsHandler,
 } from "./handlers/insights";
 import { createLogsStreamHandler } from "./handlers/logs";
 import { createLogsHistoryHandler } from "./handlers/logs-history";
@@ -196,6 +197,7 @@ export class APIRouter {
 		const analyticsHandler = createAnalyticsHandler(this.context);
 		const cacheInsightsHandler = createCacheInsightsHandler(this.context);
 		const anomalyInsightsHandler = createAnomalyInsightsHandler(this.context);
+		const contextInsightsHandler = createContextInsightsHandler(this.context);
 		const alertsHistoryHandler = createAlertsHistoryHandler(this.context);
 		const alertsConfigGetHandler = createAlertsConfigGetHandler(this.context);
 		const alertsConfigSetHandler = createAlertsConfigSetHandler(this.context);
@@ -392,6 +394,9 @@ export class APIRouter {
 		);
 		this.handlers.set("GET:/api/insights/anomalies", (_req, url) =>
 			anomalyInsightsHandler(url.searchParams),
+		);
+		this.handlers.set("GET:/api/insights/context", (_req, url) =>
+			contextInsightsHandler(url.searchParams),
 		);
 		// Alert routes
 		this.handlers.set("GET:/api/insights/alerts", (_req, url) =>

--- a/packages/http-api/src/services/__tests__/context-insights.test.ts
+++ b/packages/http-api/src/services/__tests__/context-insights.test.ts
@@ -1,0 +1,673 @@
+import { describe, expect, test } from "bun:test";
+import {
+	analyzePayloadJson,
+	buildContextInsightsResponse,
+	CHARS_PER_TOKEN,
+	type ContextGrowthRow,
+	type ContextInsightsResponse,
+	type ContextRequestRow,
+	type ContributorBlock,
+	DEFAULT_SESSION_GAP_MINUTES,
+	DEFAULT_TOP_CONTRIBUTORS,
+	ESTIMATE_NOTE,
+	estimateTokens,
+	MAX_GROWTH_SESSIONS,
+	MAX_POINTS_PER_SESSION,
+	MIN_CONTRIBUTOR_BLOCK_CHARS,
+	type PayloadAnalysis,
+} from "../context-insights";
+
+/**
+ * Tests for the pure context-composition service: payload parsing/measuring
+ * (analyzePayloadJson) and response aggregation (buildContextInsightsResponse).
+ */
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Wrap a provider request body the way the proxy stores it in request_payloads.json. */
+function wrapBody(body: unknown): string {
+	return JSON.stringify({
+		request: {
+			headers: { "content-type": "application/json" },
+			body: Buffer.from(JSON.stringify(body), "utf-8").toString("base64"),
+		},
+		response: { status: 200, headers: {}, body: "" },
+		meta: { accountId: "a1", timestamp: 1, success: true, isStream: false },
+	});
+}
+
+/** A string long enough to clear the contributor block size filter. */
+function bigText(
+	fill: string,
+	length = MIN_CONTRIBUTOR_BLOCK_CHARS + 100,
+): string {
+	return fill.repeat(Math.ceil(length / fill.length)).slice(0, length);
+}
+
+function row(partial: Partial<ContextRequestRow> = {}): ContextRequestRow {
+	return {
+		id: "r1",
+		timestamp: 1_000,
+		account: "acct-A",
+		model: "claude-sonnet-4-20250514",
+		project: "proj-x",
+		inputTokens: 0,
+		cacheReadInputTokens: 0,
+		cacheCreationInputTokens: 0,
+		outputTokens: 0,
+		...partial,
+	};
+}
+
+function analysis(partial: Partial<PayloadAnalysis> = {}): PayloadAnalysis {
+	return {
+		systemChars: 0,
+		toolsChars: 0,
+		messagesChars: 0,
+		totalChars: 0,
+		blocks: [],
+		...partial,
+	};
+}
+
+function block(partial: Partial<ContributorBlock> = {}): ContributorBlock {
+	return {
+		kind: "tool_result",
+		label: "ReadFile",
+		chars: 1_000,
+		hash: "h1",
+		...partial,
+	};
+}
+
+function growthRow(partial: Partial<ContextGrowthRow> = {}): ContextGrowthRow {
+	return {
+		id: "g1",
+		timestamp: 1_000,
+		project: "proj-x",
+		inputTokens: 10,
+		cacheReadInputTokens: 20,
+		cacheCreationInputTokens: 30,
+		outputTokens: 5,
+		...partial,
+	};
+}
+
+function build(
+	overrides: {
+		analyses?: Array<{
+			row: ContextRequestRow;
+			analysis: PayloadAnalysis | null;
+		}>;
+		coverage?: { requestsInRange: number; requestsWithPayload: number };
+		growthRows?: ContextGrowthRow[];
+		range?: string;
+		truncated?: boolean;
+		growthScanTruncated?: boolean;
+		topContributors?: number;
+		sessionGapMinutes?: number;
+	} = {},
+): ContextInsightsResponse {
+	return buildContextInsightsResponse({
+		analyses: overrides.analyses ?? [],
+		coverage: overrides.coverage ?? {
+			requestsInRange: 0,
+			requestsWithPayload: 0,
+		},
+		growthRows: overrides.growthRows ?? [],
+		options: {
+			range: overrides.range ?? "24h",
+			truncated: overrides.truncated ?? false,
+			growthScanTruncated: overrides.growthScanTruncated,
+			topContributors: overrides.topContributors,
+			sessionGapMinutes: overrides.sessionGapMinutes,
+		},
+	});
+}
+
+// ---------------------------------------------------------------------------
+// estimateTokens
+// ---------------------------------------------------------------------------
+
+describe("estimateTokens", () => {
+	test("rounds chars / CHARS_PER_TOKEN", () => {
+		expect(CHARS_PER_TOKEN).toBe(4);
+		expect(estimateTokens(0)).toBe(0);
+		expect(estimateTokens(4)).toBe(1);
+		expect(estimateTokens(10)).toBe(3); // 2.5 rounds up
+		expect(estimateTokens(9)).toBe(2); // 2.25 rounds down
+	});
+});
+
+// ---------------------------------------------------------------------------
+// analyzePayloadJson
+// ---------------------------------------------------------------------------
+
+describe("analyzePayloadJson", () => {
+	test("measures an Anthropic body with a string system prompt", () => {
+		const body = {
+			model: "claude-sonnet-4-20250514",
+			system: "You are a helpful assistant.",
+			tools: [{ name: "ReadFile", input_schema: { type: "object" } }],
+			messages: [{ role: "user", content: "hello" }],
+		};
+		const result = analyzePayloadJson(wrapBody(body));
+		expect(result).not.toBeNull();
+		expect(result?.systemChars).toBe(JSON.stringify(body.system).length);
+		expect(result?.toolsChars).toBe(JSON.stringify(body.tools).length);
+		expect(result?.messagesChars).toBe(JSON.stringify(body.messages).length);
+		expect(result?.totalChars).toBe(
+			(result?.systemChars ?? 0) +
+				(result?.toolsChars ?? 0) +
+				(result?.messagesChars ?? 0),
+		);
+	});
+
+	test("measures an Anthropic body with an array system prompt", () => {
+		const system = [
+			{
+				type: "text",
+				text: "You are Claude.",
+				cache_control: { type: "ephemeral" },
+			},
+		];
+		const result = analyzePayloadJson(wrapBody({ system, messages: [] }));
+		expect(result?.systemChars).toBe(JSON.stringify(system).length);
+		expect(result?.toolsChars).toBe(0);
+	});
+
+	test("resolves tool_result labels via the same-request tool_use id map", () => {
+		const big = bigText("output ");
+		const body = {
+			messages: [
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "tool_use",
+							id: "toolu_1",
+							name: "Bash",
+							input: { cmd: "ls" },
+						},
+					],
+				},
+				{
+					role: "user",
+					content: [
+						{ type: "tool_result", tool_use_id: "toolu_1", content: big },
+					],
+				},
+			],
+		};
+		const result = analyzePayloadJson(wrapBody(body));
+		expect(result).not.toBeNull();
+		const toolResults = result?.blocks.filter((b) => b.kind === "tool_result");
+		expect(toolResults).toHaveLength(1);
+		expect(toolResults?.[0].label).toBe("Bash");
+	});
+
+	test("falls back to the 'tool_result' label when the tool_use id is unknown", () => {
+		const body = {
+			messages: [
+				{
+					role: "user",
+					content: [
+						{
+							type: "tool_result",
+							tool_use_id: "toolu_missing",
+							content: bigText("x"),
+						},
+					],
+				},
+			],
+		};
+		const result = analyzePayloadJson(wrapBody(body));
+		expect(result?.blocks[0]?.label).toBe("tool_result");
+	});
+
+	test("extracts text and tool_use blocks with previews/names as labels", () => {
+		const longText = bigText("The quick   brown\nfox. ");
+		const body = {
+			messages: [
+				{ role: "user", content: [{ type: "text", text: longText }] },
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "tool_use",
+							id: "toolu_2",
+							name: "WriteFile",
+							input: { content: bigText("y") },
+						},
+					],
+				},
+			],
+		};
+		const result = analyzePayloadJson(wrapBody(body));
+		const kinds = result?.blocks.map((b) => b.kind).sort();
+		expect(kinds).toEqual(["text", "tool_use"]);
+		const text = result?.blocks.find((b) => b.kind === "text");
+		// Preview is single-line (whitespace collapsed) and at most 80 chars.
+		expect(text?.label.length).toBeLessThanOrEqual(80);
+		expect(text?.label).not.toContain("\n");
+		expect(text?.label).not.toContain("  ");
+		const toolUse = result?.blocks.find((b) => b.kind === "tool_use");
+		expect(toolUse?.label).toBe("WriteFile");
+	});
+
+	test("counts string message content as a single text block", () => {
+		const longText = bigText("string content ");
+		const result = analyzePayloadJson(
+			wrapBody({ messages: [{ role: "user", content: longText }] }),
+		);
+		expect(result?.blocks).toHaveLength(1);
+		expect(result?.blocks[0].kind).toBe("text");
+	});
+
+	test("skips blocks under MIN_CONTRIBUTOR_BLOCK_CHARS", () => {
+		const result = analyzePayloadJson(
+			wrapBody({
+				messages: [{ role: "user", content: [{ type: "text", text: "tiny" }] }],
+			}),
+		);
+		expect(result?.blocks).toEqual([]);
+		// ...but the chars are still measured.
+		expect(result?.messagesChars).toBeGreaterThan(0);
+	});
+
+	test("tolerates OpenAI-format bodies (no system key, function tools)", () => {
+		const body = {
+			model: "gpt-4o",
+			tools: [
+				{
+					type: "function",
+					function: { name: "get_weather", parameters: { type: "object" } },
+				},
+			],
+			messages: [
+				{ role: "system", content: "You are helpful." },
+				{ role: "user", content: bigText("question ") },
+			],
+		};
+		const result = analyzePayloadJson(wrapBody(body));
+		expect(result?.systemChars).toBe(0);
+		expect(result?.toolsChars).toBe(JSON.stringify(body.tools).length);
+		expect(result?.messagesChars).toBe(JSON.stringify(body.messages).length);
+		expect(result?.blocks.some((b) => b.kind === "text")).toBe(true);
+	});
+
+	test("returns 0 for missing keys", () => {
+		const result = analyzePayloadJson(wrapBody({ model: "m" }));
+		expect(result).toEqual({
+			systemChars: 0,
+			toolsChars: 0,
+			messagesChars: 0,
+			totalChars: 0,
+			blocks: [],
+		});
+	});
+
+	test("returns null for an unparseable wrapper", () => {
+		expect(analyzePayloadJson("not json at all")).toBeNull();
+		expect(analyzePayloadJson("enc:abcdef0123")).toBeNull();
+	});
+
+	test("returns null when request.body is missing", () => {
+		expect(
+			analyzePayloadJson(JSON.stringify({ request: { headers: {} } })),
+		).toBeNull();
+		expect(analyzePayloadJson(JSON.stringify({ meta: {} }))).toBeNull();
+	});
+
+	test("returns null for invalid base64 / non-JSON decoded bodies", () => {
+		const wrapper = JSON.stringify({
+			request: {
+				body: Buffer.from("plain text, not json", "utf-8").toString("base64"),
+			},
+		});
+		expect(analyzePayloadJson(wrapper)).toBeNull();
+	});
+
+	test("returns null for a body truncated mid-JSON (4MB write cap)", () => {
+		const full = JSON.stringify({
+			messages: [{ role: "user", content: "hi" }],
+		});
+		const truncatedBody = full.slice(0, full.length - 5);
+		const wrapper = JSON.stringify({
+			request: { body: Buffer.from(truncatedBody, "utf-8").toString("base64") },
+		});
+		expect(analyzePayloadJson(wrapper)).toBeNull();
+	});
+
+	test("re-sent identical blocks hash identically; different content does not", () => {
+		const big = bigText("repeated ");
+		const make = (text: string) =>
+			analyzePayloadJson(
+				wrapBody({
+					messages: [{ role: "user", content: [{ type: "text", text }] }],
+				}),
+			);
+		const first = make(big);
+		const second = make(big);
+		const different = make(bigText("other "));
+		expect(first?.blocks[0].hash).toBe(second?.blocks[0].hash as string);
+		expect(first?.blocks[0].hash).not.toBe(different?.blocks[0].hash as string);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// buildContextInsightsResponse — composition + meta
+// ---------------------------------------------------------------------------
+
+describe("buildContextInsightsResponse composition", () => {
+	test("sums chars, estimates tokens and computes percentages of totalChars", () => {
+		const response = build({
+			analyses: [
+				{
+					row: row({ id: "r1", inputTokens: 100, cacheReadInputTokens: 200 }),
+					analysis: analysis({
+						systemChars: 400,
+						toolsChars: 200,
+						messagesChars: 400,
+						totalChars: 1_000,
+					}),
+				},
+				{
+					row: row({ id: "r2", cacheCreationInputTokens: 50 }),
+					analysis: analysis({
+						systemChars: 600,
+						toolsChars: 0,
+						messagesChars: 400,
+						totalChars: 1_000,
+					}),
+				},
+			],
+			coverage: { requestsInRange: 5, requestsWithPayload: 2 },
+		});
+
+		const totals = response.composition.totals;
+		expect(totals.systemChars).toBe(1_000);
+		expect(totals.toolsChars).toBe(200);
+		expect(totals.messagesChars).toBe(800);
+		expect(totals.totalChars).toBe(2_000);
+		expect(totals.estimatedTokens).toEqual({
+			system: 250,
+			tools: 50,
+			messages: 200,
+			total: 500,
+		});
+		expect(totals.percentages.system).toBeCloseTo(50, 10);
+		expect(totals.percentages.tools).toBeCloseTo(10, 10);
+		expect(totals.percentages.messages).toBeCloseTo(40, 10);
+
+		// Exact token sums come from the request rows, not chars.
+		expect(response.composition.tokenTotals).toEqual({
+			uncachedInputTokens: 100,
+			cacheReadInputTokens: 200,
+			cacheCreationInputTokens: 50,
+		});
+	});
+
+	test("returns zero percentages when totalChars is 0", () => {
+		const response = build({
+			analyses: [{ row: row(), analysis: analysis() }],
+		});
+		expect(response.composition.totals.percentages).toEqual({
+			system: 0,
+			tools: 0,
+			messages: 0,
+		});
+		expect(response.composition.totals.estimatedTokens.total).toBe(0);
+	});
+
+	test("excludes unparsed payloads from perRequest and tokenTotals but counts them in meta", () => {
+		const response = build({
+			analyses: [
+				{
+					row: row({ id: "r-old", timestamp: 1_000 }),
+					analysis: analysis({ systemChars: 4, totalChars: 4 }),
+				},
+				{ row: row({ id: "r-bad", inputTokens: 999 }), analysis: null },
+				{
+					row: row({ id: "r-new", timestamp: 2_000 }),
+					analysis: analysis({ messagesChars: 8, totalChars: 8 }),
+				},
+			],
+			truncated: true,
+			coverage: { requestsInRange: 10, requestsWithPayload: 3 },
+			range: "7d",
+		});
+
+		// perRequest: parsed only, most recent first.
+		expect(response.composition.perRequest.map((r) => r.id)).toEqual([
+			"r-new",
+			"r-old",
+		]);
+		expect(response.composition.tokenTotals.uncachedInputTokens).toBe(0);
+
+		expect(response.meta.range).toBe("7d");
+		expect(response.meta.scannedPayloads).toBe(3);
+		expect(response.meta.parsedPayloads).toBe(2);
+		expect(response.meta.unparseablePayloads).toBe(1);
+		expect(response.meta.truncated).toBe(true);
+		expect(response.meta.payloadCoverage).toEqual({
+			requestsInRange: 10,
+			requestsWithPayload: 3,
+		});
+		expect(response.meta.estimateNote).toBe(ESTIMATE_NOTE);
+		expect(response.meta.generatedAt).toBeGreaterThan(0);
+	});
+
+	test("carries row metadata and estimated tokens onto perRequest entries", () => {
+		const response = build({
+			analyses: [
+				{
+					row: row({
+						id: "r1",
+						timestamp: 42,
+						account: null,
+						model: null,
+						project: null,
+						inputTokens: 1,
+						cacheReadInputTokens: 2,
+						cacheCreationInputTokens: 3,
+						outputTokens: 4,
+					}),
+					analysis: analysis({
+						systemChars: 10,
+						toolsChars: 20,
+						messagesChars: 30,
+						totalChars: 60,
+					}),
+				},
+			],
+		});
+		expect(response.composition.perRequest[0]).toEqual({
+			id: "r1",
+			timestamp: 42,
+			account: null,
+			model: null,
+			project: null,
+			systemChars: 10,
+			toolsChars: 20,
+			messagesChars: 30,
+			totalChars: 60,
+			estimatedContextTokens: 15,
+			inputTokens: 1,
+			cacheReadInputTokens: 2,
+			cacheCreationInputTokens: 3,
+			outputTokens: 4,
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// buildContextInsightsResponse — top contributors
+// ---------------------------------------------------------------------------
+
+describe("buildContextInsightsResponse contributors", () => {
+	test("groups re-sent blocks by hash across requests", () => {
+		const shared = block({ hash: "shared", chars: 2_000, label: "Bash" });
+		const response = build({
+			analyses: [
+				{
+					row: row({ id: "r1" }),
+					analysis: analysis({
+						blocks: [shared, block({ hash: "solo", chars: 900 })],
+					}),
+				},
+				{
+					row: row({ id: "r2" }),
+					analysis: analysis({ blocks: [{ ...shared, chars: 2_500 }] }),
+				},
+			],
+		});
+
+		expect(response.topContributors).toHaveLength(2);
+		const [top, second] = response.topContributors;
+		expect(top.label).toBe("Bash");
+		expect(top.maxChars).toBe(2_500);
+		expect(top.estimatedTokens).toBe(625);
+		expect(top.occurrences).toBe(2);
+		expect(top.requestCount).toBe(2);
+		expect(second.maxChars).toBe(900);
+		expect(second.requestCount).toBe(1);
+	});
+
+	test("counts repeats within one request as occurrences but one request", () => {
+		const repeated = block({ hash: "dup" });
+		const response = build({
+			analyses: [
+				{
+					row: row({ id: "r1" }),
+					analysis: analysis({ blocks: [repeated, repeated] }),
+				},
+			],
+		});
+		expect(response.topContributors[0].occurrences).toBe(2);
+		expect(response.topContributors[0].requestCount).toBe(1);
+	});
+
+	test("sorts by maxChars descending and applies the topContributors cap", () => {
+		const blocks = Array.from({ length: 5 }, (_, index) =>
+			block({ hash: `h${index}`, chars: 600 + index * 100 }),
+		);
+		const response = build({
+			analyses: [{ row: row(), analysis: analysis({ blocks }) }],
+			topContributors: 3,
+		});
+		expect(response.topContributors.map((c) => c.maxChars)).toEqual([
+			1_000, 900, 800,
+		]);
+	});
+
+	test("defaults the contributor cap to DEFAULT_TOP_CONTRIBUTORS", () => {
+		const blocks = Array.from(
+			{ length: DEFAULT_TOP_CONTRIBUTORS + 5 },
+			(_, index) => block({ hash: `h${index}`, chars: 600 + index }),
+		);
+		const response = build({
+			analyses: [{ row: row(), analysis: analysis({ blocks }) }],
+		});
+		expect(response.topContributors).toHaveLength(DEFAULT_TOP_CONTRIBUTORS);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// buildContextInsightsResponse — growth curve
+// ---------------------------------------------------------------------------
+
+describe("buildContextInsightsResponse growth curve", () => {
+	const MINUTE = 60_000;
+
+	test("groups by project and splits sessions on the time gap", () => {
+		const gap = DEFAULT_SESSION_GAP_MINUTES * MINUTE;
+		const response = build({
+			growthRows: [
+				// proj-x: two requests close together, then one after a long gap.
+				growthRow({ id: "x1", timestamp: 0, project: "proj-x" }),
+				growthRow({ id: "x2", timestamp: 5 * MINUTE, project: "proj-x" }),
+				growthRow({
+					id: "x3",
+					timestamp: 5 * MINUTE + gap + 1,
+					project: "proj-x",
+				}),
+				// proj-y (null project): independent session.
+				growthRow({ id: "y1", timestamp: 2 * MINUTE, project: null }),
+			],
+		});
+
+		const sessions = response.growthCurve.sessions;
+		expect(sessions).toHaveLength(3);
+		// Most recent session (by endTimestamp) first.
+		expect(sessions[0].points.map((p) => p.requestId)).toEqual(["x3"]);
+		expect(sessions[1].points.map((p) => p.requestId)).toEqual(["x1", "x2"]);
+		expect(sessions[2].points.map((p) => p.requestId)).toEqual(["y1"]);
+
+		const first = sessions[1];
+		expect(first.project).toBe("proj-x");
+		expect(first.startTimestamp).toBe(0);
+		expect(first.endTimestamp).toBe(5 * MINUTE);
+		expect(first.requestCount).toBe(2);
+		// contextTokens = input + cache_read + cache_creation.
+		expect(first.points[0].contextTokens).toBe(60);
+		expect(first.points[0].outputTokens).toBe(5);
+		expect(sessions[2].project).toBeNull();
+		expect(response.growthCurve.truncated).toBe(false);
+	});
+
+	test("a gap exactly at the threshold does not split", () => {
+		const gap = 10 * MINUTE;
+		const response = build({
+			growthRows: [
+				growthRow({ id: "a", timestamp: 0 }),
+				growthRow({ id: "b", timestamp: gap }),
+			],
+			sessionGapMinutes: 10,
+		});
+		expect(response.growthCurve.sessions).toHaveLength(1);
+	});
+
+	test("caps points per session, keeping the most recent points", () => {
+		const rows = Array.from(
+			{ length: MAX_POINTS_PER_SESSION + 1 },
+			(_, index) => growthRow({ id: `p${index}`, timestamp: index * 1_000 }),
+		);
+		const response = build({ growthRows: rows });
+		const session = response.growthCurve.sessions[0];
+		expect(session.points).toHaveLength(MAX_POINTS_PER_SESSION);
+		expect(session.points[0].requestId).toBe("p1"); // oldest point dropped
+		expect(session.requestCount).toBe(MAX_POINTS_PER_SESSION + 1);
+		expect(response.growthCurve.truncated).toBe(true);
+	});
+
+	test("caps the number of sessions, keeping the most recent by endTimestamp", () => {
+		const rows = Array.from({ length: MAX_GROWTH_SESSIONS + 2 }, (_, index) =>
+			growthRow({
+				id: `s${index}`,
+				timestamp: index * 1_000,
+				project: `proj-${index}`,
+			}),
+		);
+		const response = build({ growthRows: rows });
+		expect(response.growthCurve.sessions).toHaveLength(MAX_GROWTH_SESSIONS);
+		// The two oldest sessions are dropped.
+		expect(
+			response.growthCurve.sessions.some((s) => s.project === "proj-0"),
+		).toBe(false);
+		expect(
+			response.growthCurve.sessions.some((s) => s.project === "proj-1"),
+		).toBe(false);
+		expect(response.growthCurve.truncated).toBe(true);
+	});
+
+	test("propagates the growth scan truncation flag", () => {
+		const response = build({
+			growthRows: [growthRow()],
+			growthScanTruncated: true,
+		});
+		expect(response.growthCurve.truncated).toBe(true);
+	});
+});

--- a/packages/http-api/src/services/context-insights.ts
+++ b/packages/http-api/src/services/context-insights.ts
@@ -68,7 +68,8 @@ export interface ContributorBlock {
 	label: string;
 	/** Serialized size of the block. */
 	chars: number;
-	/** Cheap content hash used to group re-sent copies across requests. */
+	/** Cheap content hash used to group re-sent copies across requests.
+	 *  Theoretically collisions are possible for blocks sharing tool name, length, and first 256 chars. */
 	hash: string;
 }
 
@@ -279,8 +280,8 @@ export function analyzePayloadWrapper(
 	const bodyB64 = wrapper.request.body;
 	if (typeof bodyB64 !== "string" || bodyB64.length === 0) return null;
 
-	// Invalid base64 yields garbage rather than throwing; both that and
-	// truncated bodies surface as a JSON.parse failure here.
+	// Buffer.from silently drops invalid base64 chars producing a short buffer;
+	// truncated bodies also surface as JSON.parse failures here.
 	let body: unknown;
 	try {
 		body = JSON.parse(Buffer.from(bodyB64, "base64").toString("utf-8"));

--- a/packages/http-api/src/services/context-insights.ts
+++ b/packages/http-api/src/services/context-insights.ts
@@ -338,8 +338,9 @@ function aggregateContributors(
 		}
 	}
 
-	return [...groups.values()]
-		.map((acc) => ({
+	return [...groups.entries()]
+		.map(([hash, acc]) => ({
+			hash,
 			kind: acc.kind,
 			label: acc.label,
 			maxChars: acc.maxChars,

--- a/packages/http-api/src/services/context-insights.ts
+++ b/packages/http-api/src/services/context-insights.ts
@@ -1,0 +1,537 @@
+import type {
+	ContextCompositionTotals,
+	ContextContributor,
+	ContextContributorKind,
+	ContextGrowthPoint,
+	ContextGrowthSession,
+	ContextInsightsResponse,
+	ContextRequestComposition,
+	ContextTokenTotals,
+} from "@better-ccflare/types";
+
+/**
+ * Pure context-composition analysis for the context insights endpoint.
+ *
+ * No DB access: pre-fetched request rows, per-payload analyses and growth
+ * rows are injected as plain data. The response shapes live in
+ * @better-ccflare/types and are re-exported here for convenience.
+ *
+ * Two distinct data sources are combined:
+ * - Stored request payloads (optional, size-capped, retention-cleaned) yield
+ *   CHAR counts per section via JSON.stringify lengths — estimates, NOT
+ *   token counts, converted with the CHARS_PER_TOKEN heuristic.
+ * - The requests-table token columns yield EXACT token figures
+ *   (tokenTotals, per-request tokens, growth curve).
+ */
+
+export type {
+	ContextCompositionTotals,
+	ContextContributor,
+	ContextContributorKind,
+	ContextGrowthPoint,
+	ContextGrowthSession,
+	ContextInsightsMeta,
+	ContextInsightsResponse,
+	ContextRequestComposition,
+	ContextTokenTotals,
+} from "@better-ccflare/types";
+
+/** Clearly-labelled heuristic for char → token estimates (~4 chars/token). */
+export const CHARS_PER_TOKEN = 4;
+
+export const DEFAULT_PAYLOAD_SCAN_LIMIT = 100;
+export const MAX_PAYLOAD_SCAN_LIMIT = 500;
+export const DEFAULT_TOP_CONTRIBUTORS = 10;
+export const MAX_TOP_CONTRIBUTORS = 50;
+export const DEFAULT_SESSION_GAP_MINUTES = 30;
+/** Keep only the most recent sessions (by endTimestamp) on the growth curve. */
+export const MAX_GROWTH_SESSIONS = 20;
+/** Keep only the most recent points within one session. */
+export const MAX_POINTS_PER_SESSION = 500;
+/** Content blocks below this serialized size are never tracked as contributors. */
+export const MIN_CONTRIBUTOR_BLOCK_CHARS = 512;
+
+/** Caveat echoed verbatim in meta.estimateNote. */
+export const ESTIMATE_NOTE =
+	"Character-based estimates (~4 chars/token); not exact token counts. Coverage is partial: payload storage is optional, size-capped and retention-cleaned.";
+
+/** Max length of a single-line content preview used as a contributor label. */
+const PREVIEW_CHARS = 80;
+/** How much of a serialized block feeds the content hash (beyond kind/label/length). */
+const HASH_SAMPLE_CHARS = 256;
+/** Unit separator: never appears in labels, hash inputs cannot collide on it. */
+const FIELD_SEPARATOR = "\u001f";
+
+/** One large content block extracted from a payload's messages. */
+export interface ContributorBlock {
+	kind: ContextContributorKind;
+	label: string;
+	/** Serialized size of the block. */
+	chars: number;
+	/** Cheap content hash used to group re-sent copies across requests. */
+	hash: string;
+}
+
+/** Char breakdown + contributor blocks for one successfully parsed payload. */
+export interface PayloadAnalysis {
+	systemChars: number;
+	toolsChars: number;
+	messagesChars: number;
+	totalChars: number;
+	blocks: ContributorBlock[];
+}
+
+/** One request row (requests-table columns) paired with its payload analysis. */
+export interface ContextRequestRow {
+	id: string;
+	timestamp: number;
+	account: string | null;
+	model: string | null;
+	project: string | null;
+	inputTokens: number;
+	cacheReadInputTokens: number;
+	cacheCreationInputTokens: number;
+	outputTokens: number;
+}
+
+/** One request row for the growth curve (requests table only, no payload). */
+export interface ContextGrowthRow {
+	id: string;
+	timestamp: number;
+	project: string | null;
+	inputTokens: number;
+	cacheReadInputTokens: number;
+	cacheCreationInputTokens: number;
+	outputTokens: number;
+}
+
+export interface ContextInsightsOptions {
+	range: string;
+	/** Whether the payload candidate fetch hit its scan limit (echoed in meta). */
+	truncated: boolean;
+	/** Whether the growth-curve row fetch hit its scan cap. Default false. */
+	growthScanTruncated?: boolean;
+	/** Contributors returned. Default 10. */
+	topContributors?: number;
+	/** Gap (minutes) that splits two requests into separate sessions. Default 30. */
+	sessionGapMinutes?: number;
+}
+
+export interface BuildContextInsightsInput {
+	/** Candidate rows in any order, each with its parsed analysis (null = unparseable). */
+	analyses: Array<{ row: ContextRequestRow; analysis: PayloadAnalysis | null }>;
+	coverage: { requestsInRange: number; requestsWithPayload: number };
+	/** Growth rows in chronological order. */
+	growthRows: ContextGrowthRow[];
+	options: ContextInsightsOptions;
+}
+
+/** Convert a char count to estimated tokens via the ~4 chars/token heuristic. */
+export function estimateTokens(chars: number): number {
+	return Math.round(chars / CHARS_PER_TOKEN);
+}
+
+/** djb2 hash (unsigned 32-bit, base36) — cheap and non-cryptographic. */
+function djb2(input: string): string {
+	let hash = 5381;
+	for (let index = 0; index < input.length; index++) {
+		hash = (Math.imul(hash, 33) + input.charCodeAt(index)) >>> 0;
+	}
+	return hash.toString(36);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Serialized size of one top-level payload key; 0 when the key is absent. */
+function charsOf(value: unknown): number {
+	if (value === undefined) return 0;
+	const serialized = JSON.stringify(value);
+	return serialized === undefined ? 0 : serialized.length;
+}
+
+/** Collapse whitespace into a short single-line preview for text labels. */
+function previewLabel(text: string): string {
+	const singleLine = text.replace(/\s+/g, " ").trim();
+	return singleLine.length > PREVIEW_CHARS
+		? singleLine.slice(0, PREVIEW_CHARS)
+		: singleLine;
+}
+
+function makeBlock(
+	kind: ContextContributorKind,
+	label: string,
+	serialized: string,
+): ContributorBlock {
+	// Hash kind + label + length + a content sample: cheap, yet stable for
+	// byte-identical re-sent blocks and unlikely to collide for distinct ones.
+	const hash = djb2(
+		[
+			kind,
+			label,
+			serialized.length,
+			serialized.slice(0, HASH_SAMPLE_CHARS),
+		].join(FIELD_SEPARATOR),
+	);
+	return { kind, label, chars: serialized.length, hash };
+}
+
+/**
+ * Extract contributor-sized blocks from a body's messages. Tolerant of both
+ * Anthropic content-block arrays and OpenAI string contents; anything that
+ * isn't message-shaped is silently skipped. Blocks under
+ * MIN_CONTRIBUTOR_BLOCK_CHARS are dropped to bound memory.
+ */
+function extractContributorBlocks(messages: unknown): ContributorBlock[] {
+	if (!Array.isArray(messages)) return [];
+
+	// First pass: map tool_use ids to tool names so tool_result blocks can be
+	// labelled with the tool that produced them (within the same request).
+	const toolNamesById = new Map<string, string>();
+	for (const message of messages) {
+		if (!isRecord(message) || !Array.isArray(message.content)) continue;
+		for (const block of message.content) {
+			if (
+				isRecord(block) &&
+				block.type === "tool_use" &&
+				typeof block.id === "string" &&
+				typeof block.name === "string"
+			) {
+				toolNamesById.set(block.id, block.name);
+			}
+		}
+	}
+
+	const blocks: ContributorBlock[] = [];
+	const push = (
+		kind: ContextContributorKind,
+		label: string,
+		serialized: string,
+	) => {
+		if (serialized.length < MIN_CONTRIBUTOR_BLOCK_CHARS) return;
+		blocks.push(makeBlock(kind, label, serialized));
+	};
+
+	for (const message of messages) {
+		if (!isRecord(message)) continue;
+		const content = message.content;
+		if (typeof content === "string") {
+			// String content (OpenAI-style or simple Anthropic) is one text block.
+			push("text", previewLabel(content), JSON.stringify(content));
+			continue;
+		}
+		if (!Array.isArray(content)) continue;
+		for (const block of content) {
+			if (!isRecord(block)) continue;
+			if (block.type === "tool_result") {
+				const label =
+					(typeof block.tool_use_id === "string" &&
+						toolNamesById.get(block.tool_use_id)) ||
+					"tool_result";
+				push("tool_result", label, JSON.stringify(block));
+			} else if (block.type === "text") {
+				const label = previewLabel(
+					typeof block.text === "string" ? block.text : "",
+				);
+				push("text", label, JSON.stringify(block));
+			} else if (block.type === "tool_use") {
+				const label = typeof block.name === "string" ? block.name : "tool_use";
+				push("tool_use", label, JSON.stringify(block));
+			}
+		}
+	}
+	return blocks;
+}
+
+/**
+ * Parse one stored request_payloads.json row and measure the provider request
+ * body it wraps.
+ *
+ * Returns null when the row is unanalyzable: the wrapper JSON does not parse
+ * (including payloads encrypted at rest), request.body is missing, or the
+ * base64-decoded body is not valid JSON (bodies are size-capped at 4MB at
+ * write time, so they can be truncated mid-JSON).
+ *
+ * Char counts are JSON.stringify lengths of whatever top-level
+ * system/tools/messages keys exist (Anthropic or OpenAI format); a missing
+ * key counts as 0.
+ */
+export function analyzePayloadJson(json: string): PayloadAnalysis | null {
+	let wrapper: unknown;
+	try {
+		wrapper = JSON.parse(json);
+	} catch {
+		return null;
+	}
+	return analyzePayloadWrapper(wrapper);
+}
+
+/**
+ * Measure an already-parsed payload wrapper (as returned by
+ * dbOps.getRequestPayload, which handles at-rest decryption). Same null
+ * semantics as analyzePayloadJson for missing/unparseable request bodies.
+ */
+export function analyzePayloadWrapper(
+	wrapper: unknown,
+): PayloadAnalysis | null {
+	if (!isRecord(wrapper) || !isRecord(wrapper.request)) return null;
+	const bodyB64 = wrapper.request.body;
+	if (typeof bodyB64 !== "string" || bodyB64.length === 0) return null;
+
+	// Invalid base64 yields garbage rather than throwing; both that and
+	// truncated bodies surface as a JSON.parse failure here.
+	let body: unknown;
+	try {
+		body = JSON.parse(Buffer.from(bodyB64, "base64").toString("utf-8"));
+	} catch {
+		return null;
+	}
+	if (!isRecord(body)) return null;
+
+	const systemChars = charsOf(body.system);
+	const toolsChars = charsOf(body.tools);
+	const messagesChars = charsOf(body.messages);
+	return {
+		systemChars,
+		toolsChars,
+		messagesChars,
+		totalChars: systemChars + toolsChars + messagesChars,
+		blocks: extractContributorBlocks(body.messages),
+	};
+}
+
+interface ContributorAccumulator {
+	kind: ContextContributorKind;
+	label: string;
+	maxChars: number;
+	occurrences: number;
+	requestIds: Set<string>;
+}
+
+/**
+ * Group contributor blocks by content hash across requests: occurrences
+ * counts every hit, requestCount counts distinct requests, maxChars keeps the
+ * largest copy. Sorted by maxChars descending (label ascending on ties).
+ */
+function aggregateContributors(
+	parsed: Array<{ row: ContextRequestRow; analysis: PayloadAnalysis }>,
+	topContributors: number,
+): ContextContributor[] {
+	const groups = new Map<string, ContributorAccumulator>();
+	for (const { row, analysis } of parsed) {
+		for (const block of analysis.blocks) {
+			let acc = groups.get(block.hash);
+			if (!acc) {
+				acc = {
+					kind: block.kind,
+					label: block.label,
+					maxChars: 0,
+					occurrences: 0,
+					requestIds: new Set(),
+				};
+				groups.set(block.hash, acc);
+			}
+			acc.occurrences += 1;
+			acc.maxChars = Math.max(acc.maxChars, block.chars);
+			acc.requestIds.add(row.id);
+		}
+	}
+
+	return [...groups.values()]
+		.map((acc) => ({
+			kind: acc.kind,
+			label: acc.label,
+			maxChars: acc.maxChars,
+			estimatedTokens: estimateTokens(acc.maxChars),
+			occurrences: acc.occurrences,
+			requestCount: acc.requestIds.size,
+		}))
+		.sort((a, b) =>
+			b.maxChars !== a.maxChars
+				? b.maxChars - a.maxChars
+				: a.label < b.label
+					? -1
+					: a.label > b.label
+						? 1
+						: 0,
+		)
+		.slice(0, topContributors);
+}
+
+/** Map key for grouping by project; the separator cannot appear in names. */
+const NULL_PROJECT_KEY = `${FIELD_SEPARATOR}null`;
+
+function toGrowthPoint(row: ContextGrowthRow): ContextGrowthPoint {
+	return {
+		requestId: row.id,
+		timestamp: row.timestamp,
+		contextTokens:
+			row.inputTokens + row.cacheReadInputTokens + row.cacheCreationInputTokens,
+		outputTokens: row.outputTokens,
+	};
+}
+
+/**
+ * Build the growth curve: group rows by project, sort each group
+ * chronologically, split into sessions when the gap between neighbours
+ * exceeds sessionGapMinutes, then apply the point/session caps (keeping the
+ * most recent data and flagging truncated when anything was trimmed).
+ */
+function buildGrowthCurve(
+	rows: ContextGrowthRow[],
+	sessionGapMinutes: number,
+	scanTruncated: boolean,
+): { sessions: ContextGrowthSession[]; truncated: boolean } {
+	const gapMs = sessionGapMinutes * 60_000;
+	const byProject = new Map<string, ContextGrowthRow[]>();
+	for (const row of rows) {
+		const key = row.project ?? NULL_PROJECT_KEY;
+		const group = byProject.get(key);
+		if (group) {
+			group.push(row);
+		} else {
+			byProject.set(key, [row]);
+		}
+	}
+
+	let truncated = scanTruncated;
+	const sessions: ContextGrowthSession[] = [];
+	for (const group of byProject.values()) {
+		group.sort((a, b) => a.timestamp - b.timestamp);
+		let current: ContextGrowthRow[] = [];
+		const flush = () => {
+			if (current.length === 0) return;
+			let points = current.map(toGrowthPoint);
+			if (points.length > MAX_POINTS_PER_SESSION) {
+				points = points.slice(points.length - MAX_POINTS_PER_SESSION);
+				truncated = true;
+			}
+			sessions.push({
+				project: current[0].project,
+				startTimestamp: current[0].timestamp,
+				endTimestamp: current[current.length - 1].timestamp,
+				// Session size before the point cap, so trimmed sessions still
+				// report their true request volume.
+				requestCount: current.length,
+				points,
+			});
+			current = [];
+		};
+		for (const row of group) {
+			const last = current[current.length - 1];
+			if (last && row.timestamp - last.timestamp > gapMs) flush();
+			current.push(row);
+		}
+		flush();
+	}
+
+	// Most recent sessions first; drop the oldest beyond the cap.
+	sessions.sort((a, b) => b.endTimestamp - a.endTimestamp);
+	if (sessions.length > MAX_GROWTH_SESSIONS) {
+		sessions.length = MAX_GROWTH_SESSIONS;
+		truncated = true;
+	}
+	return { sessions, truncated };
+}
+
+/**
+ * Assemble the full context insights response from per-payload analyses,
+ * coverage counts and growth rows.
+ *
+ * - composition.totals/perRequest cover only requests whose payload PARSED;
+ *   unparseable rows are surfaced via meta.unparseablePayloads instead.
+ * - composition.tokenTotals are exact requests-table sums over those same
+ *   parsed requests.
+ * - topContributors groups blocks by content hash across requests.
+ * - growthCurve uses only exact token columns (no payload data).
+ */
+export function buildContextInsightsResponse(
+	input: BuildContextInsightsInput,
+): ContextInsightsResponse {
+	const topContributors =
+		input.options.topContributors ?? DEFAULT_TOP_CONTRIBUTORS;
+	const sessionGapMinutes =
+		input.options.sessionGapMinutes ?? DEFAULT_SESSION_GAP_MINUTES;
+
+	const parsed = input.analyses.filter(
+		(entry): entry is { row: ContextRequestRow; analysis: PayloadAnalysis } =>
+			entry.analysis !== null,
+	);
+
+	let systemChars = 0;
+	let toolsChars = 0;
+	let messagesChars = 0;
+	const tokenTotals: ContextTokenTotals = {
+		uncachedInputTokens: 0,
+		cacheReadInputTokens: 0,
+		cacheCreationInputTokens: 0,
+	};
+	for (const { row, analysis } of parsed) {
+		systemChars += analysis.systemChars;
+		toolsChars += analysis.toolsChars;
+		messagesChars += analysis.messagesChars;
+		tokenTotals.uncachedInputTokens += row.inputTokens;
+		tokenTotals.cacheReadInputTokens += row.cacheReadInputTokens;
+		tokenTotals.cacheCreationInputTokens += row.cacheCreationInputTokens;
+	}
+	const totalChars = systemChars + toolsChars + messagesChars;
+	const percentOf = (chars: number) =>
+		totalChars === 0 ? 0 : (chars * 100) / totalChars;
+	const totals: ContextCompositionTotals = {
+		systemChars,
+		toolsChars,
+		messagesChars,
+		totalChars,
+		estimatedTokens: {
+			system: estimateTokens(systemChars),
+			tools: estimateTokens(toolsChars),
+			messages: estimateTokens(messagesChars),
+			total: estimateTokens(totalChars),
+		},
+		percentages: {
+			system: percentOf(systemChars),
+			tools: percentOf(toolsChars),
+			messages: percentOf(messagesChars),
+		},
+	};
+
+	const perRequest: ContextRequestComposition[] = parsed
+		.map(({ row, analysis }) => ({
+			id: row.id,
+			timestamp: row.timestamp,
+			account: row.account,
+			model: row.model,
+			project: row.project,
+			systemChars: analysis.systemChars,
+			toolsChars: analysis.toolsChars,
+			messagesChars: analysis.messagesChars,
+			totalChars: analysis.totalChars,
+			estimatedContextTokens: estimateTokens(analysis.totalChars),
+			inputTokens: row.inputTokens,
+			cacheReadInputTokens: row.cacheReadInputTokens,
+			cacheCreationInputTokens: row.cacheCreationInputTokens,
+			outputTokens: row.outputTokens,
+		}))
+		.sort((a, b) => b.timestamp - a.timestamp);
+
+	return {
+		meta: {
+			range: input.options.range,
+			generatedAt: Date.now(),
+			scannedPayloads: input.analyses.length,
+			parsedPayloads: parsed.length,
+			unparseablePayloads: input.analyses.length - parsed.length,
+			truncated: input.options.truncated,
+			payloadCoverage: input.coverage,
+			estimateNote: ESTIMATE_NOTE,
+		},
+		composition: { totals, tokenTotals, perRequest },
+		topContributors: aggregateContributors(parsed, topContributors),
+		growthCurve: buildGrowthCurve(
+			input.growthRows,
+			sessionGapMinutes,
+			input.options.growthScanTruncated ?? false,
+		),
+	};
+}

--- a/packages/http-api/src/utils/__tests__/query-filters.test.ts
+++ b/packages/http-api/src/utils/__tests__/query-filters.test.ts
@@ -71,7 +71,7 @@ describe("buildRequestFilters", () => {
 			new URLSearchParams(),
 			START_MS,
 		);
-		expect(whereClause).toBe("timestamp > ?");
+		expect(whereClause).toBe("r.timestamp > ?");
 		expect(params).toEqual([START_MS]);
 	});
 
@@ -81,7 +81,7 @@ describe("buildRequestFilters", () => {
 			START_MS,
 		);
 
-		expect(whereClause).toContain("timestamp > ?");
+		expect(whereClause).toContain("r.timestamp > ?");
 		expect(whereClause).toContain(
 			"r.account_used IN (SELECT id FROM accounts WHERE name IN (?,?))",
 		);
@@ -102,7 +102,7 @@ describe("buildRequestFilters", () => {
 			new URLSearchParams("models=model-a,model-b"),
 			START_MS,
 		);
-		expect(whereClause).toContain("model IN (?,?)");
+		expect(whereClause).toContain("r.model IN (?,?)");
 		expect(params).toEqual([START_MS, "model-a", "model-b"]);
 	});
 
@@ -111,7 +111,7 @@ describe("buildRequestFilters", () => {
 			new URLSearchParams("apiKeys=key-1"),
 			START_MS,
 		);
-		expect(whereClause).toContain("api_key_name IN (?)");
+		expect(whereClause).toContain("r.api_key_name IN (?)");
 		expect(params).toEqual([START_MS, "key-1"]);
 	});
 
@@ -120,7 +120,7 @@ describe("buildRequestFilters", () => {
 			new URLSearchParams("status=success"),
 			START_MS,
 		);
-		expect(whereClause).toContain("success = TRUE");
+		expect(whereClause).toContain("r.success = TRUE");
 		expect(params).toEqual([START_MS]);
 	});
 
@@ -129,7 +129,7 @@ describe("buildRequestFilters", () => {
 			new URLSearchParams("status=error"),
 			START_MS,
 		);
-		expect(whereClause).toContain("success = FALSE");
+		expect(whereClause).toContain("r.success = FALSE");
 		expect(params).toEqual([START_MS]);
 	});
 
@@ -146,7 +146,7 @@ describe("buildRequestFilters", () => {
 			new URLSearchParams("accounts=&models=&apiKeys="),
 			START_MS,
 		);
-		expect(whereClause).toBe("timestamp > ?");
+		expect(whereClause).toBe("r.timestamp > ?");
 		expect(params).toEqual([START_MS]);
 	});
 
@@ -155,7 +155,7 @@ describe("buildRequestFilters", () => {
 			new URLSearchParams("models=model-a,,model-b,"),
 			START_MS,
 		);
-		expect(whereClause).toContain("model IN (?,?)");
+		expect(whereClause).toContain("r.model IN (?,?)");
 		expect(params).toEqual([START_MS, "model-a", "model-b"]);
 	});
 
@@ -167,11 +167,11 @@ describe("buildRequestFilters", () => {
 			START_MS,
 		);
 
-		const tsIdx = whereClause.indexOf("timestamp > ?");
+		const tsIdx = whereClause.indexOf("r.timestamp > ?");
 		const acctIdx = whereClause.indexOf("r.account_used IN");
-		const modelIdx = whereClause.indexOf("model IN");
-		const keyIdx = whereClause.indexOf("api_key_name IN");
-		const statusIdx = whereClause.indexOf("success = FALSE");
+		const modelIdx = whereClause.indexOf("r.model IN");
+		const keyIdx = whereClause.indexOf("r.api_key_name IN");
+		const statusIdx = whereClause.indexOf("r.success = FALSE");
 
 		expect(tsIdx).toBeGreaterThanOrEqual(0);
 		expect(acctIdx).toBeGreaterThan(tsIdx);

--- a/packages/http-api/src/utils/query-filters.ts
+++ b/packages/http-api/src/utils/query-filters.ts
@@ -84,6 +84,10 @@ export interface RequestFilterResult {
  * Conditions, in order: timestamp window, accounts (names resolved to ids via
  * subquery, plus the NO_ACCOUNT_ID sentinel escape hatch), models, apiKeys,
  * status (success/error; anything else adds no condition).
+ *
+ * Every column reference is qualified with the `r` alias so the clause stays
+ * unambiguous in queries that join other tables sharing column names (e.g.
+ * request_payloads also has a timestamp column).
  */
 export function buildRequestFilters(
 	searchParams: URLSearchParams,
@@ -97,7 +101,7 @@ export function buildRequestFilters(
 		searchParams.get("apiKeys")?.split(",").filter(Boolean) || [];
 	const statusFilter = searchParams.get("status") || "all";
 
-	const conditions: string[] = ["timestamp > ?"];
+	const conditions: string[] = ["r.timestamp > ?"];
 	const params: (string | number)[] = [startMs];
 
 	if (accountsFilter.length > 0) {
@@ -117,20 +121,20 @@ export function buildRequestFilters(
 
 	if (modelsFilter.length > 0) {
 		const placeholders = modelsFilter.map(() => "?").join(",");
-		conditions.push(`model IN (${placeholders})`);
+		conditions.push(`r.model IN (${placeholders})`);
 		params.push(...modelsFilter);
 	}
 
 	if (apiKeysFilter.length > 0) {
 		const placeholders = apiKeysFilter.map(() => "?").join(",");
-		conditions.push(`api_key_name IN (${placeholders})`);
+		conditions.push(`r.api_key_name IN (${placeholders})`);
 		params.push(...apiKeysFilter);
 	}
 
 	if (statusFilter === "success") {
-		conditions.push("success = TRUE");
+		conditions.push("r.success = TRUE");
 	} else if (statusFilter === "error") {
-		conditions.push("success = FALSE");
+		conditions.push("r.success = FALSE");
 	}
 
 	return { whereClause: conditions.join(" AND "), params };

--- a/packages/types/src/insights.ts
+++ b/packages/types/src/insights.ts
@@ -238,6 +238,8 @@ export type ContextContributorKind = "tool_result" | "text" | "tool_use";
  * so re-sent copies of the same block collapse into a single entry.
  */
 export interface ContextContributor {
+	/** Content hash the copies were grouped by; unique within the list. */
+	hash: string;
 	kind: ContextContributorKind;
 	/**
 	 * Tool name for tool_result/tool_use blocks when resolvable, else a short

--- a/packages/types/src/insights.ts
+++ b/packages/types/src/insights.ts
@@ -166,3 +166,150 @@ export interface AnomalyInsightsResponse {
 	runawayLoops: RunawayLoopGroup[];
 	misrouting: ModelMisroutingGroup[];
 }
+
+/**
+ * Response types for the context insights endpoint (/api/insights/context).
+ *
+ * Char counts are JSON.stringify lengths of stored payload sections — they
+ * are estimates, NOT token counts, and are converted with a clearly-labelled
+ * ~4 chars/token heuristic. Exact token figures (tokenTotals, growth curve)
+ * come from the requests-table token columns instead.
+ */
+
+/**
+ * Char totals per context section across all parsed payloads, with
+ * ~4 chars/token estimates and share-of-total percentages.
+ */
+export interface ContextCompositionTotals {
+	systemChars: number;
+	toolsChars: number;
+	messagesChars: number;
+	totalChars: number;
+	/** Math.round(chars / CHARS_PER_TOKEN) per section. */
+	estimatedTokens: {
+		system: number;
+		tools: number;
+		messages: number;
+		total: number;
+	};
+	/** Share of totalChars per section (0-100); all 0 when totalChars is 0. */
+	percentages: {
+		system: number;
+		tools: number;
+		messages: number;
+	};
+}
+
+/**
+ * Exact token sums over the ANALYZED (successfully parsed) requests, taken
+ * from the requests-table columns — not estimated from chars.
+ */
+export interface ContextTokenTotals {
+	uncachedInputTokens: number;
+	cacheReadInputTokens: number;
+	cacheCreationInputTokens: number;
+}
+
+/** Composition breakdown for one request whose payload parsed successfully. */
+export interface ContextRequestComposition {
+	id: string;
+	timestamp: number;
+	account: string | null;
+	model: string | null;
+	project: string | null;
+	systemChars: number;
+	toolsChars: number;
+	messagesChars: number;
+	totalChars: number;
+	/** ~4 chars/token estimate over totalChars. */
+	estimatedContextTokens: number;
+	/** Exact requests-table token columns. */
+	inputTokens: number;
+	cacheReadInputTokens: number;
+	cacheCreationInputTokens: number;
+	outputTokens: number;
+}
+
+/** Kind of message content block reported as a context contributor. */
+export type ContextContributorKind = "tool_result" | "text" | "tool_use";
+
+/**
+ * One large content block, grouped by content hash across analyzed requests
+ * so re-sent copies of the same block collapse into a single entry.
+ */
+export interface ContextContributor {
+	kind: ContextContributorKind;
+	/**
+	 * Tool name for tool_result/tool_use blocks when resolvable, else a short
+	 * single-line content preview (first ~80 chars).
+	 */
+	label: string;
+	/** Serialized size of the largest copy seen. */
+	maxChars: number;
+	/** ~4 chars/token estimate over maxChars. */
+	estimatedTokens: number;
+	/** Total times the block was seen across analyzed requests. */
+	occurrences: number;
+	/** Distinct requests the block appeared in. */
+	requestCount: number;
+}
+
+/** One request's exact token point on the context growth curve. */
+export interface ContextGrowthPoint {
+	requestId: string;
+	timestamp: number;
+	/** input + cache_read + cache_creation (exact requests-table columns). */
+	contextTokens: number;
+	outputTokens: number;
+}
+
+/**
+ * A run of requests for one project, split from its neighbours by a
+ * configurable time gap (no real session id exists in the schema).
+ */
+export interface ContextGrowthSession {
+	project: string | null;
+	startTimestamp: number;
+	endTimestamp: number;
+	/** Requests in the session BEFORE any per-session point cap was applied. */
+	requestCount: number;
+	points: ContextGrowthPoint[];
+}
+
+/** Metadata echoed back with a context insights response. */
+export interface ContextInsightsMeta {
+	range: string;
+	generatedAt: number;
+	/** Payload rows fetched and analyzed (parse attempted). */
+	scannedPayloads: number;
+	parsedPayloads: number;
+	unparseablePayloads: number;
+	/** True when more payload-bearing requests existed than the scan limit. */
+	truncated: boolean;
+	/**
+	 * Payload storage is optional and retention-cleaned, so coverage is
+	 * partial: requests in the window vs requests with a stored payload.
+	 */
+	payloadCoverage: {
+		requestsInRange: number;
+		requestsWithPayload: number;
+	};
+	/** Human-readable caveat about char-based estimates and partial coverage. */
+	estimateNote: string;
+}
+
+/** Full response of GET /api/insights/context. */
+export interface ContextInsightsResponse {
+	meta: ContextInsightsMeta;
+	composition: {
+		totals: ContextCompositionTotals;
+		tokenTotals: ContextTokenTotals;
+		perRequest: ContextRequestComposition[];
+	};
+	topContributors: ContextContributor[];
+	growthCurve: {
+		sessions: ContextGrowthSession[];
+		/** True when the growth scan cap or session/point caps trimmed data. */
+		truncated: boolean;
+	};
+}


### PR DESCRIPTION
Closes #251 — the last Token Insights slice (part of #247).

## What

New `GET /api/insights/context` endpoint plus a Context Composition section in the dashboard Insights tab, analyzing stored request payloads to show what actually fills the context window.

### Context composition breakdown
- System prompt vs tool definitions vs messages, measured as serialized chars from the stored payload bodies and converted with a clearly-labelled ~4 chars/token heuristic (`CHARS_PER_TOKEN`, echoed in `meta.estimateNote`)
- Exact uncached / cache-read / cache-creation input token mix from the `requests` table columns, shown alongside as a separate "exact" donut
- Tolerant of both Anthropic and OpenAI-format request bodies; unparseable rows (truncated 4MB-capped bodies, invalid base64) are counted in `meta.unparseablePayloads` instead of failing

### Top context contributors
- Largest `tool_result` / `text` / `tool_use` blocks (≥512 chars), with tool names resolved via `tool_use_id`
- Re-sent copies grouped across requests by content hash (djb2 over kind/label/length/content sample), reporting occurrences and distinct request counts

### Context growth curve
- Tokens-per-turn sessions from exact token columns (no payload parsing), grouped by `project` with a configurable time-gap split (`sessionGapMinutes`, default 30) — per the open question in #247, project + time-windowing is the practical session grouping
- Capped at 20 sessions / 500 points per session with a truncation flag

## Caveats handled (from the issue)
- **Partial coverage**: payload storage is optional (`store_payloads`), size-capped and retention-cleaned. The response carries `payloadCoverage` (requests in range vs with payloads) and the UI shows "analyzed N of M requests" prominently, with distinct empty states for "no requests in period" vs "no stored payloads"
- **Estimates, not tokens**: char-based figures are labelled as ~estimates everywhere; exact figures come only from the token columns
- **DB load**: candidate query is metadata-only; payload JSON is fetched one row at a time through `dbOps.getRequestPayload` (decryption-aware), scan limit 100 (max 500) with a truncation flag; growth scan capped at 20k rows

## Also
- `buildRequestFilters` now qualifies all conditions with the `r` alias (its documented contract), so joined queries against `request_payloads` stay unambiguous without string post-processing — behavior-preserving for the existing analytics/cache/anomaly consumers

## Tests
37 new tests: pure service analysis (payload parsing, contributor grouping, session splitting, caps) and in-memory SQLite handler integration (coverage counts, filters, truncation, unparseable rows). Full `packages/http-api` suite: 287 pass. Two Greptile review rounds run pre-PR; all findings addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)