### PR TITLE
feat: add Claude Fable 5 (claude-fable-5) model support

### DIFF
--- a/.claude/agents/gitnexus-analyst.md
+++ b/.claude/agents/gitnexus-analyst.md
@@ -1,0 +1,18 @@
+---
+name: gitnexus-analyst
+description: Runs GitNexus analysis (impact, context, query, detect_changes, cypher) and returns a compact summary. Use for ALL GitNexus MCP calls instead of calling them in the main session — this keeps large graph payloads out of the main context.
+tools: mcp__gitnexus__impact, mcp__gitnexus__context, mcp__gitnexus__query, mcp__gitnexus__detect_changes, mcp__gitnexus__cypher, mcp__gitnexus__list_repos, mcp__gitnexus__route_map, mcp__gitnexus__shape_check, mcp__gitnexus__api_impact, mcp__gitnexus__tool_map, mcp__gitnexus__rename
+model: haiku
+---
+
+You run GitNexus analysis for the better-ccflare repo and report back compactly.
+
+Run the requested tool calls (repo: better-ccflare). For `impact`, prefer `summaryOnly: true` first; only fetch `byDepth` detail if the caller asked for specific symbols. For `query`, use `limit: 3, max_symbols: 5` unless told otherwise. For `rename`, always run with `dry_run: true` and report the edit list; only apply with `dry_run: false` when the dispatching prompt explicitly says to apply.
+
+Return ONLY:
+- Risk level and a one-line verdict
+- Direct callers / d=1 breakage (names + file:line, max ~10)
+- Affected processes (names only)
+- Any HIGH/CRITICAL warnings, stated prominently
+
+Keep the entire reply under ~30 lines. Never paste raw tool JSON or full symbol dumps.

--- a/.claude/agents/greptile-reviewer.md
+++ b/.claude/agents/greptile-reviewer.md
@@ -1,0 +1,17 @@
+---
+name: greptile-reviewer
+description: Runs `greptile review` on the current branch and returns a compact summary of findings. Use instead of running greptile review in the main session — its output quotes code blocks and inflates the main context.
+tools: Bash, Read, Grep, Glob
+model: haiku
+---
+
+You run a Greptile pre-PR review for the better-ccflare repo and report back compactly.
+
+Run `greptile review` from the repo root (it reviews the current branch against its base; it can take a few minutes — use a generous Bash timeout, e.g. 600000ms). Wait for it to finish, then condense the output.
+
+Return ONLY a findings list, most severe first:
+- `file:line` — one-sentence description of the issue, plus a one-line suggested fix if Greptile gave one
+- Group trivial/nitpick items into a single line at the end (count + theme), don't enumerate them
+- End with a one-line verdict: blocking issues yes/no, and how many findings total
+
+Do NOT paste Greptile's quoted code blocks, diffs, or full comment bodies — file:line references are enough; the main session can read the files itself. Keep the entire reply under ~30 lines. If `greptile review` errors or finds nothing, report that in one line.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,13 +27,9 @@ PRs: `gh pr checkout <PR_NUMBER>` or `git checkout <branch-name>`.
 
 ## Pre-PR Review with Greptile
 
-Before opening a pull request, run a Greptile review from the terminal:
+Before opening a pull request, run a Greptile review — but **dispatch the `greptile-reviewer` agent** (`.claude/agents/greptile-reviewer.md`, runs on haiku) rather than running `greptile review` in the main session. Greptile's output quotes code blocks and inflates the main context; the agent runs it and returns a compact findings list (`file:line` + one-line issue), which is all the main session needs to act.
 
-```bash
-greptile review
-```
-
-Greptile reviews your branch against its base branch and shows comments directly in the terminal. Run this after checking out your branch and before pushing/opening a PR.
+Greptile reviews your branch against its base branch. Run this after checking out your branch and before pushing/opening a PR. Fallback if the agent is unavailable: `greptile review` directly.
 
 ## PR Review Against Current Main (MANDATORY)
 
