### PR TITLE
fix(codex): sanitize tool call inputs

### DIFF
--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -112,6 +112,139 @@ describe("CodexProvider request conversion", () => {
 		const body = await transformed.json();
 		expect(body.reasoning).toEqual({ effort: "medium" });
 	});
+
+	it("omits empty Read.pages when replaying Anthropic history to Codex", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-5-sonnet-20241022",
+				max_tokens: 100,
+				messages: [
+					{
+						role: "assistant",
+						content: [
+							{
+								type: "tool_use",
+								id: "call_read_1",
+								name: "Read",
+								input: {
+									file_path: "/tmp/full.diff",
+									offset: 0,
+									limit: 2000,
+									pages: "",
+								},
+							},
+						],
+					},
+				],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request);
+		const body = await transformed.json();
+
+		expect(body.input[0]).toMatchObject({
+			type: "function_call",
+			call_id: "call_read_1",
+			name: "Read",
+		});
+		expect(JSON.parse(body.input[0].arguments)).toEqual({
+			file_path: "/tmp/full.diff",
+			offset: 0,
+			limit: 2000,
+		});
+	});
+
+	it("normalizes stored WebSearch tool_use input when replaying Anthropic history to Codex", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-5-sonnet-20241022",
+				max_tokens: 100,
+				messages: [
+					{
+						role: "assistant",
+						content: [
+							{
+								type: "tool_use",
+								id: "call_search_1",
+								name: "WebSearch",
+								input: {
+									query: "latest earnings",
+									allowed_domains: [" investors.example.com ", ""],
+									blocked_domains: ["spam.example.com"],
+								},
+							},
+						],
+					},
+				],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request);
+		const body = await transformed.json();
+
+		expect(body.input[0]).toMatchObject({
+			type: "function_call",
+			call_id: "call_search_1",
+			name: "WebSearch",
+		});
+		expect(JSON.parse(body.input[0].arguments)).toEqual({
+			query: "latest earnings",
+			allowed_domains: ["investors.example.com"],
+		});
+	});
+
+	it("preserves falsy non-object tool_use input when replaying Anthropic history to Codex", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-5-sonnet-20241022",
+				max_tokens: 100,
+				messages: [
+					{
+						role: "assistant",
+						content: [
+							{
+								type: "tool_use",
+								id: "call_generic_1",
+								name: "generic_tool",
+								input: "",
+							},
+							{
+								type: "tool_use",
+								id: "call_generic_2",
+								name: "generic_tool",
+								input: null,
+							},
+						],
+					},
+				],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request);
+		const body = await transformed.json();
+
+		expect(body.input[0]).toMatchObject({
+			type: "function_call",
+			call_id: "call_generic_1",
+			name: "generic_tool",
+		});
+		expect(body.input[0].arguments).toBe('""');
+		expect(body.input[1]).toMatchObject({
+			type: "function_call",
+			call_id: "call_generic_2",
+			name: "generic_tool",
+		});
+		expect(body.input[1].arguments).toBe("null");
+	});
 });
 
 describe("CodexProvider.processResponse", () => {
@@ -164,6 +297,95 @@ describe("CodexProvider.processResponse", () => {
 		const stopPos = transformedBody.indexOf("event: content_block_stop");
 		expect(deltaPos).toBeGreaterThanOrEqual(0);
 		expect(stopPos).toBeGreaterThan(deltaPos);
+	});
+
+	it("omits empty Read.pages from streaming tool-call arguments", async () => {
+		const provider = new CodexProvider();
+		const upstreamBody = sseBody([
+			...eventLine("response.created", {
+				response: { id: "resp_test", model: "gpt-5.4" },
+			}),
+			...eventLine("response.output_item.added", {
+				item: { type: "function_call", call_id: "call_1", name: "Read" },
+				output_index: 0,
+			}),
+			...eventLine("response.function_call_arguments.delta", {
+				delta: '{"file_path":"/tmp/full.diff","offset":0,',
+				output_index: 0,
+			}),
+			...eventLine("response.function_call_arguments.delta", {
+				delta: '"limit":2000,"pages":""}',
+				output_index: 0,
+			}),
+			...eventLine("response.output_item.done", {
+				item: { type: "function_call", call_id: "call_1", name: "Read" },
+				output_index: 0,
+			}),
+			...eventLine("response.completed", {
+				response: {
+					model: "gpt-5.4",
+					usage: { input_tokens: 1, output_tokens: 1 },
+				},
+			}),
+		]);
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const transformedBody = await transformed.text();
+
+		expect(transformedBody).toContain(
+			'"partial_json":"{\\"file_path\\":\\"/tmp/full.diff\\",\\"offset\\":0,\\"limit\\":2000}"',
+		);
+		expect(transformedBody).not.toContain('\\"pages\\"');
+	});
+
+	it("omits invalid WebSearch domain filters from streaming tool-call arguments", async () => {
+		const provider = new CodexProvider();
+		const upstreamBody = sseBody([
+			...eventLine("response.created", {
+				response: { id: "resp_test", model: "gpt-5.4" },
+			}),
+			...eventLine("response.output_item.added", {
+				item: { type: "function_call", call_id: "call_1", name: "WebSearch" },
+				output_index: 0,
+			}),
+			...eventLine("response.function_call_arguments.delta", {
+				delta: '{"query":"earnings","allowed_domains":[],',
+				output_index: 0,
+			}),
+			...eventLine("response.function_call_arguments.delta", {
+				delta: '"blocked_domains":[""]}',
+				output_index: 0,
+			}),
+			...eventLine("response.output_item.done", {
+				item: { type: "function_call", call_id: "call_1", name: "WebSearch" },
+				output_index: 0,
+			}),
+			...eventLine("response.completed", {
+				response: {
+					model: "gpt-5.4",
+					usage: { input_tokens: 1, output_tokens: 1 },
+				},
+			}),
+		]);
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const transformedBody = await transformed.text();
+
+		expect(transformedBody).toContain(
+			'"partial_json":"{\\"query\\":\\"earnings\\"}"',
+		);
+		expect(transformedBody).not.toContain("allowed_domains");
+		expect(transformedBody).not.toContain("blocked_domains");
 	});
 
 	it("uses the function_call block index rather than the current text block index", async () => {
@@ -539,6 +761,165 @@ describe("CodexProvider.processResponse", () => {
 				id: "call_1",
 				name: "search",
 				input: { query: "hello" },
+			},
+		]);
+	});
+
+	it("omits invalid WebSearch domain filters from non-streaming tool_use input", async () => {
+		const provider = new CodexProvider();
+		const requestId = "req_non_stream_websearch_domains";
+		const originalRequest = new Request("https://example.test/v1/messages", {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				"x-better-ccflare-request-id": requestId,
+			},
+			body: JSON.stringify({
+				model: "claude-sonnet-4-5",
+				max_tokens: 16,
+				stream: false,
+				tools: [
+					{
+						name: "WebSearch",
+						description: "search",
+						input_schema: {
+							type: "object",
+							properties: {
+								allowed_domains: { type: "array", items: { type: "string" } },
+								blocked_domains: { type: "array", items: { type: "string" } },
+							},
+						},
+					},
+				],
+				messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+			}),
+		});
+		await provider.transformRequestBody(originalRequest);
+
+		const upstreamBody = sseBody([
+			...eventLine("response.created", {
+				response: { id: "resp_tool", model: "gpt-5.4" },
+			}),
+			...eventLine("response.output_item.added", {
+				item: { type: "function_call", call_id: "call_1", name: "WebSearch" },
+				output_index: 0,
+			}),
+			...eventLine("response.function_call_arguments.delta", {
+				delta:
+					'{"query":"earnings","allowed_domains":["reuters.com"],"blocked_domains":["seekingalpha.com"]}',
+				output_index: 0,
+			}),
+			...eventLine("response.output_item.done", {
+				item: { type: "function_call", call_id: "call_1", name: "WebSearch" },
+				output_index: 0,
+			}),
+			...eventLine("response.completed", {
+				response: {
+					model: "gpt-5.4",
+					usage: { input_tokens: 9, output_tokens: 4 },
+				},
+			}),
+		]);
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: {
+				"content-type": "text/event-stream",
+				"x-better-ccflare-request-id": requestId,
+				"x-better-ccflare-request-stream": "false",
+			},
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const payload = JSON.parse(await transformed.text()) as Record<
+			string,
+			unknown
+		>;
+		expect(payload.content).toEqual([
+			{
+				type: "tool_use",
+				id: "call_1",
+				name: "WebSearch",
+				input: { query: "earnings", allowed_domains: ["reuters.com"] },
+			},
+		]);
+	});
+
+	it("preserves non-object tool arguments in non-streaming SSE-to-JSON conversion", async () => {
+		const provider = new CodexProvider();
+		const requestId = "req_non_stream_non_object_tool_input";
+		const originalRequest = new Request("https://example.test/v1/messages", {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				"x-better-ccflare-request-id": requestId,
+			},
+			body: JSON.stringify({
+				model: "claude-sonnet-4-5",
+				max_tokens: 16,
+				stream: false,
+				tools: [
+					{
+						name: "generic_tool",
+						description: "generic",
+						input_schema: { type: "object" },
+					},
+				],
+				messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+			}),
+		});
+		await provider.transformRequestBody(originalRequest);
+
+		const upstreamBody = sseBody([
+			...eventLine("response.created", {
+				response: { id: "resp_tool", model: "gpt-5.4" },
+			}),
+			...eventLine("response.output_item.added", {
+				item: {
+					type: "function_call",
+					call_id: "call_1",
+					name: "generic_tool",
+				},
+				output_index: 0,
+			}),
+			...eventLine("response.function_call_arguments.delta", {
+				delta: "null",
+				output_index: 0,
+			}),
+			...eventLine("response.output_item.done", {
+				item: {
+					type: "function_call",
+					call_id: "call_1",
+					name: "generic_tool",
+				},
+				output_index: 0,
+			}),
+			...eventLine("response.completed", {
+				response: {
+					model: "gpt-5.4",
+					usage: { input_tokens: 9, output_tokens: 4 },
+				},
+			}),
+		]);
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: {
+				"content-type": "text/event-stream",
+				"x-better-ccflare-request-id": requestId,
+				"x-better-ccflare-request-stream": "false",
+			},
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const payload = JSON.parse(await transformed.text()) as Record<
+			string,
+			unknown
+		>;
+		expect(payload.content).toEqual([
+			{
+				type: "tool_use",
+				id: "call_1",
+				name: "generic_tool",
+				input: null,
 			},
 		]);
 	});

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -613,6 +613,9 @@ export class CodexProvider extends BaseProvider {
 			} else {
 				delete sanitized.allowed_domains;
 			}
