### PR TITLE
feat(providers): add xAI Grok OAuth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,6 +716,7 @@ We recommend using one of the workarounds above until the npm bug is fixed.
 - **Vertex AI** - Google Cloud Vertex AI integration with service account authentication
 - **z.ai, Minimax** - API key based providers with pay-as-you-go model
 - **OpenRouter** - OpenRouter integration with native API support and model mapping
+- **xAI/Grok** - Native Grok CLI OAuth import/refresh with per-request token accounting (Grok OAuth does not currently expose a pollable quota-window endpoint)
 - **Kilo** - Kilo API integration with usage tracking
 - **Anthropic-Compatible** - Custom Anthropic-compatible providers with pay-as-you-go model
 - **Ollama** - Local Ollama instance (v0.14.0+) via native Anthropic-compatible API at `/v1/messages`, no API key required

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ https://github.com/user-attachments/assets/c859872f-ca5e-4f8b-b6a0-7cc7461fe62a
 ## Why better-ccflare?
 
 - **🚀 Zero Rate Limit Errors** - Automatically distribute requests across multiple accounts
-- **🤖 Multi-Provider Support** - Claude OAuth, Claude API console, Vertex AI, AWS Bedrock, NanoGPT, z.ai, Minimax, OpenRouter, Kilo, Codex (OpenAI OAuth), Anthropic-compatible, and OpenAI-compatible providers
+- **🤖 Multi-Provider Support** - Claude OAuth, Claude API console, Vertex AI, AWS Bedrock, NanoGPT, z.ai, Minimax, OpenRouter, Kilo, Codex (OpenAI OAuth), xAI/Grok, Anthropic-compatible, and OpenAI-compatible providers
 - **🔒 OAuth Token Health** - Real-time monitoring of OAuth token status with automatic refresh and health indicators
 - **🔗 Custom API Endpoints** - Configure custom endpoints for Anthropic accounts for enterprise deployments
 - **☁️ OpenAI-Compatible Support** - Use OpenAI-compatible providers like OpenRouter, Together AI, and more with Claude API format
