### PR TITLE
fix: Postgres ERR_POSTGRES_UNSUPPORTED_INTEGER_SIZE under concurrent load (#284)

### DIFF
--- a/packages/database/src/adapters/__tests__/bun-sql-adapter-pg-integer-retry.test.ts
+++ b/packages/database/src/adapters/__tests__/bun-sql-adapter-pg-integer-retry.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for BunSqlAdapter's retry-on-ERR_POSTGRES_UNSUPPORTED_INTEGER_SIZE
+ * behavior (withPgIntegerSizeRetry, exercised through query()/get()).
+ *
+ * The real Bun.SQL client isn't exercised here — we stub a minimal fake with
+ * an `unsafe()` method that throws once before succeeding, using
+ * `(adapter as any).sql` to reach the private field. See issue #284.
+ */
+import { afterEach, describe, expect, it } from "bun:test";
+import { BunSqlAdapter } from "../bun-sql-adapter";
+
+function makeIntegerSizeError(): Error {
+	return Object.assign(
+		new Error(
+			'Failed to read data code: "ERR_POSTGRES_UNSUPPORTED_INTEGER_SIZE"',
+		),
+		{ code: "ERR_POSTGRES_UNSUPPORTED_INTEGER_SIZE" },
+	);
+}
+
+/** Minimal fake standing in for Bun's SQL client. */
+function makeFakeSql(
+	unsafeImpl: (sql: string, params: unknown[]) => Promise<unknown>,
+) {
+	return {
+		unsafe: unsafeImpl,
+		on: () => {},
+	};
+}
+
+describe("BunSqlAdapter withPgIntegerSizeRetry", () => {
+	let adapter: BunSqlAdapter | undefined;
+
+	afterEach(() => {
+		adapter = undefined;
+	});
+
+	describe("query() retries once on ERR_POSTGRES_UNSUPPORTED_INTEGER_SIZE", () => {
+		it("returns the result from the second attempt", async () => {
+			let calls = 0;
+			const fakeSql = makeFakeSql(async () => {
+				calls++;
+				if (calls === 1) throw makeIntegerSizeError();
+				return [{ id: 1, val: "hello" }];
+			});
+			// biome-ignore lint/suspicious/noExplicitAny: constructing adapter with a fake SQL client for testing
+			adapter = new BunSqlAdapter(fakeSql as any, false);
+
+			const rows = await adapter.query<{ id: number; val: string }>(
+				"SELECT id, val FROM t",
+			);
+			expect(rows).toEqual([{ id: 1, val: "hello" }]);
+			expect(calls).toBe(2);
+		});
+	});
+
+	describe("get() retries once on ERR_POSTGRES_UNSUPPORTED_INTEGER_SIZE", () => {
+		it("returns the row from the second attempt", async () => {
+			let calls = 0;
+			const fakeSql = makeFakeSql(async () => {
+				calls++;
+				if (calls === 1) throw makeIntegerSizeError();
+				return [{ id: 2, val: "world" }];
+			});
+			// biome-ignore lint/suspicious/noExplicitAny: constructing adapter with a fake SQL client for testing
+			adapter = new BunSqlAdapter(fakeSql as any, false);
+
+			const row = await adapter.get<{ id: number; val: string }>(
+				"SELECT id, val FROM t WHERE id = $1",
+				[2],
+			);
+			expect(row).toEqual({ id: 2, val: "world" });
+			expect(calls).toBe(2);
+		});
+	});
+
+	describe("a second consecutive failure is not retried again", () => {
+		it("propagates the error after one retry attempt", async () => {
+			let calls = 0;
+			const fakeSql = makeFakeSql(async () => {
+				calls++;
+				throw makeIntegerSizeError();
+			});
+			// biome-ignore lint/suspicious/noExplicitAny: constructing adapter with a fake SQL client for testing
+			adapter = new BunSqlAdapter(fakeSql as any, false);
+
+			await expect(adapter.query("SELECT id FROM t")).rejects.toMatchObject({
+				code: "ERR_POSTGRES_UNSUPPORTED_INTEGER_SIZE",
+			});
+			expect(calls).toBe(2);
+		});
+	});
+
+	describe("non-matching errors are not retried", () => {
+		it("propagates immediately without a second attempt", async () => {
+			let calls = 0;
+			const fakeSql = makeFakeSql(async () => {
+				calls++;
+				throw Object.assign(new Error("connection closed"), {
+					code: "ERR_POSTGRES_CONNECTION_CLOSED",
+				});
+			});
+			// biome-ignore lint/suspicious/noExplicitAny: constructing adapter with a fake SQL client for testing
+			adapter = new BunSqlAdapter(fakeSql as any, false);
+
+			await expect(adapter.query("SELECT id FROM t")).rejects.toMatchObject({
+				code: "ERR_POSTGRES_CONNECTION_CLOSED",
+			});
+			expect(calls).toBe(1);
+		});
+	});
+});

--- a/packages/database/src/adapters/bun-sql-adapter.ts
+++ b/packages/database/src/adapters/bun-sql-adapter.ts
@@ -147,6 +147,30 @@ export class BunSqlAdapter {
 	}
 
 	/**
+	 * Retry once on ERR_POSTGRES_UNSUPPORTED_INTEGER_SIZE — a known Bun native
+	 * PG driver bug (oven-sh/bun#16774) where concurrent queries sharing a
+	 * pooled connection can misattribute a cached statement's column
+	 * metadata, corrupting binary integer decoding (#284). The error is a
+	 * transient decode race, not a data problem, so re-running the query on a
+	 * fresh pool connection self-heals it. The callback re-issues the query
+	 * (rather than re-awaiting the original promise) since the corruption
+	 * happens during the original send/receive cycle and can't be recovered
+	 * from after the fact. Only used for read paths (query/get) — DML never
+	 * decodes column data here (no RETURNING clauses), so it isn't at risk.
+	 */
+	private async withPgIntegerSizeRetry<T>(run: () => Promise<T>): Promise<T> {
+		try {
+			return await run();
+		} catch (err) {
+			const code = (err as { code?: string } | undefined)?.code;
+			if (code !== "ERR_POSTGRES_UNSUPPORTED_INTEGER_SIZE") {
+				throw err;
+			}
+			return run();
+		}
+	}
+
+	/**
 	 * Retry a synchronous SQLite call asynchronously when the database is
 	 * locked by another connection (SQLITE_BUSY / errno 5).
 	 *
@@ -190,11 +214,13 @@ export class BunSqlAdapter {
 		}
 		// PostgreSQL via Bun.SQL unsafe
 		const pgQuery = this.pgSql(sqlStr);
-		// biome-ignore lint/suspicious/noExplicitAny: Bun.SQL accepts various binding types
-		const result = await this.withPgTimeout(
-			this.sql?.unsafe(pgQuery, params as any[]) as Promise<unknown>,
-			PG_CLIENT_QUERY_TIMEOUT_MS,
-			sqlStr,
+		const result = await this.withPgIntegerSizeRetry(() =>
+			this.withPgTimeout(
+				// biome-ignore lint/suspicious/noExplicitAny: Bun.SQL accepts various binding types
+				this.sql?.unsafe(pgQuery, params as any[]) as Promise<unknown>,
+				PG_CLIENT_QUERY_TIMEOUT_MS,
+				sqlStr,
+			),
 		);
 		return result as unknown as R[];
 	}
@@ -212,11 +238,13 @@ export class BunSqlAdapter {
 			return (result as R) ?? null;
 		}
 		const pgQuery = this.pgSql(sqlStr);
-		// biome-ignore lint/suspicious/noExplicitAny: Bun.SQL accepts various binding types
-		const rows = await this.withPgTimeout(
-			this.sql?.unsafe(pgQuery, params as any[]) as Promise<unknown>,
-			PG_CLIENT_QUERY_TIMEOUT_MS,
-			sqlStr,
+		const rows = await this.withPgIntegerSizeRetry(() =>
+			this.withPgTimeout(
+				// biome-ignore lint/suspicious/noExplicitAny: Bun.SQL accepts various binding types
+				this.sql?.unsafe(pgQuery, params as any[]) as Promise<unknown>,
+				PG_CLIENT_QUERY_TIMEOUT_MS,
+				sqlStr,
+			),
 		);
 		return ((rows as unknown as R[])[0] ?? null) as R | null;
 	}

--- a/packages/database/src/database-operations.ts
+++ b/packages/database/src/database-operations.ts
@@ -302,10 +302,18 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 				requestedPgStatementTimeout <= maxPgStatementTimeout
 					? requestedPgStatementTimeout
 					: maxPgStatementTimeout;
+			// Named prepared statements are disabled by default: Bun's native PG
+			// driver has a known class of bugs (oven-sh/bun#16774) where concurrent
+			// queries sharing a pooled connection can misattribute a cached
+			// statement's column metadata, corrupting binary integer decoding
+			// (ERR_POSTGRES_UNSUPPORTED_INTEGER_SIZE — #284). Unnamed prepared
+			// statements close this window since they don't persist across queries.
+			const pgPrepare = process.env.BETTER_CCFLARE_DB_PG_PREPARE !== "true";
 			const sqlClient = new SQL({
 				url: databaseUrl,
 				max: pgMax,
 				idleTimeout: pgIdleTimeout,
+				prepare: pgPrepare,
 				connection: {
 					// Server-side timeout so PG cancels the query and frees the
 					// connection instead of leaving it occupied after the client

--- a/packages/database/src/database-operations.ts
+++ b/packages/database/src/database-operations.ts
@@ -308,7 +308,7 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 			// statement's column metadata, corrupting binary integer decoding
 			// (ERR_POSTGRES_UNSUPPORTED_INTEGER_SIZE — #284). Unnamed prepared
 			// statements close this window since they don't persist across queries.
-			const pgPrepare = process.env.BETTER_CCFLARE_DB_PG_PREPARE !== "true";
+			const pgPrepare = process.env.BETTER_CCFLARE_DB_PG_PREPARE === "true";
 			const sqlClient = new SQL({
 				url: databaseUrl,
 				max: pgMax,


### PR DESCRIPTION
## Summary
Fixes #284 — Postgres-backed deployments intermittently throw `ERR_POSTGRES_UNSUPPORTED_INTEGER_SIZE` while loading account data.

Root cause: Bun's native Postgres driver has a known concurrency bug class (oven-sh/bun#16774) where queries sharing a pooled connection under concurrent load can misattribute a cached statement's column metadata, corrupting binary integer decoding. This isn't a better-ccflare schema or query bug — confirmed no `NUMERIC`/`DECIMAL` columns and no `RETURNING` clauses are involved in the crash path.

Two mitigations, both agreed as defense-in-depth:
- **Disable named prepared statement caching by default** (`prepare: false` on the Bun `SQL` client) — unnamed prepared statements don't persist across queries, closing the window for cross-query metadata contamination. Operators can opt back in via `BETTER_CCFLARE_DB_PG_PREPARE=true`.
- **Retry-once safety net** in `BunSqlAdapter` for the specific `ERR_POSTGRES_UNSUPPORTED_INTEGER_SIZE` error code, scoped to the read paths (`query()`/`get()`) since DML (`run()`/`runWithChanges()`) never decodes column binary data here (no `RETURNING` clauses).

## Test plan
- [x] New test file with 4 tests covering: retry succeeds on first failure, retry is not repeated on a second consecutive failure, non-matching errors are not retried — all passing
- [x] Full `packages/database` test suite passes (159 existing tests)
- [x] `bun run lint && bun run typecheck && bun run format` — clean (pre-existing unrelated warnings only)
- [x] GitNexus `detect_changes` confirms LOW risk — change is transparent to all callers (repositories, stats, alerts, handlers), no behavior change for successful queries