+			// Claude Code's WebSearch tool only accepts an allow-list at this
+			// Anthropic-compatibility boundary. Drop block-lists intentionally rather
+			// than forwarding a field the local tool schema rejects.
 			delete sanitized.blocked_domains;
 		}
 

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -169,6 +169,7 @@ interface AnthropicRequest {
 
 interface FunctionCallBuffer {
 	contentBlockIndex: number;
+	name: string;
 	arguments: string[];
 }
 
@@ -545,7 +546,9 @@ export class CodexProvider extends BaseProvider {
 					type: "function_call",
 					call_id: block.id,
 					name: block.name,
-					arguments: JSON.stringify(block.input || {}),
+					arguments: JSON.stringify(
+						this.sanitizeToolUseInput(block.name, block.input),
+					),
 				});
 			} else if (block.type === "tool_result") {
 				const outputText =
@@ -577,6 +580,66 @@ export class CodexProvider extends BaseProvider {
 		}
 
 		return items;
+	}
+
+	private sanitizeToolUseInput(name: string, input: unknown): unknown {
+		if (input === undefined) return {};
+		if (input === null || typeof input !== "object" || Array.isArray(input)) {
+			return input;
+		}
+
+		const sanitized: Record<string, unknown> = {
+			...(input as Record<string, unknown>),
+		};
+
+		if (name === "Read") {
+			const pages = sanitized.pages;
+			if (
+				pages === "" ||
+				pages === null ||
+				pages === undefined ||
+				(Array.isArray(pages) && pages.length === 0)
+			) {
+				delete sanitized.pages;
+			}
+		}
+
+		if (name === "WebSearch") {
+			const allowedDomains = this.cleanWebSearchDomains(
+				sanitized.allowed_domains,
+			);
+			if (allowedDomains.length > 0) {
+				sanitized.allowed_domains = allowedDomains;
+			} else {
+				delete sanitized.allowed_domains;
+			}
+			delete sanitized.blocked_domains;
+		}
+
+		return sanitized;
+	}
+
+	private cleanWebSearchDomains(value: unknown): string[] {
+		if (!Array.isArray(value)) return [];
+		return value
+			.filter((domain): domain is string => typeof domain === "string")
+			.map((domain) => domain.trim())
+			.filter((domain) => domain.length > 0);
+	}
+
+	private sanitizeToolUsePartialJson(
+		name: string,
+		partialJson: string,
+	): string {
+		try {
+			const input = JSON.parse(partialJson) as unknown;
+			if (typeof input !== "object" || input === null || Array.isArray(input)) {
+				return partialJson;
+			}
+			return JSON.stringify(this.sanitizeToolUseInput(name, input));
+		} catch {
+			return partialJson;
+		}
 	}
 
 	private extractContextWindow(
@@ -804,7 +867,7 @@ export class CodexProvider extends BaseProvider {
 					type: "tool_use",
 					id: tool.id || `call_${index}`,
 					name: tool.name,
-					input,
+					input: this.sanitizeToolUseInput(tool.name, input),
 				});
 			}
 		}
