### PR TITLE
feat(proxy): optional X-Anthropic-Agent-Id header for explicit agent attribution

### DIFF
--- a/packages/proxy/src/handlers/agent-interceptor.ts
+++ b/packages/proxy/src/handlers/agent-interceptor.ts
@@ -26,6 +26,7 @@ export interface AgentInterceptResult {
 export async function interceptAndModifyRequest(
 	requestBody: ArrayBuffer | RequestBodyContext | null,
 	dbOps: DatabaseOperations,
+	requestHeaders?: Headers,
 ): Promise<AgentInterceptResult> {
 	const bodyContext =
 		requestBody instanceof RequestBodyContext
@@ -52,6 +53,25 @@ export async function interceptAndModifyRequest(
 		// Extract original model
 		const originalModel =
 			typeof parsedBody.model === "string" ? parsedBody.model : null;
+
+		// Explicit agent attribution via header (vendor-neutral): lets any client —
+		// a multi-agent orchestrator, a router, an SDK wrapper — declare which agent
+		// issued the request, so downstream observability tools can attribute usage
+		// per agent. Takes precedence over system-prompt matching; absent = unchanged.
+		const explicitAgentId = requestHeaders
+			?.get("x-anthropic-agent-id")
+			?.trim();
+		if (explicitAgentId) {
+			log.debug(
+				`Agent attributed via x-anthropic-agent-id: ${explicitAgentId}`,
+			);
+			return {
+				modifiedBody: requestBodyBuffer,
+				agentUsed: explicitAgentId,
+				originalModel,
+				appliedModel: originalModel,
+			};
+		}
 
 		// Extract system prompt to detect agent usage
 		const systemPrompt = extractSystemPrompt(parsedBody as RequestBody);

--- a/packages/proxy/src/handlers/agent-interceptor.ts
+++ b/packages/proxy/src/handlers/agent-interceptor.ts
@@ -60,11 +60,26 @@ export async function interceptAndModifyRequest(
 		// per agent. Takes precedence over system-prompt matching; absent = unchanged.
 		const explicitAgentId = requestHeaders
 			?.get("x-anthropic-agent-id")
-			?.trim();
+			?.trim()
+			?.slice(0, 256);
 		if (explicitAgentId) {
 			log.debug(
 				`Agent attributed via x-anthropic-agent-id: ${explicitAgentId}`,
 			);
+			// Honor model-preference substitution for the declared agent, the same
+			// as the system-prompt path — don't silently bypass it.
+			const preference = await dbOps.getAgentPreference(explicitAgentId);
+			const preferredModel = preference?.model;
+			if (preferredModel && preferredModel !== originalModel) {
+				log.info(`Modifying model from ${originalModel} to ${preferredModel}`);
+				bodyContext.setModel(preferredModel);
+				return {
+					modifiedBody: bodyContext.getBuffer(),
+					agentUsed: explicitAgentId,
+					originalModel,
+					appliedModel: preferredModel,
+				};
+			}
 			return {
 				modifiedBody: requestBodyBuffer,
 				agentUsed: explicitAgentId,

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -215,7 +215,7 @@ export async function handleProxy(
 
 	// 4. Intercept and modify request for agent model preferences
 	const { modifiedBody, agentUsed, originalModel, appliedModel } =
-		await interceptAndModifyRequest(requestBodyContext, ctx.dbOps);
+		await interceptAndModifyRequest(requestBodyContext, ctx.dbOps, req.headers);
 
 	// Use modified body if available
 	const finalBodyBuffer = modifiedBody || requestBodyContext.getBuffer();


### PR DESCRIPTION
## What

Adds an optional `X-Anthropic-Agent-Id` request header. When present, the proxy records its value as the request's `agent_used`, taking precedence over system-prompt matching. When absent, behavior is unchanged.

## Why

Agent attribution today relies on matching a request's system prompt against the registered agent registry. That works when a client's system prompts are pre-registered, but multi-agent orchestrators, routers, and SDK wrappers usually know exactly which agent issued a call and have no way to declare it — so those requests log `agent_used = NULL`.

A small, standard opt-in header lets any client declare the agent explicitly. This makes per-agent attribution available to downstream observability tools that read better-ccflare's request log — for example [danieltamas/axon](https://github.com/danieltamas/axon), a local AI-agent observability dashboard, can then break cost/tokens down per agent instead of showing an unattributed `main`.

## Changes

- `interceptAndModifyRequest` takes an optional `requestHeaders`; if `X-Anthropic-Agent-Id` is present it sets `agentUsed` and passes the body through unmodified.
- `handleProxy` forwards `req.headers`.

## Compatibility

Fully non-breaking — no header means the existing system-prompt matching path runs unchanged. Uses the conventional `X-` vendor-extension prefix.
