### PR TITLE
fix: persist Cloudflare cookies for chatgpt.com to reduce Codex 403s

### DIFF
--- a/packages/proxy/src/__tests__/chatgpt-cloudflare-cookies.test.ts
+++ b/packages/proxy/src/__tests__/chatgpt-cloudflare-cookies.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "bun:test";
+import {
+	ChatGptCloudflareCookieJar,
+	isAllowedChatGptHost,
+} from "../chatgpt-cloudflare-cookies";
+
+function makeSetCookieResponse(setCookies: string[]): Response {
+	return new Response(null, {
+		headers: setCookies.map(
+			(value) => ["set-cookie", value] as [string, string],
+		),
+	});
+}
+
+function cookieParts(headers: Headers): string[] {
+	const cookie = headers.get("Cookie");
+	if (!cookie) return [];
+	return cookie.split("; ").sort();
+}
+
+describe("ChatGptCloudflareCookieJar", () => {
+	it("stores and replays only allowlisted Cloudflare cookie names for chatgpt.com", () => {
+		const jar = new ChatGptCloudflareCookieJar();
+		const response = makeSetCookieResponse([
+			"__cflb=west; Path=/; Secure; HttpOnly",
+			"_cfuvid=visitor; Path=/; Secure; HttpOnly",
+			"cf_clearance=clearance; Path=/; Secure; HttpOnly",
+		]);
+
+		jar.captureFromResponse(
+			"https://chatgpt.com/backend-api/codex/responses",
+			response,
+		);
+
+		const headers = new Headers();
+		jar.applyCookieHeader(
+			"https://chatgpt.com/backend-api/codex/responses",
+			headers,
+		);
+
+		expect(cookieParts(headers)).toEqual(
+			["__cflb=west", "_cfuvid=visitor", "cf_clearance=clearance"].sort(),
+		);
+	});
+
+	it("ignores cookies set for non-chatgpt hosts", () => {
+		const jar = new ChatGptCloudflareCookieJar();
+		const response = makeSetCookieResponse([
+			"_cfuvid=visitor; Path=/; Secure; HttpOnly",
+		]);
+
+		jar.captureFromResponse("https://api.openai.com/v1/responses", response);
+
+		const headers = new Headers();
+		jar.applyCookieHeader("https://api.openai.com/v1/responses", headers);
+
+		expect(headers.get("Cookie")).toBeNull();
+	});
+
+	it("ignores non-cloudflare cookies for chatgpt.com hosts", () => {
+		const jar = new ChatGptCloudflareCookieJar();
+		const response = makeSetCookieResponse([
+			"__Secure-next-auth.session-token=secret; Path=/; Secure; HttpOnly",
+		]);
+
+		jar.captureFromResponse(
+			"https://chatgpt.com/backend-api/codex/responses",
+			response,
+		);
+
+		const headers = new Headers();
+		jar.applyCookieHeader(
+			"https://chatgpt.com/backend-api/codex/responses",
+			headers,
+		);
+
+		expect(headers.get("Cookie")).toBeNull();
+	});
+
+	it("ignores mixed cloudflare and non-cloudflare cookies, keeping only cloudflare ones", () => {
+		const jar = new ChatGptCloudflareCookieJar();
+		const response = makeSetCookieResponse([
+			"_cfuvid=visitor; Path=/; Secure; HttpOnly",
+			"chatgpt_session=secret; Path=/; Secure; HttpOnly",
+		]);
+
+		jar.captureFromResponse(
+			"https://chatgpt.com/backend-api/codex/responses",
+			response,
+		);
+
+		const headers = new Headers();
+		jar.applyCookieHeader(
+			"https://chatgpt.com/backend-api/codex/responses",
+			headers,
+		);
+
+		expect(headers.get("Cookie")).toBe("_cfuvid=visitor");
+	});
+
+	it("never leaks chatgpt.com cookies to a different host", () => {
+		const jar = new ChatGptCloudflareCookieJar();
+		const response = makeSetCookieResponse([
+			"_cfuvid=visitor; Path=/; Secure; HttpOnly",
+		]);
+
+		jar.captureFromResponse(
+			"https://chatgpt.com/backend-api/codex/responses",
+			response,
+		);
+
+		const headers = new Headers();
+		jar.applyCookieHeader("https://api.openai.com/v1/responses", headers);
+
+		expect(headers.get("Cookie")).toBeNull();
+	});
+
+	it("rejects plain http chatgpt.com urls", () => {
+		const jar = new ChatGptCloudflareCookieJar();
+		const response = makeSetCookieResponse([
+			"_cfuvid=visitor; Path=/; Secure; HttpOnly",
+		]);
+
+		jar.captureFromResponse(
+			"http://chatgpt.com/backend-api/codex/responses",
+			response,
+		);
+
+		const httpHeaders = new Headers();
+		jar.applyCookieHeader(
+			"http://chatgpt.com/backend-api/codex/responses",
+			httpHeaders,
+		);
+		expect(httpHeaders.get("Cookie")).toBeNull();
+
+		const httpsHeaders = new Headers();
+		jar.applyCookieHeader(
+			"https://chatgpt.com/backend-api/codex/responses",
+			httpsHeaders,
+		);
+		expect(httpsHeaders.get("Cookie")).toBeNull();
+	});
+
+	it("replaces __cflb value on load-balancer affinity switch", () => {
+		const jar = new ChatGptCloudflareCookieJar();
+
+		jar.captureFromResponse(
+			"https://chatgpt.com/backend-api/codex/responses",
+			makeSetCookieResponse(["__cflb=west; Path=/; Secure; HttpOnly"]),
+		);
+		jar.captureFromResponse(
+			"https://chatgpt.com/backend-api/codex/responses",
+			makeSetCookieResponse(["__cflb=central; Path=/; Secure; HttpOnly"]),
+		);
+
+		const headers = new Headers();
+		jar.applyCookieHeader(
+			"https://chatgpt.com/backend-api/codex/responses",
+			headers,
+		);
+
+		expect(headers.get("Cookie")).toBe("__cflb=central");
+	});
+});
+
+describe("isAllowedChatGptHost", () => {
+	it("allows chatgpt.com and its recognized subdomains/aliases", () => {
+		for (const host of [
+			"chatgpt.com",
+			"foo.chatgpt.com",
+			"staging.chatgpt.com",
+			"chat.openai.com",
+			"chatgpt-staging.com",
+			"api.chatgpt-staging.com",
+		]) {
+			expect(isAllowedChatGptHost(host)).toBe(true);
+		}
+	});
+
+	it("rejects lookalike and unrelated hosts", () => {
+		for (const host of [
+			"evilchatgpt.com",
+			"chatgpt.com.evil.example",
+			"api.openai.com",
+			"foo.chat.openai.com",
+		]) {
+			expect(isAllowedChatGptHost(host)).toBe(false);
+		}
+	});
+});