@@ -1109,6 +1172,7 @@ export class CodexProvider extends BaseProvider {
 					if (outputIndex !== undefined) {
 						state.functionCallBlocks.set(outputIndex, {
 							contentBlockIndex: blockIdx,
+							name,
 							arguments: [],
 						});
 					}
@@ -1190,7 +1254,10 @@ export class CodexProvider extends BaseProvider {
 							index: buffer.contentBlockIndex,
 							delta: {
 								type: "input_json_delta",
-								partial_json: buffer.arguments.join(""),
+								partial_json: this.sanitizeToolUsePartialJson(
+									buffer.name,
+									buffer.arguments.join(""),
+								),
 							},
 						});
 						await writeSSE("content_block_stop", {


### PR DESCRIPTION
## Summary

Sanitizes Codex tool-call arguments at the Anthropic compatibility boundary so clients do not receive or replay tool inputs that violate local tool schemas.

## Changes

- Drop empty `Read.pages` values when replaying Anthropic tool history to Codex.
- Drop empty `Read.pages` values from Codex streaming tool-call deltas.
- Drop unsupported `WebSearch.blocked_domains` and empty/invalid `allowed_domains` values.
- Trim valid `WebSearch.allowed_domains` entries.
- Apply the same sanitizer in three paths:
  - Anthropic history replay → Codex request body
  - Codex SSE → Anthropic streaming response
  - Codex SSE → Anthropic non-streaming JSON response
- Preserve generic/non-object valid JSON tool arguments (`""`, `null`, etc.) so the sanitizer does not corrupt unrelated tools.

## Tests

- `bun test packages/providers/src/providers/codex/provider.test.ts --timeout 30000`
- `bun run typecheck`
- `bun run build`
- `bun run format`
- `bun run lint` *(reports existing repository warning backlog; no scoped lint failures introduced)*

## Review

Local reviewer pass: no blockers.

Greptile review is recommended by the repo docs but unavailable in this environment (`greptile-reviewer` missing and `greptile` CLI not installed).

## Scope

This PR intentionally avoids changing Codex failed-SSE handling, count_tokens synthesis, diagnostics, or malformed non-streaming partial JSON fallback behavior; those are separate concerns.
