### PR TITLE
fix: retry reset-less 529 (overloaded_error) in-place before cooling account

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -84,6 +84,30 @@ export function getRateLimitResetStabilityMs(): number {
 	return raw || TIME_CONSTANTS.RATE_LIMIT_RESET_STABILITY_MS;
 }
 
+/**
+ * Configuration for in-place retry of reset-less 529 (overloaded_error) responses.
+ * Used by proxyWithAccount before applying account cooldown.
+ *
+ * Env knobs:
+ *   CCFLARE_OVERLOAD_RETRY_ENABLED      — set to "false" to disable (default: true)
+ *   CCFLARE_OVERLOAD_RETRY_MAX_ATTEMPTS — max in-place attempts (default: 2)
+ *   CCFLARE_OVERLOAD_RETRY_BASE_MS      — jitter backoff base delay ms (default: 750)
+ *   CCFLARE_OVERLOAD_RETRY_MAX_MS       — jitter backoff ceiling ms (default: 3000)
+ */
+export function getOverloadRetryConfig(): {
+	enabled: boolean;
+	maxAttempts: number;
+	baseMs: number;
+	maxMs: number;
+} {
+	const enabled = process.env.CCFLARE_OVERLOAD_RETRY_ENABLED !== "false";
+	const maxAttempts =
+		Number(process.env.CCFLARE_OVERLOAD_RETRY_MAX_ATTEMPTS) || 2;
+	const baseMs = Number(process.env.CCFLARE_OVERLOAD_RETRY_BASE_MS) || 750;
+	const maxMs = Number(process.env.CCFLARE_OVERLOAD_RETRY_MAX_MS) || 3000;
+	return { enabled, maxAttempts, baseMs, maxMs };
+}
+
 // Buffer sizes (in bytes unless specified)
 export const BUFFER_SIZES = {
 	// Stream usage buffer size in KB (multiplied by 1024 to get bytes)

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -101,10 +101,14 @@ export function getOverloadRetryConfig(): {
 	maxMs: number;
 } {
 	const enabled = process.env.CCFLARE_OVERLOAD_RETRY_ENABLED !== "false";
+	// maxAttempts: 0 is not useful (use ENABLED=false to disable), so || is correct.
 	const maxAttempts =
 		Number(process.env.CCFLARE_OVERLOAD_RETRY_MAX_ATTEMPTS) || 2;
-	const baseMs = Number(process.env.CCFLARE_OVERLOAD_RETRY_BASE_MS) || 750;
-	const maxMs = Number(process.env.CCFLARE_OVERLOAD_RETRY_MAX_MS) || 3000;
+	// baseMs/maxMs: 0 is valid (zero delay for tests), so use explicit finite check.
+	const rawBase = Number(process.env.CCFLARE_OVERLOAD_RETRY_BASE_MS);
+	const rawMax = Number(process.env.CCFLARE_OVERLOAD_RETRY_MAX_MS);
+	const baseMs = Number.isFinite(rawBase) && rawBase >= 0 ? rawBase : 750;
+	const maxMs = Number.isFinite(rawMax) && rawMax >= 0 ? rawMax : 3000;
 	return { enabled, maxAttempts, baseMs, maxMs };
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export {
 	BUFFER_SIZES,
 	CACHE,
 	computeRateLimitBackoffMs,
+	getOverloadRetryConfig,
 	getRateLimitResetStabilityMs,
 	HTTP_STATUS,
 	LIMITS,

--- a/packages/proxy/src/handlers/__tests__/proxy-operations-failover.test.ts
+++ b/packages/proxy/src/handlers/__tests__/proxy-operations-failover.test.ts
@@ -705,6 +705,196 @@ describe("proxyWithAccount — 529 failover", () => {
 	});
 });
 
+describe("proxyWithAccount — 529 in-place retry", () => {
+	let originalFetch: typeof globalThis.fetch;
+	const overloadBody =
+		'{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}';
+	const successBody =
+		'{"id":"msg_1","type":"message","content":[],"model":"claude-sonnet-4-5","stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}';
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+		// Zero-delay backoff so tests don't sleep
+		process.env.CCFLARE_OVERLOAD_RETRY_BASE_MS = "0";
+		process.env.CCFLARE_OVERLOAD_RETRY_MAX_MS = "0";
+		delete process.env.CCFLARE_OVERLOAD_RETRY_ENABLED;
+		delete process.env.CCFLARE_OVERLOAD_RETRY_MAX_ATTEMPTS;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		delete process.env.CCFLARE_OVERLOAD_RETRY_BASE_MS;
+		delete process.env.CCFLARE_OVERLOAD_RETRY_MAX_MS;
+		delete process.env.CCFLARE_OVERLOAD_RETRY_ENABLED;
+		delete process.env.CCFLARE_OVERLOAD_RETRY_MAX_ATTEMPTS;
+	});
+
+	function make529NoResetCtx() {
+		const ctx = makeProxyContext();
+		(ctx as { provider: typeof ctx.provider }).provider = {
+			...ctx.provider,
+			parseRateLimit: (r: Response) => ({
+				isRateLimited: r.status === 529,
+				resetTime: undefined, // no reset — triggers in-place retry path
+				statusHeader: undefined,
+				remaining: undefined,
+			}),
+		} as typeof ctx.provider;
+		return ctx;
+	}
+
+	it("retries in-place on 529 no-reset and makes exactly 2 fetch calls before succeeding", async () => {
+		let callCount = 0;
+		globalThis.fetch = mock(async () => {
+			callCount++;
+			if (callCount === 1) {
+				return new Response(overloadBody, {
+					status: 529,
+					headers: { "content-type": "application/json" },
+				});
+			}
+			return new Response(successBody, {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		});
+
+		process.env.CCFLARE_OVERLOAD_RETRY_MAX_ATTEMPTS = "2";
+		const ctx = make529NoResetCtx();
+		const bodyBuffer = makeRequestBody();
+		// proxyWithAccount reaches forwardToClient on success, which requires
+		// UsageCollector initialization (not wired in unit tests). Catch that
+		// specific error while still verifying the retry fired.
+		try {
+			await proxyWithAccount(
+				makeRequest(bodyBuffer),
+				new URL("https://proxy.local/v1/messages"),
+				makeAccount({
+					provider: "anthropic",
+					api_key: "test-key",
+					access_token: null,
+				}),
+				makeRequestMeta(),
+				bodyBuffer,
+				() => undefined,
+				0,
+				ctx,
+			);
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : String(e);
+			if (!msg.includes("UsageCollector not initialized")) throw e;
+		}
+
+		// fetch was called twice: initial 529 + 1 in-place retry
+		expect(callCount).toBe(2);
+		// markAccountRateLimited should NOT have been called — no cooldown on successful retry
+		expect(ctx.dbOps.markAccountRateLimited).not.toHaveBeenCalled();
+	});
+
+	it("falls through to cooldown/failover when all retries are exhausted", async () => {
+		globalThis.fetch = mock(
+			async () =>
+				new Response(overloadBody, {
+					status: 529,
+					headers: { "content-type": "application/json" },
+				}),
+		);
+
+		process.env.CCFLARE_OVERLOAD_RETRY_MAX_ATTEMPTS = "3";
+		const ctx = make529NoResetCtx();
+		const bodyBuffer = makeRequestBody();
+		const result = await proxyWithAccount(
+			makeRequest(bodyBuffer),
+			new URL("https://proxy.local/v1/messages"),
+			makeAccount({
+				provider: "anthropic",
+				api_key: "test-key",
+				access_token: null,
+			}),
+			makeRequestMeta(),
+			bodyBuffer,
+			() => undefined,
+			0,
+			ctx,
+		);
+
+		// All retries exhausted → null (cooldown applied, failover to next account)
+		expect(result).toBeNull();
+	});
+
+	it("skips in-place retry when CCFLARE_OVERLOAD_RETRY_ENABLED=false", async () => {
+		let callCount = 0;
+		globalThis.fetch = mock(async () => {
+			callCount++;
+			return new Response(overloadBody, {
+				status: 529,
+				headers: { "content-type": "application/json" },
+			});
+		});
+
+		process.env.CCFLARE_OVERLOAD_RETRY_ENABLED = "false";
+		const ctx = make529NoResetCtx();
+		const bodyBuffer = makeRequestBody();
+		await proxyWithAccount(
+			makeRequest(bodyBuffer),
+			new URL("https://proxy.local/v1/messages"),
+			makeAccount({
+				provider: "anthropic",
+				api_key: "test-key",
+				access_token: null,
+			}),
+			makeRequestMeta(),
+			bodyBuffer,
+			() => undefined,
+			0,
+			ctx,
+		);
+
+		// Disabled — only the initial request, no retries
+		expect(callCount).toBe(1);
+	});
+
+	it("skips in-place retry for synthetic keepalive requests", async () => {
+		let callCount = 0;
+		globalThis.fetch = mock(async () => {
+			callCount++;
+			return new Response(overloadBody, {
+				status: 529,
+				headers: { "content-type": "application/json" },
+			});
+		});
+
+		process.env.CCFLARE_OVERLOAD_RETRY_MAX_ATTEMPTS = "3";
+		const ctx = make529NoResetCtx();
+		const bodyBuffer = makeRequestBody();
+		const keepaliveReq = new Request("https://proxy.local/v1/messages", {
+			method: "POST",
+			body: bodyBuffer,
+			headers: {
+				"Content-Type": "application/json",
+				"x-better-ccflare-keepalive": "true",
+			},
+		});
+		await proxyWithAccount(
+			keepaliveReq,
+			new URL("https://proxy.local/v1/messages"),
+			makeAccount({
+				provider: "anthropic",
+				api_key: "test-key",
+				access_token: null,
+			}),
+			makeRequestMeta(),
+			bodyBuffer,
+			() => undefined,
+			0,
+			ctx,
+		);
+
+		// Keepalive — only the initial request, no in-place retries
+		expect(callCount).toBe(1);
+	});
+});
+
 describe("proxyWithAccount — 401 failover", () => {
 	let originalFetch: typeof globalThis.fetch;
 

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -1032,7 +1032,7 @@ export async function proxyWithAccount(
 						const retryRaw = isSyntheticProviderResponse(
 							transformedRequestForRetry,
 						)
-							? materializeSyntheticResponse(transformedRequestForRetry)
+							? materializeSyntheticResponse(transformedRequestForRetry.clone())
 							: await makeProxyRequest(transformedRequestForRetry.clone());
 
 						const retryTaggedHeaders = new Headers(retryRaw.headers);
@@ -1052,6 +1052,12 @@ export async function proxyWithAccount(
 						);
 
 						response = retryResponse;
+
+						// If credentials expired mid-retry, break out and let the 401
+						// failover guard below handle it (return null → try next account).
+						if (retryResponse.status === 401) {
+							break;
+						}
 
 						if (retryResponse.status !== 529) {
 							log.info(
@@ -1073,6 +1079,17 @@ export async function proxyWithAccount(
 					}
 				}
 			}
+		}
+
+		// Re-check 401 after in-place retry — credentials might have been revoked
+		// between the initial 529 and a retry response. The guard above only covered
+		// the initial response; a retry 401 would have updated `response` and broken
+		// out of the loop, so we need to catch it here before forwarding to the client.
+		if (response.status === 401) {
+			log.warn(
+				`Authentication failed (401) on 529 retry for account ${account.name}, failing over to next account`,
+			);
+			return null;
 		}
 
 		// Check for rate limit using account-specific provider

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -1,5 +1,6 @@
 import {
 	getModelList,
+	getOverloadRetryConfig,
 	logError,
 	ProviderError,
 	TIME_CONSTANTS,
@@ -624,6 +625,9 @@ export async function proxyWithAccount(
 			);
 		}
 
+		// Capture a clone for in-place 529 retries before the body is consumed.
+		const transformedRequestForRetry = transformedRequest.clone();
+
 		// Make the request (or unwrap a synthetic provider response)
 		let rawResponse = isSyntheticProviderResponse(transformedRequest)
 			? materializeSyntheticResponse(transformedRequest)
@@ -989,7 +993,7 @@ export async function proxyWithAccount(
 		});
 
 		// Process response (transform format, sanitize headers, etc.) using account-specific provider
-		const response = await provider.processResponse(
+		let response = await provider.processResponse(
 			taggedRawResponse,
 			account,
 			req.headers,
@@ -1001,6 +1005,74 @@ export async function proxyWithAccount(
 				`Authentication failed (401) for account ${account.name}, failing over to next account`,
 			);
 			return null;
+		}
+
+		// In-place retry for reset-less 529 (overloaded_error) — bounded attempts with
+		// full-jitter exponential backoff before applying account cooldown. This prevents
+		// all accounts cooling simultaneously under concurrency spikes. Skipped for
+		// synthetic (keepalive / auto-refresh) requests to avoid loop amplification.
+		if (response.status === 529 && !isSyntheticInternal) {
+			const rlInfo = provider.parseRateLimit(response.clone());
+			if (rlInfo.isRateLimited && !rlInfo.resetTime) {
+				const retryCfg = getOverloadRetryConfig();
+				if (retryCfg.enabled && retryCfg.maxAttempts > 1) {
+					for (let attempt = 1; attempt < retryCfg.maxAttempts; attempt++) {
+						// Full-jitter backoff: sleep in [0, min(base * 2^attempt, max)]
+						const cap = Math.min(
+							retryCfg.baseMs * 2 ** attempt,
+							retryCfg.maxMs,
+						);
+						const delayMs = Math.random() * cap;
+						await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+
+						log.info(
+							`Account ${account.name}: in-place retry ${attempt}/${retryCfg.maxAttempts - 1} after ${Math.round(delayMs)}ms for 529 overloaded_error`,
+						);
+
+						const retryRaw = isSyntheticProviderResponse(
+							transformedRequestForRetry,
+						)
+							? materializeSyntheticResponse(transformedRequestForRetry)
+							: await makeProxyRequest(transformedRequestForRetry.clone());
+
+						const retryTaggedHeaders = new Headers(retryRaw.headers);
+						retryTaggedHeaders.set(
+							"x-better-ccflare-request-id",
+							requestMeta.id,
+						);
+						const retryTaggedRaw = new Response(retryRaw.body, {
+							status: retryRaw.status,
+							statusText: retryRaw.statusText,
+							headers: retryTaggedHeaders,
+						});
+						const retryResponse = await provider.processResponse(
+							retryTaggedRaw,
+							account,
+							req.headers,
+						);
+
+						response = retryResponse;
+
+						if (retryResponse.status !== 529) {
+							log.info(
+								`Account ${account.name}: 529 resolved on retry ${attempt} (status ${retryResponse.status})`,
+							);
+							break;
+						}
+
+						const retryRlInfo = provider.parseRateLimit(retryResponse.clone());
+						if (!retryRlInfo.isRateLimited || retryRlInfo.resetTime) {
+							// Got a reset hint on retry — stop; let processProxyResponse apply cooldown
+							break;
+						}
+					}
+					if (response.status === 529) {
+						log.warn(
+							`Account ${account.name}: all ${retryCfg.maxAttempts - 1} in-place 529 retries exhausted, applying cooldown and failing over`,
+						);
+					}
+				}
+			}
 		}
 
 		// Check for rate limit using account-specific provider


### PR DESCRIPTION
## Summary

- Adds a bounded in-place retry loop in `proxyWithAccount` for Anthropic 529 `overloaded_error` responses that carry **no** `Retry-After` / reset header — the transient case that previously triggered immediate account cooldown
- Uses full-jitter exponential backoff between retries (configurable via env vars)
- Skips retries for synthetic requests (keepalive / auto-refresh) to avoid loop amplification
- If all retries exhaust, falls through to the existing cooldown path unchanged

## Why

A single reset-less 529 previously cooled the account immediately. Under concurrency, multiple simultaneous 529s could cool every account in the pool at once, draining it to zero routable accounts and surfacing a 503 `pool_exhausted` to the client — even though the overload condition is transient and per-request, not account-level.

The Anthropic API docs classify `overloaded_error` as retryable with exponential backoff. The SDK retries 5xx automatically; the proxy should do the same before giving up on an account.

## Config knobs (all optional, env-var overrides)

| Var | Default | Notes |
|-----|---------|-------|
| `CCFLARE_OVERLOAD_RETRY_ENABLED` | `true` | Set to `"false"` to disable |
| `CCFLARE_OVERLOAD_RETRY_MAX_ATTEMPTS` | `2` | Total attempts (1 original + N-1 retries) |
| `CCFLARE_OVERLOAD_RETRY_BASE_MS` | `750` | Backoff base; `0` = no sleep |
| `CCFLARE_OVERLOAD_RETRY_MAX_MS` | `3000` | Backoff ceiling |

## Test plan

- [ ] 4 new tests in `proxy-operations-failover.test.ts`:
  - Retry fires and makes 2 fetch calls when first response is 529 no-reset
  - All retries exhausted → `null` (cooldown + failover)
  - `CCFLARE_OVERLOAD_RETRY_ENABLED=false` → only 1 fetch call
  - Keepalive request → only 1 fetch call (synthetic skip)
- [ ] Pre-existing 17/21 test pass rate unchanged (4 pre-existing failures unrelated to this change)
- [ ] `bun run lint && bun run typecheck && bun run format` — clean

Fixes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)