### PR TITLE
fix: auto-refresh recovers failure_threshold-paused accounts (#262)

### DIFF
--- a/packages/proxy/src/__tests__/auto-refresh-manual-pause-guard.test.ts
+++ b/packages/proxy/src/__tests__/auto-refresh-manual-pause-guard.test.ts
@@ -261,6 +261,19 @@ describe("AutoRefreshScheduler — failure_threshold re-probe cooldown", () => {
 		expect(s.shouldRefreshAccount(activeRow, Date.now())).toBe(true);
 	});
 
+	it("clears the cooldown path once a failure_threshold account is resumed (resume-then-reprobe)", async () => {
+		// Greptile #263 (round 2): a stale lastFailureProbeAt entry under the
+		// SAME id must not affect an account once it has been resumed
+		// (paused=0, pause_reason cleared). After resume the account follows normal
+		// window logic — the failure_threshold short-circuit no longer applies.
+		const s = await makeSchedulerInternals();
+		s.lastFailureProbeAt.set(failureRow.id, Date.now());
+		const resumedRow = { ...failureRow, paused: 0, pause_reason: null };
+		// First-time refresh (no lastRefreshResetTime) → true regardless of the
+		// stale probe timestamp.
+		expect(s.shouldRefreshAccount(resumedRow, Date.now())).toBe(true);
+	});
+
 	it("probes after cooldown even when a prior window is still active (long-running scheduler)", async () => {
 		// Greptile #263: once the cooldown elapses, the re-probe must fire even if
 		// lastRefreshResetTime is set and the current rate-limit window hasn't

--- a/packages/proxy/src/__tests__/auto-refresh-manual-pause-guard.test.ts
+++ b/packages/proxy/src/__tests__/auto-refresh-manual-pause-guard.test.ts
@@ -154,8 +154,12 @@ describe("AutoRefreshScheduler — manual-pause probe guard", () => {
 		expect(names.has("manual-overage-on")).toBe(false);
 	});
 
-	it("excludes failure-threshold pauses", () => {
-		expect(names.has("failure-threshold")).toBe(false);
+	it("includes failure-threshold pauses (so they can self-recover, #262)", () => {
+		// A failure_threshold pause is set by this scheduler after repeated refresh
+		// failures. It must remain probe-eligible so a successful probe can clear it
+		// — otherwise the account is stuck in API ERROR until a human clicks Force
+		// Refresh. Re-probe frequency is throttled in shouldRefreshAccount, not here.
+		expect(names.has("failure-threshold")).toBe(true);
 	});
 
 	it("excludes peak_hours pauses (zai peak-hours auto-pause)", () => {
@@ -178,9 +182,10 @@ describe("AutoRefreshScheduler — manual-pause probe guard", () => {
 	});
 
 	it("selection criteria match the auto-resume guard exactly", () => {
-		// Paused rows the query selects must be precisely the rows the resume
-		// guard (auto_pause_on_overage_enabled=1 AND pause_reason IN (NULL,'overage'))
-		// would un-pause. Anything else is a probe that can never be resumed.
+		// Paused rows the query selects must be precisely the rows the resume guard
+		// would un-pause: overage (pause_reason NULL/'overage') and failure_threshold
+		// (cleared on successful probe, #262). Anything else is a probe that can never
+		// be resumed.
 		const pausedSelected = [
 			"overage-paused",
 			"overage-null-reason",
@@ -190,7 +195,68 @@ describe("AutoRefreshScheduler — manual-pause probe guard", () => {
 			"manual-overage-off",
 		].filter((n) => names.has(n));
 		expect(pausedSelected.sort()).toEqual(
-			["overage-null-reason", "overage-paused"].sort(),
+			["failure-threshold", "overage-null-reason", "overage-paused"].sort(),
 		);
+	});
+});
+
+/**
+ * #262: failure_threshold-paused accounts must be re-probed on a cooldown so
+ * they can self-recover, but not hammered every 60s. The throttle lives in
+ * shouldRefreshAccount (which consults lastFailureProbeAt).
+ */
+describe("AutoRefreshScheduler — failure_threshold re-probe cooldown", () => {
+	const failureRow = {
+		id: "acct-ft",
+		name: "acct-ft",
+		provider: "anthropic",
+		refresh_token: "rt",
+		access_token: "at",
+		expires_at: null as number | null,
+		rate_limit_reset: null as number | null,
+		custom_endpoint: null as string | null,
+		paused: 1,
+		pause_reason: "failure_threshold" as string | null,
+	};
+
+	type SchedulerWithInternals = {
+		shouldRefreshAccount(account: typeof failureRow, now: number): boolean;
+		lastFailureProbeAt: Map<string, number>;
+		FAILURE_PROBE_COOLDOWN_MS: number;
+	};
+
+	async function makeSchedulerInternals(): Promise<SchedulerWithInternals> {
+		const scheduler = await makeScheduler(makeDb([]));
+		return scheduler as unknown as SchedulerWithInternals;
+	}
+
+	it("probes a failure_threshold account on the first cycle", async () => {
+		const s = await makeSchedulerInternals();
+		expect(s.shouldRefreshAccount(failureRow, Date.now())).toBe(true);
+	});
+
+	it("skips re-probing within the cooldown window", async () => {
+		const s = await makeSchedulerInternals();
+		const now = Date.now();
+		// Simulate sendDummyMessage having recorded a probe just now.
+		s.lastFailureProbeAt.set(failureRow.id, now);
+		expect(s.shouldRefreshAccount(failureRow, now + 60_000)).toBe(false);
+	});
+
+	it("re-probes after the cooldown elapses", async () => {
+		const s = await makeSchedulerInternals();
+		const now = Date.now();
+		s.lastFailureProbeAt.set(failureRow.id, now);
+		const afterCooldown = now + s.FAILURE_PROBE_COOLDOWN_MS + 1;
+		expect(s.shouldRefreshAccount(failureRow, afterCooldown)).toBe(true);
+	});
+
+	it("does not throttle non-failure_threshold accounts", async () => {
+		const s = await makeSchedulerInternals();
+		// A stale lastFailureProbeAt entry must not suppress a normal account.
+		s.lastFailureProbeAt.set("other", Date.now());
+		const activeRow = { ...failureRow, paused: 0, pause_reason: null };
+		// First-time refresh (no lastRefreshResetTime entry) → true regardless.
+		expect(s.shouldRefreshAccount(activeRow, Date.now())).toBe(true);
 	});
 });

--- a/packages/proxy/src/__tests__/auto-refresh-manual-pause-guard.test.ts
+++ b/packages/proxy/src/__tests__/auto-refresh-manual-pause-guard.test.ts
@@ -222,6 +222,7 @@ describe("AutoRefreshScheduler — failure_threshold re-probe cooldown", () => {
 	type SchedulerWithInternals = {
 		shouldRefreshAccount(account: typeof failureRow, now: number): boolean;
 		lastFailureProbeAt: Map<string, number>;
+		lastRefreshResetTime: Map<string, number>;
 		FAILURE_PROBE_COOLDOWN_MS: number;
 	};
 
@@ -258,5 +259,23 @@ describe("AutoRefreshScheduler — failure_threshold re-probe cooldown", () => {
 		const activeRow = { ...failureRow, paused: 0, pause_reason: null };
 		// First-time refresh (no lastRefreshResetTime entry) → true regardless.
 		expect(s.shouldRefreshAccount(activeRow, Date.now())).toBe(true);
+	});
+
+	it("probes after cooldown even when a prior window is still active (long-running scheduler)", async () => {
+		// Greptile #263: once the cooldown elapses, the re-probe must fire even if
+		// lastRefreshResetTime is set and the current rate-limit window hasn't
+		// expired — we're probing liveness, not waiting for a new window.
+		const s = await makeSchedulerInternals();
+		const now = Date.now();
+		// Prior successful refresh recorded a reset time 2h in the future, and a
+		// probe happened recently enough that the cooldown has now elapsed.
+		const futureReset = now + 2 * 60 * 60 * 1000;
+		s.lastRefreshResetTime.set(failureRow.id, now - 3 * 60 * 1000);
+		s.lastFailureProbeAt.set(
+			failureRow.id,
+			now - s.FAILURE_PROBE_COOLDOWN_MS - 1,
+		);
+		const rowWithWindow = { ...failureRow, rate_limit_reset: futureReset };
+		expect(s.shouldRefreshAccount(rowWithWindow, now)).toBe(true);
 	});
 });

--- a/packages/proxy/src/auto-refresh-scheduler.ts
+++ b/packages/proxy/src/auto-refresh-scheduler.ts
@@ -1130,6 +1130,11 @@ export class AutoRefreshScheduler {
 				);
 				return false;
 			}
+			// Cooldown elapsed (or no prior probe) — probe immediately. We're
+			// checking endpoint liveness, not whether a new usage window opened,
+			// so bypass the normal rate_limit_reset window logic (which would
+			// suppress re-probes while a prior window is still active).
+			return true;
 		}
 
 		const lastResetTime = this.lastRefreshResetTime.get(account.id);

--- a/packages/proxy/src/auto-refresh-scheduler.ts
+++ b/packages/proxy/src/auto-refresh-scheduler.ts
@@ -39,6 +39,12 @@ export class AutoRefreshScheduler {
 	private consecutiveFailures: Map<string, number> = new Map();
 	// Threshold for marking an account as needing re-authentication
 	private readonly FAILURE_THRESHOLD = 5;
+	// Timestamp (ms) of the last probe sent to a failure_threshold-paused account.
+	// Re-probing is throttled to once per FAILURE_PROBE_COOLDOWN_MS so a genuinely
+	// dead endpoint isn't hit every 60s (#199), while still letting the account
+	// self-recover automatically instead of getting stuck in API ERROR (#262).
+	private lastFailureProbeAt: Map<string, number> = new Map();
+	private readonly FAILURE_PROBE_COOLDOWN_MS = 10 * 60 * 1000; // 10 minutes
 
 	constructor(db: BunSqlAdapter, proxyContext: ProxyContext) {
 		this.db = db;
@@ -78,6 +84,7 @@ export class AutoRefreshScheduler {
 		// Clear the tracking maps to free memory
 		this.lastRefreshResetTime.clear();
 		this.consecutiveFailures.clear();
+		this.lastFailureProbeAt.clear();
 	}
 
 	/**
@@ -151,22 +158,21 @@ export class AutoRefreshScheduler {
 					AND (
 						rate_limited_until IS NULL OR rate_limited_until <= ?
 					)
-					-- Only probe a paused account if it was auto-paused due to billing
-					-- overage. The auto-resume guard in sendDummyMessage only un-pauses an
-					-- account when auto_pause_on_overage_enabled=1 AND pause_reason IN
-					-- (NULL, 'overage'); selecting any other paused account here would probe
-					-- it forever yet never resume it. So a manually-paused account
-					-- (pause_reason='manual') or one paused by the failure-threshold guard
-					-- (pause_reason='failure_threshold') is left completely alone — probing it
-					-- just burns quota and pollutes the request log with synthetic 429s for an
-					-- account the user (or the guard) intentionally disabled (issue #199, bug 1).
-					-- These criteria MUST stay in sync with the resume guard.
+					-- Probe a paused account only if it can be auto-resumed. Overage pauses
+					-- (auto_pause_on_overage_enabled=1) resume on window reset. failure_threshold
+					-- pauses (set by this scheduler after FAILURE_THRESHOLD consecutive refresh
+					-- failures) MUST be re-probed on a cooldown so they can self-recover —
+					-- otherwise they're stuck in API ERROR until a human clicks Force Refresh
+					-- (issue #262). The per-account re-probe cooldown is enforced in
+					-- shouldRefreshAccount. Manual and peak_hours pauses are left alone.
+					-- These criteria MUST stay in sync with the resume guard in sendDummyMessage.
 					AND (
 						COALESCE(paused, 0) = 0
 						OR (
 							COALESCE(auto_pause_on_overage_enabled, 0) = 1
 							AND (pause_reason IS NULL OR pause_reason = 'overage')
 						)
+						OR pause_reason = 'failure_threshold'
 					)
 			`,
 				[now, now, now],
@@ -256,6 +262,13 @@ export class AutoRefreshScheduler {
 	}): Promise<boolean> {
 		try {
 			log.info(`Sending auto-refresh message to account: ${accountRow.name}`);
+
+			// Record the probe timestamp for failure_threshold accounts so the
+			// cooldown in shouldRefreshAccount suppresses re-probes for the next
+			// FAILURE_PROBE_COOLDOWN_MS (#262).
+			if (accountRow.pause_reason === "failure_threshold") {
+				this.lastFailureProbeAt.set(accountRow.id, Date.now());
+			}
 
 			const provider = getProvider(accountRow.provider);
 			if (!provider) {
@@ -560,9 +573,24 @@ export class AutoRefreshScheduler {
 					);
 				}
 
-				// Auto-resume on window reset: if account was auto-paused due to overage, resume it now.
-				// Never auto-resume accounts paused manually or due to failure threshold.
+				// Auto-resume on a successful probe. failure_threshold-paused accounts
+				// (set by this scheduler after repeated refresh failures) resume as soon
+				// as a probe succeeds — the endpoint works again (#262). Overage-paused
+				// accounts resume when the window resets. Manual and peak_hours pauses are
+				// never auto-resumed.
 				if (
+					accountRow.paused === 1 &&
+					accountRow.pause_reason === "failure_threshold"
+				) {
+					log.info(
+						`Auto-resuming account '${accountRow.name}' — failure_threshold cleared after successful probe`,
+					);
+					await this.db.run(
+						"UPDATE accounts SET paused = 0, pause_reason = NULL WHERE id = ?",
+						[accountRow.id],
+					);
+					this.lastFailureProbeAt.delete(accountRow.id);
+				} else if (
 					accountRow.auto_pause_on_overage_enabled === 1 &&
 					accountRow.paused === 1 &&
 					(!accountRow.pause_reason || accountRow.pause_reason === "overage")
@@ -996,6 +1024,16 @@ export class AutoRefreshScheduler {
 					);
 				}
 			}
+
+			// Clean up failure-probe cooldown timestamps for non-active accounts
+			for (const accountId of this.lastFailureProbeAt.keys()) {
+				if (!activeAccountIdSet.has(accountId)) {
+					this.lastFailureProbeAt.delete(accountId);
+					log.debug(
+						`Removed failure-probe cooldown tracking for account ${accountId} (no longer exists or auto-refresh disabled)`,
+					);
+				}
+			}
 		} catch (error) {
 			if (error instanceof Error) {
 				const errorMessage = `Error cleaning up tracking map: ${error.name}: ${error.message}`;
@@ -1076,9 +1114,24 @@ export class AutoRefreshScheduler {
 			expires_at: number | null;
 			rate_limit_reset: number | null;
 			custom_endpoint: string | null;
+			paused: number;
+			pause_reason: string | null;
 		},
 		now: number,
 	): boolean {
+		// Throttle re-probes of failure_threshold-paused accounts to once per
+		// cooldown — avoids burning quota on a dead endpoint every 60s (#199)
+		// while still letting it recover automatically (#262).
+		if (account.pause_reason === "failure_threshold") {
+			const lastProbe = this.lastFailureProbeAt.get(account.id);
+			if (lastProbe && now - lastProbe < this.FAILURE_PROBE_COOLDOWN_MS) {
+				log.debug(
+					`Skipping failure_threshold probe for account ${account.name} — last probe ${Math.round((now - lastProbe) / 1000)}s ago, cooldown ${this.FAILURE_PROBE_COOLDOWN_MS / 1000}s`,
+				);
+				return false;
+			}
+		}
+
 		const lastResetTime = this.lastRefreshResetTime.get(account.id);
 
 		// If we've never refreshed this account before, refresh it


### PR DESCRIPTION
## Summary
- Accounts paused via the `failure_threshold` guard (5 consecutive refresh failures) were stranded in "API ERROR" indefinitely — Auto Refresh refused to probe them, and a successful probe was the *only* thing that could clear the pause, so recovery required a manual "Force Refresh" every ~10 min.
- Root cause: commit 9fb4c71b (the #199 manual-pause fix) excluded `pause_reason='failure_threshold'` from the scheduler's probe-eligibility query alongside manual pauses.
- Re-includes `failure_threshold` accounts in probing, adds a **10-minute per-account cooldown** (`lastFailureProbeAt`) so a genuinely dead endpoint isn't hit every 60s (preserves the #199 concern), and widens the resume guard so a successful probe clears the pause. No DB migration.

## Changes
- `packages/proxy/src/auto-refresh-scheduler.ts`
  - Eligibility query: `OR pause_reason = 'failure_threshold'`
  - `shouldRefreshAccount`: throttle re-probes via `lastFailureProbeAt` + `FAILURE_PROBE_COOLDOWN_MS` (10 min)
  - `sendDummyMessage`: record probe timestamp at start; on success, clear `failure_threshold` pause
  - Memory-safety: clear `lastFailureProbeAt` in `stop()`, prune in `cleanupTracking()`, delete entry on successful resume
- `packages/proxy/src/__tests__/auto-refresh-manual-pause-guard.test.ts`
  - Flipped failure-threshold exclusion assertion → inclusion
  - Updated resume-guard-match test
  - Added 4 cooldown tests (first cycle, within-cooldown skip, after-cooldown re-probe, non-failure accounts unaffected)

## Test plan
- [x] `bun run typecheck` (clean)
- [x] `bun run format` (clean)
- [x] `bun test packages/proxy` — 295 pass, 0 fail
- [ ] Greptile review on the PR

Closes #262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)