### PR TITLE
fix(codex): continue after Skill results

### DIFF
--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -112,6 +112,98 @@ describe("CodexProvider request conversion", () => {
 		const body = await transformed.json();
 		expect(body.reasoning).toEqual({ effort: "medium" });
 	});
+
+	it("adds a continuation nudge after Skill tool results", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-7-sonnet",
+				max_tokens: 10,
+				messages: [
+					{ role: "user", content: "load /ce-plan" },
+					{
+						role: "assistant",
+						content: [
+							{
+								type: "tool_use",
+								id: "call_skill_1",
+								name: "Skill",
+								input: { skill: "ce-plan" },
+							},
+						],
+					},
+					{
+						role: "user",
+						content: [
+							{
+								type: "tool_result",
+								tool_use_id: "call_skill_1",
+								content: [{ type: "text", text: "Successfully loaded skill" }],
+							},
+						],
+					},
+				],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request, undefined);
+		const body = await transformed.json();
+
+		expect(body.input).toContainEqual({
+			role: "user",
+			content: [
+				{
+					type: "input_text",
+					text: "The requested Skill tool has loaded additional instructions. Continue the user's original request now, applying those instructions. Do not wait for another user message.",
+				},
+			],
+		});
+	});
+
+	it("does not add a continuation nudge after non-Skill tool results", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-7-sonnet",
+				max_tokens: 10,
+				messages: [
+					{ role: "user", content: "search" },
+					{
+						role: "assistant",
+						content: [
+							{
+								type: "tool_use",
+								id: "call_search_1",
+								name: "WebSearch",
+								input: { query: "news" },
+							},
+						],
+					},
+					{
+						role: "user",
+						content: [
+							{
+								type: "tool_result",
+								tool_use_id: "call_search_1",
+								content: [{ type: "text", text: "results" }],
+							},
+						],
+					},
+				],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request, undefined);
+		const body = await transformed.json();
+
+		expect(JSON.stringify(body.input)).not.toContain(
+			"Continue the user's original request now",
+		);
+	});
 });
 
 describe("CodexProvider.processResponse", () => {

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -204,6 +204,51 @@ describe("CodexProvider request conversion", () => {
 			"Continue the user's original request now",
 		);
 	});
+
+	it("does not inject a Skill continuation nudge into replayed mid-history", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-7-sonnet",
+				max_tokens: 10,
+				messages: [
+					{ role: "user", content: "load /ce-plan" },
+					{
+						role: "assistant",
+						content: [
+							{
+								type: "tool_use",
+								id: "call_skill_1",
+								name: "Skill",
+								input: { skill: "ce-plan" },
+							},
+						],
+					},
+					{
+						role: "user",
+						content: [
+							{
+								type: "tool_result",
+								tool_use_id: "call_skill_1",
+								content: [{ type: "text", text: "Successfully loaded skill" }],
+							},
+						],
+					},
+					{ role: "assistant", content: "I will apply the plan skill." },
+					{ role: "user", content: "continue" },
+				],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request, undefined);
+		const body = await transformed.json();
+
+		expect(JSON.stringify(body.input)).not.toContain(
+			"Continue the user's original request now",
+		);
+	});
 });
 
 describe("CodexProvider.processResponse", () => {

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -36,83 +36,6 @@ describe("CodexProvider request conversion", () => {
 		expect(body.reasoning).toEqual({ effort: "high" });
 	});
 
-	it("forwards xhigh reasoning effort to Codex unchanged", async () => {
-		const provider = new CodexProvider();
-		const request = new Request("https://example.com/v1/messages", {
-			method: "POST",
-			headers: { "content-type": "application/json" },
-			body: JSON.stringify({
-				model: "claude-3-5-sonnet-20241022",
-				max_tokens: 100,
-				reasoning: { effort: "xhigh" },
-				messages: [{ role: "user", content: "Hello" }],
-			}),
-		});
-
-		const transformed = await provider.transformRequestBody(request);
-		const body = await transformed.json();
-
-		expect(body.reasoning).toEqual({ effort: "xhigh" });
-	});
-
-	it("keeps default Codex reasoning effort when Claude effort is absent", async () => {
-		const provider = new CodexProvider();
-		const request = new Request("https://example.com/v1/messages", {
-			method: "POST",
-			headers: { "content-type": "application/json" },
-			body: JSON.stringify({
-				model: "claude-3-5-sonnet-20241022",
-				max_tokens: 100,
-				messages: [{ role: "user", content: "Hello" }],
-			}),
-		});
-
-		const transformed = await provider.transformRequestBody(request);
-		const body = await transformed.json();
-
-		expect(body.reasoning).toEqual({ effort: "medium" });
-	});
-
-	it("rejects unsupported reasoning effort values", async () => {
-		const provider = new CodexProvider();
-		const request = new Request("https://example.com/v1/messages", {
-			method: "POST",
-			headers: { "content-type": "application/json" },
-			body: JSON.stringify({
-				model: "claude-3-5-sonnet-20241022",
-				max_tokens: 100,
-				reasoning: { effort: "extreme" },
-				messages: [{ role: "user", content: "Hello" }],
-			}),
-		});
-
-		await expect(provider.transformRequestBody(request)).rejects.toThrow(
-			"reasoning.effort must be one of: minimal, low, medium, high, xhigh, max",
-		);
-	});
-
-	it("downgrades efforts unsupported by the mapped Codex model", async () => {
-		const provider = new CodexProvider();
-		const account = {
-			model_mappings: JSON.stringify({ sonnet: "gpt-5.4-mini" }),
-		} as Parameters<typeof provider.transformRequestBody>[1];
-
-		const request = new Request("https://example.com/v1/messages", {
-			method: "POST",
-			headers: { "content-type": "application/json" },
-			body: JSON.stringify({
-				model: "claude-3-5-sonnet-20241022",
-				max_tokens: 100,
-				reasoning: { effort: "xhigh" },
-				messages: [{ role: "user", content: "Hello" }],
-			}),
-		});
-
-		const transformed = await provider.transformRequestBody(request, account);
-		const body = await transformed.json();
-		expect(body.reasoning).toEqual({ effort: "medium" });
-	});
-
 	it("adds a continuation nudge after Skill tool results", async () => {
 		const provider = new CodexProvider();
 		const request = new Request("https://example.com/v1/messages", {
@@ -248,6 +171,83 @@ describe("CodexProvider request conversion", () => {
 		expect(JSON.stringify(body.input)).not.toContain(
 			"Continue the user's original request now",
 		);
+	});
+
+	it("forwards xhigh reasoning effort to Codex unchanged", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-5-sonnet-20241022",
+				max_tokens: 100,
+				reasoning: { effort: "xhigh" },
+				messages: [{ role: "user", content: "Hello" }],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request);
+		const body = await transformed.json();
+
+		expect(body.reasoning).toEqual({ effort: "xhigh" });
+	});
+
+	it("keeps default Codex reasoning effort when Claude effort is absent", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-5-sonnet-20241022",
+				max_tokens: 100,
+				messages: [{ role: "user", content: "Hello" }],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request);
+		const body = await transformed.json();
+
+		expect(body.reasoning).toEqual({ effort: "medium" });
+	});
+
+	it("rejects unsupported reasoning effort values", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-5-sonnet-20241022",
+				max_tokens: 100,
+				reasoning: { effort: "extreme" },
+				messages: [{ role: "user", content: "Hello" }],
+			}),
+		});
+
+		await expect(provider.transformRequestBody(request)).rejects.toThrow(
+			"reasoning.effort must be one of: minimal, low, medium, high, xhigh, max",
+		);
+	});
+
+	it("downgrades efforts unsupported by the mapped Codex model", async () => {
+		const provider = new CodexProvider();
+		const account = {
+			model_mappings: JSON.stringify({ sonnet: "gpt-5.4-mini" }),
+		} as Parameters<typeof provider.transformRequestBody>[1];
+
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-5-sonnet-20241022",
+				max_tokens: 100,
+				reasoning: { effort: "xhigh" },
+				messages: [{ role: "user", content: "Hello" }],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request, account);
+		const body = await transformed.json();
+		expect(body.reasoning).toEqual({ effort: "medium" });
 	});
 });
 

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -638,9 +638,9 @@ export class CodexProvider extends BaseProvider {
 		// Convert messages
 		const input: CodexRequest["input"] = [];
 		const skillCallIds = new Set<string>();
-		for (const msg of body.messages) {
+		for (const [msgIndex, msg] of body.messages.entries()) {
 			const items = this.convertMessage(msg);
-			for (const item of items) {
+			for (const [itemIndex, item] of items.entries()) {
 				input.push(item);
 				if ("type" in item && item.type === "function_call") {
 					if (item.name === "Skill") {
@@ -652,6 +652,12 @@ export class CodexProvider extends BaseProvider {
 					skillCallIds.has(item.call_id)
 				) {
 					skillCallIds.delete(item.call_id);
+					if (
+						msgIndex !== body.messages.length - 1 ||
+						itemIndex !== items.length - 1
+					) {
+						continue;
+					}
 					input.push({
 						role: "user",
 						content: [

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -637,10 +637,31 @@ export class CodexProvider extends BaseProvider {
 
 		// Convert messages
 		const input: CodexRequest["input"] = [];
+		const skillCallIds = new Set<string>();
 		for (const msg of body.messages) {
 			const items = this.convertMessage(msg);
 			for (const item of items) {
 				input.push(item);
+				if ("type" in item && item.type === "function_call") {
+					if (item.name === "Skill") {
+						skillCallIds.add(item.call_id);
+					}
+				} else if (
+					"type" in item &&
+					item.type === "function_call_output" &&
+					skillCallIds.has(item.call_id)
+				) {
+					skillCallIds.delete(item.call_id);
+					input.push({
+						role: "user",
+						content: [
+							{
+								type: "input_text",
+								text: "The requested Skill tool has loaded additional instructions. Continue the user's original request now, applying those instructions. Do not wait for another user message.",
+							},
+						],
+					});
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary

Adds a narrow continuation nudge after Claude Code `Skill` tool results are replayed into Codex so Codex resumes the original request after local skill instructions load.

## Problem

The `Skill` tool is local to the Anthropic-compatible client/harness. After it returns successfully, the useful behavior is for the model to continue the user's original request using the newly loaded instructions, not to stall waiting for another user message.

## Changes

- Track replayed `Skill` tool-call IDs during Anthropic history → Codex input conversion.
- After the matching `tool_result`, append one user `input_text` continuation nudge.
- Delete the tracked call ID after injection to avoid duplicate nudges.
- Leave non-Skill tool results unchanged.

## Tests

- `bun test packages/providers/src/providers/codex/provider.test.ts --timeout 30000`
- `bun run typecheck`
- `bun run build`
- `bun run format`
- `bun run lint` *(reports existing repository warning backlog; no scoped lint failures introduced)*

## Review

Local reviewer pass: no blockers.

Greptile review is recommended by the repo docs but unavailable in this environment (`greptile-reviewer` missing and `greptile` CLI not installed).

## Scope

This PR intentionally avoids Codex protocol semantics, failed-SSE handling, count_tokens synthesis, tool input sanitization, and diagnostics; those are separate review slices.
