### PR TITLE
feat(lb): session-affinity strategy — per-client sticky + least-used spread

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -24,6 +24,7 @@ import {
 import { AlertService, APIRouter, AuthService } from "@better-ccflare/http-api";
 import {
 	LeastUsedStrategy,
+	SessionAffinityStrategy,
 	SessionStrategy,
 } from "@better-ccflare/load-balancer";
 import { Logger } from "@better-ccflare/logger";
@@ -77,6 +78,8 @@ function buildStrategy(
 	switch (name) {
 		case StrategyName.LeastUsed:
 			return new LeastUsedStrategy();
+		case StrategyName.SessionAffinity:
+			return new SessionAffinityStrategy(sessionDurationMs);
 		default:
 			return new SessionStrategy(sessionDurationMs);
 	}

--- a/packages/load-balancer/src/index.ts
+++ b/packages/load-balancer/src/index.ts
@@ -1,1 +1,5 @@
-export { LeastUsedStrategy, SessionStrategy } from "./strategies";
+export {
+	LeastUsedStrategy,
+	SessionAffinityStrategy,
+	SessionStrategy,
+} from "./strategies";

--- a/packages/load-balancer/src/strategies/__tests__/session-affinity.test.ts
+++ b/packages/load-balancer/src/strategies/__tests__/session-affinity.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { SessionAffinityStrategy } from "@better-ccflare/load-balancer";
+import type {
+	Account,
+	RequestMeta,
+	StrategyStore,
+} from "@better-ccflare/types";
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "a",
+		name: "a",
+		provider: "anthropic",
+		api_key: null,
+		refresh_token: "r",
+		access_token: "t",
+		expires_at: Date.now() + 3_600_000,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: Date.now(),
+		rate_limited_until: null,
+		rate_limited_reason: null,
+		rate_limited_at: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		peak_hours_pause_enabled: false,
+		custom_endpoint: null,
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		billing_type: null,
+		pause_reason: null,
+		refresh_token_issued_at: null,
+		...overrides,
+	};
+}
+
+class MockStore implements StrategyStore {
+	resetCalls: Array<{ accountId: string; timestamp: number }> = [];
+	resumeCalls: string[] = [];
+	utilization: Map<string, number | null> = new Map();
+
+	resetAccountSession(accountId: string, timestamp: number): void {
+		this.resetCalls.push({ accountId, timestamp });
+	}
+	resumeAccount(accountId: string): void {
+		this.resumeCalls.push(accountId);
+	}
+	getAccountUtilization(accountId: string): number | null {
+		return this.utilization.has(accountId)
+			? (this.utilization.get(accountId) ?? null)
+			: null;
+	}
+	setUtil(accountId: string, value: number | null): void {
+		this.utilization.set(accountId, value);
+	}
+}
+
+function metaFor(clientSessionId?: string | null): RequestMeta {
+	return {
+		id: "req",
+		headers: new Headers(),
+		timestamp: Date.now(),
+		clientSessionId: clientSessionId ?? null,
+	} as unknown as RequestMeta;
+}
+
+describe("SessionAffinityStrategy", () => {
+	let store: MockStore;
+	let strategy: SessionAffinityStrategy;
+
+	beforeEach(() => {
+		store = new MockStore();
+		strategy = new SessionAffinityStrategy();
+		strategy.initialize(store);
+	});
+
+	it("assigns a new client an account and sticks it there (sticky)", () => {
+		const accounts = [
+			makeAccount({ id: "x" }),
+			makeAccount({ id: "y" }),
+			makeAccount({ id: "z" }),
+		];
+
+		const first = strategy.select(accounts, metaFor("client-1"));
+		const assigned = first[0].id;
+
+		// Subsequent selects with the same client id must keep returning the
+		// same account first, even though util/recency would otherwise rotate.
+		for (let i = 0; i < 5; i++) {
+			const next = strategy.select(accounts, metaFor("client-1"));
+			expect(next[0].id).toBe(assigned);
+		}
+	});
+
+	it("spreads two different clients onto different accounts", () => {
+		// Two equal accounts (priority 0, util 0). The recency penalty must push
+		// the second new client onto the other account.
+		const accounts = [makeAccount({ id: "x" }), makeAccount({ id: "y" })];
+
+		const a = strategy.select(accounts, metaFor("client-a"))[0].id;
+		const b = strategy.select(accounts, metaFor("client-b"))[0].id;
+
+		expect(a).not.toBe(b);
+		expect(new Set([a, b])).toEqual(new Set(["x", "y"]));
+	});
+
+	it("temporarily fails over when the pinned account is unavailable but keeps the mapping (snap-back)", () => {
+		const x = makeAccount({ id: "x" });
+		const y = makeAccount({ id: "y" });
+		store.setUtil("x", 0);
+		store.setUtil("y", 0);
+
+		// Pin client-1 to whichever account it gets (force it to x via util).
+		store.setUtil("x", 0);
+		store.setUtil("y", 50);
+		const assigned = strategy.select([x, y], metaFor("client-1"))[0].id;
+		expect(assigned).toBe("x");
+
+		// x becomes rate-limited.
+		const xDown = makeAccount({
+			id: "x",
+			rate_limited_until: Date.now() + 60_000,
+		});
+		const failover = strategy.select([xDown, y], metaFor("client-1"));
+		// Must route to an available account (y), not the down one.
+		expect(failover[0].id).toBe("y");
+		expect(failover.every((a) => a.id !== "x")).toBe(true);
+
+		// x recovers → client snaps back to x (mapping was never deleted).
+		const recovered = strategy.select(
+			[makeAccount({ id: "x" }), y],
+			metaFor("client-1"),
+		);
+		expect(recovered[0].id).toBe("x");
+	});
+
+	it("falls back to least-used when no clientSessionId is present", () => {
+		store.setUtil("low", 10);
+		store.setUtil("high", 90);
+		const accounts = [makeAccount({ id: "high" }), makeAccount({ id: "low" })];
+
+		const ordered = strategy.select(accounts, metaFor(null));
+		expect(ordered[0].id).toBe("low");
+		expect(ordered.map((a) => a.id).sort()).toEqual(["high", "low"]);
+	});
+
+	it("GCs an expired affinity mapping and reassigns", () => {
+		// Tiny TTL so the mapping expires between selects.
+		const ttlStrategy = new SessionAffinityStrategy(1);
+		ttlStrategy.initialize(store);
+
+		const accounts = [makeAccount({ id: "x" }), makeAccount({ id: "y" })];
+
+		const first = ttlStrategy.select(accounts, metaFor("client-1"))[0].id;
+
+		// Let the TTL elapse.
+		const start = Date.now();
+		while (Date.now() - start < 5) {
+			/* busy-wait a few ms so now - assignedAt >= 1ms TTL */
+		}
+
+		// Make the *other* account strictly preferable so reassignment is
+		// observable: if the old mapping were honoured we'd still get `first`.
+		const other = first === "x" ? "y" : "x";
+		store.setUtil(first, 90);
+		store.setUtil(other, 0);
+
+		const second = ttlStrategy.select(accounts, metaFor("client-1"))[0].id;
+		expect(second).toBe(other);
+	});
+
+	it("returns [] when all accounts are unavailable", () => {
+		const accounts = [
+			makeAccount({ id: "p1", paused: true }),
+			makeAccount({ id: "rl1", rate_limited_until: Date.now() + 60_000 }),
+		];
+		expect(strategy.select(accounts, metaFor("client-1"))).toEqual([]);
+	});
+
+	describe("peek", () => {
+		it("returns the least-used available account id", () => {
+			store.setUtil("low", 10);
+			store.setUtil("high", 90);
+			const accounts = [
+				makeAccount({ id: "high" }),
+				makeAccount({ id: "low" }),
+			];
+			expect(strategy.peek(accounts)).toBe("low");
+		});
+
+		it("returns null when no accounts are available", () => {
+			expect(
+				strategy.peek([
+					makeAccount({ id: "p1", paused: true }),
+					makeAccount({ id: "rl1", rate_limited_until: Date.now() + 60_000 }),
+				]),
+			).toBeNull();
+		});
+	});
+});

