### PR TITLE
fix(codex): align tool call semantics

### DIFF
--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -112,6 +112,91 @@ describe("CodexProvider request conversion", () => {
 		const body = await transformed.json();
 		expect(body.reasoning).toEqual({ effort: "medium" });
 	});
+
+	it("uses role-appropriate text block types in Codex input", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-5-sonnet-20241022",
+				max_tokens: 100,
+				messages: [
+					{ role: "user", content: "hello" },
+					{ role: "assistant", content: "hi" },
+					{ role: "developer", content: "follow policy" },
+				],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request);
+		const body = await transformed.json();
+
+		expect(body.input[0]).toEqual({
+			role: "user",
+			content: [{ type: "input_text", text: "hello" }],
+		});
+		expect(body.input[1]).toEqual({
+			role: "assistant",
+			content: [{ type: "output_text", text: "hi" }],
+		});
+		expect(body.input[2]).toEqual({
+			role: "system",
+			content: [{ type: "input_text", text: "follow policy" }],
+		});
+	});
+
+	it("marks replayed tool call items as completed", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-5-sonnet-20241022",
+				max_tokens: 100,
+				messages: [
+					{
+						role: "assistant",
+						content: [
+							{
+								type: "tool_use",
+								id: "call_1",
+								name: "search",
+								input: { query: "hello" },
+							},
+						],
+					},
+					{
+						role: "user",
+						content: [
+							{
+								type: "tool_result",
+								tool_use_id: "call_1",
+								content: [{ type: "text", text: "result" }],
+							},
+						],
+					},
+				],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request);
+		const body = await transformed.json();
+
+		expect(body.input[0]).toMatchObject({
+			type: "function_call",
+			call_id: "call_1",
+			name: "search",
+			arguments: JSON.stringify({ query: "hello" }),
+			status: "completed",
+		});
+		expect(body.input[1]).toMatchObject({
+			type: "function_call_output",
+			call_id: "call_1",
+			output: "result",
+			status: "completed",
+		});
+	});
 });
 
 describe("CodexProvider.processResponse", () => {
@@ -164,6 +249,7 @@ describe("CodexProvider.processResponse", () => {
 		const stopPos = transformedBody.indexOf("event: content_block_stop");
 		expect(deltaPos).toBeGreaterThanOrEqual(0);
 		expect(stopPos).toBeGreaterThan(deltaPos);
+		expect(transformedBody).toContain('"stop_reason":"tool_use"');
 	});
 
 	it("uses the function_call block index rather than the current text block index", async () => {
@@ -541,6 +627,7 @@ describe("CodexProvider.processResponse", () => {
 				input: { query: "hello" },
 			},
 		]);
+		expect(payload.stop_reason).toBe("tool_use");
 	});
 
 	it("maps response.completed usage into Claude-compatible context_window using model metadata", async () => {

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -55,64 +55,6 @@ describe("CodexProvider request conversion", () => {
 		expect(body.reasoning).toEqual({ effort: "xhigh" });
 	});
 
-	it("keeps default Codex reasoning effort when Claude effort is absent", async () => {
-		const provider = new CodexProvider();
-		const request = new Request("https://example.com/v1/messages", {
-			method: "POST",
-			headers: { "content-type": "application/json" },
-			body: JSON.stringify({
-				model: "claude-3-5-sonnet-20241022",
-				max_tokens: 100,
-				messages: [{ role: "user", content: "Hello" }],
-			}),
-		});
-
-		const transformed = await provider.transformRequestBody(request);
-		const body = await transformed.json();
-
-		expect(body.reasoning).toEqual({ effort: "medium" });
-	});
-
-	it("rejects unsupported reasoning effort values", async () => {
-		const provider = new CodexProvider();
-		const request = new Request("https://example.com/v1/messages", {
-			method: "POST",
-			headers: { "content-type": "application/json" },
-			body: JSON.stringify({
-				model: "claude-3-5-sonnet-20241022",
-				max_tokens: 100,
-				reasoning: { effort: "extreme" },
-				messages: [{ role: "user", content: "Hello" }],
-			}),
-		});
-
-		await expect(provider.transformRequestBody(request)).rejects.toThrow(
-			"reasoning.effort must be one of: minimal, low, medium, high, xhigh, max",
-		);
-	});
-
-	it("downgrades efforts unsupported by the mapped Codex model", async () => {
-		const provider = new CodexProvider();
-		const account = {
-			model_mappings: JSON.stringify({ sonnet: "gpt-5.4-mini" }),
-		} as Parameters<typeof provider.transformRequestBody>[1];
-
-		const request = new Request("https://example.com/v1/messages", {
-			method: "POST",
-			headers: { "content-type": "application/json" },
-			body: JSON.stringify({
-				model: "claude-3-5-sonnet-20241022",
-				max_tokens: 100,
-				reasoning: { effort: "xhigh" },
-				messages: [{ role: "user", content: "Hello" }],
-			}),
-		});
-
-		const transformed = await provider.transformRequestBody(request, account);
-		const body = await transformed.json();
-		expect(body.reasoning).toEqual({ effort: "medium" });
-	});
-
 	it("uses role-appropriate text block types in Codex input", async () => {
 		const provider = new CodexProvider();
 		const request = new Request("https://example.com/v1/messages", {
@@ -196,6 +138,64 @@ describe("CodexProvider request conversion", () => {
 			output: "result",
 			status: "completed",
 		});
+	});
+
+	it("keeps default Codex reasoning effort when Claude effort is absent", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-5-sonnet-20241022",
+				max_tokens: 100,
+				messages: [{ role: "user", content: "Hello" }],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request);
+		const body = await transformed.json();
+
+		expect(body.reasoning).toEqual({ effort: "medium" });
+	});
+
+	it("rejects unsupported reasoning effort values", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-5-sonnet-20241022",
+				max_tokens: 100,
+				reasoning: { effort: "extreme" },
+				messages: [{ role: "user", content: "Hello" }],
+			}),
+		});
+
+		await expect(provider.transformRequestBody(request)).rejects.toThrow(
+			"reasoning.effort must be one of: minimal, low, medium, high, xhigh, max",
+		);
+	});
+
+	it("downgrades efforts unsupported by the mapped Codex model", async () => {
+		const provider = new CodexProvider();
+		const account = {
+			model_mappings: JSON.stringify({ sonnet: "gpt-5.4-mini" }),
+		} as Parameters<typeof provider.transformRequestBody>[1];
+
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-5-sonnet-20241022",
+				max_tokens: 100,
+				reasoning: { effort: "xhigh" },
+				messages: [{ role: "user", content: "Hello" }],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request, account);
+		const body = await transformed.json();
+		expect(body.reasoning).toEqual({ effort: "medium" });
 	});
 });
 

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -197,11 +197,11 @@ interface StreamState {
 	outputTokens: number;
 	cacheReadInputTokens: number;
 	cacheCreationInputTokens: number;
+	// Anthropic clients expect stop_reason=tool_use when the assistant emitted a tool call.
+	sawToolUse: boolean;
 	contextWindow: ContextWindow | null;
 	// Track function_call items: output_index → buffered arguments and block index
 	functionCallBlocks: Map<number, FunctionCallBuffer>;
-	// Anthropic clients expect stop_reason=tool_use when the assistant emitted a tool call.
-	sawToolUse: boolean;
 }
 
 export class CodexProvider extends BaseProvider {
@@ -550,7 +550,6 @@ export class CodexProvider extends BaseProvider {
 					call_id: block.id,
 					name: block.name,
 					arguments: JSON.stringify(block.input || {}),
-					status: "completed",
 				});
 			} else if (block.type === "tool_result") {
 				const outputText =
@@ -576,7 +575,7 @@ export class CodexProvider extends BaseProvider {
 			items.push({ role, content: textBlocks } as CodexMessage);
 		}
 		for (const fc of functionCalls) {
-			items.push(fc);
+			items.push({ ...fc, status: "completed" });
 		}
 		for (const fco of functionCallOutputs) {
 			items.push(fco);

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -82,12 +82,14 @@ interface CodexFunctionCallItem {
 	call_id: string;
 	name: string;
 	arguments: string;
+	status?: "in_progress" | "completed" | "incomplete";
 }
 
 interface CodexFunctionCallOutputItem {
 	type: "function_call_output";
 	call_id: string;
 	output: string;
+	status?: "in_progress" | "completed" | "incomplete";
 }
 
 type CodexContentItem =
@@ -97,7 +99,7 @@ type CodexContentItem =
 	| CodexFunctionCallOutputItem;
 
 interface CodexMessage {
-	role: "user" | "assistant";
+	role: "user" | "assistant" | "system";
 	content: CodexContentItem[];
 }
 
@@ -198,6 +200,8 @@ interface StreamState {
 	contextWindow: ContextWindow | null;
 	// Track function_call items: output_index → buffered arguments and block index
 	functionCallBlocks: Map<number, FunctionCallBuffer>;
+	// Anthropic clients expect stop_reason=tool_use when the assistant emitted a tool call.
+	sawToolUse: boolean;
 }
 
 export class CodexProvider extends BaseProvider {
@@ -520,7 +524,7 @@ export class CodexProvider extends BaseProvider {
 		const role = (msg.role as string) === "developer" ? "system" : msg.role;
 
 		if (typeof msg.content === "string") {
-			const contentType = role === "user" ? "input_text" : "output_text";
+			const contentType = role === "assistant" ? "output_text" : "input_text";
 			items.push({
 				role,
 				content: [{ type: contentType, text: msg.content } as CodexContentItem],
@@ -535,7 +539,7 @@ export class CodexProvider extends BaseProvider {
 
 		for (const block of msg.content) {
 			if (block.type === "text") {
-				const contentType = role === "user" ? "input_text" : "output_text";
+				const contentType = role === "assistant" ? "output_text" : "input_text";
 				textBlocks.push({
 					type: contentType,
 					text: block.text,
@@ -546,6 +550,7 @@ export class CodexProvider extends BaseProvider {
 					call_id: block.id,
 					name: block.name,
 					arguments: JSON.stringify(block.input || {}),
+					status: "completed",
 				});
 			} else if (block.type === "tool_result") {
 				const outputText =
@@ -561,6 +566,7 @@ export class CodexProvider extends BaseProvider {
 					type: "function_call_output",
 					call_id: block.tool_use_id,
 					output: outputText,
+					status: "completed",
 				});
 			}
 		}
@@ -841,6 +847,9 @@ export class CodexProvider extends BaseProvider {
 				`[codex:model-debug] request_id=${requestId} transformSseResponseToJson used fallback model=gpt-5.4 (startMessage.model missing)`,
 			);
 		}
+		const stopReason = content.some((block) => block.type === "tool_use")
+			? "tool_use"
+			: "end_turn";
 		const jsonPayload = {
 			id:
 				typeof startMessage.id === "string"
@@ -850,7 +859,7 @@ export class CodexProvider extends BaseProvider {
 			role: "assistant",
 			model: resolvedModel,
 			content: content.length > 0 ? content : [{ type: "text", text: "" }],
-			stop_reason: "end_turn",
+			stop_reason: stopReason,
 			stop_sequence: null,
 			usage,
 		};
@@ -885,6 +894,7 @@ export class CodexProvider extends BaseProvider {
 			cacheCreationInputTokens: 0,
 			contextWindow: null,
 			functionCallBlocks: new Map(),
+			sawToolUse: false,
 		};
 
 		const headers = sanitizeResponseHeaders(response.headers);
@@ -1035,7 +1045,10 @@ export class CodexProvider extends BaseProvider {
 				if (!state.hasSentTerminalEvents) {
 					await writeSSE("message_delta", {
 						type: "message_delta",
-						delta: { stop_reason: "end_turn", stop_sequence: null },
+						delta: {
+							stop_reason: state.sawToolUse ? "tool_use" : "end_turn",
+							stop_sequence: null,
+						},
 						usage: { output_tokens: state.outputTokens },
 					});
 					await writeSSE("message_stop", { type: "message_stop" });
@@ -1088,6 +1101,7 @@ export class CodexProvider extends BaseProvider {
 				} else if (itemType === "function_call") {
 					const callId = item?.call_id as string;
 					const name = item?.name as string;
+					state.sawToolUse = true;
 
 					if (state.hasSentContentBlockStart) {
 						await writeSSE("content_block_stop", {
@@ -1264,7 +1278,7 @@ export class CodexProvider extends BaseProvider {
 
 				const messageDelta: {
 					type: "message_delta";
-					delta: { stop_reason: "end_turn"; stop_sequence: null };
+					delta: { stop_reason: "end_turn" | "tool_use"; stop_sequence: null };
 					usage: {
 						input_tokens: number;
 						output_tokens: number;
@@ -1274,7 +1288,10 @@ export class CodexProvider extends BaseProvider {
 					context_window?: ContextWindow;
 				} = {
 					type: "message_delta",
-					delta: { stop_reason: "end_turn", stop_sequence: null },
+					delta: {
+						stop_reason: state.sawToolUse ? "tool_use" : "end_turn",
+						stop_sequence: null,
+					},
 					usage: {
 						input_tokens: state.inputTokens,
 						output_tokens: state.outputTokens,


### PR DESCRIPTION
## Summary

Aligns Codex tool-call request/response semantics with the Anthropic-compatible client contract so tool loops continue correctly.

## Changes

- Encode assistant text as Codex `output_text` and user/system/developer text as `input_text`.
- Allow replayed Codex messages to use the runtime `system` role when Anthropic-style `developer` messages are present.
- Mark replayed `function_call` and `function_call_output` items as `status: "completed"`.
- Return `stop_reason: "tool_use"` in streaming and non-streaming Anthropic-compatible responses when Codex emits a tool call.
- Preserve `end_turn` for text-only responses.

## Tests

- `bun test packages/providers/src/providers/codex/provider.test.ts --timeout 30000`
- `bun run typecheck`
- `bun run build`
- `bun run format`
- `bun run lint` *(reports existing repository warning backlog; no scoped lint failures introduced)*

## Review

Local reviewer pass: no blockers.

Greptile review is recommended by the repo docs but unavailable in this environment (`greptile-reviewer` missing and `greptile` CLI not installed).

## Scope

This PR intentionally avoids Codex failed-SSE handling, count_tokens synthesis, tool input sanitization, Skill continuation nudges, and diagnostics; those are separate review slices.
