### PR TITLE
fix: stop false "integrity check failed" on large DBs; bound payload growth

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -754,17 +754,30 @@ export default async function startServer(options?: {
 				log.info(
 					`Periodic cleanup: removed ${removedRequests} requests, ${removedPayloads} payloads in ${Date.now() - startTime}ms`,
 				);
-				// Reclaim a bounded chunk of freed pages. 8000 pages × 4 KiB = ~32 MiB
-				// per tick, off-thread via the incremental-vacuum worker. Small N
-				// keeps the writer-slot hold sub-100ms on local SSD so concurrent
-				// main-thread writes (rate-limit updates, OAuth refresh, post-
-				// processor inserts) don't pile up on busy_timeout. Pre-fix this
-				// path passed 200000 and silently fell back to a full main-thread
-				// VACUUM when auto_vacuum=NONE — see incrementalVacuum() in
-				// packages/database/src/database-operations.ts.
-				dbOps.incrementalVacuum(8000).catch((err) => {
-					log.error(`Incremental vacuum error: ${err}`);
-				});
+				// Reclaim freed pages adaptively. incrementalVacuumAdaptive()
+				// scales reclaim with the current freelist: in steady state it
+				// returns a small chunk (or no-ops on an empty freelist), but
+				// after a retention *drop* — which dumps a large surplus of free
+				// pages onto the freelist — it drains that surplus over a handful
+				// of hourly ticks instead of weeks. Each underlying worker call is
+				// bounded (~64 MiB) and the per-tick total is capped (~1 GiB), with
+				// yields between chunks, so the single writer slot is never held
+				// long and concurrent main-thread writes (rate-limit updates, OAuth
+				// refresh, post-processor inserts) aren't starved. Off-thread via
+				// the incremental-vacuum worker. Fire-and-forget so the cleanup
+				// callback isn't blocked on it.
+				dbOps
+					.incrementalVacuumAdaptive()
+					.then((r) => {
+						if (r.reclaimedPages > 0) {
+							log.info(
+								`Adaptive incremental vacuum reclaimed ${r.reclaimedPages} pages in ${r.chunks} chunk(s)`,
+							);
+						}
+					})
+					.catch((err) => {
+						log.error(`Incremental vacuum error: ${err}`);
+					});
 			}
 		} catch (err) {
 			log.error(`Periodic data retention cleanup error: ${err}`);

--- a/packages/config/src/data-retention.test.ts
+++ b/packages/config/src/data-retention.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Config } from "./index";
+
+function makeConfig(): { config: Config; cleanup: () => void } {
+	const dir = mkdtempSync(join(tmpdir(), "better-ccflare-config-"));
+	return {
+		config: new Config(join(dir, "config.json")),
+		cleanup: () => rmSync(dir, { recursive: true, force: true }),
+	};
+}
+
+describe("getDataRetentionDays", () => {
+	const originalEnv = process.env.DATA_RETENTION_DAYS;
+
+	beforeEach(() => {
+		delete process.env.DATA_RETENTION_DAYS;
+	});
+
+	afterEach(() => {
+		if (originalEnv === undefined) {
+			delete process.env.DATA_RETENTION_DAYS;
+		} else {
+			process.env.DATA_RETENTION_DAYS = originalEnv;
+		}
+	});
+
+	it("defaults to 1 day when no env or file override", () => {
+		const { config, cleanup } = makeConfig();
+		try {
+			expect(config.getDataRetentionDays()).toBe(1);
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("honors the env override (clamped to 1..365)", () => {
+		process.env.DATA_RETENTION_DAYS = "5";
+		const { config, cleanup } = makeConfig();
+		try {
+			expect(config.getDataRetentionDays()).toBe(5);
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("honors a file override", () => {
+		const { config, cleanup } = makeConfig();
+		try {
+			config.setDataRetentionDays(10);
+			expect(config.getDataRetentionDays()).toBe(10);
+		} finally {
+			cleanup();
+		}
+	});
+});

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -296,7 +296,11 @@ export class Config extends EventEmitter {
 		}
 		const fromFile = this.data.data_retention_days;
 		if (typeof fromFile === "number") return this.clamp(fromFile, 1, 365);
-		return 3; // Reduced from 7 to 3 days to reduce database size
+		// Default payload retention reduced to 1 day to bound request_payloads
+		// growth: each request stores up to ~4 MiB of conversation history, so
+		// high-volume proxies otherwise reach tens of GB. Override via the
+		// DATA_RETENTION_DAYS env var or the data_retention_days config key.
+		return 1;
 	}
 
 	setDataRetentionDays(days: number): void {

--- a/packages/dashboard-web/src/api.ts
+++ b/packages/dashboard-web/src/api.ts
@@ -59,6 +59,8 @@ export interface StorageInfoResponse {
 	last_quick_result: "ok" | "corrupt" | null;
 	last_full_check_at: string | null;
 	last_full_result: "ok" | "corrupt" | null;
+	last_quick_skip_reason: string | null;
+	last_full_skip_reason: string | null;
 	orphan_pages: number | null;
 	last_retention_sweep_at: string | null;
 	null_account_rows_24h: number;

--- a/packages/dashboard-web/src/components/overview/StorageIntegrityCard.tsx
+++ b/packages/dashboard-web/src/components/overview/StorageIntegrityCard.tsx
@@ -73,6 +73,9 @@ export function StorageIntegrityCard() {
 				: data?.last_quick_check_at != null
 					? `Last quick check ${formatRelative(data.last_quick_check_at)} — full check still pending`
 					: "—";
+		if (data?.last_full_skip_reason) {
+			description += " — full check skipped (DB too large); quick check passed";
+		}
 		badgeNode = (
 			<Badge variant="default" className="bg-success">
 				Healthy
@@ -142,6 +145,14 @@ export function StorageIntegrityCard() {
 									{formatRelative(data?.last_full_check_at ?? null)}
 									{data?.last_full_result === "corrupt" ? (
 										<span className="text-destructive"> (corrupt)</span>
+									) : data?.last_full_skip_reason ? (
+										<span
+											className="text-muted-foreground"
+											title={data.last_full_skip_reason}
+										>
+											{" "}
+											(skipped)
+										</span>
 									) : null}
 								</dd>
 							</div>

--- a/packages/database/src/__tests__/incremental-vacuum-adaptive.test.ts
+++ b/packages/database/src/__tests__/incremental-vacuum-adaptive.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for the adaptive incremental-vacuum backstop:
+ *   - `DatabaseOperations.getFreelistCount()` — a small PRAGMA reader.
+ *   - `DatabaseOperations.incrementalVacuumAdaptive()` — drives the
+ *     single-chunk `incrementalVacuum()` primitive in bounded chunks so the
+ *     file actually shrinks after a retention drop (large freelist) while
+ *     keeping each write transaction small.
+ *
+ * These run against a real on-disk temp DB. A fresh DB constructed through
+ * `DatabaseOperations` is born in auto_vacuum=INCREMENTAL (2) via the schema
+ * bootstrap, which is what makes `PRAGMA incremental_vacuum(N)` actually
+ * return free pages to the OS.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { randomBytes } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseOperations } from "../database-operations";
+
+function tempDbPath(): string {
+	return join(
+		tmpdir(),
+		`test-incvac-adaptive-${randomBytes(6).toString("hex")}.db`,
+	);
+}
+
+/**
+ * Insert `count` request + payload rows with a `bytesPerRow`-ish JSON blob so
+ * the on-disk file grows by a few hundred KB. request_payloads.id is a FK to
+ * requests(id) (cascade), and foreign_keys is ON, so the parent request row
+ * must exist first.
+ */
+async function seedRows(
+	dbOps: DatabaseOperations,
+	count: number,
+	bytesPerRow: number,
+): Promise<void> {
+	const adapter = dbOps.getAdapter();
+	const blob = "x".repeat(bytesPerRow);
+	const now = Date.now();
+	for (let i = 0; i < count; i++) {
+		const id = `seed-${i}-${now}`;
+		await adapter.run(
+			`INSERT INTO requests (id, timestamp, method, path, account_used, status_code, success, error_message, response_time_ms, failover_attempts)
+			 VALUES (?, ?, 'POST', '/v1/messages', NULL, 200, 1, NULL, 100, 0)`,
+			[id, now],
+		);
+		await adapter.run(
+			`INSERT INTO request_payloads (id, json, timestamp) VALUES (?, ?, ?)`,
+			[id, blob, now],
+		);
+	}
+}
+
+describe("DatabaseOperations.getFreelistCount", () => {
+	let dbOps: DatabaseOperations;
+
+	beforeEach(() => {
+		dbOps = new DatabaseOperations(tempDbPath());
+	});
+
+	afterEach(async () => {
+		await dbOps.dispose?.();
+	});
+
+	it("returns a number >= 0 on a fresh DB", () => {
+		const n = dbOps.getFreelistCount();
+		expect(typeof n).toBe("number");
+		expect(n).toBeGreaterThanOrEqual(0);
+		expect(Number.isInteger(n)).toBe(true);
+	});
+});
+
+describe("DatabaseOperations.incrementalVacuumAdaptive", () => {
+	let dbOps: DatabaseOperations;
+
+	beforeEach(() => {
+		dbOps = new DatabaseOperations(tempDbPath());
+	});
+
+	afterEach(async () => {
+		await dbOps.dispose?.();
+	});
+
+	it("returns { reclaimedPages: 0, chunks: 0 } quickly when there are no free pages", async () => {
+		// Fresh DB → no deletions → empty freelist → early return.
+		expect(dbOps.getFreelistCount()).toBe(0);
+		const r = await dbOps.incrementalVacuumAdaptive();
+		expect(r.reclaimedPages).toBe(0);
+		expect(r.chunks).toBe(0);
+	});
+
+	it("shrinks the freelist end-to-end after a bulk delete (auto_vacuum=INCREMENTAL)", async () => {
+		const adapter = dbOps.getAdapter();
+
+		// Sanity: fresh DB through DatabaseOperations is in INCREMENTAL (2).
+		const { auto_vacuum } = adapter
+			.getSQLiteDb()
+			.query("PRAGMA auto_vacuum")
+			.get() as { auto_vacuum: number };
+		expect(auto_vacuum).toBe(2);
+
+		// Grow the file: ~2000 rows of ~512 bytes of JSON ≈ ~1 MB of payload.
+		await seedRows(dbOps, 2000, 512);
+
+		// Delete everything (cascade removes payloads too).
+		await adapter.run(`DELETE FROM requests`, []);
+
+		// Checkpoint the WAL so the freed pages land on the main-file freelist.
+		await adapter.run(`PRAGMA wal_checkpoint(TRUNCATE)`, []);
+
+		const freeBefore = dbOps.getFreelistCount();
+		expect(freeBefore).toBeGreaterThan(0);
+
+		const r = await dbOps.incrementalVacuumAdaptive({
+			chunkPages: 64,
+			maxPagesPerTick: 100000,
+		});
+
+		const freeAfter = dbOps.getFreelistCount();
+		expect(freeAfter).toBeLessThan(freeBefore);
+		expect(r.reclaimedPages).toBeGreaterThan(0);
+		expect(r.chunks).toBeGreaterThan(0);
+		// With a generous per-tick budget the freelist should fully drain.
+		expect(freeAfter).toBe(0);
+	});
+
+	it("respects maxPagesPerTick (bounds the number of chunks)", async () => {
+		const adapter = dbOps.getAdapter();
+
+		await seedRows(dbOps, 2000, 512);
+		await adapter.run(`DELETE FROM requests`, []);
+		await adapter.run(`PRAGMA wal_checkpoint(TRUNCATE)`, []);
+
+		const freeBefore = dbOps.getFreelistCount();
+		expect(freeBefore).toBeGreaterThan(0);
+
+		// Cap reclaim at 32 pages with 16-page chunks → at most ceil(32/16)=2
+		// chunks should run.
+		const r = await dbOps.incrementalVacuumAdaptive({
+			chunkPages: 16,
+			maxPagesPerTick: 32,
+		});
+
+		expect(r.chunks).toBeLessThanOrEqual(2);
+		// Freelist still has pages left because the per-tick budget was small.
+		expect(dbOps.getFreelistCount()).toBeGreaterThan(0);
+	});
+});

--- a/packages/database/src/__tests__/integrity-storage-methods.test.ts
+++ b/packages/database/src/__tests__/integrity-storage-methods.test.ts
@@ -39,6 +39,8 @@ describe("DatabaseOperations.getIntegrityStatus / recordIntegrityResult", () => 
 		expect(s.lastQuickResult).toBeNull();
 		expect(s.lastFullCheckAt).toBeNull();
 		expect(s.lastFullResult).toBeNull();
+		expect(s.lastQuickSkipReason).toBeNull();
+		expect(s.lastFullSkipReason).toBeNull();
 	});
 
 	it("reflects ok status after recording a quick ok result", () => {
@@ -137,6 +139,94 @@ describe("DatabaseOperations.getIntegrityStatus / recordIntegrityResult", () => 
 		expect(dbOps.markIntegrityCheckRunning("quick")).toBe(true);
 		expect(dbOps.markIntegrityCheckRunning("full")).toBe(false);
 		expect(dbOps.markIntegrityCheckRunning("quick")).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests: recordIntegritySkipped
+// ---------------------------------------------------------------------------
+
+describe("DatabaseOperations.recordIntegritySkipped", () => {
+	let dbOps: DatabaseOperations;
+
+	beforeEach(() => {
+		dbOps = new DatabaseOperations(tempDbPath());
+	});
+
+	afterEach(() => {
+		dbOps.dispose?.();
+	});
+
+	it("fresh instance has null skip reasons", () => {
+		const s = dbOps.getIntegrityStatus();
+		expect(s.lastQuickSkipReason).toBeNull();
+		expect(s.lastFullSkipReason).toBeNull();
+	});
+
+	it("recording a full skip with no prior result leaves status unchecked", () => {
+		const before = Date.now();
+		dbOps.recordIntegritySkipped("full", "too big");
+		const after = Date.now();
+
+		const s = dbOps.getIntegrityStatus();
+		expect(s.status).toBe("unchecked");
+		expect(s.lastFullSkipReason).toBe("too big");
+		expect(s.lastFullResult).toBeNull();
+		expect(s.runningKind).toBeNull();
+		expect(s.lastFullCheckAt).toBeGreaterThanOrEqual(before);
+		expect(s.lastFullCheckAt).toBeLessThanOrEqual(after);
+	});
+
+	it("a full skip after a quick ok keeps status ok", () => {
+		dbOps.recordIntegrityResult("quick", "ok");
+		dbOps.recordIntegritySkipped("full", "too big");
+
+		const s = dbOps.getIntegrityStatus();
+		expect(s.status).toBe("ok");
+		expect(s.lastFullSkipReason).toBe("too big");
+		expect(s.lastQuickResult).toBe("ok");
+	});
+
+	it("STICKY: a full skip does NOT clear a full corrupt", () => {
+		dbOps.recordIntegrityResult("full", "corrupt", "index has missing entry");
+		dbOps.recordIntegritySkipped("full", "timeout");
+
+		const s = dbOps.getIntegrityStatus();
+		expect(s.status).toBe("corrupt");
+		expect(s.lastFullResult).toBe("corrupt");
+		expect(s.lastFullSkipReason).toBe("timeout");
+	});
+
+	it("a real quick ok after a quick skip clears the quick skip reason", () => {
+		dbOps.recordIntegritySkipped("quick", "x");
+		expect(dbOps.getIntegrityStatus().lastQuickSkipReason).toBe("x");
+
+		dbOps.recordIntegrityResult("quick", "ok");
+		const s = dbOps.getIntegrityStatus();
+		expect(s.lastQuickSkipReason).toBeNull();
+		expect(s.lastQuickResult).toBe("ok");
+	});
+
+	it("a real full ok after a full skip clears the full skip reason", () => {
+		dbOps.recordIntegritySkipped("full", "x");
+		expect(dbOps.getIntegrityStatus().lastFullSkipReason).toBe("x");
+
+		dbOps.recordIntegrityResult("full", "ok");
+		const s = dbOps.getIntegrityStatus();
+		expect(s.lastFullSkipReason).toBeNull();
+		expect(s.lastFullResult).toBe("ok");
+	});
+
+	it("releases the mutex (status not running) after a skip", () => {
+		expect(dbOps.markIntegrityCheckRunning("full")).toBe(true);
+		expect(dbOps.getIntegrityStatus().status).toBe("running");
+
+		dbOps.recordIntegritySkipped("full", "x");
+		const s = dbOps.getIntegrityStatus();
+		expect(s.status).not.toBe("running");
+		expect(s.runningKind).toBeNull();
+		// Mutex released — a new probe can be claimed.
+		expect(dbOps.markIntegrityCheckRunning("quick")).toBe(true);
 	});
 });
 

--- a/packages/database/src/database-operations.ts
+++ b/packages/database/src/database-operations.ts
@@ -229,6 +229,8 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 		lastFullCheckAt: null,
 		lastFullResult: null,
 		lastFullError: null,
+		lastQuickSkipReason: null,
+		lastFullSkipReason: null,
 	};
 
 	// Repositories
@@ -480,10 +482,14 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 			next.lastQuickCheckAt = now;
 			next.lastQuickResult = result;
 			next.lastQuickError = result === "corrupt" ? (error ?? null) : null;
+			// A completed quick probe supersedes any prior quick skip note.
+			next.lastQuickSkipReason = null;
 		} else {
 			next.lastFullCheckAt = now;
 			next.lastFullResult = result;
 			next.lastFullError = result === "corrupt" ? (error ?? null) : null;
+			// A completed full probe supersedes any prior full skip note.
+			next.lastFullSkipReason = null;
 			// A passing full check is a strict superset of quick_check, so it
 			// subsumes any lingering quick-corrupt: if the structurally-more-
 			// thorough probe is clean, the structurally-less-thorough probe's
@@ -500,6 +506,56 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 		next.lastCheckAt = now;
 
 		// Recompute collapsed status. Order: any corrupt result wins.
+		const fullCorrupt = next.lastFullResult === "corrupt";
+		const quickCorrupt = next.lastQuickResult === "corrupt";
+		if (fullCorrupt || quickCorrupt) {
+			next.status = "corrupt";
+			next.lastError =
+				next.lastFullError ?? next.lastQuickError ?? "integrity check failed";
+		} else if (next.lastQuickResult === "ok" || next.lastFullResult === "ok") {
+			next.status = "ok";
+			next.lastError = null;
+		} else {
+			next.status = "unchecked";
+			next.lastError = null;
+		}
+
+		this.integrityStatus = next;
+	}
+
+	/**
+	 * Record that an integrity probe was attempted but skipped — either the DB
+	 * is over the configured size threshold (so the full check would exceed the
+	 * worker timeout) or the worker run itself timed out. A skip is purely
+	 * informational: it preserves the last real ok/corrupt verdict and never
+	 * moves the collapsed `status` to "corrupt" (a timeout is not corruption).
+	 *
+	 * Releases the mutex just like `recordIntegrityResult` so the next tick is
+	 * eligible to run.
+	 */
+	recordIntegritySkipped(kind: "quick" | "full", reason: string): void {
+		const now = Date.now();
+		const next: IntegrityStatus = {
+			...this.integrityStatus,
+			runningKind: null,
+		};
+
+		next.lastCheckAt = now;
+
+		if (kind === "quick") {
+			next.lastQuickCheckAt = now;
+			next.lastQuickSkipReason = reason;
+			// Leave lastQuickResult/lastQuickError unchanged — preserve the last
+			// real verdict.
+		} else {
+			next.lastFullCheckAt = now;
+			next.lastFullSkipReason = reason;
+			// Leave lastFullResult/lastFullError unchanged — preserve the last
+			// real verdict.
+		}
+
+		// Recompute collapsed status with the SAME logic as
+		// recordIntegrityResult. A skip must never set status to "corrupt".
 		const fullCorrupt = next.lastFullResult === "corrupt";
 		const quickCorrupt = next.lastQuickResult === "corrupt";
 		if (fullCorrupt || quickCorrupt) {
@@ -1443,6 +1499,107 @@ OAuth tokens will need to be re-authenticated.
 		} finally {
 			worker.terminate();
 		}
+	}
+
+	/**
+	 * Read `PRAGMA freelist_count` — the number of free pages currently on the
+	 * SQLite freelist (deleted-but-not-yet-reclaimed pages). Returns 0 when not
+	 * in SQLite mode or no handle is open. Synchronous, like the other small
+	 * pragma readers in this file.
+	 */
+	getFreelistCount(): number {
+		if (!this.sqliteDb) return 0;
+		const result = this.sqliteDb.query("PRAGMA freelist_count").get() as {
+			freelist_count: number;
+		};
+		return result.freelist_count;
+	}
+
+	/**
+	 * Adaptive incremental vacuum — the unattended hourly backstop.
+	 *
+	 * With auto_vacuum=INCREMENTAL, deleted pages go to the freelist and are
+	 * reused by new inserts; the file only shrinks when we return surplus free
+	 * pages to the OS via `PRAGMA incremental_vacuum`. A fixed 8000-page chunk
+	 * per hour is fine in steady state, but after a retention *drop* the
+	 * freelist can hold hundreds of thousands of pages — at 8000/hour that file
+	 * shrinks over weeks. This method instead scales reclaim with the current
+	 * freelist so the file recovers over hours.
+	 *
+	 * It does NOT reclaim everything in one transaction. It drives the
+	 * single-chunk `incrementalVacuum()` primitive repeatedly:
+	 *   - each worker call reclaims at most `chunkPages` (~64 MiB at 4 KiB),
+	 *     bounding how long any one write transaction holds SQLite's single
+	 *     writer slot;
+	 *   - a per-tick ceiling of `maxPagesPerTick` (~1 GiB) caps total reclaim
+	 *     for one hourly tick;
+	 *   - between chunks we yield (`setTimeout(25)`) so concurrent proxy writes
+	 *     (rate-limit updates, OAuth refresh, post-processor inserts) can
+	 *     interleave and aren't starved.
+	 *
+	 * This keeps the LIVE proxy responsive while still draining a large
+	 * surplus over a handful of ticks. For a large *immediate* reclaim, the
+	 * one-off `scripts/shrink-db.sh` is the fast path; this is the hands-off
+	 * backstop.
+	 *
+	 * A STALL GUARD breaks the loop if a chunk fails to decrease the freelist
+	 * (e.g. auto_vacuum != 2 makes `incrementalVacuum()` a no-op, or writer
+	 * contention prevents progress) so we never spin on a no-op.
+	 *
+	 * `reclaimedPages` is the actual freelist delta across the whole call
+	 * (first reading minus last, clamped at >= 0). Under concurrent inserts
+	 * this is approximate — new deletes can re-grow the freelist mid-call — but
+	 * it's a faithful "how much did the file shrink" signal for logging.
+	 */
+	async incrementalVacuumAdaptive(opts?: {
+		maxPagesPerTick?: number;
+		chunkPages?: number;
+	}): Promise<{ reclaimedPages: number; chunks: number }> {
+		if (!this.sqliteDb || !this.resolvedDbPath) {
+			return { reclaimedPages: 0, chunks: 0 };
+		}
+
+		const MAX = opts?.maxPagesPerTick ?? 262144; // ~1 GiB at 4 KiB pages — per-tick reclaim ceiling
+		const CHUNK = opts?.chunkPages ?? 16384; // ~64 MiB per worker call — bounds each writer-slot hold
+
+		const initialFreelist = this.getFreelistCount();
+		let freelist = initialFreelist;
+		if (freelist <= 0) {
+			// Nothing to reclaim — steady state. Avoid spawning a worker.
+			return { reclaimedPages: 0, chunks: 0 };
+		}
+
+		const budget = Math.min(freelist, MAX);
+		let requestedPages = 0;
+		let chunks = 0;
+
+		while (requestedPages < budget && freelist > 0) {
+			const n = Math.min(CHUNK, budget - requestedPages);
+			const before = this.getFreelistCount();
+			await this.incrementalVacuum(n); // one bounded worker txn
+			const after = this.getFreelistCount();
+			requestedPages += n;
+			chunks += 1;
+
+			// STALL GUARD: if the freelist didn't shrink, further chunks won't
+			// either (no-op auto_vacuum mode, or writer contention). Stop rather
+			// than spin.
+			if (after >= before) {
+				break;
+			}
+
+			freelist = after;
+
+			// More work to do — yield the writer slot briefly so concurrent
+			// proxy writes can interleave between chunks.
+			if (requestedPages < budget && freelist > 0) {
+				await new Promise((r) => setTimeout(r, 25));
+			}
+		}
+
+		const finalFreelist = this.getFreelistCount();
+		const reclaimedPages = Math.max(0, initialFreelist - finalFreelist);
+		return { reclaimedPages, chunks };
 	}
 
 	// API Key operations delegated to repository

--- a/packages/database/src/integrity-check-runner.ts
+++ b/packages/database/src/integrity-check-runner.ts
@@ -42,7 +42,7 @@ export async function runIntegrityCheckInWorker(
 		busyTimeoutMs?: number;
 		timeoutMs?: number;
 	},
-): Promise<{ ok: true } | { ok: false; error: string }> {
+): Promise<{ ok: true } | { ok: false; error: string; timedOut?: boolean }> {
 	let worker: Worker;
 	if (EMBEDDED_INTEGRITY_CHECK_WORKER_CODE) {
 		const workerCode = Buffer.from(
@@ -62,18 +62,20 @@ export async function runIntegrityCheckInWorker(
 
 	try {
 		const result = await new Promise<
-			{ ok: true } | { ok: false; error: string }
+			{ ok: true } | { ok: false; error: string; timedOut?: boolean }
 		>((resolve, reject) => {
 			worker.onmessage = (event: MessageEvent) => resolve(event.data);
 			worker.onerror = (event: ErrorEvent) =>
 				reject(new Error(event.message ?? "integrity worker error"));
 			timeoutHandle = setTimeout(() => {
 				// resolve (not reject) — we want this to look like any other
-				// "non-ok" result so callers (recordIntegrityResult, the
-				// on-demand endpoint) treat it uniformly and release the mutex.
+				// "non-ok" result so callers release the mutex. `timedOut` lets
+				// callers distinguish a hung worker (not corruption) from a
+				// genuine corrupt verdict and record it as "skipped" instead.
 				resolve({
 					ok: false,
 					error: `worker timed out after ${timeoutMs}ms — bun:sqlite call likely hung on disk I/O; check filesystem health`,
+					timedOut: true,
 				});
 			}, timeoutMs);
 			worker.postMessage({

--- a/packages/http-api/src/handlers/storage.ts
+++ b/packages/http-api/src/handlers/storage.ts
@@ -27,6 +27,8 @@ export function createStorageHandler(dbOps: DatabaseOperations) {
 				? new Date(integrity.lastFullCheckAt).toISOString()
 				: null,
 			last_full_result: integrity.lastFullResult,
+			last_quick_skip_reason: integrity.lastQuickSkipReason,
+			last_full_skip_reason: integrity.lastFullSkipReason,
 			orphan_pages: metrics.orphanPages,
 			last_retention_sweep_at: metrics.lastRetentionSweepAt
 				? new Date(metrics.lastRetentionSweepAt).toISOString()

--- a/packages/proxy/src/__tests__/integrity-scheduler.test.ts
+++ b/packages/proxy/src/__tests__/integrity-scheduler.test.ts
@@ -24,7 +24,9 @@ import type { DatabaseOperations } from "@better-ccflare/database";
 // type-only import and is erased at runtime, so it doesn't need a stub.
 // ---------------------------------------------------------------------------
 
-type WorkerResult = { ok: true } | { ok: false; error: string };
+type WorkerResult =
+	| { ok: true }
+	| { ok: false; error: string; timedOut?: boolean };
 
 let workerResultByKind: { quick: WorkerResult; full: WorkerResult } = {
 	quick: { ok: true },
@@ -53,6 +55,9 @@ interface MockDbOpsOptions {
 	fullResult?: { ok: true } | { ok: false; error: string } | Error;
 	dbPath?: string | undefined;
 	canClaim?: boolean;
+	/** Bytes returned by getDbSizeBytes(); defaults small (below the full-check
+	 *  size threshold) so full checks run normally unless a test overrides it. */
+	dbSizeBytes?: number;
 }
 
 function makeDbOps(opts: MockDbOpsOptions = {}): DatabaseOperations {
@@ -77,14 +82,22 @@ function makeDbOps(opts: MockDbOpsOptions = {}): DatabaseOperations {
 	const recordIntegrityResult = mock(() => {
 		claimed = false;
 	});
+	const recordIntegritySkipped = mock(() => {
+		claimed = false;
+	});
 	const getResolvedDbPath = mock(() => opts.dbPath);
+	// Default well below the 16 GiB full-check threshold so full checks run
+	// normally; tests that exercise the size-skip path pass a large value.
+	const getDbSizeBytes = mock(async () => opts.dbSizeBytes ?? 1024);
 
 	return {
 		runQuickIntegrityCheck,
 		runFullIntegrityCheck,
 		markIntegrityCheckRunning,
 		recordIntegrityResult,
+		recordIntegritySkipped,
 		getResolvedDbPath,
+		getDbSizeBytes,
 	} as unknown as DatabaseOperations;
 }
 
@@ -272,6 +285,60 @@ describe("runIntegrityCheckOnDemand", () => {
 		const [, calledOpts] = mockRunIntegrityCheckInWorker.mock.calls[0];
 		expect(calledOpts).toEqual({ kind: "full" });
 		expect(dbOps.runFullIntegrityCheck).not.toHaveBeenCalled();
+	});
+
+	it("full on an oversized DB skips integrity_check and runs quick_check instead", async () => {
+		// 20 GiB — above the 16 GiB default threshold. The full integrity_check
+		// would time out, so it's recorded as skipped (not corrupt) and a
+		// quick_check is run in its place.
+		const dbOps = makeDbOps({
+			dbPath: "/tmp/test.db",
+			dbSizeBytes: 20 * 1024 * 1024 * 1024,
+		});
+		workerResultByKind.quick = { ok: true };
+
+		const out = await runIntegrityCheckOnDemand(dbOps, "full");
+		expect(out.ok).toBe(true);
+		if (out.ok) expect(out.result).toBe("ok"); // a skip is not corruption
+
+		// Full probe recorded as skipped with an explanatory reason…
+		const skipCall = (
+			dbOps.recordIntegritySkipped as ReturnType<typeof mock>
+		).mock.calls.at(-1);
+		expect(skipCall?.[0]).toBe("full");
+		expect(String(skipCall?.[1])).toContain("skipped");
+
+		// …and the worker was invoked for a quick check, not a full one.
+		expect(mockRunIntegrityCheckInWorker).toHaveBeenCalledTimes(1);
+		const [, calledOpts] = mockRunIntegrityCheckInWorker.mock.calls[0];
+		expect(calledOpts).toEqual({ kind: "quick" });
+		expect(dbOps.recordIntegrityResult).toHaveBeenCalledWith("quick", "ok");
+	});
+
+	it("a worker TIMEOUT is recorded as skipped, not corrupt", async () => {
+		const dbOps = makeDbOps({ dbPath: "/tmp/test.db" });
+		workerResultByKind.full = {
+			ok: false,
+			error: "worker timed out after 600000ms — bun:sqlite call likely hung",
+			timedOut: true,
+		};
+
+		const out = await runIntegrityCheckOnDemand(dbOps, "full");
+		expect(out.ok).toBe(true);
+		// A timeout is a hung worker, not corruption.
+		if (out.ok) expect(out.result).toBe("ok");
+
+		const skipCall = (
+			dbOps.recordIntegritySkipped as ReturnType<typeof mock>
+		).mock.calls.at(-1);
+		expect(skipCall?.[0]).toBe("full");
+		expect(String(skipCall?.[1])).toContain("timed out");
+		// Crucially: it must NOT be recorded as corrupt.
+		expect(dbOps.recordIntegrityResult).not.toHaveBeenCalledWith(
+			"full",
+			"corrupt",
+			expect.anything(),
+		);
 	});
 
 	it("a quick on-demand check followed by a full corrupt produces sticky-corrupt status", async () => {

--- a/packages/proxy/src/integrity-scheduler.ts
+++ b/packages/proxy/src/integrity-scheduler.ts
@@ -35,6 +35,14 @@ import { Logger } from "@better-ccflare/logger";
 
 const DEFAULT_QUICK_INTERVAL_HOURS = 6;
 const DEFAULT_FULL_INTERVAL_HOURS = 24;
+/**
+ * Above this DB size the full `PRAGMA integrity_check` can't finish inside the
+ * worker timeout (a 27 GiB DB times out), so the scheduler skips it and runs a
+ * `quick_check` instead. A timeout is NOT corruption — recording one as such
+ * lights a false cross-dashboard "integrity check failed" banner. Override via
+ * `CCFLARE_FULL_INTEGRITY_MAX_DB_BYTES` (0 = no limit / never skip).
+ */
+const DEFAULT_FULL_INTEGRITY_MAX_DB_BYTES = 16 * 1024 * 1024 * 1024; // 16 GiB
 const QUICK_INITIAL_DELAY_MS = 30 * TIME_CONSTANTS.SECOND;
 /** Delay full check past startup spike of disk I/O (dashboard build, schema
  *  migrations, performance index creation) so it doesn't compound with
@@ -57,6 +65,29 @@ function parseIntervalEnv(
 	}
 	if (parsed === 0) return null;
 	return parsed * TIME_CONSTANTS.HOUR;
+}
+
+/**
+ * Resolve the max DB size (bytes) above which the full integrity check is
+ * skipped in favour of a quick check. Reads
+ * `CCFLARE_FULL_INTEGRITY_MAX_DB_BYTES`: unset/empty → default; positive
+ * integer → that value; `0` → no limit (never skip, returns +Infinity);
+ * anything else → warn + default.
+ */
+function resolveMaxFullIntegrityBytes(logger: Logger): number {
+	const raw = process.env.CCFLARE_FULL_INTEGRITY_MAX_DB_BYTES;
+	if (raw === undefined || raw === "")
+		return DEFAULT_FULL_INTEGRITY_MAX_DB_BYTES;
+	const parsed = Number(raw);
+	if (!Number.isInteger(parsed) || parsed < 0) {
+		logger.warn(
+			`Invalid CCFLARE_FULL_INTEGRITY_MAX_DB_BYTES="${raw}", using default ${DEFAULT_FULL_INTEGRITY_MAX_DB_BYTES}`,
+		);
+		return DEFAULT_FULL_INTEGRITY_MAX_DB_BYTES;
+	}
+	// 0 disables the size limit — the full check always runs.
+	if (parsed === 0) return Number.POSITIVE_INFINITY;
+	return parsed;
 }
 
 export function startIntegrityScheduler(
@@ -170,12 +201,26 @@ export function startIntegrityScheduler(
  * lightweight there, so blocking is fine).
  *
  * Records the result and (implicitly) releases the mutex via
- * `recordIntegrityResult`.
+ * `recordIntegrityResult` (or `recordIntegritySkipped` for size-threshold /
+ * timeout skips).
+ *
+ * Skip semantics (neither is corruption, so both keep the dashboard healthy):
+ *  - **Size threshold**: when a `full` check is requested but the DB is over
+ *    `CCFLARE_FULL_INTEGRITY_MAX_DB_BYTES`, the full `integrity_check` can't
+ *    finish inside the worker timeout, so we record the full probe as skipped
+ *    and run a `quick_check` instead, recording ITS result normally.
+ *  - **Worker timeout**: a `!ok && timedOut` worker result is a hung
+ *    bun:sqlite call (failing disk / unresponsive NFS), not corruption — it is
+ *    recorded as skipped, not corrupt.
+ *
+ * The return contract stays `{ result: "ok" | "corrupt"; error }`; a skip
+ * returns `{ result: "ok", error: null }` because nothing is corrupt.
  */
 async function runCheckLocked(
 	dbOps: DatabaseOperations,
 	kind: "quick" | "full",
 ): Promise<{ result: "ok" | "corrupt"; error: string | null }> {
+	const logger = new Logger("IntegrityScheduler");
 	try {
 		const dbPath = dbOps.getResolvedDbPath();
 		if (!dbPath) {
@@ -191,17 +236,50 @@ async function runCheckLocked(
 			);
 			return { result, error: result === "corrupt" ? out : null };
 		}
+
+		// Full check on an oversized DB: skip integrity_check (it would time
+		// out) and run quick_check instead, recording each probe separately.
+		if (kind === "full") {
+			const sizeBytes = await dbOps.getDbSizeBytes();
+			const maxBytes = resolveMaxFullIntegrityBytes(logger);
+			if (sizeBytes > maxBytes) {
+				const reason = `full integrity_check skipped — DB is ${(
+					sizeBytes / 1024 / 1024 / 1024
+				).toFixed(1)} GB (> ${(maxBytes / 1024 / 1024 / 1024).toFixed(
+					1,
+				)} GB threshold, CCFLARE_FULL_INTEGRITY_MAX_DB_BYTES); ran quick_check instead`;
+				logger.warn(reason);
+				dbOps.recordIntegritySkipped("full", reason);
+
+				const quickResult = await runIntegrityCheckInWorker(dbPath, {
+					kind: "quick",
+				});
+				if (quickResult.ok) {
+					dbOps.recordIntegrityResult("quick", "ok");
+					return { result: "ok", error: null };
+				}
+				if (quickResult.timedOut) {
+					dbOps.recordIntegritySkipped("quick", quickResult.error);
+					return { result: "ok", error: null };
+				}
+				dbOps.recordIntegrityResult("quick", "corrupt", quickResult.error);
+				return { result: "corrupt", error: quickResult.error };
+			}
+		}
+
 		const workerResult = await runIntegrityCheckInWorker(dbPath, { kind });
-		const result = workerResult.ok ? "ok" : "corrupt";
-		dbOps.recordIntegrityResult(
-			kind,
-			result,
-			workerResult.ok ? null : workerResult.error,
-		);
-		return {
-			result,
-			error: workerResult.ok ? null : workerResult.error,
-		};
+		if (workerResult.ok) {
+			dbOps.recordIntegrityResult(kind, "ok");
+			return { result: "ok", error: null };
+		}
+		// A worker timeout is a hung bun:sqlite call, not corruption — record
+		// it as skipped so it doesn't light the false corruption banner.
+		if (workerResult.timedOut) {
+			dbOps.recordIntegritySkipped(kind, workerResult.error);
+			return { result: "ok", error: null };
+		}
+		dbOps.recordIntegrityResult(kind, "corrupt", workerResult.error);
+		return { result: "corrupt", error: workerResult.error };
 	} catch (error) {
 		const msg = String(error);
 		dbOps.recordIntegrityResult(kind, "corrupt", msg);

--- a/packages/types/src/stats.ts
+++ b/packages/types/src/stats.ts
@@ -19,6 +19,12 @@ export type IntegrityCheckKind = "quick" | "full";
  *  - `corrupt`: at least one of the last-known probes returned non-"ok".
  *    A subsequent quick `ok` clears quick-only corruption but does NOT clear
  *    a full `corrupt`; only another full `ok` does that.
+ *
+ * A "skipped" probe (the full check was skipped because the DB is over the
+ * size threshold, or a worker run timed out) is informational only: it is
+ * recorded in `lastQuickSkipReason` / `lastFullSkipReason` and does NOT mark
+ * the DB corrupt. The collapsed `status` stays driven by the last real
+ * ok/corrupt results — a skip never moves `status` to "corrupt".
  */
 export interface IntegrityStatus {
 	status: "ok" | "corrupt" | "unchecked" | "running";
@@ -36,6 +42,10 @@ export interface IntegrityStatus {
 	lastFullCheckAt: number | null;
 	lastFullResult: "ok" | "corrupt" | null;
 	lastFullError: string | null;
+	/** Reason the most recent quick probe was skipped (size threshold / timeout) instead of completing; null if it completed. */
+	lastQuickSkipReason: string | null;
+	/** Reason the most recent full probe was skipped (DB over size threshold, or worker timeout) instead of completing; null if it completed. */
+	lastFullSkipReason: string | null;
 }
 
 // Stats types

--- a/scripts/shrink-db.sh
+++ b/scripts/shrink-db.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+#
+# shrink-db.sh — prune old request payloads and reclaim disk for a bloated
+# better-ccflare SQLite database, WITHOUT a full blocking VACUUM.
+#
+# WHY THIS SCRIPT EXISTS
+#   On a busy proxy the request_payloads table can grow to tens of GB (full
+#   request/response JSON, capped at 4 MiB request + 256 KiB response each).
+#   Retention deletes keep the *logical* window bounded, but with
+#   auto_vacuum=INCREMENTAL the freed pages are recycled by new inserts and
+#   the file stays at its high-water mark until you explicitly return pages to
+#   the OS. This script does that the safe way: prune, checkpoint, then
+#   incremental_vacuum in bounded chunks — each chunk a short write
+#   transaction that shares the writer slot with the live proxy via
+#   busy_timeout, instead of one multi-minute exclusive VACUUM.
+#
+# SAFETY
+#   * Runs against the LIVE database while the proxy keeps serving. Each step
+#     uses a busy_timeout so it backs off rather than fighting the proxy.
+#   * Prefer running during a low-traffic window — deletes and vacuum chunks
+#     contend for SQLite's single writer slot.
+#   * Does NOT take the proxy offline. Does NOT do a full VACUUM by default
+#     (that needs an exclusive lock + up to ~1x the DB size in temp space).
+#   * Idempotent and resumable: re-run any time; it only ever removes rows
+#     older than the retention window and reclaims already-free pages.
+#
+# USAGE
+#   scripts/shrink-db.sh [--days N] [--dry-run] [--chunk PAGES] [--full-vacuum] [--yes]
+#
+#   --days N        Delete payloads older than N days (default: 1).
+#                   Request *metadata* (the `requests` table) is left alone.
+#   --dry-run       Report what would be deleted/reclaimed; change nothing.
+#   --chunk PAGES   Pages per incremental_vacuum step (default: 65536 = 256 MiB
+#                   at 4 KiB pages). Smaller = shorter writer holds.
+#   --full-vacuum   After pruning, run a full blocking VACUUM instead of
+#                   incremental. EXCLUSIVE lock; stalls the proxy for minutes;
+#                   needs free disk ~= final DB size. Use only in a real
+#                   maintenance window.
+#   --yes           Skip the confirmation prompt.
+#
+# ENV
+#   BETTER_CCFLARE_DB_PATH   Override DB path (default:
+#                            ~/.config/better-ccflare/better-ccflare.db)
+#
+set -euo pipefail
+
+DAYS=1
+DRY_RUN=0
+CHUNK=65536
+FULL_VACUUM=0
+ASSUME_YES=0
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--days) DAYS="${2:?--days needs a value}"; shift 2 ;;
+		--dry-run) DRY_RUN=1; shift ;;
+		--chunk) CHUNK="${2:?--chunk needs a value}"; shift 2 ;;
+		--full-vacuum) FULL_VACUUM=1; shift ;;
+		--yes) ASSUME_YES=1; shift ;;
+		-h|--help) sed -n '2,52p' "$0"; exit 0 ;;
+		*) echo "Unknown arg: $1" >&2; exit 2 ;;
+	esac
+done
+
+DB="${BETTER_CCFLARE_DB_PATH:-$HOME/.config/better-ccflare/better-ccflare.db}"
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+	echo "ERROR: sqlite3 not found on PATH." >&2; exit 1
+fi
+if [[ ! -f "$DB" ]]; then
+	echo "ERROR: database not found at: $DB" >&2
+	echo "Set BETTER_CCFLARE_DB_PATH if it lives elsewhere." >&2; exit 1
+fi
+
+# Validate numeric args.
+[[ "$DAYS" =~ ^[0-9]+$ ]] || { echo "ERROR: --days must be an integer" >&2; exit 2; }
+[[ "$CHUNK" =~ ^[0-9]+$ && "$CHUNK" -ge 1 ]] || { echo "ERROR: --chunk must be a positive integer" >&2; exit 2; }
+
+# 10s busy timeout so every statement backs off under proxy write contention
+# instead of erroring out immediately. `.timeout` is a dot-command (no output
+# row), unlike `PRAGMA busy_timeout` which would print its value and corrupt
+# scalar query captures below.
+SQLITE=(sqlite3 -cmd ".timeout 10000" "$DB")
+
+human() { # bytes -> human readable
+	awk -v b="$1" 'BEGIN{ s="B KB MB GB TB"; split(s,u," "); i=1; while(b>=1024 && i<5){b/=1024;i++} printf "%.2f %s", b, u[i] }'
+}
+
+cutoff_ms() { # N days ago, as Unix ms epoch (matches request_payloads.timestamp)
+	"${SQLITE[@]}" "SELECT CAST(strftime('%s','now','-$DAYS days') AS INTEGER) * 1000;"
+}
+
+echo "=== better-ccflare DB shrink ==="
+echo "DB:            $DB"
+PAGE_SIZE="$("${SQLITE[@]}" 'PRAGMA page_size;')"
+AUTO_VACUUM="$("${SQLITE[@]}" 'PRAGMA auto_vacuum;')"
+SIZE_BEFORE="$(stat -f%z "$DB" 2>/dev/null || stat -c%s "$DB")"
+FREELIST_BEFORE="$("${SQLITE[@]}" 'PRAGMA freelist_count;')"
+PAYLOAD_ROWS="$("${SQLITE[@]}" 'SELECT COUNT(*) FROM request_payloads;')"
+PAYLOAD_BYTES="$("${SQLITE[@]}" 'SELECT COALESCE(SUM(LENGTH(json)),0) FROM request_payloads;')"
+CUTOFF="$(cutoff_ms)"
+OLD_ROWS="$("${SQLITE[@]}" "SELECT COUNT(*) FROM request_payloads WHERE timestamp IS NOT NULL AND timestamp < $CUTOFF;")"
+
+echo "page_size:     $PAGE_SIZE   auto_vacuum: $AUTO_VACUUM (2=incremental)"
+echo "file size:     $(human "$SIZE_BEFORE")"
+echo "freelist:      $FREELIST_BEFORE pages (~$(human $((FREELIST_BEFORE * PAGE_SIZE))) reclaimable now)"
+echo "payload rows:  $PAYLOAD_ROWS   payload bytes: $(human "$PAYLOAD_BYTES")"
+echo "retention:     deleting payloads older than $DAYS day(s)  → $OLD_ROWS rows eligible"
+echo
+
+if [[ "$AUTO_VACUUM" != "2" && "$FULL_VACUUM" != "1" ]]; then
+	echo "WARNING: auto_vacuum=$AUTO_VACUUM (not INCREMENTAL). incremental_vacuum will" >&2
+	echo "         be a no-op. Use --full-vacuum, or let the server's startup migration" >&2
+	echo "         convert the DB to incremental mode first." >&2
+fi
+
+if [[ "$DRY_RUN" == "1" ]]; then
+	echo "[dry-run] Would delete $OLD_ROWS payload rows and reclaim free pages. No changes made."
+	exit 0
+fi
+
+if [[ "$ASSUME_YES" != "1" ]]; then
+	read -r -p "Proceed against the LIVE database? [y/N] " ans
+	[[ "$ans" == "y" || "$ans" == "Y" ]] || { echo "Aborted."; exit 0; }
+fi
+
+# ---------------------------------------------------------------------------
+# 1) Prune old payloads in small batches (matches the app's BATCH_SIZE=2000),
+#    so each DELETE is a short transaction the proxy can interleave with.
+# ---------------------------------------------------------------------------
+echo "[1/3] Pruning payloads older than $DAYS day(s)…"
+deleted_total=0
+while :; do
+	n="$("${SQLITE[@]}" "
+		DELETE FROM request_payloads
+		WHERE id IN (
+			SELECT id FROM request_payloads
+			WHERE timestamp IS NOT NULL AND timestamp < $CUTOFF
+			LIMIT 2000
+		);
+		SELECT changes();
+	")"
+	deleted_total=$((deleted_total + n))
+	printf '\r      deleted %s rows…' "$deleted_total"
+	[[ "$n" -eq 2000 ]] || break
+done
+# Also sweep orphaned payloads (payload with no matching request row).
+"${SQLITE[@]}" "DELETE FROM request_payloads WHERE id NOT IN (SELECT id FROM requests);" >/dev/null
+echo " done ($deleted_total removed)."
+
+# ---------------------------------------------------------------------------
+# 2) Checkpoint the WAL so freed pages are visible to the vacuum, and the WAL
+#    doesn't balloon from the deletes above.
+# ---------------------------------------------------------------------------
+echo "[2/3] Checkpointing WAL (TRUNCATE)…"
+"${SQLITE[@]}" "PRAGMA wal_checkpoint(TRUNCATE);" >/dev/null || true
+
+# ---------------------------------------------------------------------------
+# 3) Reclaim free pages back to the OS.
+# ---------------------------------------------------------------------------
+if [[ "$FULL_VACUUM" == "1" ]]; then
+	echo "[3/3] Running FULL VACUUM (exclusive lock — proxy writes will stall)…"
+	AVAIL="$(df -k "$(dirname "$DB")" | awk 'NR==2{print $4*1024}')"
+	if [[ "$AVAIL" -lt "$SIZE_BEFORE" ]]; then
+		echo "ERROR: full VACUUM needs ~$(human "$SIZE_BEFORE") free; only $(human "$AVAIL") available." >&2
+		echo "       Free disk or use the default incremental path instead." >&2
+		exit 1
+	fi
+	time "${SQLITE[@]}" "VACUUM;"
+else
+	echo "[3/3] Reclaiming free pages via incremental_vacuum (chunk=$CHUNK pages)…"
+	while :; do
+		free="$("${SQLITE[@]}" 'PRAGMA freelist_count;')"
+		[[ "$free" -gt 0 ]] || break
+		"${SQLITE[@]}" "PRAGMA incremental_vacuum($CHUNK); PRAGMA wal_checkpoint(TRUNCATE);" >/dev/null
+		now_size="$(stat -f%z "$DB" 2>/dev/null || stat -c%s "$DB")"
+		printf '\r      freelist %s pages, file %s…   ' "$free" "$(human "$now_size")"
+		# brief yield so the proxy's writer can slip in between chunks
+		sleep 0.1
+	done
+	echo " done."
+fi
+
+SIZE_AFTER="$(stat -f%z "$DB" 2>/dev/null || stat -c%s "$DB")"
+echo
+echo "=== Result ==="
+echo "before: $(human "$SIZE_BEFORE")"
+echo "after:  $(human "$SIZE_AFTER")"
+echo "freed:  $(human $((SIZE_BEFORE - SIZE_AFTER)))"
+echo
+echo "Tip: set a smaller retention window so it doesn't regrow —"
+echo "     bun run cli  (Settings), or DATA_RETENTION_DAYS env, or"
+echo "     POST /api/config/retention {\"payloadDays\": $DAYS}."


### PR DESCRIPTION
## Problem

The Storage Integrity card surfaced **"Database integrity check failed — worker timed out after 3600000ms — bun:sqlite call likely hung on disk I/O"** on a ~27 GB database.

This was a **false alarm**: a full `PRAGMA integrity_check` reads the entire file and can't finish inside the worker timeout on a multi-GB DB, and a worker **timeout was recorded as `corrupt`**, which lights the cross-dashboard corruption banner. A timeout (or a deliberate size-skip) is **not** corruption.

Diagnosis (verified read-only): the 27 GB is entirely `request_payloads.json` (~29 GB of JSON, avg 780 KB/row, max 7.8 MB) spanning only ~3 days — payload logging produces ~9 GB/day. `freelist_count` was 0, so the file is all live data (pages recycle at steady state); it only shrinks when a retention drop creates a free-page surplus that `incremental_vacuum` returns to the OS.

## Changes

### Integrity robustness — size-aware + clear, non-alarming status
- Skip the full `integrity_check` when the DB exceeds a size threshold (default **16 GiB**, env `CCFLARE_FULL_INTEGRITY_MAX_DB_BYTES`; `0` = never skip) and run `quick_check` instead.
- Record both the size-skip **and** any worker timeout as a non-corrupt **`skipped`** outcome with a clear reason (`lastQuickSkipReason` / `lastFullSkipReason`), surfaced via `/api/storage` and the Storage Integrity card — instead of `corrupt`.
- The collapsed `status` stays driven by real `ok`/`corrupt` verdicts (sticky-corrupt rule preserved); a skip never marks the DB corrupt, and a completed probe clears a stale skip note.

### Bound payload growth + reclaim (prevent regrowth)
- Lower default payload retention **3d → 1d** (each request stores up to ~4 MiB of conversation history; high-volume proxies otherwise reach tens of GB). Still overridable via `DATA_RETENTION_DAYS` / `data_retention_days`.
- Make the hourly incremental vacuum **adaptive**: it scales reclaim with the freelist so a retention drop's surplus drains over **hours, not weeks**, while keeping each worker transaction ~64 MiB and the per-tick total ~1 GiB (with yields) so the live proxy's single writer slot is never held long. Steady state with an empty freelist is a no-op.

### Operator tooling
- `scripts/shrink-db.sh`: prune old payloads + chunked `incremental_vacuum` to shrink a bloated **live** DB without a full blocking VACUUM. Supports `--dry-run`, `--days N`, `--chunk`, and `--full-vacuum`. Intended to be run in a low-traffic window for the one-time reclaim; the adaptive vacuum is the unattended backstop.

## Notes
- **No schema change** → no migration / PostgreSQL port needed (in-memory status fields + a config default + SQLite-only vacuum).
- Auto-generated inline workers untouched.
- Version intentionally **not** bumped (handled by the release system).

## Tests
- `recordIntegritySkipped` semantics (preserves last verdict, never corrupt, releases mutex, clears on completion).
- Scheduler **size-skip** and **timeout-skip** branches (result `ok`, recorded as skipped not corrupt).
- 1-day retention default (+ env/file overrides).
- Adaptive vacuum drains the freelist and reports reclaimed pages.

All affected suites pass (735 pass / 0 fail repo-wide; the unrelated `oauth.test.ts` `SQLITE_IOERR_VNODE` teardown error reproduces on a clean baseline and is environmental).

🤖 Generated with [Claude Code](https://claude.com/claude-code)