@@ -109,7 +105,7 @@ When creating new functionality: write tests first, then implement, then run tes
 ## After Code Changes
 Always run: `bun run lint && bun run typecheck && bun run format`
 
-After pushing commits to main, run `npx gitnexus analyze` to keep the GitNexus index up to date.
+The GitNexus index refreshes automatically via a local git post-commit hook (`.git/hooks/post-commit`, runs `node .gitnexus/run.cjs analyze` detached). Do NOT run `gitnexus analyze` manually after commits — ignore "index is stale" reminders that appear right after committing; the background refresh is already running. Only run `node .gitnexus/run.cjs analyze` manually if the index stays stale long after the last commit (the hook may be missing on this machine — recreate it if so).
 
 ## Git Commits
 - **Before making any changes, run `git status` to check for pre-existing uncommitted changes.** Note which files were already modified so you can distinguish your changes from theirs throughout the session.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,10 +170,18 @@ Automated release system uses commit prefixes for changelog:
 
 **Acknowledgement commits** (when merging external PRs): always use `chore: acknowledge <name> for PR #<N>` as the commit subject. This prefix is excluded from release notes. If the merge also includes real fixes, commit them separately with the appropriate prefix.
 
+## ⚠️ GitNexus Token Discipline: route ALL GitNexus calls through the `gitnexus-analyst` subagent
+
+This section OVERRIDES the auto-generated GitNexus section below (everything between the `gitnexus:start`/`gitnexus:end` markers — do not edit inside those markers, `gitnexus analyze` regenerates them).
+
+GitNexus MCP results are large and stay in the main context for the whole session. **Never call GitNexus MCP tools (`impact`, `context`, `query`, `detect_changes`, `cypher`, `rename`, etc.) directly in the main session.** Wherever the section below says to run a GitNexus tool, instead dispatch the `gitnexus-analyst` agent (`.claude/agents/gitnexus-analyst.md`, runs on haiku) with a description of what you need; it returns a ~30-line summary (risk level, d=1 callers, affected processes, HIGH/CRITICAL warnings) and the raw payloads stay in its throwaway context.
+
+Fallback (only if the subagent is unavailable): call the tools inline but minimize payloads — `impact({summaryOnly: true})`, `query({limit: 3, max_symbols: 5})`.
+
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **better-ccflare** (6747 symbols, 15266 relationships, 235 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **better-ccflare** (6784 symbols, 15362 relationships, 240 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 

--- a/packages/agents/src/discovery.ts
+++ b/packages/agents/src/discovery.ts
@@ -146,7 +146,9 @@ export class AgentRegistry {
 			// Handle shorthand model names
 			if (data.model) {
 				const modelLower = data.model.toLowerCase();
-				if (modelLower === "opus") {
+				if (modelLower === "fable") {
+					model = CLAUDE_MODEL_IDS.FABLE_5 as AllowedModel;
+				} else if (modelLower === "opus") {
 					model = CLAUDE_MODEL_IDS.OPUS_4 as AllowedModel; // Keep existing default
 				} else if (modelLower === "sonnet") {
 					model = CLAUDE_MODEL_IDS.SONNET_4 as AllowedModel; // Keep existing default

--- a/packages/cli-commands/src/commands/account.ts
+++ b/packages/cli-commands/src/commands/account.ts
@@ -644,6 +644,7 @@ async function promptModelMappings(
 	},
 ): Promise<ModelMapping | null> {
 	const defaults = providerDefaults ?? {
+		fable: "openai/gpt-5",
 		opus: "openai/gpt-5",
 		sonnet: "openai/gpt-5",
 		haiku: "openai/gpt-5-mini",

--- a/packages/cli-commands/src/commands/account.ts
+++ b/packages/cli-commands/src/commands/account.ts
@@ -636,7 +636,12 @@ function parseModelInput(value: string): string | string[] | null {
 async function promptModelMappings(
 	adapter: PromptAdapter,
 	existingMappings?: ModelMapping,
-	providerDefaults?: { opus: string; sonnet: string; haiku: string },
+	providerDefaults?: {
+		fable?: string;
+		opus: string;
+		sonnet: string;
+		haiku: string;
+	},
 ): Promise<ModelMapping | null> {
 	const defaults = providerDefaults ?? {
 		opus: "openai/gpt-5",
@@ -663,6 +668,13 @@ async function promptModelMappings(
 		"\nEnter model mappings (comma-separated for multiple models to cycle through):",
 	);
 	const mappings: ModelMapping = {};
+
+	// Get fable mapping
+	const fableModel = await adapter.input(
+		`Fable model (default: ${defaults.fable ?? defaults.opus}): `,
+	);
+	const fable = parseModelInput(fableModel);
+	if (fable) mappings.fable = fable;
 
 	// Get opus mapping
 	const opusModel = await adapter.input(

--- a/packages/cli-commands/src/commands/account.ts
+++ b/packages/cli-commands/src/commands/account.ts
@@ -644,10 +644,10 @@ async function promptModelMappings(
 	},
 ): Promise<ModelMapping | null> {
 	const defaults = providerDefaults ?? {
-		fable: "openai/gpt-5",
-		opus: "openai/gpt-5",
-		sonnet: "openai/gpt-5",
-		haiku: "openai/gpt-5-mini",
+		fable: "openai/gpt-5.5",
+		opus: "openai/gpt-5.5",
+		sonnet: "openai/gpt-5.5",
+		haiku: "openai/gpt-5.4-mini",
 	};
 
 	const wantsCustomMappings = await adapter.select(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -61,6 +61,7 @@ export {
 	getModelDisplayName,
 	getModelShortName,
 	isValidModelId,
+	LATEST_FABLE_MODEL,
 	LATEST_HAIKU_MODEL,
 	LATEST_OPUS_MODEL,
 	LATEST_SONNET_MODEL,

--- a/packages/core/src/model-mappings.test.ts
+++ b/packages/core/src/model-mappings.test.ts
@@ -236,6 +236,12 @@ describe("Model Validation Utilities", () => {
 		expect(getModelFamily("claude-haiku-5-0")).toBe("haiku");
 	});
 
+	test("getModelFamily detects fable models", () => {
+		expect(getModelFamily("claude-fable-5")).toBe("fable");
+		expect(getModelFamily("claude-fable-5-20260601")).toBe("fable");
+		expect(getModelFamily("CLAUDE-FABLE-5")).toBe("fable"); // case insensitive
+	});
+
 	test("getModelFamily returns null for invalid models", () => {
 		expect(getModelFamily("gpt-4")).toBeNull();
 		expect(getModelFamily("invalid-model")).toBeNull();
@@ -246,6 +252,7 @@ describe("Model Validation Utilities", () => {
 		expect(isValidClaudeModel("claude-opus-4-6")).toBe(true);
 		expect(isValidClaudeModel("claude-sonnet-4-5-20250929")).toBe(true);
 		expect(isValidClaudeModel("claude-haiku-4-5-20251001")).toBe(true);
+		expect(isValidClaudeModel("claude-fable-5")).toBe(true);
 		expect(isValidClaudeModel("claude-opus-5-0-future")).toBe(true); // future models
 	});
 
@@ -260,5 +267,32 @@ describe("Model Validation Utilities", () => {
 		expect(message).toContain("opus");
 		expect(message).toContain("sonnet");
 		expect(message).toContain("haiku");
+		expect(message).toContain("fable");
+	});
+
+	test("mapModelName maps fable family via family mapping", () => {
+		const mockAccount: Account = {
+			id: "test",
+			name: "test-account",
+			provider: "openai-compatible",
+			api_key: "test-key",
+			refresh_token: "",
+			access_token: "",
+			expires_at: null,
+			created_at: Date.now(),
+			request_count: 0,
+			total_requests: 0,
+			priority: 10,
+			model_mappings: JSON.stringify({
+				fable: "my-fable-model",
+			}),
+			custom_endpoint: null,
+		} as Account;
+
+		expect(mapModelName("claude-fable-5", mockAccount)).toBe("my-fable-model");
+		// Unmapped families pass through unchanged
+		expect(mapModelName("claude-opus-4-6", mockAccount)).toBe(
+			"claude-opus-4-6",
+		);
 	});
 });

--- a/packages/core/src/model-mappings.ts
+++ b/packages/core/src/model-mappings.ts
@@ -8,18 +8,18 @@ const log = new Logger("ModelMappings");
 // Types are now defined in index.ts and exported from there
 
 // Known model family patterns for O(1) direct matching
-// Pattern order: Check "opus" before "haiku" before "sonnet" to avoid substring collisions
-// in edge cases like "claude-opus-haiku-test" (though we would never see this pattern from the client)
-export const KNOWN_PATTERNS = ["opus", "haiku", "sonnet"] as const;
+// Pattern order: Check "fable" before "opus" before "haiku" before "sonnet" to avoid substring
+// collisions in edge cases like "claude-opus-haiku-test" (though we would never see this pattern from the client)
+export const KNOWN_PATTERNS = ["fable", "opus", "haiku", "sonnet"] as const;
 
 /**
- * Get the model family (opus/sonnet/haiku) from a model ID
+ * Get the model family (fable/opus/sonnet/haiku) from a model ID
  * Uses the same pattern matching as mapModelName()
  * @returns Model family or null if no pattern matches
  */
 export function getModelFamily(
 	modelId: string,
-): "opus" | "sonnet" | "haiku" | null {
+): "fable" | "opus" | "sonnet" | "haiku" | null {
 	const normalized = modelId.toLowerCase();
 	for (const pattern of KNOWN_PATTERNS) {
 		if (normalized.includes(pattern)) {
@@ -31,7 +31,7 @@ export function getModelFamily(
 
 /**
  * Validate if a model ID is a valid Claude model
- * Accepts any model containing opus, sonnet, or haiku (case-insensitive)
+ * Accepts any model containing fable, opus, sonnet, or haiku (case-insensitive)
  * @returns true if model matches a known pattern
  */
 export function isValidClaudeModel(modelId: string): boolean {
@@ -43,7 +43,7 @@ export function isValidClaudeModel(modelId: string): boolean {
  * @returns Error message string for API responses
  */
 export function getAllowedModelsMessage(): string {
-	return "Model must contain one of: opus, sonnet, haiku (e.g., claude-opus-4-6, claude-sonnet-4-5-20250929)";
+	return "Model must contain one of: fable, opus, sonnet, haiku (e.g., claude-fable-5, claude-opus-4-6, claude-sonnet-4-5-20250929)";
 }
 
 /**

--- a/packages/core/src/model-mappings.ts
+++ b/packages/core/src/model-mappings.ts
@@ -299,7 +299,7 @@ export function createCustomEndpointData(
 
 /**
  * Parse model fallbacks from account's model_fallbacks field.
- * Model fallbacks map model family names (opus/sonnet/haiku) to fallback model names.
+ * Model fallbacks map model family names (fable/opus/sonnet/haiku) to fallback model names.
  */
 export function parseModelFallbacks(
 	modelFallbacks: string | null,

--- a/packages/core/src/models.ts
+++ b/packages/core/src/models.ts
@@ -15,6 +15,7 @@ export const CLAUDE_MODEL_IDS = {
 	OPUS_4_5: "claude-opus-4-5-20251101",
 	OPUS_4_6: "claude-opus-4-6",
 	OPUS_4_7: "claude-opus-4-7",
+	FABLE_5: "claude-fable-5",
 } as const;
 
 // Model display names
@@ -28,6 +29,7 @@ export const MODEL_DISPLAY_NAMES: Record<string, string> = {
 	[CLAUDE_MODEL_IDS.OPUS_4_5]: "Claude Opus 4.5",
 	[CLAUDE_MODEL_IDS.OPUS_4_6]: "Claude Opus 4.6",
 	[CLAUDE_MODEL_IDS.OPUS_4_7]: "Claude Opus 4.7",
+	[CLAUDE_MODEL_IDS.FABLE_5]: "Claude Fable 5",
 };
 
 // Short model names used in UI (for color mapping, etc.)
@@ -41,10 +43,12 @@ export const MODEL_SHORT_NAMES: Record<string, string> = {
 	[CLAUDE_MODEL_IDS.OPUS_4_5]: "claude-opus-4.5",
 	[CLAUDE_MODEL_IDS.OPUS_4_6]: "claude-opus-4.6",
 	[CLAUDE_MODEL_IDS.OPUS_4_7]: "claude-opus-4.7",
+	[CLAUDE_MODEL_IDS.FABLE_5]: "claude-fable-5",
 };
 
 // Latest model aliases — update these when Anthropic releases new models.
 // Check https://docs.anthropic.com/en/docs/about-claude/models for the current list.
+export const LATEST_FABLE_MODEL = CLAUDE_MODEL_IDS.FABLE_5;
 export const LATEST_OPUS_MODEL = CLAUDE_MODEL_IDS.OPUS_4_7;
 export const LATEST_SONNET_MODEL = CLAUDE_MODEL_IDS.SONNET_4_6;
 export const LATEST_HAIKU_MODEL = CLAUDE_MODEL_IDS.HAIKU_4_5;

--- a/packages/core/src/models.ts
+++ b/packages/core/src/models.ts
@@ -15,6 +15,7 @@ export const CLAUDE_MODEL_IDS = {
 	OPUS_4_5: "claude-opus-4-5-20251101",
 	OPUS_4_6: "claude-opus-4-6",
 	OPUS_4_7: "claude-opus-4-7",
+	OPUS_4_8: "claude-opus-4-8",
 	FABLE_5: "claude-fable-5",
 } as const;
 
@@ -29,6 +30,7 @@ export const MODEL_DISPLAY_NAMES: Record<string, string> = {
 	[CLAUDE_MODEL_IDS.OPUS_4_5]: "Claude Opus 4.5",
 	[CLAUDE_MODEL_IDS.OPUS_4_6]: "Claude Opus 4.6",
 	[CLAUDE_MODEL_IDS.OPUS_4_7]: "Claude Opus 4.7",
+	[CLAUDE_MODEL_IDS.OPUS_4_8]: "Claude Opus 4.8",
 	[CLAUDE_MODEL_IDS.FABLE_5]: "Claude Fable 5",
 };
 
@@ -43,13 +45,14 @@ export const MODEL_SHORT_NAMES: Record<string, string> = {
 	[CLAUDE_MODEL_IDS.OPUS_4_5]: "claude-opus-4.5",
 	[CLAUDE_MODEL_IDS.OPUS_4_6]: "claude-opus-4.6",
 	[CLAUDE_MODEL_IDS.OPUS_4_7]: "claude-opus-4.7",
+	[CLAUDE_MODEL_IDS.OPUS_4_8]: "claude-opus-4.8",
 	[CLAUDE_MODEL_IDS.FABLE_5]: "claude-fable-5",
 };
 
 // Latest model aliases — update these when Anthropic releases new models.
 // Check https://docs.anthropic.com/en/docs/about-claude/models for the current list.
 export const LATEST_FABLE_MODEL = CLAUDE_MODEL_IDS.FABLE_5;
-export const LATEST_OPUS_MODEL = CLAUDE_MODEL_IDS.OPUS_4_7;
+export const LATEST_OPUS_MODEL = CLAUDE_MODEL_IDS.OPUS_4_8;
 export const LATEST_SONNET_MODEL = CLAUDE_MODEL_IDS.SONNET_4_6;
 export const LATEST_HAIKU_MODEL = CLAUDE_MODEL_IDS.HAIKU_4_5;
 

--- a/packages/core/src/pricing.ts
+++ b/packages/core/src/pricing.ts
@@ -126,6 +126,16 @@ const BUNDLED_PRICING: ApiResponse = {
 					cache_write: 6.25,
 				},
 			},
+			[CLAUDE_MODEL_IDS.OPUS_4_8]: {
+				id: CLAUDE_MODEL_IDS.OPUS_4_8,
+				name: MODEL_DISPLAY_NAMES[CLAUDE_MODEL_IDS.OPUS_4_8],
+				cost: {
+					input: 5,
+					output: 25,
+					cache_read: 0.5,
+					cache_write: 6.25,
+				},
+			},
 			[CLAUDE_MODEL_IDS.FABLE_5]: {
 				id: CLAUDE_MODEL_IDS.FABLE_5,
 				name: MODEL_DISPLAY_NAMES[CLAUDE_MODEL_IDS.FABLE_5],

--- a/packages/core/src/pricing.ts
+++ b/packages/core/src/pricing.ts
@@ -116,6 +116,26 @@ const BUNDLED_PRICING: ApiResponse = {
 					cache_write: 6.25,
 				},
 			},
+			[CLAUDE_MODEL_IDS.OPUS_4_7]: {
+				id: CLAUDE_MODEL_IDS.OPUS_4_7,
+				name: MODEL_DISPLAY_NAMES[CLAUDE_MODEL_IDS.OPUS_4_7],
+				cost: {
+					input: 5,
+					output: 25,
+					cache_read: 0.5,
+					cache_write: 6.25,
+				},
+			},
+			[CLAUDE_MODEL_IDS.FABLE_5]: {
+				id: CLAUDE_MODEL_IDS.FABLE_5,
+				name: MODEL_DISPLAY_NAMES[CLAUDE_MODEL_IDS.FABLE_5],
+				cost: {
+					input: 10,
+					output: 50,
+					cache_read: 1,
+					cache_write: 12.5,
+				},
+			},
 		},
 	},
 };

--- a/packages/dashboard-web/src/components/accounts/AccountModelMappingsDialog.tsx
+++ b/packages/dashboard-web/src/components/accounts/AccountModelMappingsDialog.tsx
@@ -1,4 +1,5 @@
 import {
+	LATEST_FABLE_MODEL,
 	LATEST_HAIKU_MODEL,
 	LATEST_OPUS_MODEL,
 	LATEST_SONNET_MODEL,
@@ -48,10 +49,12 @@ export function AccountModelMappingsDialog({
 	onUpdateModelMappings,
 }: AccountModelMappingsDialogProps) {
 	const [modelMappings, setModelMappings] = useState<{
+		fable: string;
 		opus: string;
 		sonnet: string;
 		haiku: string;
 	}>({
+		fable: "",
 		opus: "",
 		sonnet: "",
 		haiku: "",
@@ -62,12 +65,14 @@ export function AccountModelMappingsDialog({
 	React.useEffect(() => {
 		if (account?.modelMappings) {
 			setModelMappings({
+				fable: formatMappingValue(account.modelMappings.fable || ""),
 				opus: formatMappingValue(account.modelMappings.opus || ""),
 				sonnet: formatMappingValue(account.modelMappings.sonnet || ""),
 				haiku: formatMappingValue(account.modelMappings.haiku || ""),
 			});
 		} else {
 			setModelMappings({
+				fable: "",
 				opus: "",
 				sonnet: "",
 				haiku: "",
@@ -81,10 +86,12 @@ export function AccountModelMappingsDialog({
 		setIsLoading(true);
 		try {
 			const mappingsToSend: { [key: string]: string | string[] } = {};
+			const fable = parseMappingValue(modelMappings.fable);
 			const opus = parseMappingValue(modelMappings.opus);
 			const sonnet = parseMappingValue(modelMappings.sonnet);
 			const haiku = parseMappingValue(modelMappings.haiku);
 
+			if (fable) mappingsToSend.fable = fable;
 			if (opus) mappingsToSend.opus = opus;
 			if (sonnet) mappingsToSend.sonnet = sonnet;
 			if (haiku) mappingsToSend.haiku = haiku;
@@ -99,7 +106,7 @@ export function AccountModelMappingsDialog({
 	};
 
 	const handleInputChange = (
-		modelType: "opus" | "sonnet" | "haiku",
+		modelType: "fable" | "opus" | "sonnet" | "haiku",
 		value: string,
 	) => {
 		setModelMappings((prev) => ({
@@ -131,7 +138,19 @@ export function AccountModelMappingsDialog({
 							</code>
 							) to cycle on rate limits.
 						</p>
-						<div className="grid grid-cols-3 gap-3">
+						<div className="grid grid-cols-2 gap-3">
+							<div className="space-y-1">
+								<Label htmlFor="fable" className="text-xs">
+									Fable
+								</Label>
+								<Input
+									id="fable"
+									value={modelMappings.fable}
+									onChange={(e) => handleInputChange("fable", e.target.value)}
+									placeholder={`e.g., ${LATEST_FABLE_MODEL}`}
+									className="h-8"
+								/>
+							</div>
 							<div className="space-y-1">
 								<Label htmlFor="opus" className="text-xs">
 									Opus

--- a/packages/dashboard-web/src/components/combos/FamilyActivationSection.tsx
+++ b/packages/dashboard-web/src/components/combos/FamilyActivationSection.tsx
@@ -18,9 +18,10 @@ import {
 } from "../ui/select";
 import { Switch } from "../ui/switch";
 
-const FAMILIES: ComboFamily[] = ["opus", "sonnet", "haiku"];
+const FAMILIES: ComboFamily[] = ["fable", "opus", "sonnet", "haiku"];
 
 const FAMILY_LABELS: Record<ComboFamily, string> = {
+	fable: "Fable",
 	opus: "Opus",
 	sonnet: "Sonnet",
 	haiku: "Haiku",

--- a/packages/database/src/migrations-pg.ts
+++ b/packages/database/src/migrations-pg.ts
@@ -274,7 +274,7 @@ export async function ensureSchemaPg(adapter: BunSqlAdapter): Promise<void> {
 	// Seed canonical families
 	await adapter.unsafe(`
 		INSERT INTO combo_family_assignments (family, combo_id, enabled)
-		VALUES ('opus', NULL, 0), ('sonnet', NULL, 0), ('haiku', NULL, 0)
+		VALUES ('fable', NULL, 0), ('opus', NULL, 0), ('sonnet', NULL, 0), ('haiku', NULL, 0)
 		ON CONFLICT (family) DO NOTHING
 	`);
 
@@ -527,7 +527,7 @@ export async function runMigrationsPg(adapter: BunSqlAdapter): Promise<void> {
 	`);
 	await adapter.unsafe(`
 		INSERT INTO combo_family_assignments (family, combo_id, enabled)
-		VALUES ('opus', NULL, 0), ('sonnet', NULL, 0), ('haiku', NULL, 0)
+		VALUES ('fable', NULL, 0), ('opus', NULL, 0), ('sonnet', NULL, 0), ('haiku', NULL, 0)
 		ON CONFLICT (family) DO NOTHING
 	`);
 

--- a/packages/database/src/migrations.ts
+++ b/packages/database/src/migrations.ts
@@ -342,10 +342,12 @@ export function ensureSchema(db: Database): void {
 		)
 	`);
 
-	// Seed the three canonical families so fresh installs have assignment rows
+	// Seed the canonical families so fresh installs have assignment rows
+	// (INSERT OR IGNORE also backfills new families on existing installs)
 	db.run(`
 		INSERT OR IGNORE INTO combo_family_assignments (family, combo_id, enabled)
-		VALUES ('opus',   NULL, 0),
+		VALUES ('fable',  NULL, 0),
+		       ('opus',   NULL, 0),
 		       ('sonnet', NULL, 0),
 		       ('haiku',  NULL, 0);
 	`);

--- a/packages/http-api/src/handlers/combos.ts
+++ b/packages/http-api/src/handlers/combos.ts
@@ -350,10 +350,10 @@ export function createFamiliesListHandler(dbOps: DatabaseOperations) {
 export function createFamilyAssignHandler(dbOps: DatabaseOperations) {
 	return async (req: Request, family: string): Promise<Response> => {
 		try {
-			const validFamilies: ComboFamily[] = ["opus", "sonnet", "haiku"];
+			const validFamilies: ComboFamily[] = ["fable", "opus", "sonnet", "haiku"];
 			if (!validFamilies.includes(family as ComboFamily)) {
 				return errorResponse(
-					BadRequest("family must be one of: opus, sonnet, haiku"),
+					BadRequest("family must be one of: fable, opus, sonnet, haiku"),
 				);
 			}
 

--- a/packages/openai-formats/src/reasoning.ts
+++ b/packages/openai-formats/src/reasoning.ts
@@ -26,9 +26,10 @@ const EFFORT_RANK: Record<ReasoningEffort, number> = {
 };
 
 const CLAUDE_REASONING_EFFORTS: Record<
-	"opus" | "sonnet" | "haiku",
+	"fable" | "opus" | "sonnet" | "haiku",
 	readonly ReasoningEffort[]
 > = {
+	fable: ["low", "medium", "high", "xhigh", "max"],
 	opus: ["low", "medium", "high", "xhigh", "max"],
 	sonnet: ["low", "medium", "high", "xhigh", "max"],
 	haiku: ["low", "medium"],

--- a/packages/providers/src/providers/bedrock/model-cache.ts
+++ b/packages/providers/src/providers/bedrock/model-cache.ts
@@ -19,9 +19,10 @@ interface BedrockModel {
 	searchKey: string;
 }
 
-type ModelFamily = "opus" | "sonnet" | "haiku";
+type ModelFamily = "fable" | "opus" | "sonnet" | "haiku";
 
 const MODEL_FAMILY_ALIASES: Record<ModelFamily, string[]> = {
+	fable: ["fable", "claude-fable", "claude-fable-5"],
 	opus: ["opus", "claude-opus", "claude-opus-4-6", "claude-4-opus"],
 	sonnet: ["sonnet", "claude-sonnet", "claude-sonnet-4-6", "claude-4-sonnet"],
 	haiku: ["haiku", "claude-haiku", "claude-haiku-4-5", "claude-4-haiku"],

--- a/packages/proxy/src/handlers/account-selector.ts
+++ b/packages/proxy/src/handlers/account-selector.ts
@@ -169,7 +169,12 @@ export async function selectAccountsForRequest(
 	if (model) {
 		const family = getModelFamily(model);
 		if (family) {
-			const validFamilies: readonly string[] = ["opus", "sonnet", "haiku"];
+			const validFamilies: readonly string[] = [
+				"fable",
+				"opus",
+				"sonnet",
+				"haiku",
+			];
 			if (!validFamilies.includes(family)) {
 				log.warn(`Unknown model family "${family}", skipping combo lookup`);
 			} else {

--- a/packages/types/src/combo.ts
+++ b/packages/types/src/combo.ts
@@ -1,4 +1,4 @@
-export type ComboFamily = "opus" | "sonnet" | "haiku";
+export type ComboFamily = "fable" | "opus" | "sonnet" | "haiku";
 
 // Database row types (snake_case, INTEGER booleans — match SQLite storage)
 export interface ComboRow {


### PR DESCRIPTION
## Summary

- Add Claude Fable 5 (`claude-fable-5`) as a new model family across model mappings, agent discovery, provider model caches (incl. Bedrock aliases), the CLI account wizard, and the dashboard mapping dialog
- Register Claude Opus 4.8 and make it the latest Opus
- Address Greptile review gaps from the initial fable family expansion (3514d4eb)

## Session tooling (token-usage reduction)

- Add `gitnexus-analyst` and `greptile-reviewer` haiku subagents (`.claude/agents/`) so GitNexus MCP calls and Greptile reviews run in throwaway contexts and return compact summaries instead of inflating the main session
- Update CLAUDE.md to route those workflows through the subagents; the GitNexus token-discipline section lives outside the auto-generated `gitnexus:start/end` block so reindexing doesn't wipe it

## Test plan

- [x] `greptile review` run on the branch — no blocking issues (remaining findings verified stale, fixed in 3514d4eb)
- [x] Verified fable present in Bedrock model aliases, CLI wizard prompts, and model-mapping JSDoc
- [ ] Smoke-test a fable-mapped account via the proxy on port 8081

🤖 Generated with [Claude Code](https://claude.com/claude-code)