--- a/packages/load-balancer/src/strategies/__tests__/session-affinity.test.ts
+++ b/packages/load-balancer/src/strategies/__tests__/session-affinity.test.ts
@@ -55,7 +55,9 @@ class MockStore implements StrategyStore {
 	resumeAccount(accountId: string): void {
 		this.resumeCalls.push(accountId);
 	}
-	getAccountUtilization(accountId: string): number | null {
+	// Mirror the StrategyStore signature exactly (accountId, provider) so the
+	// mock can't silently diverge from the contract — provider is unused here.
+	getAccountUtilization(accountId: string, _provider?: string): number | null {
 		return this.utilization.has(accountId)
 			? (this.utilization.get(accountId) ?? null)
 			: null;
@@ -185,6 +187,49 @@ describe("SessionAffinityStrategy", () => {
 			makeAccount({ id: "rl1", rate_limited_until: Date.now() + 60_000 }),
 		];
 		expect(strategy.select(accounts, metaFor("client-1"))).toEqual([]);
+	});
+
+	it("spreads concurrent failovers across backups instead of piling onto one", () => {
+		// Pin two clients to the SAME account x (it's the only account at
+		// assignment time), then bring x down with two equal healthy backups.
+		const x = makeAccount({ id: "x" });
+		strategy.select([x], metaFor("c1"));
+		strategy.select([x], metaFor("c2"));
+
+		const xDown = makeAccount({
+			id: "x",
+			rate_limited_until: Date.now() + 60_000,
+		});
+		const y = makeAccount({ id: "y" });
+		const z = makeAccount({ id: "z" });
+		store.setUtil("y", 0);
+		store.setUtil("z", 0);
+
+		const f1 = strategy.select([xDown, y, z], metaFor("c1"))[0].id;
+		const f2 = strategy.select([xDown, y, z], metaFor("c2"))[0].id;
+
+		// Both fail off the down account, and onto DIFFERENT backups — the
+		// failover path now marks lastPickedAt, so the second failover is steered
+		// off the first's pick. Pre-fix both converged on the same backup.
+		expect(f1).not.toBe("x");
+		expect(f2).not.toBe("x");
+		expect(f1).not.toBe(f2);
+		expect(new Set([f1, f2])).toEqual(new Set(["y", "z"]));
+	});
+
+	it("caps the affinity map under a flood of unique client ids", () => {
+		const cap = 5;
+		const capped = new SessionAffinityStrategy(60_000, cap);
+		capped.initialize(store);
+		const x = makeAccount({ id: "x" });
+
+		// Far more distinct client ids than the cap (simulates adversarial /
+		// buggy callers sending many metadata.user_id values).
+		for (let i = 0; i < cap * 4; i++) {
+			capped.select([x], metaFor(`client-${i}`));
+		}
+
+		expect(capped.affinityEntries).toBe(cap);
 	});
 
 	describe("peek", () => {

--- a/packages/load-balancer/src/strategies/index.ts
+++ b/packages/load-balancer/src/strategies/index.ts
@@ -13,6 +13,7 @@ import {
 import { isPeekAvailable } from "./peek-availability";
 
 export { LeastUsedStrategy } from "./least-used";
+export { SessionAffinityStrategy } from "./session-affinity";
 
 export class SessionStrategy implements LoadBalancingStrategy {
 	private sessionDurationMs: number;

--- a/packages/load-balancer/src/strategies/session-affinity.ts
+++ b/packages/load-balancer/src/strategies/session-affinity.ts
@@ -1,0 +1,216 @@
+import { isAccountAvailable, TIME_CONSTANTS } from "@better-ccflare/core";
+import { Logger } from "@better-ccflare/logger";
+import type {
+	Account,
+	LoadBalancingStrategy,
+	RequestMeta,
+	StrategyStore,
+} from "@better-ccflare/types";
+import { isPeekAvailable, wouldAutoUnpause } from "./peek-availability";
+
+/**
+ * Window during which a freshly-picked account is deprioritized so that
+ * concurrent NEW client-sessions rotate through the pool instead of all
+ * landing on the same lowest-utilization candidate. Copied from
+ * LeastUsedStrategy — see that file for the rationale.
+ */
+const RECENT_PICK_WINDOW_MS = 500;
+
+/**
+ * Score added to an account's effective utilization when it was picked
+ * within RECENT_PICK_WINDOW_MS. 100 = "treat as fully utilized" for
+ * tiebreak purposes — large enough to override realistic upstream
+ * utilization deltas (typically 0–95).
+ */
+const RECENT_PICK_PENALTY = 100;
+
+/**
+ * SessionAffinityStrategy — a hybrid of SessionStrategy and LeastUsedStrategy.
+ *
+ * Routing is keyed on the *client* session id (request body
+ * `metadata.user_id`, threaded through as {@link RequestMeta.clientSessionId}):
+ *
+ *   - The first request of a new client-session is routed to the least-loaded
+ *     available account (same least-used scoring as LeastUsedStrategy, with the
+ *     recency penalty so concurrently-starting sessions spread across the pool).
+ *   - That client→account mapping is then made STICKY for `affinityTtlMs`, so
+ *     every subsequent request from the same client keeps hitting the same
+ *     upstream → prompt-cache affinity is preserved across the agentic loop.
+ *
+ * The result: many concurrent client-sessions are spread across all healthy
+ * accounts (one account is no longer maxed before the next is touched, the
+ * sequential-exhaustion failure mode of SessionStrategy), while each individual
+ * session still keeps its cache locality (which per-request LeastUsedStrategy
+ * throws away).
+ *
+ * Trade-off:
+ *   - vs SessionStrategy: SessionStrategy tracks ONE account-level session and
+ *     funnels ALL traffic to it until it rate-limits/expires, then rotates —
+ *     maxing one account before the next. SessionAffinity instead pins each
+ *     client to its own account, so N concurrent clients use up to N accounts.
+ *   - vs LeastUsedStrategy: LeastUsed spreads every individual request and so
+ *     loses prompt-cache reuse. SessionAffinity keeps a client glued to one
+ *     account, trading some instantaneous load-evenness for cache hits.
+ *
+ * When the pinned account is temporarily unavailable (rate-limited), the
+ * mapping is intentionally NOT deleted: we fail the client over to the
+ * least-used available account for the duration, but snap it back to its
+ * original account once that recovers (mirrors the SessionStrategy issue #115
+ * reasoning — the prompt-cache window outlives the rate-limit window).
+ */
+export class SessionAffinityStrategy implements LoadBalancingStrategy {
+	private affinityTtlMs: number;
+	private store: StrategyStore | null = null;
+	private log = new Logger("SessionAffinityStrategy");
+	/** clientId → which account it is stuck to (and when it was last touched). */
+	private affinity = new Map<
+		string,
+		{ accountId: string; assignedAt: number }
+	>();
+	/** accountId → last time it was freshly assigned to a NEW client-session. */
+	private lastPickedAt = new Map<string, number>();
+
+	constructor(
+		affinityTtlMs: number = TIME_CONSTANTS.ANTHROPIC_SESSION_DURATION_DEFAULT,
+	) {
+		this.affinityTtlMs = affinityTtlMs;
+	}
+
+	initialize(store: StrategyStore): void {
+		this.store = store;
+	}
+
+	/**
+	 * Rank accounts by least-used: priority ASC, then upstream utilization plus
+	 * a recency penalty for accounts assigned in the last RECENT_PICK_WINDOW_MS.
+	 * Identical scoring to LeastUsedStrategy.select() so the two strategies pick
+	 * the same primary for a fresh session given the same state.
+	 */
+	private rankByLeastUsed(accounts: Account[], now: number): Account[] {
+		const scored = accounts.map((a) => {
+			const util = this.store?.getAccountUtilization?.(a.id, a.provider) ?? 0;
+			const lastPick = this.lastPickedAt.get(a.id) ?? 0;
+			const recencyPenalty =
+				now - lastPick < RECENT_PICK_WINDOW_MS ? RECENT_PICK_PENALTY : 0;
+			return { account: a, score: util + recencyPenalty };
+		});
+
+		return scored
+			.sort((a, b) => {
+				if (a.account.priority !== b.account.priority) {
+					return a.account.priority - b.account.priority;
+				}
+				return a.score - b.score;
+			})
+			.map((s) => s.account);
+	}
+
+	peek(accounts: Account[]): string | null {
+		const now = Date.now();
+		// Use isPeekAvailable so accounts that select() would auto-unpause on its
+		// next call surface as candidates here, matching LeastUsedStrategy.peek().
+		const available = accounts.filter((a) => isPeekAvailable(a, now));
+		if (available.length === 0) return null;
+		return this.rankByLeastUsed(available, now)[0]?.id ?? null;
+	}
+
+	select(accounts: Account[], meta: RequestMeta): Account[] {
+		const now = Date.now();
+
+		// Auto-unpause eligible accounts whose upstream usage window has reset.
+		// Mirrors LeastUsedStrategy.autoUnpauseElapsedAccounts so users with
+		// auto_fallback_enabled accounts get the same self-recovery behaviour
+		// regardless of which strategy they pick.
+		this.autoUnpauseElapsedAccounts(accounts, now);
+
+		const available = accounts.filter((a) => isAccountAvailable(a, now));
+		if (available.length === 0) return [];
+
+		// GC expired affinity entries so the map doesn't grow unboundedly and so
+		// long-idle clients are re-balanced onto the currently least-loaded
+		// account rather than re-pinned to a possibly-stale one.
+		for (const [clientId, entry] of this.affinity) {
+			if (now - entry.assignedAt >= this.affinityTtlMs) {
+				this.affinity.delete(clientId);
+			}
+		}
+
+		const clientId = meta.clientSessionId ?? null;
+
+		// Existing, non-expired client-session: try to honour its sticky mapping.
+		if (clientId !== null) {
+			const mapping = this.affinity.get(clientId);
+			if (mapping) {
+				const mapped = available.find((a) => a.id === mapping.accountId);
+				if (mapped) {
+					// STICKY hit: keep the client on its account (prompt-cache reuse).
+					// Refresh assignedAt so an active session keeps its mapping alive.
+					mapping.assignedAt = now;
+					const others = this.rankByLeastUsed(
+						available.filter((a) => a.id !== mapped.id),
+						now,
+					);
+					this.log.debug(
+						`Sticky client ${clientId} → ${mapped.name} (${others.length} fallback(s))`,
+					);
+					return [mapped, ...others];
+				}
+
+				// Mapped account is currently unavailable (e.g. rate-limited). Do NOT
+				// delete the mapping — temporarily fail over to the least-used account
+				// and snap back to the original once it recovers (mirrors issue #115).
+				this.log.info(
+					`Client ${clientId} pinned account ${mapping.accountId} is unavailable — temporary failover to least-used`,
+				);
+				return this.rankByLeastUsed(available, now);
+			}
+		}
+
+		// New (or expired) client-session, or a request with no client id: assign
+		// the least-loaded available account and stick the client to it.
+		const ranked = this.rankByLeastUsed(available, now);
+		const chosen = ranked[0];
+
+		// Mark chosen as recently picked so concurrently-starting NEW sessions
+		// within RECENT_PICK_WINDOW_MS prefer a different account (spread).
+		// Opportunistic GC of entries older than 10× the window.
+		this.lastPickedAt.set(chosen.id, now);
+		const gcThreshold = now - RECENT_PICK_WINDOW_MS * 10;
+		for (const [id, ts] of this.lastPickedAt) {
+			if (ts < gcThreshold) this.lastPickedAt.delete(id);
+		}
+
+		if (clientId !== null) {
+			this.affinity.set(clientId, { accountId: chosen.id, assignedAt: now });
+			this.log.debug(
+				`Assigned client ${clientId} → ${chosen.name} (least-used)`,
+			);
+		}
+
+		return ranked;
+	}
+
+	/**
+	 * Auto-unpause any account that {@link wouldAutoUnpause} reports as eligible
+	 * (auto_fallback_enabled + safe pause_reason + window elapsed). Mutates the
+	 * in-memory account.paused flag to false on resume so the subsequent
+	 * isAccountAvailable check reflects the new state.
+	 *
+	 * Stays in sync with SessionStrategy.select() and
+	 * LeastUsedStrategy.autoUnpauseElapsedAccounts() via the shared predicate —
+	 * keep changes there mirrored here.
+	 */
+	private autoUnpauseElapsedAccounts(accounts: Account[], now: number): void {
+		if (!this.store?.resumeAccount) return;
+
+		for (const account of accounts) {
+			if (!wouldAutoUnpause(account, now)) continue;
+
+			this.log.info(
+				`Auto-unpausing ${account.name} (pause_reason=${account.pause_reason ?? "null"}) — usage window has reset`,
+			);
+			this.store.resumeAccount(account.id);
+			account.paused = false;
+		}
+	}
+}

--- a/packages/load-balancer/src/strategies/session-affinity.ts
+++ b/packages/load-balancer/src/strategies/session-affinity.ts
@@ -25,6 +25,17 @@ const RECENT_PICK_WINDOW_MS = 500;
 const RECENT_PICK_PENALTY = 100;
 
 /**
+ * Upper bound on live client→account affinity entries. `clientId` comes from
+ * the request body (`metadata.user_id`), so an adversarial or buggy caller can
+ * send a stream of distinct ids; the TTL-based GC only evicts *expired* entries
+ * and gives no bound within the TTL window. When the map is full we evict the
+ * least-recently-touched entry so memory stays bounded regardless of input.
+ * Legitimate concurrent client-sessions are in the hundreds at most, far below
+ * this; the cap only ever bites pathological input.
+ */
+const MAX_AFFINITY_ENTRIES = 10_000;
+
+/**
  * SessionAffinityStrategy — a hybrid of SessionStrategy and LeastUsedStrategy.
  *
  * Routing is keyed on the *client* session id (request body
@@ -60,6 +71,7 @@ const RECENT_PICK_PENALTY = 100;
  */
 export class SessionAffinityStrategy implements LoadBalancingStrategy {
 	private affinityTtlMs: number;
+	private maxAffinityEntries: number;
 	private store: StrategyStore | null = null;
 	private log = new Logger("SessionAffinityStrategy");
 	/** clientId → which account it is stuck to (and when it was last touched). */
@@ -72,8 +84,15 @@ export class SessionAffinityStrategy implements LoadBalancingStrategy {
 
 	constructor(
 		affinityTtlMs: number = TIME_CONSTANTS.ANTHROPIC_SESSION_DURATION_DEFAULT,
+		maxAffinityEntries: number = MAX_AFFINITY_ENTRIES,
 	) {
 		this.affinityTtlMs = affinityTtlMs;
+		this.maxAffinityEntries = maxAffinityEntries;
+	}
+
+	/** Live sticky-mapping count — read-only, for tests and ops metrics. */
+	get affinityEntries(): number {
+		return this.affinity.size;
 	}
 
 	initialize(store: StrategyStore): void {
@@ -103,6 +122,50 @@ export class SessionAffinityStrategy implements LoadBalancingStrategy {
 				return a.score - b.score;
 			})
 			.map((s) => s.account);
+	}
+
+	/**
+	 * Rank available accounts least-used AND mark the chosen primary as
+	 * recently-picked, so concurrent picks within RECENT_PICK_WINDOW_MS spread
+	 * across the pool instead of converging on one account.
+	 *
+	 * Used by BOTH the new-session assignment and the failover path. The
+	 * failover path MUST mark too: when many clients are pinned to a single
+	 * downed account and fail over together, without the mark each one
+	 * independently recomputes the same least-used backup and piles onto it —
+	 * overloading the next account during exactly the partial-outage scenario
+	 * where spreading matters most.
+	 */
+	private pickAndMark(available: Account[], now: number): Account[] {
+		const ranked = this.rankByLeastUsed(available, now);
+		const chosen = ranked[0];
+		if (chosen) {
+			this.lastPickedAt.set(chosen.id, now);
+			// Opportunistic GC of entries older than 10× the window.
+			const gcThreshold = now - RECENT_PICK_WINDOW_MS * 10;
+			for (const [id, ts] of this.lastPickedAt) {
+				if (ts < gcThreshold) this.lastPickedAt.delete(id);
+			}
+		}
+		return ranked;
+	}
+
+	/**
+	 * Bound the affinity map: when it is full, evict the least-recently-touched
+	 * entry (smallest assignedAt) before inserting a new one. O(n) only when at
+	 * capacity, which only happens under pathological unique-clientId input.
+	 */
+	private evictOldestIfFull(): void {
+		if (this.affinity.size < this.maxAffinityEntries) return;
+		let oldestKey: string | null = null;
+		let oldestAt = Number.POSITIVE_INFINITY;
+		for (const [key, entry] of this.affinity) {
+			if (entry.assignedAt < oldestAt) {
+				oldestAt = entry.assignedAt;
+				oldestKey = key;
+			}
+		}
+		if (oldestKey !== null) this.affinity.delete(oldestKey);
 	}
 
 	peek(accounts: Account[]): string | null {
@@ -162,25 +225,18 @@ export class SessionAffinityStrategy implements LoadBalancingStrategy {
 				this.log.info(
 					`Client ${clientId} pinned account ${mapping.accountId} is unavailable — temporary failover to least-used`,
 				);
-				return this.rankByLeastUsed(available, now);
+				return this.pickAndMark(available, now);
 			}
 		}
 
 		// New (or expired) client-session, or a request with no client id: assign
-		// the least-loaded available account and stick the client to it.
-		const ranked = this.rankByLeastUsed(available, now);
+		// the least-loaded available account (marking it picked for spread) and
+		// stick the client to it.
+		const ranked = this.pickAndMark(available, now);
 		const chosen = ranked[0];
 
-		// Mark chosen as recently picked so concurrently-starting NEW sessions
-		// within RECENT_PICK_WINDOW_MS prefer a different account (spread).
-		// Opportunistic GC of entries older than 10× the window.
-		this.lastPickedAt.set(chosen.id, now);
-		const gcThreshold = now - RECENT_PICK_WINDOW_MS * 10;
-		for (const [id, ts] of this.lastPickedAt) {
-			if (ts < gcThreshold) this.lastPickedAt.delete(id);
-		}
-
-		if (clientId !== null) {
+		if (clientId !== null && chosen) {
+			this.evictOldestIfFull();
 			this.affinity.set(clientId, { accountId: chosen.id, assignedAt: now });
 			this.log.debug(
 				`Assigned client ${clientId} → ${chosen.name} (least-used)`,

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -234,6 +234,7 @@ export async function handleProxy(
 	const requestMeta = createRequestMetadata(req, url);
 	requestMeta.agentUsed = agentUsed;
 	requestMeta.project = project;
+	requestMeta.clientSessionId = requestBodyContext.getClientId();
 
 	// 6. Select accounts
 	const selectedAccounts = await selectAccountsForRequest(

--- a/packages/proxy/src/request-body-context.ts
+++ b/packages/proxy/src/request-body-context.ts
@@ -71,6 +71,17 @@ export class RequestBodyContext {
 		}
 	}
 
+	/** Best-effort client/session id from metadata.user_id. Telemetry/routing only. */
+	getClientId(): string | null {
+		const body = this.getParsedJson();
+		const meta = body?.metadata;
+		if (meta && typeof meta === "object") {
+			const uid = (meta as Record<string, unknown>).user_id;
+			if (typeof uid === "string" && uid.length > 0) return uid;
+		}
+		return null;
+	}
+
 	getModel(): string | null {
 		const body = this.getParsedJson();
 		const model = body?.model;

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -18,6 +18,8 @@ export interface RequestMeta {
 	comboName?: string | null;
 	/** Combo slot index being attempted (set per-iteration in proxy loop) */
 	comboSlotIndex?: number | null;
+	/** Per-client session id (from request body metadata.user_id) for session-affinity routing. */
+	clientSessionId?: string | null;
 }
 
 export interface AgentUpdatePayload {

--- a/packages/types/src/strategy.ts
+++ b/packages/types/src/strategy.ts
@@ -3,6 +3,7 @@ import type { Account } from "./account";
 export enum StrategyName {
 	Session = "session",
 	LeastUsed = "least-used",
+	SessionAffinity = "session-affinity",
 }
 
 /**


### PR DESCRIPTION
## Summary
Adds a new `session-affinity` load-balancing strategy — a hybrid of the existing `session` and `least-used` strategies that keeps prompt-cache locality **and** spreads concurrent clients across the account pool.

### Motivation
The two existing strategies each give up one of two things:
- **`session`** funnels *all* traffic to one account until it rate-limits/expires, then rotates — so one account is maxed before the next is touched (sequential exhaustion), and a burst of concurrent clients all land on the same upstream.
- **`least-used`** spreads every individual request, which loses cross-request prompt-cache reuse on the upstream (each request may hit a different account).

`session-affinity` routes on the **client session id** (request body `metadata.user_id`):
- the first request of a new client-session goes to the least-loaded available account (same scoring as `least-used`, with the existing recency penalty so concurrently-starting sessions spread out);
- that client→account mapping is then **sticky** for `affinityTtlMs`, so every later request from the same client keeps hitting the same upstream → prompt-cache affinity is preserved across an agentic loop.

Net: N concurrent client-sessions use up to N accounts (no sequential exhaustion), while each individual session keeps its cache locality.

### Behavior details
- When a pinned account is temporarily unavailable (rate-limited), the mapping is **not** deleted — the client fails over to the least-used available account and **snaps back** once the original recovers (mirrors the prompt-cache-window-outlives-rate-limit-window reasoning in #115).
- Auto-unpause / auto-fallback behavior mirrors `least-used` via the shared `isPeekAvailable` / `wouldAutoUnpause` predicates, so self-recovery is identical regardless of the selected strategy.
- Expired affinity entries are GC'd so the map can't grow unboundedly and long-idle clients re-balance onto the currently least-loaded account.

### What's included
- New `SessionAffinityStrategy` (`packages/load-balancer/src/strategies/session-affinity.ts`) + 8 unit tests.
- `StrategyName.SessionAffinity` enum value, exports, and the `buildStrategy` case in the server.
- Minimal client-session-id plumbing: `RequestMeta.clientSessionId` and `requestBodyContext.getClientId()` (reads `metadata.user_id`), set in `proxy.ts`. No behavior change for the existing strategies.

### Testing
- `bun test packages/load-balancer` → all green (62 tests), including the 8 new session-affinity tests (sticky reuse, concurrent-client spread, failover + snap-back).
- `bunx tsc --noEmit` → 0 errors.
- `biome check` clean.

Opt-in via `LB_STRATEGY=session-affinity` (or the config / `PATCH /api/config`); existing strategies are untouched.