@@ -34,7 +34,7 @@ This project builds upon the excellent foundation of [snipeship/ccflare](https:/
 **🎯 Core Improvements (v3.0.0):**
 - **Enhanced Security** - Critical fixes for authentication bypass, command injection, and PKCE implementation
 - **OAuth Token Health Monitoring** - Real-time status indicators and automatic token refresh with 30-minute buffer
-- **Extended Provider Support** - AWS Bedrock, NanoGPT (with dynamic pricing), Minimax, OpenRouter, Kilo, Codex (OpenAI OAuth), Anthropic-compatible, and OpenAI-compatible providers
+- **Extended Provider Support** - AWS Bedrock, NanoGPT (with dynamic pricing), Minimax, OpenRouter, Kilo, Codex (OpenAI OAuth), xAI/Grok, Anthropic-compatible, and OpenAI-compatible providers
 - **Simplified Load Balancing** - Removed tier system for O(1) priority-based selection
 - **Real-time Analytics Dashboard** - Beautiful web UI with fixed request history (no disappearing requests)
 - **Package Distribution** - Available via npm and bun for easy installation

--- a/README.md
+++ b/README.md
@@ -716,7 +716,7 @@ We recommend using one of the workarounds above until the npm bug is fixed.
 - **Vertex AI** - Google Cloud Vertex AI integration with service account authentication
 - **z.ai, Minimax** - API key based providers with pay-as-you-go model
 - **OpenRouter** - OpenRouter integration with native API support and model mapping
-- **xAI/Grok** - Native Grok CLI OAuth import/refresh with per-request token accounting (Grok OAuth does not currently expose a pollable quota-window endpoint)
+- **xAI/Grok** - Native Grok CLI OAuth import/refresh with per-request token accounting and Grok Build credits usage polling via grok.com gRPC-web
 - **Kilo** - Kilo API integration with usage tracking
 - **Anthropic-Compatible** - Custom Anthropic-compatible providers with pay-as-you-go model
 - **Ollama** - Local Ollama instance (v0.14.0+) via native Anthropic-compatible API at `/v1/messages`, no API key required

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -716,6 +716,7 @@ We recommend using one of the workarounds above until the npm bug is fixed.
 - **Vertex AI** - Google Cloud Vertex AI integration with service account authentication
 - **z.ai, Minimax** - API key based providers with pay-as-you-go model
 - **OpenRouter** - OpenRouter integration with native API support and model mapping
+- **xAI/Grok** - Native Grok CLI OAuth import/refresh with per-request token accounting and Grok Build credits usage polling via grok.com gRPC-web
 - **Kilo** - Kilo API integration with usage tracking
 - **Anthropic-Compatible** - Custom Anthropic-compatible providers with pay-as-you-go model
 - **Ollama** - Local Ollama instance (v0.14.0+) via native Anthropic-compatible API at `/v1/messages`, no API key required

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -716,7 +716,6 @@ We recommend using one of the workarounds above until the npm bug is fixed.
 - **Vertex AI** - Google Cloud Vertex AI integration with service account authentication
 - **z.ai, Minimax** - API key based providers with pay-as-you-go model
 - **OpenRouter** - OpenRouter integration with native API support and model mapping
-- **xAI/Grok** - Native Grok CLI OAuth import/refresh with per-request token accounting and Grok Build credits usage polling via grok.com gRPC-web
 - **Kilo** - Kilo API integration with usage tracking
 - **Anthropic-Compatible** - Custom Anthropic-compatible providers with pay-as-you-go model
 - **Ollama** - Local Ollama instance (v0.14.0+) via native Anthropic-compatible API at `/v1/messages`, no API key required

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -87,6 +87,7 @@ interface ParsedArgs {
 		| "kilo"
 		| "alibaba-coding-plan"
 		| "codex"
+		| "xai"
 		| "ollama"
 		| null;
 	priority: number | null;
@@ -542,6 +543,7 @@ function parseArgs(args: string[]): ParsedArgs {
 					| "kilo"
 					| "alibaba-coding-plan"
 					| "codex"
+					| "xai"
 					| "ollama"
 					| "max";
 
@@ -565,6 +567,7 @@ function parseArgs(args: string[]): ParsedArgs {
 					| "kilo"
 					| "alibaba-coding-plan"
 					| "codex"
+					| "xai"
 					| "ollama";
 				const validModes: Array<
 					| "claude-oauth"
@@ -578,6 +581,7 @@ function parseArgs(args: string[]): ParsedArgs {
 					| "kilo"
 					| "alibaba-coding-plan"
 					| "codex"
+					| "xai"
 					| "ollama"
 				> = [
 					"claude-oauth",
@@ -591,6 +595,7 @@ function parseArgs(args: string[]): ParsedArgs {
 					"kilo",
 					"alibaba-coding-plan",
 					"codex",
+					"xai",
 					"ollama",
 				];
 				if (!validModes.includes(modeValue)) {
@@ -842,7 +847,7 @@ Options:
   --ssl-cert <path>    Path to SSL certificate file (enables HTTPS)
   --stats              Show statistics (JSON output)
   --add-account <name> Add a new account
-    --mode <claude-oauth|console|zai|minimax|nanogpt|anthropic-compatible|openai-compatible|bedrock|kilo|alibaba-coding-plan|codex>  Account mode (default: claude-oauth)
+    --mode <claude-oauth|console|zai|minimax|nanogpt|anthropic-compatible|openai-compatible|bedrock|kilo|alibaba-coding-plan|codex|xai>  Account mode (default: claude-oauth)
       claude-oauth: Claude CLI account (OAuth)
       console: Claude API account (OAuth)
       zai: z.ai account (API key)
@@ -856,6 +861,7 @@ Options:
       kilo: Kilo Gateway provider (API key)
       alibaba-coding-plan: Alibaba Coding Plan International provider (API key)
       codex: Codex (OpenAI OAuth) provider
+      xai: xAI/Grok provider (imports local Grok CLI OAuth credentials)
     --priority <number>   Account priority (default: 0)
   --list               List all accounts
   --remove <name>      Remove an account
@@ -1014,6 +1020,9 @@ Examples:
 			console.error(
 				"  --mode codex               Codex (OpenAI OAuth) provider",
 			);
+			console.error(
+				"  --mode xai                 xAI/Grok (Grok CLI OAuth) provider",
+			);
 			console.error("\nExample:");
 			console.error(
 				"  better-ccflare --add-account work --mode claude-oauth --priority 0",
@@ -1061,6 +1070,20 @@ Examples:
 							_prompt: string,
 							_options: Array<{ label: string; value: T }>,
 						) => (_options[0]?.value as T) || ("yes" as T),
+						input: async (_prompt: string) => "",
+						confirm: async (_prompt: string) => true,
+					},
+				});
+			} else if (mode === "xai") {
+				await addAccount(dbOps, new Config(), {
+					name: parsed.addAccount,
+					mode: "xai",
+					priority,
+					adapter: {
+						select: async <T extends string | number>(
+							_prompt: string,
+							_options: Array<{ label: string; value: T }>,
+						) => (_options[0]?.value as T) || ("no" as T),
 						input: async (_prompt: string) => "",
 						confirm: async (_prompt: string) => true,
 					},

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+import { supportsRefreshBackedUsagePolling } from "./server";
+
+describe("supportsRefreshBackedUsagePolling", () => {
+	it("includes pollable OAuth providers that need token refresh", () => {
+		expect(supportsRefreshBackedUsagePolling("anthropic")).toBe(true);
+		expect(supportsRefreshBackedUsagePolling("xai")).toBe(true);
+	});
+
+	it("does not include providers whose usage is not polled through this path", () => {
+		expect(supportsRefreshBackedUsagePolling("codex")).toBe(false);
+		expect(supportsRefreshBackedUsagePolling("qwen")).toBe(false);
+		expect(supportsRefreshBackedUsagePolling("nanogpt")).toBe(false);
+		expect(supportsRefreshBackedUsagePolling(null)).toBe(false);
+	});
+});

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -894,9 +894,9 @@ export default async function startServer(options?: {
 			);
 			return false;
 		}
-		if (account.provider !== "anthropic") {
+		if (!supportsRefreshBackedUsagePolling(account.provider)) {
 			log.warn(
-				`Cannot restart usage polling: account ${account.name} is not an Anthropic OAuth account`,
+				`Cannot restart usage polling: account ${account.name} does not support refresh-backed usage polling`,
 			);
 			return false;
 		}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -111,6 +111,12 @@ const MEMORY_MONITOR_INTERVAL_MS = 60 * 1000;
 const MEMORY_GROWTH_WARN_BYTES = 512 * 1024 * 1024;
 const MEMORY_GROWTH_ERROR_BYTES = 1024 * 1024 * 1024;
 
+export function supportsRefreshBackedUsagePolling(
+	provider: string | null | undefined,
+): boolean {
+	return provider === "anthropic" || provider === "xai";
+}
+
 // Helper function to resolve dashboard assets with fallback
 function resolveDashboardAsset(assetPath: string): string | null {
 	try {
@@ -1341,15 +1347,21 @@ Available endpoints:
 		);
 	}
 
-	// Start usage polling for Anthropic accounts with token refresh (regardless of paused status)
-	const anthropicAccounts = accounts.filter((a) => a.provider === "anthropic");
-	if (anthropicAccounts.length > 0) {
+	// Start usage polling for refresh-backed providers (regardless of paused status).
+	// Anthropic polls Claude quota windows; xAI polls Grok Build credits via
+	// grok.com gRPC-web and may need to refresh an expired imported Grok CLI token
+	// before the first usage fetch.
+	const refreshBackedUsageAccounts = accounts.filter((a) =>
+		supportsRefreshBackedUsagePolling(a.provider),
+	);
+	if (refreshBackedUsageAccounts.length > 0) {
 		log.info(
-			`Found ${anthropicAccounts.length} Anthropic accounts, starting usage polling...`,
+			`Found ${refreshBackedUsageAccounts.length} refresh-backed usage account(s), starting usage polling...`,
 		);
-		for (const [index, account] of anthropicAccounts.entries()) {
-			log.debug(`Processing account: ${account.name}`, {
+		for (const [index, account] of refreshBackedUsageAccounts.entries()) {
+			log.debug(`Processing usage account: ${account.name}`, {
 				accountId: account.id,
+				provider: account.provider,
 				hasAccessToken: !!account.access_token,
 				hasRefreshToken: !!account.refresh_token,
 				paused: account.paused,
@@ -1359,9 +1371,9 @@ Available endpoints:
 			});
 
 			if (account.access_token || account.refresh_token) {
-				// Start usage polling with token refresh capability
-				// Usage data fetching should work independently of account paused status
-				// Stagger startup by 5s per account to avoid simultaneous 429s on boot
+				// Start usage polling with token refresh capability.
+				// Usage data fetching should work independently of account paused status.
+				// Stagger startup by 5s per account to avoid simultaneous rate-limit bursts.
 				const startupDelayMs = index * 5000;
 				startUsagePollingWithRefresh(
 					account,
@@ -1370,7 +1382,7 @@ Available endpoints:
 					config.getUsagePollIntervalMs(),
 				);
 				log.info(
-					`Started usage polling for account ${account.name}${startupDelayMs > 0 ? ` (delayed ${startupDelayMs / 1000}s)` : ""}`,
+					`Started usage polling for ${account.provider} account ${account.name}${startupDelayMs > 0 ? ` (delayed ${startupDelayMs / 1000}s)` : ""}`,
 				);
 			} else {
 				log.warn(
@@ -1379,7 +1391,9 @@ Available endpoints:
 			}
 		}
 	} else {
-		log.info(`No Anthropic accounts found, usage polling will not start`);
+		log.info(
+			`No refresh-backed usage accounts found, usage polling will not start`,
+		);
 	}
 
 	// Start usage polling for NanoGPT accounts (PayG with optional subscription tracking)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -131,7 +131,7 @@ bun run cli --add-account <name> --mode <claude-oauth|console|codex|qwen|xai|zai
   - `console`: Claude API account
   - `codex`: Codex/OpenAI account (OAuth)
   - `qwen`: Qwen account (OAuth device code)
-  - `xai`: xAI/Grok account (imports local Grok CLI OAuth credentials from `~/.grok/auth.json`; token values are never displayed). xAI refresh tokens may rotate, so if you keep using Grok CLI separately, re-authenticate or refresh Grok CLI after importing so each tool has a fresh token chain.
+  - `xai`: xAI/Grok account (imports local Grok CLI OAuth credentials from `~/.grok/auth.json`; token values are never displayed). xAI refresh tokens may rotate, so if you keep using Grok CLI separately, re-authenticate or refresh Grok CLI after importing so each tool has a fresh token chain. Per-request token usage is recorded from responses, but Grok CLI OAuth does not currently expose a pollable quota-window endpoint for dashboard bars.
   - `zai`: z.ai account (API key)
   - `openai-compatible`: OpenAI-compatible provider (API key)
 - `--priority`: Account priority (optional, defaults to 0)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -131,7 +131,7 @@ bun run cli --add-account <name> --mode <claude-oauth|console|codex|qwen|xai|zai
   - `console`: Claude API account
   - `codex`: Codex/OpenAI account (OAuth)
   - `qwen`: Qwen account (OAuth device code)
-  - `xai`: xAI/Grok account (imports local Grok CLI OAuth credentials from `~/.grok/auth.json`; token values are never displayed). xAI refresh tokens may rotate, so if you keep using Grok CLI separately, re-authenticate or refresh Grok CLI after importing so each tool has a fresh token chain. Per-request token usage is recorded from responses, but Grok CLI OAuth does not currently expose a pollable quota-window endpoint for dashboard bars.
+  - `xai`: xAI/Grok account (imports local Grok CLI OAuth credentials from `~/.grok/auth.json`; token values are never displayed). xAI refresh tokens may rotate, so if you keep using Grok CLI separately, re-authenticate or refresh Grok CLI after importing so each tool has a fresh token chain. Per-request token usage is recorded from responses, and Grok Build credits usage is polled via grok.com gRPC-web for dashboard bars.
   - `zai`: z.ai account (API key)
   - `openai-compatible`: OpenAI-compatible provider (API key)
 - `--priority`: Account priority (optional, defaults to 0)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -120,7 +120,7 @@ Add a new OAuth account to the load balancer pool.
 
 **Syntax:**
 ```bash
-bun run cli --add-account <name> --mode <claude-oauth|console|zai|minimax|anthropic-compatible|openai-compatible> --priority <number>
+bun run cli --add-account <name> --mode <claude-oauth|console|codex|qwen|xai|zai|minimax|anthropic-compatible|openai-compatible> --priority <number>
 ```
 
 **Note:** All flags must be provided explicitly as the CLI requires explicit parameters.
@@ -129,6 +129,9 @@ bun run cli --add-account <name> --mode <claude-oauth|console|zai|minimax|anthro
 - `--mode`: Account type (required)
   - `claude-oauth`: Claude CLI OAuth account
   - `console`: Claude API account
+  - `codex`: Codex/OpenAI account (OAuth)
+  - `qwen`: Qwen account (OAuth device code)
+  - `xai`: xAI/Grok account (imports local Grok CLI OAuth credentials from `~/.grok/auth.json`; token values are never displayed). xAI refresh tokens may rotate, so if you keep using Grok CLI separately, re-authenticate or refresh Grok CLI after importing so each tool has a fresh token chain.
   - `zai`: z.ai account (API key)
   - `openai-compatible`: OpenAI-compatible provider (API key)
 - `--priority`: Account priority (optional, defaults to 0)
@@ -139,8 +142,9 @@ bun run cli --add-account <name> --mode <claude-oauth|console|zai|minimax|anthro
 1. Execute command with all required flags
 2. For OAuth accounts (claude-oauth/console), opens browser for authentication
 3. Waits for OAuth callback on localhost:7856
-4. For API key accounts (zai/openai-compatible), prompts for API key
-5. Stores account credentials securely in the database
+4. For xAI/Grok accounts, imports existing Grok CLI OAuth credentials from `~/.grok/auth.json` without printing token values
+5. For API key accounts (zai/openai-compatible), prompts for API key
+6. Stores account credentials securely in the database
 
 #### `--list`
 

--- a/packages/cli-commands/src/commands/__tests__/xai-account.test.ts
+++ b/packages/cli-commands/src/commands/__tests__/xai-account.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Config } from "@better-ccflare/config";
+import type { DatabaseOperations } from "@better-ccflare/database";
+import { DatabaseFactory } from "@better-ccflare/database";
+import type { PromptAdapter } from "../../prompts";
+import { addAccount, reauthenticateAccount } from "../account";
+
+const DEFAULT_XAI_TOKEN_TTL_MS = 6 * 60 * 60 * 1000;
+
+const config = {} as Config;
+const quietAdapter: PromptAdapter = {
+	async select(_question, options) {
+		return (options.find((option) => option.value === "no") ?? options[0])
+			.value;
+	},
+	async input() {
+		return "";
+	},
+	async confirm() {
+		return true;
+	},
+};
+
+describe("CLI xAI account import", () => {
+	let dbOps: DatabaseOperations;
+	let dbPath: string;
+	let homeDir: string;
+	let grokAuthPath: string;
+	let previousGrokAuthPath: string | undefined;
+
+	beforeEach(() => {
+		const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+		dbPath = join(tmpdir(), `test-xai-cli-${suffix}.db`);
+		homeDir = join(tmpdir(), `test-xai-home-${suffix}`);
+		grokAuthPath = join(homeDir, ".grok", "auth.json");
+		mkdirSync(join(homeDir, ".grok"), { recursive: true });
+
+		previousGrokAuthPath = process.env.BETTER_CCFLARE_GROK_AUTH_PATH;
+		process.env.BETTER_CCFLARE_GROK_AUTH_PATH = grokAuthPath;
+
+		DatabaseFactory.initialize(dbPath);
+		dbOps = DatabaseFactory.getInstance();
+	});
+
+	afterEach(() => {
+		DatabaseFactory.reset();
+		if (previousGrokAuthPath === undefined) {
+			delete process.env.BETTER_CCFLARE_GROK_AUTH_PATH;
+		} else {
+			process.env.BETTER_CCFLARE_GROK_AUTH_PATH = previousGrokAuthPath;
+		}
+		for (const path of [dbPath, `${dbPath}-shm`, `${dbPath}-wal`, homeDir]) {
+			if (existsSync(path)) {
+				rmSync(path, { recursive: true, force: true });
+			}
+		}
+	});
+
+	it("uses the refresh fallback TTL when imported Grok auth has no readable expiry", async () => {
+		writeGrokAuth({
+			key: "access-token-create",
+			refresh_token: "refresh-token-create",
+		});
+
+		const before = Date.now();
+		await addAccount(dbOps, config, {
+			name: "xai-create",
+			mode: "xai",
+			priority: 50,
+			adapter: quietAdapter,
+		});
+		const after = Date.now();
+
+		const account = dbOps
+			.getDatabase()
+			.query<
+				{ access_token: string; refresh_token: string; expires_at: number },
+				[string]
+			>(
+				"SELECT access_token, refresh_token, expires_at FROM accounts WHERE name = ?",
+			)
+			.get("xai-create");
+
+		expect(account).toBeDefined();
+		expect(account?.access_token).toBe("access-token-create");
+		expect(account?.refresh_token).toBe("refresh-token-create");
+		expect(account?.expires_at).toBeGreaterThanOrEqual(
+			before + DEFAULT_XAI_TOKEN_TTL_MS,
+		);
+		expect(account?.expires_at).toBeLessThanOrEqual(
+			after + DEFAULT_XAI_TOKEN_TTL_MS,
+		);
+	});
+
+	it("uses the refresh fallback TTL when re-imported Grok auth has no readable expiry", async () => {
+		writeGrokAuth({
+			key: "access-token-original",
+			refresh_token: "refresh-token-original",
+			expires_at: new Date(Date.now() + 60_000).toISOString(),
+		});
+		await addAccount(dbOps, config, {
+			name: "xai-reauth",
+			mode: "xai",
+			priority: 50,
+			adapter: quietAdapter,
+		});
+
+		writeGrokAuth({
+			key: "access-token-reauth",
+			refresh_token: "refresh-token-reauth",
+		});
+
+		const before = Date.now();
+		const result = await reauthenticateAccount(dbOps, config, "xai-reauth");
+		const after = Date.now();
+
+		expect(result.success).toBe(true);
+		const account = dbOps
+			.getDatabase()
+			.query<
+				{ access_token: string; refresh_token: string; expires_at: number },
+				[string]
+			>(
+				"SELECT access_token, refresh_token, expires_at FROM accounts WHERE name = ?",
+			)
+			.get("xai-reauth");
+
+		expect(account).toBeDefined();
+		expect(account?.access_token).toBe("access-token-reauth");
+		expect(account?.refresh_token).toBe("refresh-token-reauth");
+		expect(account?.expires_at).toBeGreaterThanOrEqual(
+			before + DEFAULT_XAI_TOKEN_TTL_MS,
+		);
+		expect(account?.expires_at).toBeLessThanOrEqual(
+			after + DEFAULT_XAI_TOKEN_TTL_MS,
+		);
+	});
+
+	function writeGrokAuth(entry: {
+		key: string;
+		refresh_token: string;
+		expires_at?: string;
+	}) {
+		writeFileSync(
+			grokAuthPath,
+			JSON.stringify({ "test@example.com": entry }),
+			"utf8",
+		);
+	}
+});

--- a/packages/cli-commands/src/commands/account.ts
+++ b/packages/cli-commands/src/commands/account.ts
@@ -717,8 +717,21 @@ interface GrokAuthEntry {
 	email?: string;
 }
 
+const XAI_IMPORTED_TOKEN_DEFAULT_TTL_MS = 6 * 60 * 60 * 1000;
+
+function resolveGrokAuthExpiresAt(
+	expiresAt: string | undefined,
+	fallbackFrom = Date.now(),
+): number {
+	const parsedExpiresAt = Date.parse(expiresAt ?? "");
+	return Number.isFinite(parsedExpiresAt)
+		? parsedExpiresAt
+		: fallbackFrom + XAI_IMPORTED_TOKEN_DEFAULT_TTL_MS;
+}
+
 function loadGrokAuthEntry(
-	authPath = join(homedir(), ".grok", "auth.json"),
+	authPath = process.env.BETTER_CCFLARE_GROK_AUTH_PATH ||
+		join(homedir(), ".grok", "auth.json"),
 ): GrokAuthEntry | null {
 	try {
 		const raw = readFileSync(authPath, "utf8");
@@ -765,7 +778,8 @@ async function createXaiAccount(
 			? modelMappings
 			: XAI_MODEL_MAPPINGS,
 	);
-	const expiresAt = Date.parse(auth.expires_at ?? "");
+	const parsedExpiresAt = Date.parse(auth.expires_at ?? "");
+	const expiresAt = resolveGrokAuthExpiresAt(auth.expires_at, now);
 
 	await dbOps.getAdapter().run(
 		`INSERT INTO accounts (
@@ -778,7 +792,7 @@ async function createXaiAccount(
 			"xai",
 			auth.refresh_token,
 			auth.key,
-			Number.isFinite(expiresAt) ? expiresAt : now,
+			expiresAt,
 			now,
 			0,
 			0,
@@ -796,7 +810,7 @@ async function createXaiAccount(
 	console.log(
 		"Note: xAI refresh tokens may rotate. If you keep using Grok CLI separately, re-authenticate or refresh Grok CLI after importing so each tool has a fresh token chain.",
 	);
-	if (Number.isFinite(expiresAt)) {
+	if (Number.isFinite(parsedExpiresAt)) {
 		console.log(`Token expires: ${new Date(expiresAt).toISOString()}`);
 	}
 	if (mappings) {
@@ -2216,7 +2230,7 @@ async function reauthenticateXaiAccount(
 		};
 	}
 
-	const expiresAt = Date.parse(auth.expires_at ?? "");
+	const expiresAt = resolveGrokAuthExpiresAt(auth.expires_at);
 	try {
 		await dbOps.getAdapter().run(
 			`UPDATE accounts SET
@@ -2228,7 +2242,7 @@ async function reauthenticateXaiAccount(
 			[
 				auth.refresh_token,
 				auth.key,
-				Number.isFinite(expiresAt) ? expiresAt : Date.now(),
+				expiresAt,
 				account.custom_endpoint || XAI_DEFAULT_ENDPOINT,
 				account.id,
 			],

--- a/packages/cli-commands/src/commands/account.ts
+++ b/packages/cli-commands/src/commands/account.ts
@@ -17,6 +17,8 @@ import {
 	generatePKCE,
 	getOAuthProvider,
 	type TokenRefreshResult as TokenResult,
+	XAI_DEFAULT_ENDPOINT,
+	XAI_MODEL_MAPPINGS,
 } from "@better-ccflare/providers";
 import {
 	initiateDeviceFlow as initiateQwenDeviceFlow,
@@ -48,6 +50,7 @@ export interface AddAccountOptionsWithAdapter {
 		| "alibaba-coding-plan"
 		| "codex"
 		| "qwen"
+		| "xai"
 		| "ollama"
 		| "ollama-cloud";
 	priority?: number;
@@ -80,6 +83,7 @@ export interface AccountListItemWithMode extends AccountListItem {
 		| "alibaba-coding-plan"
 		| "codex"
 		| "qwen"
+		| "xai"
 		| "ollama"
 		| "ollama-cloud";
 }
@@ -704,6 +708,105 @@ async function promptModelMappings(
 /**
  * Create an OpenAI-compatible account in the database
  */
+interface GrokAuthEntry {
+	key?: string;
+	refresh_token?: string;
+	expires_at?: string;
+	oidc_client_id?: string;
+	oidc_issuer?: string;
+	email?: string;
+}
+
+function loadGrokAuthEntry(
+	authPath = join(homedir(), ".grok", "auth.json"),
+): GrokAuthEntry | null {
+	try {
+		const raw = readFileSync(authPath, "utf8");
+		const parsed = JSON.parse(raw) as Record<string, GrokAuthEntry>;
+		const entries = Object.entries(parsed)
+			.filter(([, entry]) => entry?.key && entry?.refresh_token)
+			.sort(([, a], [, b]) => {
+				const aExpires = Date.parse(a.expires_at ?? "");
+				const bExpires = Date.parse(b.expires_at ?? "");
+				return (
+					(Number.isFinite(bExpires) ? bExpires : 0) -
+					(Number.isFinite(aExpires) ? aExpires : 0)
+				);
+			});
+		return entries[0]?.[1] ?? null;
+	} catch {
+		return null;
+	}
+}
+
+async function createXaiAccount(
+	dbOps: DatabaseOperations,
+	name: string,
+	priority: number,
+	customEndpoint?: string,
+	modelMappings?: ModelMapping | null,
+): Promise<void> {
+	const auth = loadGrokAuthEntry();
+	if (!auth?.key || !auth.refresh_token) {
+		throw new Error(
+			"No Grok CLI OAuth credentials found in ~/.grok/auth.json. Run `grok --oauth` first, then try adding the xAI account again.",
+		);
+	}
+
+	const accountId = crypto.randomUUID();
+	const now = Date.now();
+	const endpoint = validateEndpointUrl(
+		customEndpoint || XAI_DEFAULT_ENDPOINT,
+		"xAI endpoint",
+	);
+	const validatedPriority = validatePriority(priority, "priority");
+	const mappings = validateAndSanitizeModelMappings(
+		modelMappings && Object.keys(modelMappings).length > 0
+			? modelMappings
+			: XAI_MODEL_MAPPINGS,
+	);
+	const expiresAt = Date.parse(auth.expires_at ?? "");
+
+	await dbOps.getAdapter().run(
+		`INSERT INTO accounts (
+			id, name, provider, api_key, refresh_token, access_token,
+			expires_at, created_at, request_count, total_requests, priority, custom_endpoint, model_mappings, model_fallbacks
+		) VALUES (?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
+		[
+			accountId,
+			name,
+			"xai",
+			auth.refresh_token,
+			auth.key,
+			Number.isFinite(expiresAt) ? expiresAt : now,
+			now,
+			0,
+			0,
+			validatedPriority,
+			endpoint,
+			mappings ? JSON.stringify(mappings) : null,
+		],
+	);
+
+	console.log(`\nAccount '${name}' added successfully!`);
+	console.log("Type: xAI / Grok (Grok CLI OAuth)");
+	console.log(`Endpoint: ${endpoint}`);
+	console.log(`Priority: ${validatedPriority}`);
+	console.log("Imported credentials from ~/.grok/auth.json (tokens hidden)");
+	console.log(
+		"Note: xAI refresh tokens may rotate. If you keep using Grok CLI separately, re-authenticate or refresh Grok CLI after importing so each tool has a fresh token chain.",
+	);
+	if (Number.isFinite(expiresAt)) {
+		console.log(`Token expires: ${new Date(expiresAt).toISOString()}`);
+	}
+	if (mappings) {
+		console.log("Model mappings:");
+		for (const [key, value] of Object.entries(mappings)) {
+			console.log(`  ${key} → ${value}`);
+		}
+	}
+}
+
 async function createOpenAIAccount(
 	dbOps: DatabaseOperations,
 	name: string,
@@ -1056,6 +1159,7 @@ export async function addAccount(
 			{ label: "Claude API account", value: "console" },
 			{ label: "Codex (OpenAI OAuth)", value: "codex" },
 			{ label: "Qwen (Alibaba Cloud OAuth)", value: "qwen" },
+			{ label: "xAI / Grok (Grok CLI OAuth)", value: "xai" },
 			{ label: "Vertex AI (Google Cloud)", value: "vertex-ai" },
 			{ label: "AWS Bedrock (AWS profile credentials)", value: "bedrock" },
 			{ label: "z.ai account (API key)", value: "zai" },
@@ -1457,6 +1561,31 @@ export async function addAccount(
 				: parseInt(String(priority), 10) || 0,
 			finalModelMappings,
 		);
+	} else if (mode === "xai") {
+		// Handle xAI/Grok accounts by importing local Grok CLI OAuth credentials.
+		const priority =
+			providedPriority ??
+			Number(
+				(await adapter.input(
+					"\nEnter priority (0 = highest, lower number = higher priority, default 0): ",
+				)) || 0,
+			);
+
+		const finalModelMappings = await promptModelMappings(
+			adapter,
+			modelMappings,
+			XAI_MODEL_MAPPINGS,
+		);
+
+		await createXaiAccount(
+			dbOps,
+			name,
+			typeof priority === "number"
+				? priority
+				: parseInt(String(priority), 10) || 0,
+			customEndpoint,
+			finalModelMappings,
+		);
 	} else if (mode === "anthropic-compatible") {
 		// Handle Anthropic-compatible accounts with API keys
 		const apiKey = await adapter.input(
@@ -1670,7 +1799,8 @@ export async function getAccountsList(
 					account.provider === "anthropic-compatible" ||
 					account.provider === "bedrock" ||
 					account.provider === "openrouter" ||
-					account.provider === "codex"
+					account.provider === "codex" ||
+					account.provider === "xai"
 				) {
 					return account.provider;
 				}
@@ -2070,6 +2200,53 @@ async function reauthenticateQwenAccount(
 }
 
 /**
+ * Re-authenticate an xAI account by re-importing local Grok CLI OAuth credentials.
+ */
+async function reauthenticateXaiAccount(
+	dbOps: DatabaseOperations,
+	account: { id: string; custom_endpoint: string | null },
+	name: string,
+): Promise<{ success: boolean; message: string }> {
+	const auth = loadGrokAuthEntry();
+	if (!auth?.key || !auth.refresh_token) {
+		return {
+			success: false,
+			message:
+				"No Grok CLI OAuth credentials found in ~/.grok/auth.json. Run `grok --oauth`, then try re-authenticating again.",
+		};
+	}
+
+	const expiresAt = Date.parse(auth.expires_at ?? "");
+	try {
+		await dbOps.getAdapter().run(
+			`UPDATE accounts SET
+				refresh_token = ?,
+				access_token = ?,
+				expires_at = ?,
+				custom_endpoint = COALESCE(custom_endpoint, ?)
+			WHERE id = ?`,
+			[
+				auth.refresh_token,
+				auth.key,
+				Number.isFinite(expiresAt) ? expiresAt : Date.now(),
+				account.custom_endpoint || XAI_DEFAULT_ENDPOINT,
+				account.id,
+			],
+		);
+	} catch (dbError) {
+		return {
+			success: false,
+			message: `Database error while updating xAI tokens: ${dbError instanceof Error ? dbError.message : String(dbError)}`,
+		};
+	}
+
+	return {
+		success: true,
+		message: `Account '${name}' re-authenticated successfully from local Grok CLI credentials. Tokens were updated without displaying secret values.`,
+	};
+}
+
+/**
  * Re-authenticate an account by name (preserves all metadata)
  * This performs soft re-authentication: only updates OAuth tokens, keeps all other data
  */
@@ -2100,16 +2277,24 @@ export async function reauthenticateAccount(
 	}
 
 	// Check if account supports OAuth re-authentication
-	if (account.provider !== "anthropic" && account.provider !== "qwen") {
+	if (
+		account.provider !== "anthropic" &&
+		account.provider !== "qwen" &&
+		account.provider !== "xai"
+	) {
 		return {
 			success: false,
-			message: `Account '${name}' (${account.provider}) does not support OAuth re-authentication. Only Anthropic and Qwen accounts can be re-authenticated.`,
+			message: `Account '${name}' (${account.provider}) does not support OAuth re-authentication. Only Anthropic, Qwen, and xAI accounts can be re-authenticated.`,
 		};
 	}
 
 	// Handle Qwen re-authentication via device code flow
 	if (account.provider === "qwen") {
 		return reauthenticateQwenAccount(dbOps, account, name);
+	}
+
+	if (account.provider === "xai") {
+		return reauthenticateXaiAccount(dbOps, account, name);
 	}
 
 	// Create OAuth flow instance

--- a/packages/cli-commands/src/commands/help.ts
+++ b/packages/cli-commands/src/commands/help.ts
@@ -6,11 +6,14 @@ export function getHelpText(): string {
 Usage: better-ccflare <command> [options]
 
 Commands:
-  add <name> [--mode <claude-oauth|console|zai|minimax|anthropic-compatible|openai-compatible|nanogpt|kilo|openrouter|ollama|ollama-cloud>] [--priority <number>] [--modelMappings <JSON>]
+  add <name> [--mode <claude-oauth|console|codex|qwen|xai|zai|minimax|anthropic-compatible|openai-compatible|nanogpt|kilo|openrouter|ollama|ollama-cloud>] [--priority <number>] [--modelMappings <JSON>]
     Add a new account using OAuth or API key
     --mode: Account type (optional, will prompt if not provided)
       claude-oauth: Claude CLI OAuth account (OAuth)
       console: Claude API account (OAuth)
+      codex: Codex/OpenAI account (OAuth)
+      qwen: Qwen account (OAuth device code)
+      xai: xAI/Grok account (imports local Grok CLI OAuth credentials)
       zai: z.ai account (API key)
       minimax: Minimax account (API key)
       anthropic-compatible: Anthropic-compatible provider (API key)
@@ -62,6 +65,7 @@ Commands:
 
 Examples:
   better-ccflare add myaccount --mode claude-oauth --priority 10
+  better-ccflare add grok --mode xai --priority 50
   better-ccflare add anthropic-account --mode anthropic-compatible --priority 5 --modelMappings '{"opus":"claude-3-opus","sonnet":"claude-3-sonnet"}'
   better-ccflare add "My Account" --mode claude-oauth --priority 10  # Account names with spaces must be quoted
   better-ccflare list

--- a/packages/cli-commands/src/runner.ts
+++ b/packages/cli-commands/src/runner.ts
@@ -48,7 +48,7 @@ export async function runCli(argv: string[]): Promise<void> {
 				if (!name) {
 					console.error("Error: Account name is required");
 					console.log(
-						"Usage: ccflare-cli add <name> [--mode <claude-oauth|console|zai|minimax|anthropic-compatible|openai-compatible>] [--priority <number>] [--modelMappings <JSON>]",
+						"Usage: ccflare-cli add <name> [--mode <claude-oauth|console|codex|qwen|xai|zai|minimax|anthropic-compatible|openai-compatible|nanogpt|kilo|openrouter|ollama|ollama-cloud>] [--priority <number>] [--modelMappings <JSON>]",
 					);
 					process.exit(1);
 				}
@@ -57,10 +57,21 @@ export async function runCli(argv: string[]): Promise<void> {
 				let mode = values.mode as
 					| "claude-oauth"
 					| "console"
+					| "codex"
+					| "qwen"
+					| "xai"
 					| "zai"
 					| "minimax"
 					| "anthropic-compatible"
 					| "openai-compatible"
+					| "nanogpt"
+					| "vertex-ai"
+					| "bedrock"
+					| "kilo"
+					| "openrouter"
+					| "alibaba-coding-plan"
+					| "ollama"
+					| "ollama-cloud"
 					| "max"
 					| undefined;
 

--- a/packages/dashboard-web/src/components/accounts/RateLimitProgress.tsx
+++ b/packages/dashboard-web/src/components/accounts/RateLimitProgress.tsx
@@ -132,6 +132,8 @@ function formatWindowName(window: string | null): string {
 			return "Time Quota";
 		case "tokens_limit":
 			return "5-hour";
+		case "credits":
+			return "Grok credits";
 		default:
 			return window.replace("_", " ");
 	}
@@ -242,6 +244,9 @@ export function RateLimitProgress({
 	const isZaiData =
 		usageData && ("time_limit" in usageData || "tokens_limit" in usageData);
 
+	// Check if this is xAI/Grok usage data
+	const isXaiData = usageData && "credits" in usageData;
+
 	// Check if this is Alibaba Coding Plan usage data
 	const isAlibabaData =
 		usageData && "five_hour" in usageData && "weekly" in usageData;
@@ -282,6 +287,18 @@ export function RateLimitProgress({
 				? new Date(alibabaData.monthly.resetAt).toISOString()
 				: null,
 		});
+	} else if (isXaiData && showWeekly) {
+		// xAI/Grok usage data - show Grok Build credits utilization.
+		const xaiData = usageData as {
+			credits?: { utilization: number; resets_at: string | null };
+		};
+		if (xaiData.credits) {
+			usages.push({
+				utilization: xaiData.credits.utilization,
+				window: "credits",
+				resetTime: xaiData.credits.resets_at,
+			});
+		}
 	} else if (isZaiData && showWeekly) {
 		// Zai usage data - show tokens_limit (5-hour token quota) and time_limit (peak-hour limit)
 		const zaiData = usageData as {

--- a/packages/dashboard-web/src/utils/provider-utils.ts
+++ b/packages/dashboard-web/src/utils/provider-utils.ts
@@ -49,7 +49,8 @@ export function providerShowsWeeklyUsage(provider: string): boolean {
 		provider === PROVIDER_NAMES.ANTHROPIC ||
 		provider === PROVIDER_NAMES.CODEX ||
 		provider === PROVIDER_NAMES.NANOGPT ||
-		provider === PROVIDER_NAMES.ZAI
+		provider === PROVIDER_NAMES.ZAI ||
+		provider === PROVIDER_NAMES.XAI
 	);
 }
 

--- a/packages/http-api/src/handlers/__tests__/account-refresh-usage.test.ts
+++ b/packages/http-api/src/handlers/__tests__/account-refresh-usage.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, mock } from "bun:test";
+import { registerPollingRestarter } from "@better-ccflare/proxy";
+import { createAccountRefreshUsageHandler } from "../accounts";
+
+describe("createAccountRefreshUsageHandler", () => {
+	it("allows xAI/Grok accounts to restart usage polling", async () => {
+		const accountId = "xai-account";
+		const restarter = mock(async (id: string) => id === accountId);
+		registerPollingRestarter(`test-xai-refresh-${Date.now()}`, restarter);
+
+		const handler = createAccountRefreshUsageHandler({
+			getAccount: async (id: string) =>
+				id === accountId
+					? {
+							id: accountId,
+							name: "grok-dogfood",
+							provider: "xai",
+							access_token: "access-token",
+							refresh_token: "refresh-token",
+						}
+					: null,
+		} as never);
+
+		const response = await handler({} as Request, accountId);
+		const payload = (await response.json()) as {
+			success: boolean;
+			pollingRestarted: boolean;
+		};
+
+		expect(response.status).toBe(200);
+		expect(payload.success).toBe(true);
+		expect(payload.pollingRestarted).toBe(true);
+		expect(restarter).toHaveBeenCalledWith(accountId);
+	});
+});

--- a/packages/http-api/src/handlers/accounts.ts
+++ b/packages/http-api/src/handlers/accounts.ts
@@ -439,6 +439,25 @@ export function createAccountsListHandler(
 							);
 						}
 					}
+				} else if (account.provider === "xai" && usageData) {
+					// xAI/Grok usage data - Grok Build credits from gRPC-web billing probe
+					const isXaiData = "credits" in usageData;
+					if (isXaiData) {
+						try {
+							const {
+								getRepresentativeXaiUtilization,
+								getRepresentativeXaiWindow,
+							} = require("@better-ccflare/providers");
+							usageUtilization = getRepresentativeXaiUtilization(usageData);
+							usageWindow = getRepresentativeXaiWindow(usageData);
+							fullUsageData = usageData as FullUsageData;
+						} catch (error) {
+							log.warn(
+								`Failed to process xAI usage data for account ${account.name}:`,
+								error,
+							);
+						}
+					}
 				}
 
 				const usageThrottleSettings = {

--- a/packages/http-api/src/handlers/accounts.ts
+++ b/packages/http-api/src/handlers/accounts.ts
@@ -3577,10 +3577,14 @@ export function createAccountRefreshUsageHandler(dbOps: DatabaseOperations) {
 				return errorResponse(NotFound("Account not found"));
 			}
 
-			if (account.provider !== "anthropic" && account.provider !== "codex") {
+			if (
+				account.provider !== "anthropic" &&
+				account.provider !== "codex" &&
+				account.provider !== "xai"
+			) {
 				return errorResponse(
 					BadRequest(
-						"Usage refresh is only available for Anthropic OAuth and Codex accounts",
+						"Usage refresh is only available for Anthropic OAuth, Codex, and xAI accounts",
 					),
 				);
 			}

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -7,7 +7,8 @@
 		".": "./src/index.ts",
 		"./bedrock": "./src/providers/bedrock/index.ts",
 		"./codex": "./src/providers/codex/index.ts",
-		"./qwen": "./src/providers/qwen/index.ts"
+		"./qwen": "./src/providers/qwen/index.ts",
+		"./xai": "./src/providers/xai/index.ts"
 	},
 	"scripts": {
 		"typecheck": "bunx tsc --noEmit"

--- a/packages/providers/src/__tests__/window-reset-detection.test.ts
+++ b/packages/providers/src/__tests__/window-reset-detection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, mock } from "bun:test";
 import type { UsageData } from "../usage-fetcher";
 import { extractWindowResetTime, usageCache } from "../usage-fetcher";
+import type { XaiUsageData } from "../xai-usage-fetcher";
 import type { ZaiUsageData } from "../zai-usage-fetcher";
 
 // ── extractWindowResetTime ────────────────────────────────────────────────────
@@ -42,6 +43,16 @@ describe("extractWindowResetTime", () => {
 			seven_day: { utilization: 10, resets_at: null },
 		};
 		expect(extractWindowResetTime(data, "anthropic")).toBeNull();
+	});
+
+	it("returns parsed credits reset for xai provider", () => {
+		const resetIso = "2030-02-01T00:00:00.000Z";
+		const data: XaiUsageData = {
+			credits: { utilization: 11, resets_at: resetIso },
+		};
+		expect(extractWindowResetTime(data, "xai")).toBe(
+			new Date(resetIso).getTime(),
+		);
 	});
 
 	it("returns null for unknown/unsupported provider", () => {

--- a/packages/providers/src/__tests__/xai-usage-fetcher.test.ts
+++ b/packages/providers/src/__tests__/xai-usage-fetcher.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+	fetchXaiUsageData,
+	parseXaiGrokCreditsResponse,
+	XAI_GROK_CREDITS_ENDPOINT,
+} from "../xai-usage-fetcher";
+
+function varint(value: number): number[] {
+	const out: number[] = [];
+	let v = value;
+	while (v >= 0x80) {
+		out.push((v & 0x7f) | 0x80);
+		v = Math.floor(v / 128);
+	}
+	out.push(v);
+	return out;
+}
+
+function float32(value: number): number[] {
+	const bytes = new Uint8Array(4);
+	new DataView(bytes.buffer).setFloat32(0, value, true);
+	return [...bytes];
+}
+
+function frame(flags: number, payload: Uint8Array | string): Uint8Array {
+	const payloadBytes =
+		typeof payload === "string" ? new TextEncoder().encode(payload) : payload;
+	const out = new Uint8Array(5 + payloadBytes.length);
+	out[0] = flags;
+	out[1] = (payloadBytes.length >>> 24) & 0xff;
+	out[2] = (payloadBytes.length >>> 16) & 0xff;
+	out[3] = (payloadBytes.length >>> 8) & 0xff;
+	out[4] = payloadBytes.length & 0xff;
+	out.set(payloadBytes, 5);
+	return out;
+}
+
+function concat(...parts: Uint8Array[]): Uint8Array {
+	const len = parts.reduce((sum, part) => sum + part.length, 0);
+	const out = new Uint8Array(len);
+	let offset = 0;
+	for (const part of parts) {
+		out.set(part, offset);
+		offset += part.length;
+	}
+	return out;
+}
+
+function creditsPayload(
+	percent: number,
+	resetEpochSeconds: number,
+): Uint8Array {
+	const resetSub = new Uint8Array([0x08, ...varint(resetEpochSeconds)]);
+	const currentPeriod = new Uint8Array([
+		0x0d, // field 1, fixed32: credit_usage_percent
+		...float32(percent),
+		0x2a, // field 5, length-delimited: reset window
+		...varint(resetSub.length),
+		...resetSub,
+	]);
+	return new Uint8Array([
+		0x0a, // field 1, length-delimited: current_period
+		...varint(currentPeriod.length),
+		...currentPeriod,
+	]);
+}
+
+describe("xAI Grok usage fetcher", () => {
+	let originalFetch: typeof fetch;
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("parses Grok Build credits utilization and reset from gRPC-web frames", () => {
+		const reset = 1_814_400_000; // 2027-07-01T00:00:00.000Z
+		const body = concat(
+			frame(0x00, creditsPayload(11.25, reset)),
+			frame(0x80, "grpc-status: 0\r\n"),
+		);
+
+		const parsed = parseXaiGrokCreditsResponse(
+			body,
+			Date.parse("2026-06-27T00:00:00.000Z"),
+		);
+
+		expect(parsed).toEqual({
+			credits: {
+				utilization: 11.25,
+				resets_at: "2027-07-01T00:00:00.000Z",
+			},
+		});
+	});
+
+	it("treats non-zero gRPC status as unavailable usage", () => {
+		const body = frame(
+			0x80,
+			"grpc-status: 12\r\ngrpc-message: unimplemented\r\n",
+		);
+
+		expect(parseXaiGrokCreditsResponse(body)).toBeNull();
+	});
+
+	it("posts the empty gRPC-web request with Grok-compatible headers", async () => {
+		const reset = 1_814_400_000;
+		const responseBody = concat(
+			frame(0x00, creditsPayload(42, reset)),
+			frame(0x80, "grpc-status: 0\r\n"),
+		);
+		const fetchMock = mock(
+			async (input: RequestInfo | URL, init?: RequestInit) => {
+				expect(String(input)).toBe(XAI_GROK_CREDITS_ENDPOINT);
+				expect(init?.method).toBe("POST");
+				expect((init?.headers as Record<string, string>).Authorization).toBe(
+					"Bearer access-token",
+				);
+				expect((init?.headers as Record<string, string>)["Content-Type"]).toBe(
+					"application/grpc-web+proto",
+				);
+				expect((init?.headers as Record<string, string>)["x-grpc-web"]).toBe(
+					"1",
+				);
+				expect([...(init?.body as Uint8Array)]).toEqual([0, 0, 0, 0, 0]);
+				return new Response(responseBody, { status: 200 });
+			},
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const usage = await fetchXaiUsageData(" access-token ");
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(usage?.credits.utilization).toBe(42);
+		expect(usage?.credits.resets_at).toBe("2027-07-01T00:00:00.000Z");
+	});
+});

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -47,6 +47,7 @@ import { OpenAICompatibleProvider } from "./providers/openai/provider";
 import { OpenRouterProvider } from "./providers/openrouter/provider";
 import { QwenProvider } from "./providers/qwen/provider";
 import { VertexAIProvider } from "./providers/vertex-ai/provider";
+import { XaiProvider } from "./providers/xai/provider";
 import { ZaiProvider } from "./providers/zai/provider";
 // Auto-register built-in providers
 import { registry } from "./registry";
@@ -62,6 +63,7 @@ registry.registerProvider(new MinimaxProvider());
 registry.registerProvider(new NanoGPTProvider());
 registry.registerProvider(new ZaiProvider());
 registry.registerProvider(new VertexAIProvider());
+registry.registerProvider(new XaiProvider());
 registry.registerProvider(new OpenAICompatibleProvider());
 registry.registerProvider(new OllamaProvider());
 registry.registerProvider(new OllamaCloudProvider());

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -30,6 +30,8 @@ export {
 export * from "./types";
 // Export usage fetcher
 export * from "./usage-fetcher";
+// Export xAI usage fetcher
+export * from "./xai-usage-fetcher";
 // Export Zai usage fetcher
 export * from "./zai-usage-fetcher";
 

--- a/packages/providers/src/providers/index.ts
+++ b/packages/providers/src/providers/index.ts
@@ -25,4 +25,11 @@ export { OllamaCloudProvider, OllamaProvider } from "./ollama/index";
 export { OpenAICompatibleProvider } from "./openai/index";
 export { OpenRouterProvider } from "./openrouter/index";
 export { type VertexAIConfig, VertexAIProvider } from "./vertex-ai/index";
+export {
+	XAI_DEFAULT_CLIENT_ID,
+	XAI_DEFAULT_ENDPOINT,
+	XAI_MODEL_MAPPINGS,
+	XAI_TOKEN_ENDPOINT,
+	XaiProvider,
+} from "./xai/index";
 export { ZaiProvider } from "./zai/index";

--- a/packages/providers/src/providers/xai/index.ts
+++ b/packages/providers/src/providers/xai/index.ts
@@ -1,0 +1,7 @@
+export {
+	XAI_DEFAULT_CLIENT_ID,
+	XAI_DEFAULT_ENDPOINT,
+	XAI_MODEL_MAPPINGS,
+	XAI_TOKEN_ENDPOINT,
+	XaiProvider,
+} from "./provider";

--- a/packages/providers/src/providers/xai/provider.test.ts
+++ b/packages/providers/src/providers/xai/provider.test.ts
@@ -102,6 +102,12 @@ describe("XaiProvider", () => {
 		expect(body.model).toBe("grok-custom");
 	});
 
+	it("does not advertise a pollable quota-window usage endpoint", () => {
+		const provider = new XaiProvider();
+
+		expect(provider.supportsUsageTracking()).toBe(false);
+	});
+
 	it("requests stream usage chunks for streaming xAI requests", async () => {
 		const provider = new XaiProvider();
 		const request = new Request("https://proxy.local/v1/messages", {

--- a/packages/providers/src/providers/xai/provider.test.ts
+++ b/packages/providers/src/providers/xai/provider.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { Account } from "@better-ccflare/types";
+import {
+	XAI_DEFAULT_ENDPOINT,
+	XAI_MODEL_MAPPINGS,
+	XAI_TOKEN_ENDPOINT,
+	XaiProvider,
+} from "./provider";
+
+const account = (overrides: Partial<Account> = {}): Account => ({
+	id: "xai-1",
+	name: "xai-test",
+	provider: "xai",
+	api_key: null,
+	refresh_token: "refresh-token",
+	access_token: "access-token",
+	expires_at: Date.now() + 60_000,
+	request_count: 0,
+	total_requests: 0,
+	last_used: null,
+	created_at: Date.now(),
+	rate_limited_until: null,
+	rate_limited_reason: null,
+	rate_limited_at: null,
+	session_start: null,
+	session_request_count: 0,
+	paused: false,
+	rate_limit_reset: null,
+	rate_limit_status: null,
+	rate_limit_remaining: null,
+	priority: 50,
+	auto_fallback_enabled: true,
+	auto_refresh_enabled: true,
+	auto_pause_on_overage_enabled: false,
+	peak_hours_pause_enabled: false,
+	custom_endpoint: null,
+	model_mappings: null,
+	cross_region_mode: null,
+	model_fallbacks: null,
+	billing_type: null,
+	pause_reason: null,
+	refresh_token_issued_at: null,
+	consecutive_rate_limits: 0,
+	...overrides,
+});
+
+describe("XaiProvider", () => {
+	let originalFetch: typeof fetch;
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("builds xAI chat completions URLs from Anthropic messages paths", () => {
+		const provider = new XaiProvider();
+
+		expect(provider.buildUrl("/v1/messages", "?foo=bar", account())).toBe(
+			`${XAI_DEFAULT_ENDPOINT}/chat/completions?foo=bar`,
+		);
+	});
+
+	it("uses default Grok model mappings when the account has none", async () => {
+		const provider = new XaiProvider();
+		const request = new Request("https://proxy.local/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-5-sonnet-20241022",
+				max_tokens: 32,
+				messages: [{ role: "user", content: "hello" }],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request, account());
+		const body = await transformed.json();
+
+		expect(body.model).toBe(XAI_MODEL_MAPPINGS.sonnet);
+	});
+
+	it("preserves custom model mappings", async () => {
+		const provider = new XaiProvider();
+		const request = new Request("https://proxy.local/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-haiku",
+				max_tokens: 32,
+				messages: [{ role: "user", content: "hello" }],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(
+			request,
+			account({ model_mappings: JSON.stringify({ haiku: "grok-custom" }) }),
+		);
+		const body = await transformed.json();
+
+		expect(body.model).toBe("grok-custom");
+	});
+
+	it("requests stream usage chunks for streaming xAI requests", async () => {
+		const provider = new XaiProvider();
+		const request = new Request("https://proxy.local/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-5-sonnet-20241022",
+				max_tokens: 32,
+				stream: true,
+				messages: [{ role: "user", content: "hello" }],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request, account());
+		const body = await transformed.json();
+
+		expect(body.stream).toBe(true);
+		expect(body.stream_options).toEqual({ include_usage: true });
+	});
+
+	it("refreshes xAI OAuth tokens with the Grok client id", async () => {
+		const provider = new XaiProvider();
+		const fetchMock = mock(
+			async (_input: RequestInfo | URL, init?: RequestInit) => {
+				expect(String(_input)).toBe(XAI_TOKEN_ENDPOINT);
+				expect(init?.method).toBe("POST");
+				const body = init?.body?.toString() ?? "";
+				expect(body).toContain("grant_type=refresh_token");
+				expect(body).toContain("refresh_token=refresh-token");
+				return new Response(
+					JSON.stringify({
+						access_token: "new-access-token",
+						refresh_token: "new-refresh-token",
+						expires_in: 3600,
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			},
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const result = await provider.refreshToken(account(), "unused");
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(result.accessToken).toBe("new-access-token");
+		expect(result.refreshToken).toBe("new-refresh-token");
+		expect(result.expiresAt).toBeGreaterThan(Date.now());
+	});
+});

--- a/packages/providers/src/providers/xai/provider.test.ts
+++ b/packages/providers/src/providers/xai/provider.test.ts
@@ -102,10 +102,10 @@ describe("XaiProvider", () => {
 		expect(body.model).toBe("grok-custom");
 	});
 
-	it("does not advertise a pollable quota-window usage endpoint", () => {
+	it("advertises Grok Build credits usage polling", () => {
 		const provider = new XaiProvider();
 
-		expect(provider.supportsUsageTracking()).toBe(false);
+		expect(provider.supportsUsageTracking()).toBe(true);
 	});
 
 	it("requests stream usage chunks for streaming xAI requests", async () => {

--- a/packages/providers/src/providers/xai/provider.ts
+++ b/packages/providers/src/providers/xai/provider.ts
@@ -1,0 +1,144 @@
+import { getEndpointUrl, validateEndpointUrl } from "@better-ccflare/core";
+import { Logger } from "@better-ccflare/logger";
+import type { OpenAIRequest } from "@better-ccflare/openai-formats";
+import type { Account } from "@better-ccflare/types";
+import type { TokenRefreshResult } from "../../types";
+import { OpenAICompatibleProvider } from "../openai/provider";
+
+const log = new Logger("XaiProvider");
+
+export const XAI_DEFAULT_ENDPOINT = "https://api.x.ai/v1";
+export const XAI_TOKEN_ENDPOINT = "https://auth.x.ai/oauth2/token";
+export const XAI_DEFAULT_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
+
+export const XAI_MODEL_MAPPINGS = {
+	opus: "grok-4.3",
+	sonnet: "grok-4.3",
+	haiku: "grok-4.3",
+	fable: "grok-4.3",
+};
+
+export class XaiProvider extends OpenAICompatibleProvider {
+	override name = "xai";
+
+	override async refreshToken(
+		account: Account,
+		_clientId: string,
+	): Promise<TokenRefreshResult> {
+		if (!account.refresh_token) {
+			throw new Error(`No xAI refresh token for account ${account.name}`);
+		}
+
+		log.info(`Refreshing xAI token for account ${account.name}`);
+
+		const body = new URLSearchParams({
+			grant_type: "refresh_token",
+			client_id: XAI_DEFAULT_CLIENT_ID,
+			refresh_token: account.refresh_token,
+		});
+
+		const response = await fetch(XAI_TOKEN_ENDPOINT, {
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: body.toString(),
+		});
+
+		if (!response.ok) {
+			let message = response.statusText;
+			try {
+				const data = (await response.json()) as {
+					error?: string;
+					error_description?: string;
+				};
+				message = data.error_description || data.error || message;
+			} catch {
+				// Do not include raw response bodies in refresh errors; auth servers
+				// should not echo credentials, but keeping messages structured avoids
+				// accidental token exposure if that ever changes.
+			}
+			throw new Error(
+				`Failed to refresh xAI token for account ${account.name}: ${response.status} ${message}`,
+			);
+		}
+
+		const json = (await response.json()) as {
+			access_token: string;
+			refresh_token?: string;
+			expires_in?: number;
+		};
+
+		if (!json.access_token) {
+			throw new Error(
+				`xAI refresh response for account ${account.name} did not include an access token`,
+			);
+		}
+
+		const expiresInSeconds =
+			typeof json.expires_in === "number" && Number.isFinite(json.expires_in)
+				? json.expires_in
+				: 6 * 60 * 60;
+
+		return {
+			accessToken: json.access_token,
+			refreshToken: json.refresh_token || account.refresh_token,
+			expiresAt: Date.now() + expiresInSeconds * 1000,
+		};
+	}
+
+	override buildUrl(path: string, query: string, account?: Account): string {
+		let endpoint = XAI_DEFAULT_ENDPOINT;
+		try {
+			endpoint = account?.custom_endpoint
+				? getEndpointUrl(account)
+				: XAI_DEFAULT_ENDPOINT;
+			endpoint = validateEndpointUrl(endpoint, "xAI endpoint");
+		} catch (error) {
+			log.warn(
+				`Invalid xAI endpoint for ${account?.name ?? "unknown"}; using default`,
+				error,
+			);
+		}
+
+		let openaiPath = path === "/v1/messages" ? "/v1/chat/completions" : path;
+		if (endpoint.endsWith("/v1") && openaiPath.startsWith("/v1/")) {
+			openaiPath = openaiPath.replace(/^\/v1/, "");
+		}
+		return `${endpoint}${openaiPath}${query}`;
+	}
+
+	override supportsOAuth(): boolean {
+		return true;
+	}
+
+	override supportsUsageTracking(): boolean {
+		return true;
+	}
+
+	override beforeConvert(
+		_body: Record<string, unknown>,
+		account?: Account,
+	): Account | undefined {
+		if (!account) return account;
+		return {
+			...account,
+			custom_endpoint: account.custom_endpoint ?? XAI_DEFAULT_ENDPOINT,
+			model_mappings:
+				account.model_mappings ?? JSON.stringify(XAI_MODEL_MAPPINGS),
+		};
+	}
+
+	override afterConvert(body: OpenAIRequest): void {
+		// Ask OpenAI-compatible streaming APIs to include a final usage chunk when
+		// supported. xAI accepts this OpenAI field and it improves request accounting
+		// when the downstream client streams responses.
+		if (body.stream) {
+			const record = body as unknown as Record<string, unknown>;
+			record.stream_options = {
+				...(typeof record.stream_options === "object" && record.stream_options
+					? (record.stream_options as Record<string, unknown>)
+					: {}),
+				include_usage: true,
+			};
+		}
+	}
+}

--- a/packages/providers/src/providers/xai/provider.ts
+++ b/packages/providers/src/providers/xai/provider.ts
@@ -111,7 +111,7 @@ export class XaiProvider extends OpenAICompatibleProvider {
 	}
 
 	override supportsUsageTracking(): boolean {
-		return false;
+		return true;
 	}
 
 	override beforeConvert(

--- a/packages/providers/src/providers/xai/provider.ts
+++ b/packages/providers/src/providers/xai/provider.ts
@@ -111,7 +111,7 @@ export class XaiProvider extends OpenAICompatibleProvider {
 	}
 
 	override supportsUsageTracking(): boolean {
-		return true;
+		return false;
 	}
 
 	override beforeConvert(

--- a/packages/providers/src/usage-fetcher.ts
+++ b/packages/providers/src/usage-fetcher.ts
@@ -18,6 +18,12 @@ import {
 	getRepresentativeNanoGPTUtilization,
 	type NanoGPTUsageData,
 } from "./nanogpt-usage-fetcher";
+import {
+	fetchXaiUsageData,
+	getRepresentativeXaiUtilization,
+	getRepresentativeXaiWindow,
+	type XaiUsageData,
+} from "./xai-usage-fetcher";
 import { fetchZaiUsageData, type ZaiUsageData } from "./zai-usage-fetcher";
 
 const log = new Logger("UsageFetcher");
@@ -54,7 +60,8 @@ export type AnyUsageData =
 	| NanoGPTUsageData
 	| ZaiUsageData
 	| KiloUsageData
-	| AlibabaCodingPlanUsageData;
+	| AlibabaCodingPlanUsageData
+	| XaiUsageData;
 
 /**
  * Extract the primary window reset timestamp (ms) from usage data.
@@ -78,6 +85,13 @@ export function extractWindowResetTime(
 	if (provider === "codex") {
 		const codex = data as UsageData;
 		const resetsAt = codex.five_hour?.resets_at;
+		if (!resetsAt) return null;
+		const ms = new Date(resetsAt).getTime();
+		return Number.isFinite(ms) ? ms : null;
+	}
+	if (provider === "xai") {
+		const xai = data as XaiUsageData;
+		const resetsAt = xai.credits?.resets_at;
 		if (!resetsAt) return null;
 		const ms = new Date(resetsAt).getTime();
 		return Number.isFinite(ms) ? ms : null;
@@ -313,6 +327,9 @@ export function getRepresentativeUtilizationForProvider(
 			return getRepresentativeAlibabaCodingPlanUtilization(
 				data as AlibabaCodingPlanUsageData,
 			);
+		}
+		case "xai": {
+			return getRepresentativeXaiUtilization(data as XaiUsageData);
 		}
 		default:
 			return null;
@@ -683,6 +700,23 @@ class UsageCache {
 					);
 					log.debug(
 						`Successfully fetched Alibaba Coding Plan usage data for account ${accountId}: ${utilization?.toFixed(1)}% used (${window} window)`,
+					);
+					return { success: true, retryAfterMs: null };
+				}
+			} else if (provider === "xai") {
+				// Fetch xAI/Grok Build credits data via grok.com gRPC-web.
+				data = await fetchXaiUsageData(token);
+				if (data) {
+					const callback = this.windowResetCallbacks.get(accountId);
+					if (callback)
+						this.notifyWindowReset(accountId, data, "xai", callback);
+					this.cache.set(accountId, { data, timestamp: Date.now() });
+					const utilization = getRepresentativeXaiUtilization(
+						data as XaiUsageData,
+					);
+					const window = getRepresentativeXaiWindow(data as XaiUsageData);
+					log.debug(
+						`Successfully fetched xAI Grok usage data for account ${accountId}: ${utilization?.toFixed(1)}% used (${window} window)`,
 					);
 					return { success: true, retryAfterMs: null };
 				}

--- a/packages/providers/src/xai-usage-fetcher.ts
+++ b/packages/providers/src/xai-usage-fetcher.ts
@@ -1,0 +1,379 @@
+import { Logger } from "@better-ccflare/logger";
+
+const log = new Logger("XaiUsageFetcher");
+
+export const XAI_GROK_CREDITS_ENDPOINT =
+	"https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig";
+
+const EMPTY_GRPC_WEB_FRAME = new Uint8Array([0, 0, 0, 0, 0]);
+
+export interface XaiUsageWindow {
+	/** Grok Build credits utilization percentage in the current billing window. */
+	utilization: number;
+	/** ISO reset timestamp when Grok exposes one; null when unavailable. */
+	resets_at: string | null;
+}
+
+export interface XaiUsageData {
+	credits: XaiUsageWindow;
+}
+
+interface ProtobufScan {
+	fixed32: Array<{ path: number[]; value: number; order: number }>;
+	varints: Array<{ path: number[]; value: number }>;
+}
+
+function mergeScan(target: ProtobufScan, source: ProtobufScan): void {
+	target.fixed32.push(...source.fixed32);
+	target.varints.push(...source.varints);
+}
+
+function readVarint(
+	bytes: Uint8Array,
+	cursor: { index: number },
+): number | null {
+	let value = 0;
+	let multiplier = 1;
+	let shift = 0;
+
+	while (cursor.index < bytes.length && shift < 64) {
+		const byte = bytes[cursor.index++];
+		value += (byte & 0x7f) * multiplier;
+		if ((byte & 0x80) === 0) return value;
+		multiplier *= 128;
+		shift += 7;
+	}
+
+	return null;
+}
+
+function scanProtobuf(
+	bytes: Uint8Array,
+	depth = 0,
+	path: number[] = [],
+	order = 0,
+): { scan: ProtobufScan; nextOrder: number } {
+	const scan: ProtobufScan = { fixed32: [], varints: [] };
+	let index = 0;
+	let nextOrder = order;
+
+	while (index < bytes.length) {
+		const start = index;
+		const keyCursor = { index };
+		const key = readVarint(bytes, keyCursor);
+		if (key === null || key === 0) {
+			index = start + 1;
+			continue;
+		}
+		index = keyCursor.index;
+
+		const fieldNumber = Math.floor(key / 8);
+		const wireType = key & 0x07;
+		const fieldPath = [...path, fieldNumber];
+
+		switch (wireType) {
+			case 0: {
+				const valueCursor = { index };
+				const value = readVarint(bytes, valueCursor);
+				if (value === null) {
+					index = start + 1;
+					break;
+				}
+				index = valueCursor.index;
+				scan.varints.push({ path: fieldPath, value });
+				break;
+			}
+			case 1: {
+				index = index + 8 <= bytes.length ? index + 8 : start + 1;
+				break;
+			}
+			case 2: {
+				const lengthCursor = { index };
+				const length = readVarint(bytes, lengthCursor);
+				if (
+					length === null ||
+					length < 0 ||
+					length > bytes.length - lengthCursor.index
+				) {
+					index = start + 1;
+					break;
+				}
+				index = lengthCursor.index;
+				const sub = bytes.subarray(index, index + length);
+				if (depth < 4) {
+					const nested = scanProtobuf(sub, depth + 1, fieldPath, nextOrder);
+					mergeScan(scan, nested.scan);
+					nextOrder = nested.nextOrder;
+				}
+				index += length;
+				break;
+			}
+			case 5: {
+				if (index + 4 > bytes.length) {
+					index = start + 1;
+					break;
+				}
+				const view = new DataView(bytes.buffer, bytes.byteOffset + index, 4);
+				scan.fixed32.push({
+					path: fieldPath,
+					value: view.getFloat32(0, true),
+					order: nextOrder++,
+				});
+				index += 4;
+				break;
+			}
+			default:
+				index = start + 1;
+				break;
+		}
+	}
+
+	return { scan, nextOrder };
+}
+
+function looksLikeProtobufPayload(bytes: Uint8Array): boolean {
+	if (bytes.length === 0) return false;
+	const field = bytes[0] >> 3;
+	const wire = bytes[0] & 0x07;
+	return field > 0 && (wire === 0 || wire === 1 || wire === 2 || wire === 5);
+}
+
+function grpcWebDataFrames(bytes: Uint8Array): Uint8Array[] {
+	const frames: Uint8Array[] = [];
+	let index = 0;
+
+	while (index + 5 <= bytes.length) {
+		const flags = bytes[index];
+		const length =
+			(bytes[index + 1] << 24) |
+			(bytes[index + 2] << 16) |
+			(bytes[index + 3] << 8) |
+			bytes[index + 4];
+		if (length < 0 || index + 5 + length > bytes.length) return [];
+		if ((flags & 0x80) === 0) {
+			frames.push(bytes.subarray(index + 5, index + 5 + length));
+		}
+		index += 5 + length;
+	}
+
+	return frames;
+}
+
+function grpcWebTrailerFields(bytes: Uint8Array): Record<string, string> {
+	const fields: Record<string, string> = {};
+	const decoder = new TextDecoder();
+	let index = 0;
+
+	while (index + 5 <= bytes.length) {
+		const flags = bytes[index];
+		const length =
+			(bytes[index + 1] << 24) |
+			(bytes[index + 2] << 16) |
+			(bytes[index + 3] << 8) |
+			bytes[index + 4];
+		if (length < 0 || index + 5 + length > bytes.length) break;
+		if ((flags & 0x80) !== 0) {
+			const text = decoder.decode(
+				bytes.subarray(index + 5, index + 5 + length),
+			);
+			for (const line of text.split("\n")) {
+				if (!line) continue;
+				const sep = line.indexOf(":");
+				if (sep <= 0) continue;
+				fields[line.slice(0, sep).trim().toLowerCase()] = line
+					.slice(sep + 1)
+					.trim();
+			}
+		}
+		index += 5 + length;
+	}
+
+	return fields;
+}
+
+function grpcStatusFromHeaders(
+	headers: Headers,
+): { status: number; message: string } | null {
+	const raw = headers.get("grpc-status");
+	if (!raw) return null;
+	const status = Number.parseInt(raw, 10);
+	if (!Number.isFinite(status)) return null;
+	return { status, message: headers.get("grpc-message") ?? "" };
+}
+
+function grpcStatusFromBody(
+	bytes: Uint8Array,
+): { status: number; message: string } | null {
+	const fields = grpcWebTrailerFields(bytes);
+	const raw = fields["grpc-status"];
+	if (!raw) return null;
+	const status = Number.parseInt(raw, 10);
+	if (!Number.isFinite(status)) return null;
+	return { status, message: fields["grpc-message"] ?? "" };
+}
+
+export function parseXaiGrokCreditsResponse(
+	bytes: Uint8Array,
+	nowMs = Date.now(),
+): XaiUsageData | null {
+	const grpcStatus = grpcStatusFromBody(bytes);
+	if (grpcStatus && grpcStatus.status !== 0) {
+		log.warn(
+			`xAI Grok credits gRPC-web response returned grpc-status=${grpcStatus.status}${grpcStatus.message ? ` ${grpcStatus.message}` : ""}`,
+		);
+		return null;
+	}
+
+	let payloads = grpcWebDataFrames(bytes);
+	if (payloads.length === 0 && looksLikeProtobufPayload(bytes)) {
+		payloads = [bytes];
+	}
+	if (payloads.length === 0) return null;
+
+	const merged: ProtobufScan = { fixed32: [], varints: [] };
+	for (const payload of payloads) {
+		const { scan } = scanProtobuf(payload);
+		mergeScan(merged, scan);
+	}
+
+	let bestPercent: { value: number; depth: number } | null = null;
+	for (const field of merged.fixed32) {
+		if (field.path.length === 0) continue;
+		if (field.path[field.path.length - 1] !== 1) continue;
+		if (!Number.isFinite(field.value) || field.value < 0 || field.value > 100) {
+			continue;
+		}
+		const depth = field.path.length;
+		if (!bestPercent || depth < bestPercent.depth) {
+			bestPercent = { value: field.value, depth };
+		}
+	}
+
+	const now = new Date(nowMs);
+	const futureResetTimes: Array<{ path: number[]; time: Date }> = [];
+	for (const field of merged.varints) {
+		if (field.value < 1_700_000_000 || field.value > 2_100_000_000) continue;
+		const time = new Date(field.value * 1000);
+		if (time.getTime() > now.getTime()) {
+			futureResetTimes.push({ path: field.path, time });
+		}
+	}
+
+	let resetTime: Date | null = null;
+	const preferredReset = futureResetTimes.find(
+		(field) =>
+			field.path.length === 3 &&
+			field.path[0] === 1 &&
+			field.path[1] === 5 &&
+			field.path[2] === 1,
+	);
+	if (preferredReset) {
+		resetTime = preferredReset.time;
+	} else if (futureResetTimes.length > 0) {
+		resetTime = futureResetTimes.reduce((earliest, current) =>
+			current.time.getTime() < earliest.time.getTime() ? current : earliest,
+		).time;
+	}
+
+	let hasUsagePeriod = false;
+	for (const field of merged.varints) {
+		if (field.path.length >= 2 && field.path[0] === 1 && field.path[1] === 6) {
+			hasUsagePeriod = true;
+			break;
+		}
+		if (
+			field.path.length === 3 &&
+			field.path[0] === 1 &&
+			field.path[1] === 8 &&
+			field.path[2] === 1 &&
+			(field.value === 1 || field.value === 2)
+		) {
+			hasUsagePeriod = true;
+			break;
+		}
+	}
+
+	let utilization = bestPercent?.value;
+	if (utilization === undefined) {
+		const noUsageYet =
+			merged.fixed32.length === 0 && resetTime && hasUsagePeriod;
+		if (!noUsageYet) return null;
+		utilization = 0;
+	}
+
+	return {
+		credits: {
+			utilization,
+			resets_at: resetTime ? resetTime.toISOString() : null,
+		},
+	};
+}
+
+export async function fetchXaiUsageData(
+	accessToken: string,
+): Promise<XaiUsageData | null> {
+	const token = accessToken.trim();
+	if (!token) return null;
+
+	const controller = new AbortController();
+	const timeoutId = setTimeout(() => controller.abort(), 5000);
+	try {
+		const response = await fetch(XAI_GROK_CREDITS_ENDPOINT, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				Origin: "https://grok.com",
+				Referer: "https://grok.com/?_s=usage",
+				Accept: "*/*",
+				"Content-Type": "application/grpc-web+proto",
+				"x-grpc-web": "1",
+				"x-user-agent": "connect-es/2.1.1",
+				"User-Agent": "better-ccflare/xai-usage",
+			},
+			body: EMPTY_GRPC_WEB_FRAME,
+			signal: controller.signal,
+		});
+
+		if (!response.ok) {
+			log.warn(
+				`Failed to fetch xAI Grok credits: HTTP ${response.status} ${response.statusText}`,
+			);
+			return null;
+		}
+
+		const headerStatus = grpcStatusFromHeaders(response.headers);
+		if (headerStatus && headerStatus.status !== 0) {
+			log.warn(
+				`xAI Grok credits returned grpc-status=${headerStatus.status}${headerStatus.message ? ` ${headerStatus.message}` : ""}`,
+			);
+			return null;
+		}
+
+		const bytes = new Uint8Array(await response.arrayBuffer());
+		const data = parseXaiGrokCreditsResponse(bytes);
+		if (!data) {
+			log.warn("Failed to parse xAI Grok credits response");
+		}
+		return data;
+	} catch (error) {
+		log.warn(
+			"Error fetching xAI Grok credits:",
+			error instanceof Error ? error.message : String(error),
+		);
+		return null;
+	} finally {
+		clearTimeout(timeoutId);
+	}
+}
+
+export function getRepresentativeXaiUtilization(
+	usage: XaiUsageData | null,
+): number | null {
+	return usage?.credits?.utilization ?? null;
+}
+
+export function getRepresentativeXaiWindow(
+	usage: XaiUsageData | null,
+): string | null {
+	return usage ? "credits" : null;
+}

--- a/packages/providers/src/xai-usage-fetcher.ts
+++ b/packages/providers/src/xai-usage-fetcher.ts
@@ -1,4 +1,7 @@
 import { Logger } from "@better-ccflare/logger";
+import type { XaiUsageData } from "@better-ccflare/types";
+
+export type { XaiUsageData, XaiUsageWindow } from "@better-ccflare/types";
 
 const log = new Logger("XaiUsageFetcher");
 
@@ -6,17 +9,6 @@ export const XAI_GROK_CREDITS_ENDPOINT =
 	"https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig";
 
 const EMPTY_GRPC_WEB_FRAME = new Uint8Array([0, 0, 0, 0, 0]);
-
-export interface XaiUsageWindow {
-	/** Grok Build credits utilization percentage in the current billing window. */
-	utilization: number;
-	/** ISO reset timestamp when Grok exposes one; null when unavailable. */
-	resets_at: string | null;
-}
-
-export interface XaiUsageData {
-	credits: XaiUsageWindow;
-}
 
 interface ProtobufScan {
 	fixed32: Array<{ path: number[]; value: number; order: number }>;

--- a/packages/proxy/src/auto-refresh-scheduler.ts
+++ b/packages/proxy/src/auto-refresh-scheduler.ts
@@ -213,8 +213,8 @@ export class AutoRefreshScheduler {
 				await this.sendDummyMessage(accountRow);
 			}
 
-			// Proactively refresh Qwen OAuth tokens expiring within the safety window
-			await this.checkAndRefreshQwenTokens();
+			// Proactively refresh OpenAI-compatible OAuth tokens expiring within the safety window
+			await this.checkAndRefreshOpenAICompatibleOAuthTokens();
 
 			// Proactively refresh Codex OAuth tokens expiring within the safety window
 			await this.checkAndRefreshCodexTokens();
@@ -727,11 +727,11 @@ export class AutoRefreshScheduler {
 	}
 
 	/**
-	 * Proactively refresh Qwen OAuth access tokens that are expiring within the safety window.
+	 * Proactively refresh OpenAI-compatible OAuth access tokens that are expiring within the safety window.
 	 * Unlike Anthropic accounts (which use dummy messages to reset rate-limit windows),
-	 * Qwen only needs the OAuth token refreshed — no dummy message required.
+	 * these providers only need the OAuth token refreshed — no dummy message required.
 	 */
-	private async checkAndRefreshQwenTokens(): Promise<void> {
+	private async checkAndRefreshOpenAICompatibleOAuthTokens(): Promise<void> {
 		if (!this.db) return;
 
 		const now = Date.now();
@@ -750,7 +750,7 @@ export class AutoRefreshScheduler {
 			SELECT id, name, provider, refresh_token, access_token, expires_at, custom_endpoint
 			FROM accounts
 			WHERE
-				provider = 'qwen'
+				provider IN ('qwen', 'xai')
 				AND refresh_token IS NOT NULL
 				AND (
 					access_token IS NULL
@@ -764,24 +764,26 @@ export class AutoRefreshScheduler {
 		if (accounts.length === 0) return;
 
 		log.info(
-			`Proactive Qwen token refresh: ${accounts.length} account(s) need refresh`,
+			`Proactive OpenAI-compatible OAuth token refresh: ${accounts.length} account(s) need refresh`,
 		);
 
 		for (const row of accounts) {
 			// Skip if a refresh is already in-flight for this account (deduplication)
 			if (this.proxyContext.refreshInFlight.has(row.id)) {
 				log.debug(
-					`Skipping proactive Qwen refresh for ${row.name} — refresh already in-flight`,
+					`Skipping proactive ${row.provider} refresh for ${row.name} — refresh already in-flight`,
 				);
 				continue;
 			}
 
 			try {
-				log.info(`Refreshing Qwen token for account: ${row.name}`);
+				log.info(`Refreshing ${row.provider} token for account: ${row.name}`);
 
 				const provider = getProvider(row.provider);
 				if (!provider) {
-					log.error(`No provider found for qwen (account: ${row.name})`);
+					log.error(
+						`No provider found for ${row.provider} (account: ${row.name})`,
+					);
 					continue;
 				}
 
@@ -837,7 +839,7 @@ export class AutoRefreshScheduler {
 							],
 						);
 						log.info(
-							`Qwen token refreshed for ${row.name}, expires at ${new Date(result.expiresAt).toISOString()}`,
+							`${row.provider} token refreshed for ${row.name}, expires at ${new Date(result.expiresAt).toISOString()}`,
 						);
 						return result.accessToken;
 					})
@@ -849,7 +851,7 @@ export class AutoRefreshScheduler {
 				await refreshPromise;
 			} catch (error) {
 				log.error(
-					`Failed to proactively refresh Qwen token for ${row.name}:`,
+					`Failed to proactively refresh ${row.provider} token for ${row.name}:`,
 					error,
 				);
 			}

--- a/packages/proxy/src/handlers/__tests__/proxy-operations-count-tokens.test.ts
+++ b/packages/proxy/src/handlers/__tests__/proxy-operations-count-tokens.test.ts
@@ -1,6 +1,15 @@
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	mock,
+	spyOn,
+} from "bun:test";
 import { CodexProvider } from "@better-ccflare/providers";
 import type { Account, RequestMeta } from "@better-ccflare/types";
+import * as usageCollectorModule from "../../usage-collector";
 import { proxyWithAccount } from "../proxy-operations";
 import type { ProxyContext } from "../proxy-types";
 
@@ -176,15 +185,27 @@ describe("proxyWithAccount — Codex count_tokens", () => {
 		});
 		globalThis.fetch = fetchMock;
 
-		const bodyBuffer = new TextEncoder().encode(
-			JSON.stringify({
-				model: "claude-sonnet-4-5",
-				messages: [{ role: "user", content: "hello world" }],
-				max_tokens: 16,
-			}),
-		).buffer;
-		await expect(
-			proxyWithAccount(
+		const collector = {
+			handleStart: mock(() => {}),
+			handleChunk: mock(() => {}),
+			handleEnd: mock(() => Promise.resolve()),
+		};
+		const collectorSpy = spyOn(
+			usageCollectorModule,
+			"getUsageCollector",
+		).mockReturnValue(
+			collector as unknown as usageCollectorModule.UsageCollector,
+		);
+
+		try {
+			const bodyBuffer = new TextEncoder().encode(
+				JSON.stringify({
+					model: "claude-sonnet-4-5",
+					messages: [{ role: "user", content: "hello world" }],
+					max_tokens: 16,
+				}),
+			).buffer;
+			const result = await proxyWithAccount(
 				makeMessagesRequest(bodyBuffer, {
 					"Content-Type": "application/json",
 					"x-better-ccflare-synthetic-response": "true",
@@ -200,8 +221,14 @@ describe("proxyWithAccount — Codex count_tokens", () => {
 				() => undefined,
 				0,
 				makeProxyContext(),
-			),
-		).rejects.toThrow("UsageCollector not initialized");
+			);
+
+			expect(result).toBeInstanceOf(Response);
+			expect(result?.status).toBe(200);
+			await result?.text();
+		} finally {
+			collectorSpy.mockRestore();
+		}
 
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 		expect(

--- a/packages/types/src/account.ts
+++ b/packages/types/src/account.ts
@@ -90,13 +90,24 @@ export interface AlibabaCodingPlanUsageData {
 	remainingDays: number | null;
 }
 
+// Usage data types for xAI/Grok accounts
+export interface XaiUsageWindow {
+	utilization: number; // 0-100 Grok Build credits utilization
+	resets_at: string | null; // ISO timestamp when available
+}
+
+export interface XaiUsageData {
+	credits: XaiUsageWindow;
+}
+
 // Combined usage data type that supports all providers
 export type FullUsageData =
 	| AnthropicUsageData
 	| NanoGPTUsageData
 	| ZaiUsageData
 	| KiloUsageData
-	| AlibabaCodingPlanUsageData;
+	| AlibabaCodingPlanUsageData
+	| XaiUsageData;
 
 // Database row types that match the actual database schema
 export interface AccountRow {

--- a/packages/types/src/account.ts
+++ b/packages/types/src/account.ts
@@ -277,6 +277,7 @@ export interface AccountListItem {
 		| "alibaba-coding-plan"
 		| "codex"
 		| "qwen"
+		| "xai"
 		| "ollama"
 		| "ollama-cloud";
 	priority: number;
@@ -297,7 +298,8 @@ export interface AddAccountOptions {
 		| "anthropic-compatible"
 		| "openai-compatible"
 		| "bedrock"
-		| "openrouter";
+		| "openrouter"
+		| "xai";
 	priority?: number;
 	customEndpoint?: string;
 }

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -34,6 +34,7 @@ export const ACCOUNT_MODES = {
 	ANTHROPIC_COMPATIBLE: "anthropic-compatible", // Anthropic-compatible provider (API key)
 	OPENAI_COMPATIBLE: "openai-compatible", // OpenAI-compatible provider (API key)
 	NANOGPT: "nanogpt", // NanoGPT provider (API key)
+	XAI: "xai", // xAI/Grok account (Grok CLI OAuth)
 	OLLAMA: "ollama", // Ollama local provider (v0.14.0+, no API key required)
 } as const;
 
@@ -46,8 +47,7 @@ export function usesApiKey(provider: string): boolean {
 	if (!isKnownProvider(provider)) {
 		return false; // Unknown providers don't use API key authentication by default
 	}
-	// API key providers are all providers except Anthropic OAuth
-	return provider !== PROVIDER_NAMES.ANTHROPIC;
+	return !supportsOAuth(provider);
 }
 
 /**
@@ -69,6 +69,8 @@ export function getProviderFromMode(mode: AccountMode): ProviderName {
 			return PROVIDER_NAMES.OPENAI_COMPATIBLE;
 		case ACCOUNT_MODES.NANOGPT:
 			return PROVIDER_NAMES.NANOGPT;
+		case ACCOUNT_MODES.XAI:
+			return PROVIDER_NAMES.XAI;
 		case ACCOUNT_MODES.OLLAMA:
 			return PROVIDER_NAMES.OLLAMA;
 		default:

--- a/packages/types/src/provider-config.ts
+++ b/packages/types/src/provider-config.ts
@@ -16,6 +16,7 @@ export const PROVIDER_NAMES = {
 	ALIBABA_CODING_PLAN: "alibaba-coding-plan",
 	CODEX: "codex",
 	QWEN: "qwen",
+	XAI: "xai",
 	OLLAMA: "ollama",
 	OLLAMA_CLOUD: "ollama-cloud",
 } as const;
@@ -131,6 +132,12 @@ export const PROVIDER_CONFIG: Record<ProviderName, ProviderConfig> = {
 		supportsUsageTracking: true, // Usage tracked via response body (OpenAI-compatible)
 		supportsOAuth: true, // Qwen uses OAuth 2.0 device code flow
 		defaultEndpoint: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+	},
+	[PROVIDER_NAMES.XAI]: {
+		requiresSessionTracking: false, // xAI OAuth/API usage is per request, no session stickiness
+		supportsUsageTracking: true, // Usage tracked via OpenAI-compatible response body
+		supportsOAuth: true, // Imports/refreshes Grok CLI OAuth credentials
+		defaultEndpoint: "https://api.x.ai/v1",
 	},
 	[PROVIDER_NAMES.OLLAMA]: {
 		requiresSessionTracking: false,

--- a/packages/types/src/provider-config.ts
+++ b/packages/types/src/provider-config.ts
@@ -135,7 +135,7 @@ export const PROVIDER_CONFIG: Record<ProviderName, ProviderConfig> = {
 	},
 	[PROVIDER_NAMES.XAI]: {
 		requiresSessionTracking: false, // xAI OAuth/API usage is per request, no session stickiness
-		supportsUsageTracking: true, // Usage tracked via OpenAI-compatible response body
+		supportsUsageTracking: false, // xAI exposes per-response tokens, but no pollable quota-window endpoint for Grok CLI OAuth
 		supportsOAuth: true, // Imports/refreshes Grok CLI OAuth credentials
 		defaultEndpoint: "https://api.x.ai/v1",
 	},

--- a/packages/types/src/provider-config.ts
+++ b/packages/types/src/provider-config.ts
@@ -134,8 +134,8 @@ export const PROVIDER_CONFIG: Record<ProviderName, ProviderConfig> = {
 		defaultEndpoint: "https://dashscope.aliyuncs.com/compatible-mode/v1",
 	},
 	[PROVIDER_NAMES.XAI]: {
-		requiresSessionTracking: false, // xAI OAuth/API usage is per request, no session stickiness
-		supportsUsageTracking: false, // xAI exposes per-response tokens, but no pollable quota-window endpoint for Grok CLI OAuth
+		requiresSessionTracking: false, // Grok Build credits reset by billing window, not session stickiness
+		supportsUsageTracking: true, // Grok CLI OAuth bearer can poll grok.com Grok Build credits via gRPC-web
 		supportsOAuth: true, // Imports/refreshes Grok CLI OAuth credentials
 		defaultEndpoint: "https://api.x.ai/v1",
 	},


### PR DESCRIPTION
## Summary
- add a native `xai` provider built on the existing OpenAI-compatible Anthropic conversion path
- import local Grok CLI OAuth credentials from `~/.grok/auth.json` without printing token values
- refresh xAI OAuth access tokens via `https://auth.x.ai/oauth2/token`, persisting rotated refresh tokens to the account DB
- poll Grok Build credits usage via `grok.com` gRPC-web using the Grok CLI OAuth bearer, so dashboard bars can show credits utilization and reset time without depending on onwatch
- add default Grok model mappings, CLI/help/docs wiring, provider config metadata, dashboard/API usage plumbing, and focused provider tests
- use the same 6-hour fallback TTL during xAI account import/re-auth as the refresh path, avoiding an immediate refresh when Grok auth lacks a readable expiry

## Secret handling
- no bearer tokens or refresh tokens are logged, printed, committed, or included in this PR
- refresh errors intentionally avoid surfacing raw upstream response bodies
- usage polling sends only the current access token as an Authorization bearer; it does not force-refresh or write `~/.grok/auth.json`
- local runtime smokes used the current access token only; no refresh-token probe was performed
- docs/CLI warn that xAI refresh tokens may rotate, so users who keep using Grok CLI separately should refresh/re-authenticate it after import to keep token chains independent

## Usage-window findings
- xAI chat responses include per-request token usage and better-ccflare records that request-level accounting
- xAI Management API exposes billing/usage endpoints, but Grok CLI OAuth tokens are rejected there; a separate management key would be needed for those endpoints
- onwatch's working model showed that Grok Build credits can be polled from `https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig` with a gRPC-web empty-frame request and the Grok CLI OAuth bearer
- this PR implements that directly inside better-ccflare: it parses gRPC-web frames/trailers, scans the protobuf payload for `credit_usage_percent` and reset timestamps, caches the result in the existing usage cache, and exposes it through the accounts API/dashboard
- live read-only smoke matched onwatch's cached data: Grok Build credits utilization `11%`, reset `2026-07-01T00:00:00Z`

## Validation
- `bun test packages/providers/src/__tests__/xai-usage-fetcher.test.ts packages/providers/src/__tests__/window-reset-detection.test.ts packages/providers/src/providers/xai/provider.test.ts --timeout 30000`
- `bun test --timeout 30000` (1727 pass)
- `bun run typecheck`
- `bun run build`
- `bunx --bun biome check . --diagnostic-level=error`
- `git diff --check`
- Redacted direct xAI smoke using the Grok CLI access token only: `POST https://api.x.ai/v1/chat/completions` returned HTTP 200 for `grok-4.3` with `content='xai smoke ok'` and usage fields present
- Redacted direct Grok Build credits smoke using the Grok CLI access token only: gRPC-web credits polling returned utilization `11` and reset `2026-07-01T00:00:00.000Z`
- Isolated better-ccflare proxy smoke on a temp HOME/DB and alternate port: `--add-account grok-local-smoke --mode xai --priority 50`, `--serve --port 8798`, then `POST /v1/messages` returned HTTP 200, Anthropic message shape, `model=grok-4.3`, `content='better-ccflare xai proxy ok'`, and usage tokens. Logs showed no xAI token refresh was triggered.
