### PR TITLE
fix(codex): surface failed SSE responses

### DIFF
--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -747,6 +747,153 @@ describe("CodexProvider.processResponse", () => {
 		expect(await transformed.text()).toBe("ok");
 	});
 
+	it("returns Anthropic JSON for non-streaming missing-content-type SSE bodies", async () => {
+		const provider = new CodexProvider();
+		const upstreamBody = sseBody([
+			...eventLine("response.created", {
+				response: { id: "resp_test", model: "gpt-5.4" },
+			}),
+			...eventLine("response.output_item.added", {
+				item: { type: "message" },
+				output_index: 0,
+			}),
+			...eventLine("response.content_part.added", {
+				part: { type: "output_text" },
+			}),
+			...eventLine("response.output_text.delta", { delta: "hello" }),
+			...eventLine("response.completed", {
+				response: {
+					model: "gpt-5.4",
+					usage: { input_tokens: 2, output_tokens: 1 },
+				},
+			}),
+		]);
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: { "x-better-ccflare-request-stream": "false" },
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		expect(transformed.headers.get("content-type")).toContain(
+			"application/json",
+		);
+		const payload = await transformed.json();
+		expect(payload.content).toEqual([{ type: "text", text: "hello" }]);
+		expect(payload.usage).toEqual({
+			input_tokens: 2,
+			output_tokens: 1,
+			cache_read_input_tokens: 0,
+			cache_creation_input_tokens: 0,
+		});
+	});
+
+	it("surfaces Codex SSE errors instead of fabricating an empty streaming success", async () => {
+		const provider = new CodexProvider();
+		const upstreamBody = sseBody([
+			...eventLine("response.created", {
+				response: { id: "resp_failed", model: "gpt-5.5" },
+			}),
+			...eventLine("response.failed", {
+				response: {
+					status: "failed",
+					error: {
+						type: "invalid_request_error",
+						code: "context_length_exceeded",
+						message: "Input is too large",
+					},
+				},
+			}),
+		]);
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const transformedBody = await transformed.text();
+
+		expect(transformedBody).toContain("event: error");
+		expect(transformedBody).toContain("Input is too large");
+		expect(transformedBody).toContain("context_length_exceeded");
+		expect(transformedBody).not.toContain("event: message_delta");
+		expect(transformedBody).not.toContain("event: message_stop");
+	});
+
+	it("surfaces Codex SSE errors as JSON errors for non-streaming clients", async () => {
+		const provider = new CodexProvider();
+		const upstreamBody = sseBody([
+			...eventLine("response.created", {
+				response: { id: "resp_failed", model: "gpt-5.5" },
+			}),
+			...eventLine("response.failed", {
+				response: {
+					status: "failed",
+					error: {
+						type: "invalid_request_error",
+						message: "Codex failed",
+					},
+				},
+			}),
+		]);
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: {
+				"content-type": "text/event-stream",
+				"x-better-ccflare-request-stream": "false",
+			},
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const body = await transformed.json();
+
+		expect(transformed.status).toBe(400);
+		expect(body).toEqual({
+			type: "error",
+			error: {
+				type: "invalid_request_error",
+				message: "Codex failed",
+			},
+		});
+	});
+
+	it("maps non-streaming Codex context-window SSE errors to non-retryable bad requests", async () => {
+		const provider = new CodexProvider();
+		const upstreamBody = sseBody([
+			...eventLine("response.created", {
+				response: { id: "resp_failed", model: "gpt-5.5" },
+			}),
+			...eventLine("error", {
+				type: "error",
+				code: "context_length_exceeded",
+				message: "Input is too large",
+			}),
+		]);
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: {
+				"content-type": "text/event-stream",
+				"x-better-ccflare-request-stream": "false",
+			},
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const body = await transformed.json();
+
+		expect(transformed.status).toBe(400);
+		expect(body).toEqual({
+			type: "error",
+			error: {
+				type: "invalid_request_error",
+				message: "Input is too large",
+				code: "context_length_exceeded",
+			},
+		});
+	});
+
 	it("passes through non-streaming error responses", async () => {
 		const provider = new CodexProvider();
 		const response = new Response('{"error":"bad_request"}', {

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -821,6 +821,46 @@ describe("CodexProvider.processResponse", () => {
 		expect(transformedBody).not.toContain("event: message_stop");
 	});
 
+	it("closes an open content block before surfacing a streaming Codex error", async () => {
+		const provider = new CodexProvider();
+		const upstreamBody = sseBody([
+			...eventLine("response.created", {
+				response: { id: "resp_failed", model: "gpt-5.5" },
+			}),
+			...eventLine("response.output_item.added", {
+				item: { type: "message" },
+				output_index: 0,
+			}),
+			...eventLine("response.content_part.added", {
+				part: { type: "output_text" },
+			}),
+			...eventLine("response.output_text.delta", { delta: "partial" }),
+			...eventLine("response.failed", {
+				response: {
+					status: "failed",
+					error: {
+						type: "invalid_request_error",
+						message: "Codex failed after partial output",
+					},
+				},
+			}),
+		]);
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const transformedBody = await transformed.text();
+
+		const stopPos = transformedBody.indexOf("event: content_block_stop");
+		const errorPos = transformedBody.indexOf("event: error");
+		expect(stopPos).toBeGreaterThan(-1);
+		expect(errorPos).toBeGreaterThan(stopPos);
+		expect(transformedBody).toContain("Codex failed after partial output");
+	});
+
 	it("surfaces Codex SSE errors as JSON errors for non-streaming clients", async () => {
 		const provider = new CodexProvider();
 		const upstreamBody = sseBody([
@@ -892,6 +932,62 @@ describe("CodexProvider.processResponse", () => {
 				code: "context_length_exceeded",
 			},
 		});
+	});
+
+	it("maps generic Codex error events to a valid Anthropic api_error type", async () => {
+		const provider = new CodexProvider();
+		const upstreamBody = sseBody([
+			...eventLine("error", {
+				type: "error",
+				code: "some_other_code",
+				message: "Generic Codex failure",
+			}),
+		]);
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: {
+				"content-type": "text/event-stream",
+				"x-better-ccflare-request-stream": "false",
+			},
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const body = await transformed.json();
+
+		expect(transformed.status).toBe(502);
+		expect(body.error.type).toBe("api_error");
+		expect(body.error.code).toBe("some_other_code");
+	});
+
+	it("maps Codex rate-limited status to a non-streaming 429", async () => {
+		const provider = new CodexProvider();
+		const upstreamBody = sseBody([
+			...eventLine("response.failed", {
+				response: {
+					status: "rate_limited",
+					error: {
+						type: "error",
+						message: "Rate limited by Codex",
+					},
+				},
+			}),
+		]);
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: {
+				"content-type": "text/event-stream",
+				"x-better-ccflare-request-stream": "false",
+			},
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const body = await transformed.json();
+
+		expect(transformed.status).toBe(429);
+		expect(body.error.type).toBe("rate_limit_error");
+		expect(body.error.status).toBe("rate_limited");
 	});
 
 	it("passes through non-streaming error responses", async () => {

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -198,6 +198,12 @@ interface StreamState {
 	contextWindow: ContextWindow | null;
 	// Track function_call items: output_index → buffered arguments and block index
 	functionCallBlocks: Map<number, FunctionCallBuffer>;
+	upstreamError?: {
+		type: string;
+		message: string;
+		code?: string;
+		status?: string;
+	};
 }
 
 export class CodexProvider extends BaseProvider {
@@ -696,6 +702,7 @@ export class CodexProvider extends BaseProvider {
 			.getReader();
 		let messageStartPayload: Record<string, unknown> | null = null;
 		let messageDeltaPayload: Record<string, unknown> | null = null;
+		let errorPayload: Record<string, unknown> | null = null;
 		const content: Array<Record<string, unknown>> = [];
 		const textByIndex = new Map<number, string>();
 		const toolByIndex = new Map<
@@ -716,6 +723,10 @@ export class CodexProvider extends BaseProvider {
 				try {
 					data = JSON.parse(line.slice("data:".length).trim());
 				} catch {
+					return;
+				}
+				if (eventName === "error") {
+					errorPayload = data;
 					return;
 				}
 				if (eventName === "message_start") {
@@ -782,6 +793,18 @@ export class CodexProvider extends BaseProvider {
 			} finally {
 				reader.releaseLock();
 			}
+		}
+
+		if (errorPayload) {
+			const headers = sanitizeResponseHeaders(response.headers);
+			headers.set("content-type", "application/json");
+			const { status, statusText } =
+				this.httpStatusForAnthropicErrorPayload(errorPayload);
+			return new Response(JSON.stringify(errorPayload), {
+				status,
+				statusText,
+				headers,
+			});
 		}
 
 		const allIndices = new Set([...textByIndex.keys(), ...toolByIndex.keys()]);
@@ -1020,6 +1043,10 @@ export class CodexProvider extends BaseProvider {
 					}
 				}
 
+				if (state.upstreamError) {
+					return;
+				}
+
 				// Flush any remaining
 				await ensureMessageStart();
 
@@ -1054,6 +1081,102 @@ export class CodexProvider extends BaseProvider {
 			statusText: response.statusText,
 			headers,
 		});
+	}
+
+	private normalizeCodexStreamError(
+		eventName: string,
+		data: Record<string, unknown>,
+	): StreamState["upstreamError"] {
+		const response =
+			data.response && typeof data.response === "object"
+				? (data.response as Record<string, unknown>)
+				: undefined;
+		const responseError =
+			response?.error && typeof response.error === "object"
+				? (response.error as Record<string, unknown>)
+				: undefined;
+		const directError =
+			data.error && typeof data.error === "object"
+				? (data.error as Record<string, unknown>)
+				: undefined;
+		const error = responseError ?? directError ?? data;
+		const messageCandidate = error.message ?? data.message ?? response?.status;
+		const typeCandidate = error.type ?? error.code ?? eventName;
+		const codeCandidate = error.code ?? data.code;
+		const statusCandidate = response?.status ?? data.status;
+
+		return {
+			type:
+				typeof typeCandidate === "string" && typeCandidate.length > 0
+					? typeCandidate
+					: "api_error",
+			message:
+				typeof messageCandidate === "string" && messageCandidate.length > 0
+					? messageCandidate
+					: "Codex upstream failed while generating a response.",
+			...(typeof codeCandidate === "string" ? { code: codeCandidate } : {}),
+			...(typeof statusCandidate === "string"
+				? { status: statusCandidate }
+				: {}),
+		};
+	}
+
+	private toAnthropicErrorPayload(error: StreamState["upstreamError"]): {
+		type: "error";
+		error: { type: string; message: string; code?: string };
+	} {
+		const code = error?.code;
+		const type =
+			code === "context_length_exceeded"
+				? "invalid_request_error"
+				: error?.type || "api_error";
+		return {
+			type: "error",
+			error: {
+				type,
+				message: error?.message || "Codex upstream failed.",
+				...(code ? { code } : {}),
+			},
+		};
+	}
+
+	private httpStatusForAnthropicErrorPayload(
+		payload: Record<string, unknown>,
+	): {
+		status: number;
+		statusText: string;
+	} {
+		const error =
+			payload.error && typeof payload.error === "object"
+				? (payload.error as Record<string, unknown>)
+				: {};
+		const type = typeof error.type === "string" ? error.type : "";
+		const code = typeof error.code === "string" ? error.code : "";
+		const status = typeof error.status === "string" ? error.status : "";
+
+		if (code === "context_length_exceeded") {
+			return { status: 400, statusText: "Bad Request" };
+		}
+		if (type === "invalid_request_error") {
+			return { status: 400, statusText: "Bad Request" };
+		}
+		if (type === "authentication_error") {
+			return { status: 401, statusText: "Unauthorized" };
+		}
+		if (type === "permission_error") {
+			return { status: 403, statusText: "Forbidden" };
+		}
+		if (
+			type === "rate_limit_error" ||
+			code === "rate_limit_exceeded" ||
+			status === "rate_limited"
+		) {
+			return { status: 429, statusText: "Too Many Requests" };
+		}
+		if (type === "overloaded_error") {
+			return { status: 529, statusText: "Overloaded" };
+		}
+		return { status: 502, statusText: "Bad Gateway" };
 	}
 
 	private async handleCodexEvent(
@@ -1218,6 +1341,19 @@ export class CodexProvider extends BaseProvider {
 					});
 					state.contentBlockIndex++;
 					state.hasSentContentBlockStart = false;
+				}
+				break;
+			}
+
+			case "error":
+			case "response.failed": {
+				state.upstreamError = this.normalizeCodexStreamError(eventName, data);
+				if (!state.hasSentTerminalEvents) {
+					await writeSSE(
+						"error",
+						this.toAnthropicErrorPayload(state.upstreamError),
+					);
+					state.hasSentTerminalEvents = true;
 				}
 				break;
 			}

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -1101,15 +1101,14 @@ export class CodexProvider extends BaseProvider {
 				: undefined;
 		const error = responseError ?? directError ?? data;
 		const messageCandidate = error.message ?? data.message ?? response?.status;
-		const typeCandidate = error.type ?? error.code ?? eventName;
+		const rawType = typeof error.type === "string" ? error.type : "";
+		const rawCode = typeof error.code === "string" ? error.code : "";
+		const typeCandidate = rawType && rawType !== "error" ? rawType : rawCode;
 		const codeCandidate = error.code ?? data.code;
 		const statusCandidate = response?.status ?? data.status;
 
 		return {
-			type:
-				typeof typeCandidate === "string" && typeCandidate.length > 0
-					? typeCandidate
-					: "api_error",
+			type: typeCandidate || "api_error",
 			message:
 				typeof messageCandidate === "string" && messageCandidate.length > 0
 					? messageCandidate
@@ -1123,19 +1122,34 @@ export class CodexProvider extends BaseProvider {
 
 	private toAnthropicErrorPayload(error: StreamState["upstreamError"]): {
 		type: "error";
-		error: { type: string; message: string; code?: string };
+		error: { type: string; message: string; code?: string; status?: string };
 	} {
 		const code = error?.code;
-		const type =
-			code === "context_length_exceeded"
-				? "invalid_request_error"
-				: error?.type || "api_error";
+		const status = error?.status === "rate_limited" ? error.status : undefined;
+		const rawType = error?.type;
+		let type = "api_error";
+		if (code === "context_length_exceeded") {
+			type = "invalid_request_error";
+		} else if (code === "rate_limit_exceeded" || status === "rate_limited") {
+			type = "rate_limit_error";
+		} else if (
+			rawType === "invalid_request_error" ||
+			rawType === "authentication_error" ||
+			rawType === "permission_error" ||
+			rawType === "not_found_error" ||
+			rawType === "rate_limit_error" ||
+			rawType === "overloaded_error" ||
+			rawType === "api_error"
+		) {
+			type = rawType;
+		}
 		return {
 			type: "error",
 			error: {
 				type,
 				message: error?.message || "Codex upstream failed.",
 				...(code ? { code } : {}),
+				...(status ? { status } : {}),
 			},
 		};
 	}
@@ -1349,6 +1363,14 @@ export class CodexProvider extends BaseProvider {
 			case "response.failed": {
 				state.upstreamError = this.normalizeCodexStreamError(eventName, data);
 				if (!state.hasSentTerminalEvents) {
+					if (state.hasSentContentBlockStart) {
+						await writeSSE("content_block_stop", {
+							type: "content_block_stop",
+							index: state.contentBlockIndex,
+						});
+						state.contentBlockIndex++;
+						state.hasSentContentBlockStart = false;
+					}
 					await writeSSE(
 						"error",
 						this.toAnthropicErrorPayload(state.upstreamError),


### PR DESCRIPTION
## Summary

Fixes Codex Responses API streams that terminate with `error` or `response.failed` events so they surface to Anthropic-compatible clients instead of being converted into empty successful assistant turns.

## Problem

Codex can return a successful HTTP response containing SSE events like:

- `event: error`
- `event: response.failed`

When those events were ignored, the transformer could fall through to its fallback terminal path and emit a successful empty Anthropic response (`message_delta` / `message_stop`). For Claude Code this can look like a blank completed turn.

## Changes

- Normalize Codex SSE `error` and `response.failed` payloads into Anthropic-style error payloads.
- Emit `event: error` for streaming clients and stop before synthesizing success terminal events.
- Convert transformed SSE errors into JSON errors for non-streaming clients.
- Map invalid request / context-window failures to HTTP 400 for non-streaming callers so deterministic client-side failures are not treated as retryable upstream 502s.
- Add coverage for non-streaming missing-content-type SSE bodies while keeping existing success behavior intact.

## Tests

- `bun test packages/providers/src/providers/codex/provider.test.ts --timeout 30000`
- `bun run build`
- `bun run typecheck`
- `bun run format`
- `bun run lint` *(completed with existing repo warnings; no fixes applied beyond the scoped provider files)*

## Review notes

- Scope is intentionally limited to `packages/providers/src/providers/codex/provider.ts` and its tests.
- Does not change account routing, rate-limit policy, `count_tokens`, tool-call behavior, local launcher config, or diagnostics.
- Project Greptile pre-PR reviewer was not available in this environment (`greptile-reviewer` agent not configured; `greptile` CLI not installed), so I ran a focused local review of this diff instead.