--- a/packages/proxy/src/__tests__/chatgpt-cloudflare-cookies.test.ts
+++ b/packages/proxy/src/__tests__/chatgpt-cloudflare-cookies.test.ts
@@ -141,6 +141,50 @@ describe("ChatGptCloudflareCookieJar", () => {
 		expect(httpsHeaders.get("Cookie")).toBeNull();
 	});
 
+	it("removes a stored cookie when Cloudflare sends a Max-Age=0 revocation", () => {
+		const jar = new ChatGptCloudflareCookieJar();
+
+		jar.captureFromResponse(
+			"https://chatgpt.com/backend-api/codex/responses",
+			makeSetCookieResponse(["cf_clearance=clearance; Path=/; Secure"]),
+		);
+		jar.captureFromResponse(
+			"https://chatgpt.com/backend-api/codex/responses",
+			makeSetCookieResponse(["cf_clearance=; Path=/; Secure; Max-Age=0"]),
+		);
+
+		const headers = new Headers();
+		jar.applyCookieHeader(
+			"https://chatgpt.com/backend-api/codex/responses",
+			headers,
+		);
+
+		expect(headers.get("Cookie")).toBeNull();
+	});
+
+	it("removes a stored cookie when Cloudflare sends an expired Expires attribute", () => {
+		const jar = new ChatGptCloudflareCookieJar();
+
+		jar.captureFromResponse(
+			"https://chatgpt.com/backend-api/codex/responses",
+			makeSetCookieResponse(["__cflb=west; Path=/; Secure"]),
+		);
+		jar.captureFromResponse(
+			"https://chatgpt.com/backend-api/codex/responses",
+			makeSetCookieResponse([
+				"__cflb=; Path=/; Secure; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+			]),
+		);
+
+		const headers = new Headers();
+		jar.applyCookieHeader(
+			"https://chatgpt.com/backend-api/codex/responses",
+			headers,
+		);
+
+		expect(headers.get("Cookie")).toBeNull();
+	});
+
 	it("replaces __cflb value on load-balancer affinity switch", () => {
 		const jar = new ChatGptCloudflareCookieJar();
 

--- a/packages/proxy/src/chatgpt-cloudflare-cookies.ts
+++ b/packages/proxy/src/chatgpt-cloudflare-cookies.ts
@@ -1,0 +1,114 @@
+const ALLOWED_EXACT_HOSTS = new Set([
+	"chatgpt.com",
+	"chat.openai.com",
+	"chatgpt-staging.com",
+]);
+const ALLOWED_SUFFIXES = [".chatgpt.com", ".chatgpt-staging.com"];
+
+export function isAllowedChatGptHost(host: string): boolean {
+	return (
+		ALLOWED_EXACT_HOSTS.has(host) ||
+		ALLOWED_SUFFIXES.some((suffix) => host.endsWith(suffix))
+	);
+}
+
+// WARNING: never add ChatGPT account/session/auth cookie names to this allowlist.
+const ALLOWED_COOKIE_NAMES = new Set([
+	"__cf_bm",
+	"__cflb",
+	"__cfruid",
+	"__cfseq",
+	"__cfwaitingroom",
+	"_cfuvid",
+	"cf_clearance",
+	"cf_ob_info",
+	"cf_use_ob",
+]);
+
+function isAllowedCloudflareCookieName(name: string): boolean {
+	return ALLOWED_COOKIE_NAMES.has(name) || name.startsWith("cf_chl_");
+}
+
+function parseCookieNameValue(
+	cookiePair: string,
+): { name: string; value: string } | null {
+	const separatorIndex = cookiePair.indexOf("=");
+	if (separatorIndex === -1) return null;
+	const name = cookiePair.slice(0, separatorIndex).trim();
+	if (name.length === 0) return null;
+	const value = cookiePair.slice(separatorIndex + 1).trim();
+	return { name, value };
+}
+
+function parseSetCookieNameValue(
+	setCookie: string,
+): { name: string; value: string } | null {
+	const attributeIndex = setCookie.indexOf(";");
+	const pair =
+		attributeIndex === -1 ? setCookie : setCookie.slice(0, attributeIndex);
+	return parseCookieNameValue(pair);
+}
+
+function isAllowedChatGptCookieUrl(url: URL): boolean {
+	return url.protocol === "https:" && isAllowedChatGptHost(url.hostname);
+}
+
+export class ChatGptCloudflareCookieJar {
+	private readonly cookiesByHost = new Map<string, Map<string, string>>();
+
+	captureFromResponse(url: string, response: Response): void {
+		let parsed: URL;
+		try {
+			parsed = new URL(url);
+		} catch {
+			return;
+		}
+		if (!isAllowedChatGptCookieUrl(parsed)) return;
+
+		const setCookieHeaders = response.headers.getSetCookie
+			? response.headers.getSetCookie()
+			: [];
+		if (setCookieHeaders.length === 0) return;
+
+		let hostCookies = this.cookiesByHost.get(parsed.hostname);
+		for (const setCookie of setCookieHeaders) {
+			const parsedCookie = parseSetCookieNameValue(setCookie);
+			if (!parsedCookie) continue;
+			if (!isAllowedCloudflareCookieName(parsedCookie.name)) continue;
+			if (!hostCookies) {
+				hostCookies = new Map<string, string>();
+				this.cookiesByHost.set(parsed.hostname, hostCookies);
+			}
+			hostCookies.set(parsedCookie.name, parsedCookie.value);
+		}
+	}
+
+	applyCookieHeader(url: string, headers: Headers): void {
+		let parsed: URL;
+		try {
+			parsed = new URL(url);
+		} catch {
+			return;
+		}
+		if (!isAllowedChatGptCookieUrl(parsed)) return;
+
+		const hostCookies = this.cookiesByHost.get(parsed.hostname);
+		if (!hostCookies || hostCookies.size === 0) return;
+
+		const merged = new Map<string, string>();
+		const existing = headers.get("Cookie");
+		if (existing) {
+			for (const part of existing.split(";")) {
+				const parsedExisting = parseCookieNameValue(part);
+				if (parsedExisting) merged.set(parsedExisting.name, part.trim());
+			}
+		}
+		for (const [name, value] of hostCookies) {
+			merged.set(name, `${name}=${value}`);
+		}
+
+		headers.set("Cookie", Array.from(merged.values()).join("; "));
+	}
+}
+
+export const chatGptCloudflareCookieJar = new ChatGptCloudflareCookieJar();

--- a/packages/proxy/src/chatgpt-cloudflare-cookies.ts
+++ b/packages/proxy/src/chatgpt-cloudflare-cookies.ts
@@ -40,13 +40,30 @@ function parseCookieNameValue(
 	return { name, value };
 }
 
+function isExpiredAttributes(attributes: string): boolean {
+	const maxAgeMatch = attributes.match(/;\s*max-age\s*=\s*(-?\d+)/i);
+	if (maxAgeMatch && Number(maxAgeMatch[1]) <= 0) return true;
+
+	const expiresMatch = attributes.match(/;\s*expires\s*=\s*([^;]+)/i);
+	if (expiresMatch) {
+		const expiresAt = Date.parse(expiresMatch[1].trim());
+		if (!Number.isNaN(expiresAt) && expiresAt <= Date.now()) return true;
+	}
+
+	return false;
+}
+
 function parseSetCookieNameValue(
 	setCookie: string,
-): { name: string; value: string } | null {
+): { name: string; value: string; expired: boolean } | null {
 	const attributeIndex = setCookie.indexOf(";");
 	const pair =
 		attributeIndex === -1 ? setCookie : setCookie.slice(0, attributeIndex);
-	return parseCookieNameValue(pair);
+	const parsed = parseCookieNameValue(pair);
+	if (!parsed) return null;
+	const attributes =
+		attributeIndex === -1 ? "" : setCookie.slice(attributeIndex);
+	return { ...parsed, expired: isExpiredAttributes(attributes) };
 }
 
 function isAllowedChatGptCookieUrl(url: URL): boolean {
@@ -75,6 +92,10 @@ export class ChatGptCloudflareCookieJar {
 			const parsedCookie = parseSetCookieNameValue(setCookie);
 			if (!parsedCookie) continue;
 			if (!isAllowedCloudflareCookieName(parsedCookie.name)) continue;
+			if (parsedCookie.expired) {
+				hostCookies?.delete(parsedCookie.name);
+				continue;
+			}
 			if (!hostCookies) {
 				hostCookies = new Map<string, string>();
 				this.cookiesByHost.set(parsed.hostname, hostCookies);

--- a/packages/proxy/src/handlers/request-handler.ts
+++ b/packages/proxy/src/handlers/request-handler.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import { TIME_CONSTANTS, ValidationError } from "@better-ccflare/core";
 import type { Provider } from "@better-ccflare/providers";
 import type { RequestMeta } from "@better-ccflare/types";
+import { chatGptCloudflareCookieJar } from "../chatgpt-cloudflare-cookies";
 import { ERROR_MESSAGES } from "./proxy-types";
 
 /**
@@ -96,16 +97,32 @@ export async function makeProxyRequest(
 
 	try {
 		if (target instanceof Request) {
-			return await fetch(new Request(target, { signal: effectiveSignal }));
+			const targetUrl = target.url;
+			const mutableHeaders = new Headers(target.headers);
+			chatGptCloudflareCookieJar.applyCookieHeader(targetUrl, mutableHeaders);
+
+			const response = await fetch(
+				new Request(target, {
+					headers: mutableHeaders,
+					signal: effectiveSignal,
+				}),
+			);
+			chatGptCloudflareCookieJar.captureFromResponse(targetUrl, response);
+			return response;
 		}
 
-		return await fetch(target, {
+		const mutableHeaders = new Headers(headers);
+		chatGptCloudflareCookieJar.applyCookieHeader(target, mutableHeaders);
+
+		const response = await fetch(target, {
 			method,
-			headers,
+			headers: mutableHeaders,
 			body: createBodyStream ? createBodyStream() : undefined,
 			signal: effectiveSignal,
 			...(hasBody ? ({ duplex: "half" } as RequestInit) : {}),
 		});
+		chatGptCloudflareCookieJar.captureFromResponse(target, response);
+		return response;
 	} finally {
 		if (timeoutId) clearTimeout(timeoutId);
 	}


### PR DESCRIPTION
## Summary
- Fixes #291 — Codex OAuth requests to `chatgpt.com/backend-api/codex/responses` were consistently getting 403'd by Cloudflare because the shared upstream fetch path (`makeProxyRequest()`) discarded all cookies between requests, so every request looked like a brand-new, unrecognized client to Cloudflare.
- Ports the same fix OpenAI's own Codex CLI uses: a process-wide, host-scoped cookie jar (`packages/proxy/src/chatgpt-cloudflare-cookies.ts`) that persists only Cloudflare's own infrastructure cookies (`__cflb`, `cf_clearance`, `_cfuvid`, etc. — never ChatGPT account/session/auth cookies) for `chatgpt.com`-family hosts, and replays them on subsequent requests.
- Wired into `makeProxyRequest()` (`packages/proxy/src/handlers/request-handler.ts`), so it's transparent to all providers — non-`chatgpt.com` hosts (Anthropic, xAI, etc.) are unaffected no-ops.
- Does **not** solve an active Cloudflare JS challenge (no proxy can browser-solve that) — it addresses the concrete root cause named in the issue: repeated re-challenging caused by never persisting Cloudflare's own affinity/clearance cookies.

## Test plan
- [x] New unit tests: `packages/proxy/src/__tests__/chatgpt-cloudflare-cookies.test.ts` (9 tests, mirroring the reference Rust implementation's test coverage) — all pass
- [x] Full proxy suite (`bun test packages/proxy`) — no new failures (4 pre-existing, unrelated failures confirmed via `git stash`)
- [x] `bun run lint && bun run typecheck && bun run format` — clean
- [x] `detect_changes` (GitNexus) — LOW risk, no unexpected affected processes
- [ ] Awaiting confirmation from issue reporter that this resolves the 403s in their environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)