### PR TITLE
fix(codex): synthesize count token responses

### DIFF
--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -11,10 +11,11 @@ const eventLine = (name: string, data: unknown) => [
 ];
 
 describe("CodexProvider request conversion", () => {
-	it("handles only /v1/messages path", () => {
+	it("handles messages and synthetic count_tokens paths", () => {
 		const provider = new CodexProvider();
 		expect(provider.canHandle("/v1/messages")).toBeTrue();
-		expect(provider.canHandle("/v1/messages/count_tokens")).toBeFalse();
+		expect(provider.canHandle("/v1/messages/count_tokens")).toBeTrue();
+		expect(provider.canHandle("/v1/complete")).toBeFalse();
 	});
 
 	it("forwards Claude reasoning effort to Codex reasoning.effort", async () => {
@@ -762,6 +763,87 @@ describe("CodexProvider.processResponse", () => {
 });
 
 describe("CodexProvider.transformRequestBody", () => {
+	it("returns a synthetic Anthropic count_tokens response", async () => {
+		const provider = new CodexProvider();
+		const url = provider.buildUrl("/v1/messages/count_tokens", "");
+		const request = new Request(url, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-7-sonnet",
+				messages: [{ role: "user", content: "hello world" }],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request, undefined);
+		const body = await transformed.json();
+
+		expect(transformed.headers.get("content-type")).toContain(
+			"application/json",
+		);
+		expect(transformed.headers.get("x-better-ccflare-synthetic-response")).toBe(
+			"true",
+		);
+		expect(transformed.headers.get("x-better-ccflare-synthetic-status")).toBe(
+			"200",
+		);
+		expect(body.input_tokens).toBeNumber();
+		expect(body.input_tokens).toBeGreaterThan(0);
+		expect(body).not.toHaveProperty("input");
+		expect(body).not.toHaveProperty("stream");
+		expect(body).not.toHaveProperty("store");
+	});
+
+	it("returns a synthetic error for malformed count_tokens requests", async () => {
+		const provider = new CodexProvider();
+		const url = provider.buildUrl("/v1/messages/count_tokens", "");
+		const request = new Request(url, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: "{not-json",
+		});
+
+		const transformed = await provider.transformRequestBody(request, undefined);
+		const body = await transformed.json();
+
+		expect(transformed.headers.get("x-better-ccflare-synthetic-response")).toBe(
+			"true",
+		);
+		expect(transformed.headers.get("x-better-ccflare-synthetic-status")).toBe(
+			"400",
+		);
+		expect(body).toEqual({
+			type: "error",
+			error: {
+				type: "invalid_request_error",
+				message: "Codex count_tokens requires a valid JSON request body.",
+			},
+		});
+	});
+
+	it("returns a synthetic error for non-JSON count_tokens requests", async () => {
+		const provider = new CodexProvider();
+		const url = provider.buildUrl("/v1/messages/count_tokens", "");
+		const request = new Request(url, {
+			method: "POST",
+			headers: { "content-type": "text/plain" },
+			body: "hello",
+		});
+
+		const transformed = await provider.transformRequestBody(request, undefined);
+		const body = await transformed.json();
+
+		expect(transformed.headers.get("x-better-ccflare-synthetic-response")).toBe(
+			"true",
+		);
+		expect(transformed.headers.get("x-better-ccflare-synthetic-status")).toBe(
+			"400",
+		);
+		expect(body.error.message).toBe(
+			"Codex count_tokens requires an application/json request body.",
+		);
+	});
+
 	it("maps sonnet-family models to the default Codex model", async () => {
 		const provider = new CodexProvider();
 		const request = new Request("https://example.com/v1/messages", {

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -794,6 +794,25 @@ describe("CodexProvider.transformRequestBody", () => {
 		expect(body).not.toHaveProperty("store");
 	});
 
+	it("estimates count_tokens from prompt material instead of the full JSON envelope", async () => {
+		const provider = new CodexProvider();
+		const url = provider.buildUrl("/v1/messages/count_tokens", "");
+		const request = new Request(url, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-7-sonnet",
+				messages: [{ role: "user", content: "hello" }],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request, undefined);
+		const body = await transformed.json();
+
+		expect(body.input_tokens).toBeGreaterThan(0);
+		expect(body.input_tokens).toBeLessThan(10);
+	});
+
 	it("returns a synthetic error for malformed count_tokens requests", async () => {
 		const provider = new CodexProvider();
 		const url = provider.buildUrl("/v1/messages/count_tokens", "");

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -32,6 +32,8 @@ export const CODEX_DEFAULT_ENDPOINT =
 export const CODEX_VERSION = "0.142.0";
 export const CODEX_USER_AGENT = `codex-cli/${CODEX_VERSION} (Windows 10.0.26100; x64)`;
 export const CODEX_PING_MODEL = "gpt-5-codex";
+const CODEX_SYNTHETIC_COUNT_TOKENS_URL =
+	"https://better-ccflare.local/codex/count_tokens";
 
 const _normalizeUsage = (value: unknown): Record<string, number> => {
 	const usage =
@@ -221,7 +223,7 @@ export class CodexProvider extends BaseProvider {
 	}
 
 	canHandle(path: string): boolean {
-		return path === "/v1/messages";
+		return path === "/v1/messages" || path === "/v1/messages/count_tokens";
 	}
 
 	async refreshToken(
@@ -292,6 +294,10 @@ export class CodexProvider extends BaseProvider {
 	}
 
 	buildUrl(_path: string, _query: string, account?: Account): string {
+		if (_path === "/v1/messages/count_tokens") {
+			return CODEX_SYNTHETIC_COUNT_TOKENS_URL;
+		}
+
 		if (account?.custom_endpoint) {
 			try {
 				return validateEndpointUrl(account.custom_endpoint, "custom_endpoint");
@@ -332,14 +338,28 @@ export class CodexProvider extends BaseProvider {
 		request: Request,
 		account?: Account,
 	): Promise<Request> {
+		const isSyntheticCountTokens = this.isSyntheticCountTokensRequest(
+			request.url,
+		);
 		const contentType = request.headers.get("content-type");
 		if (!contentType?.includes("application/json")) {
-			return request;
+			return isSyntheticCountTokens
+				? this.createSyntheticErrorResponse(
+						request,
+						400,
+						"invalid_request_error",
+						"Codex count_tokens requires an application/json request body.",
+					)
+				: request;
 		}
 
 		try {
 			this.sweepRequestStreamById();
 			const body = (await request.json()) as AnthropicRequest;
+			if (isSyntheticCountTokens) {
+				return this.createSyntheticCountTokensResponse(request, body);
+			}
+
 			const requestId = request.headers.get("x-better-ccflare-request-id");
 			if (requestId) {
 				this.requestStreamById.set(requestId, {
@@ -369,6 +389,14 @@ export class CodexProvider extends BaseProvider {
 		} catch (error) {
 			if (error instanceof ValidationError) {
 				throw error;
+			}
+			if (isSyntheticCountTokens) {
+				return this.createSyntheticErrorResponse(
+					request,
+					400,
+					"invalid_request_error",
+					"Codex count_tokens requires a valid JSON request body.",
+				);
 			}
 			log.error("Failed to transform request body to Codex format:", error);
 			return request;
@@ -620,6 +648,68 @@ export class CodexProvider extends BaseProvider {
 			},
 			context_window_size: contextWindowSize,
 		};
+	}
+
+	private isSyntheticCountTokensRequest(url: string): boolean {
+		try {
+			return url === CODEX_SYNTHETIC_COUNT_TOKENS_URL;
+		} catch {
+			return false;
+		}
+	}
+
+	private createSyntheticJsonResponse(
+		request: Request,
+		status: number,
+		body: unknown,
+	): Request {
+		const headers = new Headers({
+			"content-type": "application/json",
+			"x-better-ccflare-synthetic-response": "true",
+			"x-better-ccflare-synthetic-status": String(status),
+		});
+		return new Request(request.url, {
+			method: request.method,
+			headers,
+			body: JSON.stringify(body),
+		});
+	}
+
+	private createSyntheticCountTokensResponse(
+		request: Request,
+		body: unknown,
+	): Request {
+		return this.createSyntheticJsonResponse(request, 200, {
+			input_tokens: this.estimateCountTokensInput(body),
+		});
+	}
+
+	private createSyntheticErrorResponse(
+		request: Request,
+		status: number,
+		type: string,
+		message: string,
+	): Request {
+		return this.createSyntheticJsonResponse(request, status, {
+			type: "error",
+			error: { type, message },
+		});
+	}
+
+	private estimateCountTokensInput(body: unknown): number {
+		let serialized = "";
+		try {
+			serialized = JSON.stringify(body) ?? "";
+		} catch {
+			serialized = String(body ?? "");
+		}
+
+		// Anthropic's count_tokens endpoint is advisory for client-side budgeting.
+		// Codex has no equivalent endpoint, so return a conservative local estimate
+		// instead of failing flows that ask for a token count between real messages.
+		// Roughly 3 UTF-16 chars/token overestimates English text and gives clients a
+		// safe context-budget signal.
+		return Math.max(1, Math.ceil(serialized.length / 3));
 	}
 
 	private convertToCodexFormat(

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -651,11 +651,7 @@ export class CodexProvider extends BaseProvider {
 	}
 
 	private isSyntheticCountTokensRequest(url: string): boolean {
-		try {
-			return url === CODEX_SYNTHETIC_COUNT_TOKENS_URL;
-		} catch {
-			return false;
-		}
+		return url === CODEX_SYNTHETIC_COUNT_TOKENS_URL;
 	}
 
 	private createSyntheticJsonResponse(
@@ -697,19 +693,82 @@ export class CodexProvider extends BaseProvider {
 	}
 
 	private estimateCountTokensInput(body: unknown): number {
-		let serialized = "";
-		try {
-			serialized = JSON.stringify(body) ?? "";
-		} catch {
-			serialized = String(body ?? "");
+		const material = this.extractCountTokensMaterial(body);
+		let serialized = material.join("\n");
+		if (serialized.length === 0) {
+			try {
+				serialized = JSON.stringify(body) ?? "";
+			} catch {
+				serialized = String(body ?? "");
+			}
 		}
 
 		// Anthropic's count_tokens endpoint is advisory for client-side budgeting.
 		// Codex has no equivalent endpoint, so return a conservative local estimate
 		// instead of failing flows that ask for a token count between real messages.
+		// Estimate over prompt material rather than the entire request envelope so
+		// short prompts are not dominated by JSON field names and punctuation.
 		// Roughly 3 UTF-16 chars/token overestimates English text and gives clients a
 		// safe context-budget signal.
 		return Math.max(1, Math.ceil(serialized.length / 3));
+	}
+
+	private extractCountTokensMaterial(body: unknown): string[] {
+		if (!body || typeof body !== "object") return [];
+		const request = body as Record<string, unknown>;
+		const chunks: string[] = [];
+		this.appendCountTokensContent(chunks, request.system);
+		const messages = request.messages;
+		if (Array.isArray(messages)) {
+			for (const message of messages) {
+				if (!message || typeof message !== "object") continue;
+				const msg = message as Record<string, unknown>;
+				if (typeof msg.role === "string") chunks.push(msg.role);
+				this.appendCountTokensContent(chunks, msg.content);
+			}
+		}
+		const tools = request.tools;
+		if (Array.isArray(tools)) {
+			for (const tool of tools) {
+				this.appendCountTokensContent(chunks, tool);
+			}
+		}
+		return chunks;
+	}
+
+	private appendCountTokensContent(chunks: string[], value: unknown): void {
+		if (typeof value === "string") {
+			chunks.push(value);
+			return;
+		}
+		if (Array.isArray(value)) {
+			for (const item of value) {
+				this.appendCountTokensContent(chunks, item);
+			}
+			return;
+		}
+		if (!value || typeof value !== "object") return;
+		const record = value as Record<string, unknown>;
+		const before = chunks.length;
+		if (typeof record.text === "string") chunks.push(record.text);
+		if (typeof record.name === "string") chunks.push(record.name);
+		if (typeof record.description === "string") chunks.push(record.description);
+		if ("input" in record) this.appendCountTokensContent(chunks, record.input);
+		if ("content" in record)
+			this.appendCountTokensContent(chunks, record.content);
+		if ("input_schema" in record) {
+			this.appendCountTokensContent(chunks, record.input_schema);
+		}
+		if ("parameters" in record) {
+			this.appendCountTokensContent(chunks, record.parameters);
+		}
+		if (Object.keys(record).length > 0 && chunks.length === before) {
+			try {
+				chunks.push(JSON.stringify(record));
+			} catch {
+				// Ignore non-serializable objects; the caller has a request-level fallback.
+			}
+		}
 	}
 
 	private convertToCodexFormat(

--- a/packages/proxy/src/handlers/__tests__/proxy-operations-count-tokens.test.ts
+++ b/packages/proxy/src/handlers/__tests__/proxy-operations-count-tokens.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { CodexProvider } from "@better-ccflare/providers";
+import type { Account, RequestMeta } from "@better-ccflare/types";
+import { proxyWithAccount } from "../proxy-operations";
+import type { ProxyContext } from "../proxy-types";
+
+function makeCodexAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "codex-1",
+		name: "codex-test",
+		provider: "codex",
+		api_key: "",
+		refresh_token: "refresh-token",
+		access_token: null,
+		expires_at: null,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: Date.now(),
+		rate_limited_until: null,
+		rate_limited_reason: null,
+		rate_limited_at: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		peak_hours_pause_enabled: false,
+		custom_endpoint: null,
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		billing_type: null,
+		pause_reason: null,
+		refresh_token_issued_at: null,
+		consecutive_rate_limits: 0,
+		...overrides,
+	};
+}
+
+function makeRequestMeta(path = "/v1/messages/count_tokens"): RequestMeta {
+	return {
+		id: "req-count-tokens",
+		method: "POST",
+		path,
+		timestamp: Date.now(),
+		headers: new Headers(),
+	};
+}
+
+function makeProxyContext(): ProxyContext {
+	return {
+		strategy: { getNextAccount: () => null } as never,
+		dbOps: {
+			markAccountRateLimited: mock(() => Promise.resolve(1)),
+			saveRequest: mock(() => Promise.resolve()),
+			updateAccountUsage: mock(() => Promise.resolve()),
+			getAdapter: mock(() => ({
+				run: mock(() => Promise.resolve()),
+				get: mock(() => Promise.resolve(null)),
+			})),
+		} as never,
+		runtime: { port: 8080, clientId: "test" } as never,
+		provider: new CodexProvider() as never,
+		refreshInFlight: new Map(),
+		asyncWriter: { enqueue: mock(() => {}) } as never,
+		config: { getStorePayloads: () => true } as never,
+	};
+}
+
+function makeCountTokensRequest(body: ArrayBuffer) {
+	return new Request("https://proxy.local/v1/messages/count_tokens", {
+		method: "POST",
+		body,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+function makeMessagesRequest(
+	body: ArrayBuffer,
+	headers: Record<string, string>,
+) {
+	return new Request("https://proxy.local/v1/messages", {
+		method: "POST",
+		body,
+		headers,
+	});
+}
+
+describe("proxyWithAccount — Codex count_tokens", () => {
+	let originalFetch: typeof globalThis.fetch;
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("returns a synthetic token count without fetching or refreshing Codex", async () => {
+		const fetchMock = mock(async () => {
+			throw new Error("count_tokens should not call upstream or refresh Codex");
+		});
+		globalThis.fetch = fetchMock;
+
+		const bodyBuffer = new TextEncoder().encode(
+			JSON.stringify({
+				model: "claude-sonnet-4-5",
+				messages: [{ role: "user", content: "hello world" }],
+			}),
+		).buffer;
+		const ctx = makeProxyContext();
+		const result = await proxyWithAccount(
+			makeCountTokensRequest(bodyBuffer),
+			new URL("https://proxy.local/v1/messages/count_tokens"),
+			makeCodexAccount(),
+			makeRequestMeta(),
+			bodyBuffer,
+			() => undefined,
+			0,
+			ctx,
+		);
+
+		expect(fetchMock).toHaveBeenCalledTimes(0);
+		expect(ctx.asyncWriter.enqueue).toHaveBeenCalledTimes(0);
+		expect(result).toBeInstanceOf(Response);
+		expect(result?.status).toBe(200);
+		const payload = await result?.json();
+		expect(payload.input_tokens).toBeNumber();
+		expect(payload.input_tokens).toBeGreaterThan(0);
+	});
+
+	it("returns a synthetic error for malformed count_tokens without fetching", async () => {
+		const fetchMock = mock(async () => {
+			throw new Error("malformed count_tokens should not call upstream Codex");
+		});
+		globalThis.fetch = fetchMock;
+
+		const bodyBuffer = new TextEncoder().encode("{not-json").buffer;
+		const ctx = makeProxyContext();
+		const result = await proxyWithAccount(
+			makeCountTokensRequest(bodyBuffer),
+			new URL("https://proxy.local/v1/messages/count_tokens"),
+			makeCodexAccount(),
+			makeRequestMeta(),
+			bodyBuffer,
+			() => undefined,
+			0,
+			ctx,
+		);
+
+		expect(fetchMock).toHaveBeenCalledTimes(0);
+		expect(ctx.asyncWriter.enqueue).toHaveBeenCalledTimes(0);
+		expect(result).toBeInstanceOf(Response);
+		expect(result?.status).toBe(400);
+		const payload = await result?.json();
+		expect(payload.error.message).toBe(
+			"Codex count_tokens requires a valid JSON request body.",
+		);
+	});
+
+	it("does not trust client-supplied synthetic response markers", async () => {
+		let fetchedRequest: Request | null = null;
+		const fetchMock = mock(async (input: RequestInfo | URL) => {
+			fetchedRequest = input instanceof Request ? input : new Request(input);
+			return new Response(JSON.stringify({ ok: true }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		});
+		globalThis.fetch = fetchMock;
+
+		const bodyBuffer = new TextEncoder().encode(
+			JSON.stringify({
+				model: "claude-sonnet-4-5",
+				messages: [{ role: "user", content: "hello world" }],
+				max_tokens: 16,
+			}),
+		).buffer;
+		await expect(
+			proxyWithAccount(
+				makeMessagesRequest(bodyBuffer, {
+					"Content-Type": "application/json",
+					"x-better-ccflare-synthetic-response": "true",
+					"x-better-ccflare-synthetic-status": "418",
+				}),
+				new URL("https://proxy.local/v1/messages"),
+				makeCodexAccount({
+					access_token: "access-token",
+					expires_at: Date.now() + 60 * 60 * 1000,
+				}),
+				makeRequestMeta("/v1/messages"),
+				bodyBuffer,
+				() => undefined,
+				0,
+				makeProxyContext(),
+			),
+		).rejects.toThrow("UsageCollector not initialized");
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(
+			fetchedRequest?.url.startsWith(
+				"https://chatgpt.com/backend-api/codex/responses",
+			),
+		).toBeTrue();
+		expect(
+			fetchedRequest?.headers.get("x-better-ccflare-synthetic-response"),
+		).toBeNull();
+		expect(
+			fetchedRequest?.headers.get("x-better-ccflare-synthetic-status"),
+		).toBeNull();
+	});
+});

--- a/packages/proxy/src/handlers/__tests__/request-handler.test.ts
+++ b/packages/proxy/src/handlers/__tests__/request-handler.test.ts
@@ -21,9 +21,9 @@ describe("validateProviderPath", () => {
 		).not.toThrow();
 	});
 
-	it("rejects count_tokens for Codex provider", () => {
+	it("accepts count_tokens for Codex provider", () => {
 		expect(() =>
 			validateProviderPath(new CodexProvider(), "/v1/messages/count_tokens"),
-		).toThrow();
+		).not.toThrow();
 	});
 });

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -29,6 +29,10 @@ import { getValidAccessToken } from "./token-manager";
 
 const log = new Logger("ProxyOperations");
 
+const SYNTHETIC_RESPONSE_HEADER = "x-better-ccflare-synthetic-response";
+const SYNTHETIC_STATUS_HEADER = "x-better-ccflare-synthetic-status";
+const SYNTHETIC_RESPONSE_URL_PREFIX = "https://better-ccflare.local/";
+
 /**
  * Determines the absolute epoch timestamp (ms since epoch) until which an account
  * should be marked rate-limited after model exhaustion. Priority:
@@ -99,23 +103,39 @@ export function extractCooldownUntil(
 }
 
 /**
- * Bedrock provider currently returns a synthetic Request containing the
- * provider response payload (instead of a real URL to fetch).
- * Detect and unwrap that request so we don't try to fetch a fake host.
+ * Some providers return a synthetic Request containing the provider response
+ * payload (instead of a real URL to fetch). Detect and unwrap those requests so
+ * we don't try to fetch fake hosts. Bedrock's historical x-bedrock-response
+ * marker is kept for compatibility; newer providers use the generic marker.
  */
 function isSyntheticProviderResponse(request: Request): boolean {
 	return (
-		request.headers.get("x-bedrock-response") === "true" &&
-		request.url.startsWith("https://bedrock.aws/response")
+		(request.headers.get("x-bedrock-response") === "true" &&
+			request.url.startsWith("https://bedrock.aws/response")) ||
+		(request.headers.get(SYNTHETIC_RESPONSE_HEADER) === "true" &&
+			request.url.startsWith(SYNTHETIC_RESPONSE_URL_PREFIX))
 	);
 }
 
+function parseSyntheticStatus(request: Request): number {
+	const status = Number.parseInt(
+		request.headers.get(SYNTHETIC_STATUS_HEADER) ?? "200",
+		10,
+	);
+	return Number.isInteger(status) && status >= 200 && status <= 599
+		? status
+		: 200;
+}
+
 function materializeSyntheticResponse(request: Request): Response {
-	const headers = new Headers(request.headers);
-	headers.delete("x-bedrock-response");
+	const headers = new Headers();
+	const contentType = request.headers.get("content-type");
+	const cacheControl = request.headers.get("cache-control");
+	if (contentType) headers.set("content-type", contentType);
+	if (cacheControl) headers.set("cache-control", cacheControl);
 
 	return new Response(request.body, {
-		status: 200,
+		status: parseSyntheticStatus(request),
 		headers,
 	});
 }
@@ -562,8 +582,14 @@ export async function proxyWithAccount(
 		// Validate that the account-specific provider can handle this path
 		validateProviderPath(provider, url.pathname);
 
-		// Get valid access token
-		const accessToken = await getValidAccessToken(account, ctx);
+		const isSyntheticCodexCountTokens =
+			provider.name === "codex" && url.pathname === "/v1/messages/count_tokens";
+
+		// Synthetic Codex count_tokens never calls upstream, so it should not require
+		// or refresh OAuth credentials just to return an advisory local estimate.
+		const accessToken = isSyntheticCodexCountTokens
+			? ""
+			: await getValidAccessToken(account, ctx);
 
 		// Pre-process request if provider supports it (e.g., to extract model for URL)
 		if (provider.prepareRequest) {
@@ -576,6 +602,10 @@ export async function proxyWithAccount(
 			accessToken,
 			account.api_key || undefined,
 		);
+		// Synthetic-response markers are internal provider-to-proxy signals. Strip
+		// client-supplied copies before providers transform the outbound request.
+		headers.delete(SYNTHETIC_RESPONSE_HEADER);
+		headers.delete(SYNTHETIC_STATUS_HEADER);
 		const targetUrl = provider.buildUrl(url.pathname, url.search, account);
 
 		const requestInit: RequestInit & { duplex?: "half" } = {

--- a/packages/proxy/src/handlers/response-processor.ts
+++ b/packages/proxy/src/handlers/response-processor.ts
@@ -11,6 +11,16 @@ import { applyRateLimitCooldown } from "./rate-limit-cooldown";
 
 const log = new Logger("ResponseProcessor");
 
+function isSyntheticCountTokensRequest(
+	ctx: ProxyContext,
+	requestMeta?: { path?: string },
+): boolean {
+	return (
+		requestMeta?.path === "/v1/messages/count_tokens" &&
+		(ctx.provider.name === "openai-compatible" || ctx.provider.name === "codex")
+	);
+}
+
 /**
  * Handles rate limit response for an account
  * @param account - The rate-limited account
@@ -220,7 +230,7 @@ export async function processProxyResponse(
 	account: Account,
 	ctx: ProxyContext,
 	requestId?: string,
-	requestMeta?: { headers?: Headers },
+	requestMeta?: { headers?: Headers; path?: string },
 ): Promise<boolean> {
 	let rateLimitInfo = ctx.provider.parseRateLimit(response);
 
@@ -301,12 +311,15 @@ export async function processProxyResponse(
 		return true; // Signal rate limit
 	}
 
-	// Update account metadata in background
-	const bypassSession =
-		requestMeta?.headers?.get("x-better-ccflare-bypass-session") === "true";
-	updateAccountMetadata(account, response, ctx, requestId, bypassSession);
+	const skipAccountMetadata = isSyntheticCountTokensRequest(ctx, requestMeta);
+	if (!skipAccountMetadata) {
+		// Update account metadata in background
+		const bypassSession =
+			requestMeta?.headers?.get("x-better-ccflare-bypass-session") === "true";
+		updateAccountMetadata(account, response, ctx, requestId, bypassSession);
+	}
 
-	if (!rateLimitInfo.isRateLimited) {
+	if (!rateLimitInfo.isRateLimited && !skipAccountMetadata) {
 		// (a) Stability reset — gated only on rate_limited_at.
 		// clearExpiredRateLimits nulls rate_limited_until without touching rate_limited_at,
 		// so we must not gate on rate_limited_until or we'd miss accounts already cleared

--- a/packages/proxy/src/response-handler.ts
+++ b/packages/proxy/src/response-handler.ts
@@ -115,19 +115,19 @@ export async function forwardToClient(
 	const shouldStorePayloads = ctx.config.getStorePayloads?.() ?? true;
 
 	// Filter out:
-	//   - count_tokens requests on OpenAI-compatible providers (existing
-	//     filter — these aren't billable user traffic).
+	//   - count_tokens requests on providers that synthesize or proxy advisory
+	//     token counts; these aren't billable user traffic.
 	//   - synthetic auto-refresh probes (issue #199, bug 2). Logging these
 	//     pollutes the user-visible 503/200 metrics on the dashboard with
 	//     internal scheduler activity. Header set by AutoRefreshScheduler
 	//     mirrors the existing keepalive pattern.
 	const isAutoRefreshProbe =
 		requestHeaders.get("x-better-ccflare-auto-refresh") === "true";
-	const shouldProcessRequest =
-		!(
-			ctx.provider.name === "openai-compatible" &&
-			path === "/v1/messages/count_tokens"
-		) && !isAutoRefreshProbe;
+	const isSyntheticCountTokens =
+		path === "/v1/messages/count_tokens" &&
+		(ctx.provider.name === "openai-compatible" ||
+			ctx.provider.name === "codex");
+	const shouldProcessRequest = !isSyntheticCountTokens && !isAutoRefreshProbe;
 
 	// Send START message immediately if not filtered
 	if (shouldProcessRequest) {


### PR DESCRIPTION
## Summary

Adds safe Codex support for Anthropic `/v1/messages/count_tokens` by returning a local advisory token estimate instead of forwarding an unsupported request to Codex.

## Problem

Claude-compatible clients can call `/v1/messages/count_tokens` between real turns for context budgeting. Codex does not expose an equivalent endpoint in this provider path, so accepting this route without special handling would either reject useful client flows or risk sending a fake count_tokens request upstream.

## Changes

- Allow `CodexProvider` to handle `/v1/messages/count_tokens`.
- Route Codex count_tokens to a trusted local synthetic URL and return `{ input_tokens }` JSON.
- Return local 400 JSON errors for malformed or non-JSON Codex count_tokens bodies without fetching upstream.
- Generalize provider synthetic response unwrapping beyond Bedrock while requiring a trusted local URL for the generic marker.
- Strip client-supplied generic synthetic markers before outbound provider requests so clients cannot spoof provider-to-proxy control headers.
- Allowlist synthetic response headers and validate synthetic status values.
- Avoid request/account usage metadata writes for advisory Codex/OpenAI-compatible count_tokens calls.

## Tests

- `bun test packages/providers/src/providers/codex/provider.test.ts packages/proxy/src/handlers/__tests__/request-handler.test.ts packages/proxy/src/handlers/__tests__/proxy-operations-count-tokens.test.ts --timeout 30000`
- `bun run typecheck`
- `bun run build`
- `bun run format`
- `bun run lint` *(reports the existing repository warning backlog; no scoped lint failures introduced)*

## Safety notes

The synthetic response marker is not trusted by itself. The proxy only unwraps generic synthetic responses when the transformed provider request also targets `https://better-ccflare.local/...`; client-supplied synthetic headers on normal `/v1/messages` requests are stripped and the request still goes to upstream Codex. This is covered by `proxy-operations-count-tokens.test.ts`.

## Scope

This PR intentionally does not change Codex streaming/tool-call translation or failed SSE error handling; those are separate patches.
