### PR TITLE
feat: usage history — persist usage-window utilization, predict exhaustion, chart it

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -244,6 +244,9 @@ async function runStartupMaintenance(
 		log.info(
 			`Startup cleanup removed ${removedRequests} requests and ${removedPayloads} payloads (payload=${payloadDays}d, requests=${requestDays}d)`,
 		);
+		await dbOps.pruneUsageSnapshots(
+			Date.now() - config.getUsageHistoryRetentionDays() * TIME_CONSTANTS.DAY,
+		);
 	} catch (err) {
 		log.error(`Startup cleanup error: ${err}`);
 	}
@@ -404,6 +407,15 @@ function startUsagePollingWithRefresh(
 						.catch((err) =>
 							logger.warn(
 								`Failed to check/clear rate_limited_until for account ${accountId} on capacity restore: ${err}`,
+							),
+						);
+				},
+				(accountId, data) => {
+					proxyContext.dbOps
+						.recordUsageSnapshot(accountId, data, Date.now())
+						.catch((err) =>
+							logger.warn(
+								`Failed to record usage snapshot for account ${accountId}: ${err}`,
 							),
 						);
 				},
@@ -787,6 +799,13 @@ export default async function startServer(options?: {
 					.catch((err) => {
 						log.error(`Incremental vacuum error: ${err}`);
 					});
+			}
+			const usageHistoryDays = config.getUsageHistoryRetentionDays();
+			const removedSnapshots = await dbOps.pruneUsageSnapshots(
+				Date.now() - usageHistoryDays * TIME_CONSTANTS.DAY,
+			);
+			if (removedSnapshots > 0) {
+				log.info(`Pruned ${removedSnapshots} old usage snapshots`);
 			}
 		} catch (err) {
 			log.error(`Periodic data retention cleanup error: ${err}`);

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -244,9 +244,12 @@ async function runStartupMaintenance(
 		log.info(
 			`Startup cleanup removed ${removedRequests} requests and ${removedPayloads} payloads (payload=${payloadDays}d, requests=${requestDays}d)`,
 		);
-		await dbOps.pruneUsageSnapshots(
+		const removedSnapshots = await dbOps.pruneUsageSnapshots(
 			Date.now() - config.getUsageHistoryRetentionDays() * TIME_CONSTANTS.DAY,
 		);
+		if (removedSnapshots > 0) {
+			log.info(`Pruned ${removedSnapshots} old usage snapshots`);
+		}
 	} catch (err) {
 		log.error(`Startup cleanup error: ${err}`);
 	}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -55,6 +55,7 @@ export interface ConfigData {
 	default_agent_model?: string;
 	data_retention_days?: number;
 	request_retention_days?: number;
+	usage_history_retention_days?: number;
 	store_payloads?: boolean;
 	usage_poll_interval_ms?: number;
 	cache_keepalive_ttl_minutes?: number;
@@ -324,6 +325,22 @@ export class Config extends EventEmitter {
 		this.set("request_retention_days", clamped);
 	}
 
+	getUsageHistoryRetentionDays(): number {
+		const fromEnv = process.env.USAGE_HISTORY_RETENTION_DAYS;
+		if (fromEnv) {
+			const n = parseInt(fromEnv, 10);
+			if (!Number.isNaN(n)) return this.clamp(n, 1, 3650);
+		}
+		const fromFile = this.data.usage_history_retention_days;
+		if (typeof fromFile === "number") return this.clamp(fromFile, 1, 3650);
+		return 90; // default: keep 90 days of usage-window history
+	}
+
+	setUsageHistoryRetentionDays(days: number): void {
+		const clamped = this.clamp(days, 1, 3650);
+		this.set("usage_history_retention_days", clamped);
+	}
+
 	getStorePayloads(): boolean {
 		const fromEnv = process.env.STORE_PAYLOADS;
 		if (fromEnv) {
@@ -557,6 +574,7 @@ export class Config extends EventEmitter {
 			default_agent_model: this.getDefaultAgentModel(),
 			data_retention_days: this.getDataRetentionDays(),
 			request_retention_days: this.getRequestRetentionDays(),
+			usage_history_retention_days: this.getUsageHistoryRetentionDays(),
 			store_payloads: this.getStorePayloads(),
 			usage_poll_interval_ms: this.getUsagePollIntervalMs(),
 			cache_keepalive_ttl_minutes: this.getCacheKeepaliveTtlMinutes(),

--- a/packages/config/src/usage-history-retention.test.ts
+++ b/packages/config/src/usage-history-retention.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Config } from "./index";
+
+function makeConfig(): { config: Config; cleanup: () => void } {
+	const dir = mkdtempSync(join(tmpdir(), "better-ccflare-config-"));
+	return {
+		config: new Config(join(dir, "config.json")),
+		cleanup: () => rmSync(dir, { recursive: true, force: true }),
+	};
+}
+
+describe("getUsageHistoryRetentionDays", () => {
+	const original = process.env.USAGE_HISTORY_RETENTION_DAYS;
+	beforeEach(() => {
+		delete process.env.USAGE_HISTORY_RETENTION_DAYS;
+	});
+	afterEach(() => {
+		if (original === undefined) delete process.env.USAGE_HISTORY_RETENTION_DAYS;
+		else process.env.USAGE_HISTORY_RETENTION_DAYS = original;
+	});
+
+	it("defaults to 90 when no env or file override", () => {
+		const { config, cleanup } = makeConfig();
+		try {
+			expect(config.getUsageHistoryRetentionDays()).toBe(90);
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("reads and clamps the env override", () => {
+		const { config, cleanup } = makeConfig();
+		try {
+			process.env.USAGE_HISTORY_RETENTION_DAYS = "5000"; // above max
+			expect(config.getUsageHistoryRetentionDays()).toBe(3650);
+		} finally {
+			cleanup();
+		}
+	});
+});

--- a/packages/dashboard-web/src/App.tsx
+++ b/packages/dashboard-web/src/App.tsx
@@ -34,6 +34,11 @@ const LazyInsightsTab = lazy(() =>
 		default: module.InsightsTab,
 	})),
 );
+const LazyUsageHistoryTab = lazy(() =>
+	import("./components/usage-history/UsageHistoryTab").then((m) => ({
+		default: m.UsageHistoryTab,
+	})),
+);
 const LoadingSkeleton = () => (
 	<div className="space-y-6 p-6">
 		<div className="animate-pulse">
@@ -102,6 +107,16 @@ export function App() {
 				element: <AccountsTab />,
 				title: "Account Management",
 				subtitle: "Manage your OAuth accounts and settings",
+			},
+			{
+				path: "/usage-history",
+				element: (
+					<Suspense fallback={<LoadingSkeleton />}>
+						<LazyUsageHistoryTab />
+					</Suspense>
+				),
+				title: "Usage History",
+				subtitle: "Per-account usage windows over time, with limit prediction",
 			},
 			{
 				path: "/agents",

--- a/packages/dashboard-web/src/api.ts
+++ b/packages/dashboard-web/src/api.ts
@@ -19,6 +19,7 @@ import type {
 	RequestPayload,
 	RequestResponse,
 	StatsWithAccounts,
+	UsageHistoryResponse,
 } from "@better-ccflare/types";
 import { API_LIMITS, API_TIMEOUT } from "./constants";
 
@@ -977,6 +978,16 @@ class API extends HttpClient {
 
 		return this.get<CacheInsightsResponse>(
 			`/api/insights/cache?${params.toString()}`,
+		);
+	}
+
+	async getUsageHistory(
+		account: string,
+		range = "24h",
+	): Promise<UsageHistoryResponse> {
+		const params = new URLSearchParams({ account, range });
+		return this.get<UsageHistoryResponse>(
+			`/api/usage-history?${params.toString()}`,
 		);
 	}
 

--- a/packages/dashboard-web/src/components/charts/BaseLineChart.tsx
+++ b/packages/dashboard-web/src/components/charts/BaseLineChart.tsx
@@ -24,10 +24,13 @@ interface LineConfig {
 	strokeWidth?: number;
 	dot?: boolean;
 	name?: string;
+	strokeDasharray?: string;
+	connectNulls?: boolean;
 }
 
 interface ReferenceLineConfig {
-	y: number;
+	x?: number | string;
+	y?: number;
 	stroke?: string;
 	strokeDasharray?: string;
 	label?: string;
@@ -36,6 +39,8 @@ interface ReferenceLineConfig {
 interface BaseLineChartProps extends CommonChartProps {
 	lines: LineConfig | LineConfig[];
 	referenceLines?: ReferenceLineConfig[];
+	xAxisType?: "number" | "category";
+	xAxisDomain?: [number | string, number | string];
 }
 
 export function BaseLineChart({
@@ -48,6 +53,8 @@ export function BaseLineChart({
 	xAxisTextAnchor = "middle",
 	xAxisHeight = 30,
 	xAxisTickFormatter,
+	xAxisType,
+	xAxisDomain,
 	yAxisDomain,
 	yAxisTickFormatter,
 	tooltipFormatter,
@@ -85,6 +92,9 @@ export function BaseLineChart({
 					/>
 					<XAxis
 						dataKey={xAxisKey}
+						type={xAxisType}
+						domain={xAxisDomain}
+						allowDataOverflow
 						className="text-xs"
 						angle={xAxisAngle}
 						textAnchor={xAxisTextAnchor}
@@ -114,11 +124,15 @@ export function BaseLineChart({
 							dot={lineConfig.dot ?? false}
 							name={lineConfig.name || lineConfig.dataKey}
 							animationDuration={animationDuration}
+							strokeDasharray={lineConfig.strokeDasharray}
+							connectNulls={lineConfig.connectNulls ?? false}
 						/>
 					))}
-					{referenceLines.map((refLine) => (
+					{referenceLines.map((refLine, refIndex) => (
 						<ReferenceLine
-							key={`ref-line-${refLine.y}`}
+							// biome-ignore lint/suspicious/noArrayIndexKey: referenceLines is a static config array (no reorder); y may be undefined for x-only markers so it cannot key
+							key={`ref-line-${refIndex}`}
+							x={refLine.x}
 							y={refLine.y}
 							stroke={refLine.stroke || COLORS.primary}
 							strokeDasharray={

--- a/packages/dashboard-web/src/components/charts/BaseLineChart.tsx
+++ b/packages/dashboard-web/src/components/charts/BaseLineChart.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from "react";
 import {
 	CartesianGrid,
 	Legend,
@@ -41,6 +42,10 @@ interface BaseLineChartProps extends CommonChartProps {
 	referenceLines?: ReferenceLineConfig[];
 	xAxisType?: "number" | "category";
 	xAxisDomain?: [number | string, number | string];
+	// Fully custom recharts tooltip. recharts clones this element with the
+	// injected `active`/`payload`/`label` props. When set, it replaces the
+	// default formatter-based tooltip (other charts are unaffected).
+	tooltipContent?: ReactElement;
 }
 
 export function BaseLineChart({
@@ -59,6 +64,7 @@ export function BaseLineChart({
 	yAxisTickFormatter,
 	tooltipFormatter,
 	tooltipLabelFormatter,
+	tooltipContent,
 	tooltipStyle = "default",
 	animationDuration = 1000,
 	showLegend = false,
@@ -106,13 +112,17 @@ export function BaseLineChart({
 						domain={yAxisDomain}
 						tickFormatter={yAxisTickFormatter}
 					/>
-					<Tooltip
-						contentStyle={tooltipStyles}
-						// biome-ignore lint/suspicious/noExplicitAny: recharts v3.8 widened Formatter to include undefined
-						formatter={tooltipFormatter as any}
-						// biome-ignore lint/suspicious/noExplicitAny: recharts v3.8 widened labelFormatter label to ReactNode
-						labelFormatter={tooltipLabelFormatter as any}
-					/>
+					{tooltipContent ? (
+						<Tooltip content={tooltipContent} />
+					) : (
+						<Tooltip
+							contentStyle={tooltipStyles}
+							// biome-ignore lint/suspicious/noExplicitAny: recharts v3.8 widened Formatter to include undefined
+							formatter={tooltipFormatter as any}
+							// biome-ignore lint/suspicious/noExplicitAny: recharts v3.8 widened labelFormatter label to ReactNode
+							labelFormatter={tooltipLabelFormatter as any}
+						/>
+					)}
 					{showLegend && <Legend height={legendHeight} />}
 					{lineConfigs.map((lineConfig, _index) => (
 						<Line

--- a/packages/dashboard-web/src/components/charts/BaseScatterChart.tsx
+++ b/packages/dashboard-web/src/components/charts/BaseScatterChart.tsx
@@ -136,8 +136,8 @@ export function BaseScatterChart({
 							data.map((entry) => (
 								<text
 									key={`label-${entry[xKey]}-${entry[yKey]}`}
-									x={entry[xKey]}
-									y={entry[yKey]}
+									x={entry[xKey] ?? undefined}
+									y={entry[yKey] ?? undefined}
 									dy={-10}
 									textAnchor="middle"
 									className="text-xs fill-foreground"

--- a/packages/dashboard-web/src/components/charts/types.ts
+++ b/packages/dashboard-web/src/components/charts/types.ts
@@ -1,5 +1,5 @@
 // Common types for chart components
-export type ChartDataPoint = Record<string, string | number>;
+export type ChartDataPoint = Record<string, string | number | null>;
 
 export type TooltipFormatterValue = string | number | [number, number];
 

--- a/packages/dashboard-web/src/components/navigation.tsx
+++ b/packages/dashboard-web/src/components/navigation.tsx
@@ -5,6 +5,7 @@ import {
 	Bot,
 	FileText,
 	GitBranch,
+	History,
 	Key,
 	LayoutDashboard,
 	Lightbulb,
@@ -87,6 +88,7 @@ export function Navigation({
 			},
 			{ label: "Requests", icon: Activity, path: "/requests" },
 			{ label: "Accounts", icon: Users, path: "/accounts" },
+			{ label: "Usage History", icon: History, path: "/usage-history" },
 		];
 
 		// Add combos item if feature is enabled

--- a/packages/dashboard-web/src/components/usage-history/UsageHistoryChart.tsx
+++ b/packages/dashboard-web/src/components/usage-history/UsageHistoryChart.tsx
@@ -1,0 +1,117 @@
+import type { UsageHistoryWindowSeries } from "@better-ccflare/types";
+import { COLORS } from "../../constants";
+import { BaseLineChart } from "../charts/BaseLineChart";
+import { buildUsageChartData } from "./chart-data";
+
+const WINDOW_COLORS: Record<string, string> = {
+	five_hour: COLORS.primary,
+	seven_day: COLORS.blue,
+	seven_day_opus: COLORS.purple,
+	seven_day_sonnet: COLORS.cyan,
+};
+
+interface Props {
+	windows: UsageHistoryWindowSeries[];
+	rangeMs: number;
+	loading?: boolean;
+	height?: number;
+	emptyState?: string;
+}
+
+export function UsageHistoryChart({
+	windows,
+	rangeMs,
+	loading,
+	height = 400,
+	emptyState = "Collecting usage data…",
+}: Props) {
+	const now = Date.now();
+	const { rows, windowKeys, predictionKeys, markers } = buildUsageChartData(
+		windows,
+		now,
+		rangeMs,
+	);
+
+	const lines = [
+		...windowKeys.map((key) => ({
+			dataKey: key,
+			stroke: WINDOW_COLORS[key] ?? COLORS.indigo,
+			name: key,
+			connectNulls: true, // bridge the gaps left by per-window sampling
+		})),
+		// dashed forecast line per rising window, same colour as its actual line
+		...predictionKeys.map((key) => {
+			const base = key.replace("__pred", "");
+			return {
+				dataKey: key,
+				stroke: WINDOW_COLORS[base] ?? COLORS.indigo,
+				name: `${base} (forecast)`,
+				strokeDasharray: "6 4",
+				strokeWidth: 1,
+				connectNulls: true,
+			};
+		}),
+	];
+
+	const referenceLines = markers.map((m) => ({
+		x: m.x,
+		stroke: COLORS.warning,
+		label: m.label,
+	}));
+
+	// Numeric time axis with a domain extended to cover future reset markers and
+	// forecast endpoints — otherwise recharts (category axis / data-bounded domain)
+	// drops them entirely (Fable H1). Y headroom keeps overage (>100%) visible (L6).
+	// Compute the x-domain and y-max with explicit loops rather than spreading
+	// the point arrays into Math.min/Math.max — on the 7d/30d ranges a long-lived
+	// instance accumulates tens of thousands of rows, and spreading that many
+	// arguments throws `RangeError: Maximum call stack size exceeded`.
+	let xMin = Number.POSITIVE_INFINITY;
+	let xMax = Number.NEGATIVE_INFINITY;
+	for (const r of rows) {
+		if (r.t < xMin) xMin = r.t;
+		if (r.t > xMax) xMax = r.t;
+	}
+	for (const m of markers) {
+		if (m.x < xMin) xMin = m.x;
+		if (m.x > xMax) xMax = m.x;
+	}
+	// Cap the right edge at the selected range's forward horizon so a far-future
+	// forecast endpoint (clipped by allowDataOverflow) can't stretch a short
+	// selection out to days. Markers are already bounded by the same horizon in
+	// buildUsageChartData. Never let the cap fall below xMin (guards the empty /
+	// single-point case where xMin would otherwise exceed the capped xMax).
+	const cap = now + rangeMs;
+	if (xMax > cap) xMax = cap;
+	if (xMax < xMin) xMax = xMin;
+	const hasX = Number.isFinite(xMin) && Number.isFinite(xMax);
+	const xDomain: [number, number] = hasX ? [xMin, xMax] : [0, 1];
+
+	let yMax = 100;
+	const yKeys = [...windowKeys, ...predictionKeys];
+	for (const r of rows) {
+		for (const k of yKeys) {
+			const v = r[k];
+			if (typeof v === "number" && v > yMax) yMax = v;
+		}
+	}
+
+	return (
+		<BaseLineChart
+			data={rows}
+			xAxisKey="t"
+			xAxisType="number"
+			xAxisDomain={xDomain}
+			lines={lines}
+			referenceLines={referenceLines}
+			loading={loading}
+			height={height}
+			showLegend
+			yAxisDomain={[0, yMax]}
+			emptyState={emptyState}
+			xAxisTickFormatter={(v) => new Date(Number(v)).toLocaleString()}
+			tooltipLabelFormatter={(v) => new Date(Number(v)).toLocaleString()}
+			tooltipFormatter={(value, name) => [`${value}%`, String(name)]}
+		/>
+	);
+}

--- a/packages/dashboard-web/src/components/usage-history/UsageHistoryChart.tsx
+++ b/packages/dashboard-web/src/components/usage-history/UsageHistoryChart.tsx
@@ -2,6 +2,7 @@ import type { UsageHistoryWindowSeries } from "@better-ccflare/types";
 import { useMemo } from "react";
 import { COLORS } from "../../constants";
 import { BaseLineChart } from "../charts/BaseLineChart";
+import { getTooltipStyles } from "../charts/chart-utils";
 import { buildUsageChartData } from "./chart-data";
 
 const WINDOW_COLORS: Record<string, string> = {
@@ -10,6 +11,63 @@ const WINDOW_COLORS: Record<string, string> = {
 	seven_day_opus: COLORS.purple,
 	seven_day_sonnet: COLORS.cyan,
 };
+
+const PRED_SUFFIX = "__pred";
+
+interface TooltipPayloadItem {
+	dataKey?: string | number;
+	name?: string;
+	value?: number | string | null;
+	color?: string;
+}
+
+/**
+ * Custom recharts tooltip for the usage-history chart. recharts injects
+ * `active`, `payload`, and `label` when it clones this element. It:
+ *  - rounds every utilization to a whole percent,
+ *  - hides forecast (`__pred`) series at or before the latest actual point,
+ *    since at the anchor (t == now) the forecast just duplicates the actual.
+ */
+function UsageHistoryTooltip({
+	latestActualT,
+	active,
+	payload,
+	label,
+}: {
+	latestActualT: number;
+	active?: boolean;
+	payload?: TooltipPayloadItem[];
+	label?: number | string;
+}) {
+	if (!active || !payload?.length) return null;
+	const t = Number(label);
+	const entries = payload.filter((entry) => {
+		if (entry.value == null) return false;
+		const key = String(entry.dataKey ?? "");
+		if (key.endsWith(PRED_SUFFIX) && t <= latestActualT) return false;
+		return true;
+	});
+	if (!entries.length) return null;
+	return (
+		<div
+			className="p-2 rounded-md shadow-lg text-xs"
+			style={getTooltipStyles("default")}
+		>
+			<p className="font-medium mb-1">{new Date(t).toLocaleString()}</p>
+			<div className="space-y-0.5">
+				{entries.map((entry, index) => (
+					<div
+						// biome-ignore lint/suspicious/noArrayIndexKey: index tiebreaks duplicate dataKeys in a single payload
+						key={`${String(entry.dataKey ?? "")}-${index}`}
+						style={{ color: entry.color }}
+					>
+						{entry.name}: <strong>{Math.round(Number(entry.value))}%</strong>
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}
 
 interface Props {
 	windows: UsageHistoryWindowSeries[];
@@ -33,79 +91,87 @@ export function UsageHistoryChart({
 	// out and re-renders the (potentially ~28,800-point) SVG on every render.
 	const nowBucket = Math.floor(Date.now() / 60_000) * 60_000;
 
-	const { rows, lines, referenceLines, xDomain, yMax } = useMemo(() => {
-		const { rows, windowKeys, predictionKeys, markers } = buildUsageChartData(
-			windows,
-			nowBucket,
-			rangeMs,
-		);
+	const { rows, lines, referenceLines, xDomain, yMax, latestActualT } =
+		useMemo(() => {
+			const { rows, windowKeys, predictionKeys, markers } = buildUsageChartData(
+				windows,
+				nowBucket,
+				rangeMs,
+			);
 
-		const lines = [
-			...windowKeys.map((key) => ({
-				dataKey: key,
-				stroke: WINDOW_COLORS[key] ?? COLORS.indigo,
-				name: key,
-				connectNulls: true, // bridge the gaps left by per-window sampling
-			})),
-			// dashed forecast line per rising window, same colour as its actual line
-			...predictionKeys.map((key) => {
-				const base = key.replace("__pred", "");
-				return {
-					dataKey: key,
-					stroke: WINDOW_COLORS[base] ?? COLORS.indigo,
-					name: `${base} (forecast)`,
-					strokeDasharray: "6 4",
-					strokeWidth: 1,
-					connectNulls: true,
-				};
-			}),
-		];
-
-		const referenceLines = markers.map((m) => ({
-			x: m.x,
-			stroke: COLORS.warning,
-			label: m.label,
-		}));
-
-		// Numeric time axis with a domain extended to cover future reset markers and
-		// forecast endpoints — otherwise recharts (category axis / data-bounded domain)
-		// drops them entirely (Fable H1). Y headroom keeps overage (>100%) visible (L6).
-		// Compute the x-domain and y-max with explicit loops rather than spreading
-		// the point arrays into Math.min/Math.max — on the 7d/30d ranges a long-lived
-		// instance accumulates tens of thousands of rows, and spreading that many
-		// arguments throws `RangeError: Maximum call stack size exceeded`.
-		let xMin = Number.POSITIVE_INFINITY;
-		let xMax = Number.NEGATIVE_INFINITY;
-		for (const r of rows) {
-			if (r.t < xMin) xMin = r.t;
-			if (r.t > xMax) xMax = r.t;
-		}
-		for (const m of markers) {
-			if (m.x < xMin) xMin = m.x;
-			if (m.x > xMax) xMax = m.x;
-		}
-		// Cap the right edge at the selected range's forward horizon so a far-future
-		// forecast endpoint (clipped by allowDataOverflow) can't stretch a short
-		// selection out to days. Markers are already bounded by the same horizon in
-		// buildUsageChartData. Never let the cap fall below xMin (guards the empty /
-		// single-point case where xMin would otherwise exceed the capped xMax).
-		const cap = nowBucket + rangeMs;
-		if (xMax > cap) xMax = cap;
-		if (xMax < xMin) xMax = xMin;
-		const hasX = Number.isFinite(xMin) && Number.isFinite(xMax);
-		const xDomain: [number, number] = hasX ? [xMin, xMax] : [0, 1];
-
-		let yMax = 100;
-		const yKeys = [...windowKeys, ...predictionKeys];
-		for (const r of rows) {
-			for (const k of yKeys) {
-				const v = r[k];
-				if (typeof v === "number" && v > yMax) yMax = v;
+			// The most recent ACTUAL sample time — forecast entries at or before it
+			// are redundant (they coincide with the actual) and hidden in the tooltip.
+			let latestActualT = nowBucket;
+			for (const w of windows) {
+				for (const p of w.points) if (p.t > latestActualT) latestActualT = p.t;
 			}
-		}
 
-		return { rows, lines, referenceLines, xDomain, yMax };
-	}, [windows, rangeMs, nowBucket]);
+			const lines = [
+				...windowKeys.map((key) => ({
+					dataKey: key,
+					stroke: WINDOW_COLORS[key] ?? COLORS.indigo,
+					name: key,
+					connectNulls: true, // bridge the gaps left by per-window sampling
+				})),
+				// dashed forecast line per rising window, same colour as its actual line
+				...predictionKeys.map((key) => {
+					const base = key.replace("__pred", "");
+					return {
+						dataKey: key,
+						stroke: WINDOW_COLORS[base] ?? COLORS.indigo,
+						name: `${base} (forecast)`,
+						strokeDasharray: "6 4",
+						strokeWidth: 1,
+						connectNulls: true,
+					};
+				}),
+			];
+
+			const referenceLines = markers.map((m) => ({
+				x: m.x,
+				stroke: COLORS.warning,
+				label: m.label,
+			}));
+
+			// Numeric time axis with a domain extended to cover future reset markers and
+			// forecast endpoints — otherwise recharts (category axis / data-bounded domain)
+			// drops them entirely (Fable H1). Y headroom keeps overage (>100%) visible (L6).
+			// Compute the x-domain and y-max with explicit loops rather than spreading
+			// the point arrays into Math.min/Math.max — on the 7d/30d ranges a long-lived
+			// instance accumulates tens of thousands of rows, and spreading that many
+			// arguments throws `RangeError: Maximum call stack size exceeded`.
+			let xMin = Number.POSITIVE_INFINITY;
+			let xMax = Number.NEGATIVE_INFINITY;
+			for (const r of rows) {
+				if (r.t < xMin) xMin = r.t;
+				if (r.t > xMax) xMax = r.t;
+			}
+			for (const m of markers) {
+				if (m.x < xMin) xMin = m.x;
+				if (m.x > xMax) xMax = m.x;
+			}
+			// Cap the right edge at the selected range's forward horizon so a far-future
+			// forecast endpoint (clipped by allowDataOverflow) can't stretch a short
+			// selection out to days. Markers are already bounded by the same horizon in
+			// buildUsageChartData. Never let the cap fall below xMin (guards the empty /
+			// single-point case where xMin would otherwise exceed the capped xMax).
+			const cap = nowBucket + rangeMs;
+			if (xMax > cap) xMax = cap;
+			if (xMax < xMin) xMax = xMin;
+			const hasX = Number.isFinite(xMin) && Number.isFinite(xMax);
+			const xDomain: [number, number] = hasX ? [xMin, xMax] : [0, 1];
+
+			let yMax = 100;
+			const yKeys = [...windowKeys, ...predictionKeys];
+			for (const r of rows) {
+				for (const k of yKeys) {
+					const v = r[k];
+					if (typeof v === "number" && v > yMax) yMax = v;
+				}
+			}
+
+			return { rows, lines, referenceLines, xDomain, yMax, latestActualT };
+		}, [windows, rangeMs, nowBucket]);
 
 	return (
 		<BaseLineChart
@@ -121,8 +187,7 @@ export function UsageHistoryChart({
 			yAxisDomain={[0, yMax]}
 			emptyState={emptyState}
 			xAxisTickFormatter={(v) => new Date(Number(v)).toLocaleString()}
-			tooltipLabelFormatter={(v) => new Date(Number(v)).toLocaleString()}
-			tooltipFormatter={(value, name) => [`${value}%`, String(name)]}
+			tooltipContent={<UsageHistoryTooltip latestActualT={latestActualT} />}
 		/>
 	);
 }

--- a/packages/dashboard-web/src/components/usage-history/UsageHistoryChart.tsx
+++ b/packages/dashboard-web/src/components/usage-history/UsageHistoryChart.tsx
@@ -1,4 +1,5 @@
 import type { UsageHistoryWindowSeries } from "@better-ccflare/types";
+import { useMemo } from "react";
 import { COLORS } from "../../constants";
 import { BaseLineChart } from "../charts/BaseLineChart";
 import { buildUsageChartData } from "./chart-data";
@@ -25,76 +26,86 @@ export function UsageHistoryChart({
 	height = 400,
 	emptyState = "Collecting usage data…",
 }: Props) {
-	const now = Date.now();
-	const { rows, windowKeys, predictionKeys, markers } = buildUsageChartData(
-		windows,
-		now,
-		rangeMs,
-	);
+	// Bucket `now` to the minute so the memo is stable across the sub-minute
+	// re-renders — sub-minute precision is irrelevant for reset markers and a
+	// domain cap that sits hours away. Without this, `Date.now()` shifts every
+	// render, making `rows`/`xDomain` fresh references so recharts can never bail
+	// out and re-renders the (potentially ~28,800-point) SVG on every render.
+	const nowBucket = Math.floor(Date.now() / 60_000) * 60_000;
 
-	const lines = [
-		...windowKeys.map((key) => ({
-			dataKey: key,
-			stroke: WINDOW_COLORS[key] ?? COLORS.indigo,
-			name: key,
-			connectNulls: true, // bridge the gaps left by per-window sampling
-		})),
-		// dashed forecast line per rising window, same colour as its actual line
-		...predictionKeys.map((key) => {
-			const base = key.replace("__pred", "");
-			return {
+	const { rows, lines, referenceLines, xDomain, yMax } = useMemo(() => {
+		const { rows, windowKeys, predictionKeys, markers } = buildUsageChartData(
+			windows,
+			nowBucket,
+			rangeMs,
+		);
+
+		const lines = [
+			...windowKeys.map((key) => ({
 				dataKey: key,
-				stroke: WINDOW_COLORS[base] ?? COLORS.indigo,
-				name: `${base} (forecast)`,
-				strokeDasharray: "6 4",
-				strokeWidth: 1,
-				connectNulls: true,
-			};
-		}),
-	];
+				stroke: WINDOW_COLORS[key] ?? COLORS.indigo,
+				name: key,
+				connectNulls: true, // bridge the gaps left by per-window sampling
+			})),
+			// dashed forecast line per rising window, same colour as its actual line
+			...predictionKeys.map((key) => {
+				const base = key.replace("__pred", "");
+				return {
+					dataKey: key,
+					stroke: WINDOW_COLORS[base] ?? COLORS.indigo,
+					name: `${base} (forecast)`,
+					strokeDasharray: "6 4",
+					strokeWidth: 1,
+					connectNulls: true,
+				};
+			}),
+		];
 
-	const referenceLines = markers.map((m) => ({
-		x: m.x,
-		stroke: COLORS.warning,
-		label: m.label,
-	}));
+		const referenceLines = markers.map((m) => ({
+			x: m.x,
+			stroke: COLORS.warning,
+			label: m.label,
+		}));
 
-	// Numeric time axis with a domain extended to cover future reset markers and
-	// forecast endpoints — otherwise recharts (category axis / data-bounded domain)
-	// drops them entirely (Fable H1). Y headroom keeps overage (>100%) visible (L6).
-	// Compute the x-domain and y-max with explicit loops rather than spreading
-	// the point arrays into Math.min/Math.max — on the 7d/30d ranges a long-lived
-	// instance accumulates tens of thousands of rows, and spreading that many
-	// arguments throws `RangeError: Maximum call stack size exceeded`.
-	let xMin = Number.POSITIVE_INFINITY;
-	let xMax = Number.NEGATIVE_INFINITY;
-	for (const r of rows) {
-		if (r.t < xMin) xMin = r.t;
-		if (r.t > xMax) xMax = r.t;
-	}
-	for (const m of markers) {
-		if (m.x < xMin) xMin = m.x;
-		if (m.x > xMax) xMax = m.x;
-	}
-	// Cap the right edge at the selected range's forward horizon so a far-future
-	// forecast endpoint (clipped by allowDataOverflow) can't stretch a short
-	// selection out to days. Markers are already bounded by the same horizon in
-	// buildUsageChartData. Never let the cap fall below xMin (guards the empty /
-	// single-point case where xMin would otherwise exceed the capped xMax).
-	const cap = now + rangeMs;
-	if (xMax > cap) xMax = cap;
-	if (xMax < xMin) xMax = xMin;
-	const hasX = Number.isFinite(xMin) && Number.isFinite(xMax);
-	const xDomain: [number, number] = hasX ? [xMin, xMax] : [0, 1];
-
-	let yMax = 100;
-	const yKeys = [...windowKeys, ...predictionKeys];
-	for (const r of rows) {
-		for (const k of yKeys) {
-			const v = r[k];
-			if (typeof v === "number" && v > yMax) yMax = v;
+		// Numeric time axis with a domain extended to cover future reset markers and
+		// forecast endpoints — otherwise recharts (category axis / data-bounded domain)
+		// drops them entirely (Fable H1). Y headroom keeps overage (>100%) visible (L6).
+		// Compute the x-domain and y-max with explicit loops rather than spreading
+		// the point arrays into Math.min/Math.max — on the 7d/30d ranges a long-lived
+		// instance accumulates tens of thousands of rows, and spreading that many
+		// arguments throws `RangeError: Maximum call stack size exceeded`.
+		let xMin = Number.POSITIVE_INFINITY;
+		let xMax = Number.NEGATIVE_INFINITY;
+		for (const r of rows) {
+			if (r.t < xMin) xMin = r.t;
+			if (r.t > xMax) xMax = r.t;
 		}
-	}
+		for (const m of markers) {
+			if (m.x < xMin) xMin = m.x;
+			if (m.x > xMax) xMax = m.x;
+		}
+		// Cap the right edge at the selected range's forward horizon so a far-future
+		// forecast endpoint (clipped by allowDataOverflow) can't stretch a short
+		// selection out to days. Markers are already bounded by the same horizon in
+		// buildUsageChartData. Never let the cap fall below xMin (guards the empty /
+		// single-point case where xMin would otherwise exceed the capped xMax).
+		const cap = nowBucket + rangeMs;
+		if (xMax > cap) xMax = cap;
+		if (xMax < xMin) xMax = xMin;
+		const hasX = Number.isFinite(xMin) && Number.isFinite(xMax);
+		const xDomain: [number, number] = hasX ? [xMin, xMax] : [0, 1];
+
+		let yMax = 100;
+		const yKeys = [...windowKeys, ...predictionKeys];
+		for (const r of rows) {
+			for (const k of yKeys) {
+				const v = r[k];
+				if (typeof v === "number" && v > yMax) yMax = v;
+			}
+		}
+
+		return { rows, lines, referenceLines, xDomain, yMax };
+	}, [windows, rangeMs, nowBucket]);
 
 	return (
 		<BaseLineChart

--- a/packages/dashboard-web/src/components/usage-history/UsageHistoryTab.tsx
+++ b/packages/dashboard-web/src/components/usage-history/UsageHistoryTab.tsx
@@ -30,6 +30,10 @@ export function UsageHistoryTab() {
 	const selectedAccount = accounts?.find((a) => a.id === selected);
 	const { data, isLoading } = useUsageHistory(selected, range);
 	const windows = data?.windows ?? [];
+	// Bucket "now" to 1-minute granularity (matching the chart's nowBucket) so the
+	// per-window annotations use a single, stable reference rather than a fresh
+	// Date.now() per window per render — avoids sub-minute ETA display drift.
+	const nowBucket = Math.floor(Date.now() / 60_000) * 60_000;
 
 	return (
 		<div className="space-y-4">
@@ -73,9 +77,7 @@ export function UsageHistoryTab() {
 			{windows.length > 0 && (
 				<Card className="p-4 space-y-1 text-sm">
 					{windows.map((w) => (
-						<div key={w.window}>
-							{formatPredictionAnnotation(w, Date.now())}
-						</div>
+						<div key={w.window}>{formatPredictionAnnotation(w, nowBucket)}</div>
 					))}
 				</Card>
 			)}

--- a/packages/dashboard-web/src/components/usage-history/UsageHistoryTab.tsx
+++ b/packages/dashboard-web/src/components/usage-history/UsageHistoryTab.tsx
@@ -1,0 +1,84 @@
+import { useState } from "react";
+import type { TimeRange } from "../../constants";
+import { useAccounts, useUsageHistory } from "../../hooks/queries";
+import { Card } from "../ui/card";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "../ui/select";
+import { formatPredictionAnnotation } from "./chart-data";
+import {
+	pickDefaultAccount,
+	rangeToMs,
+	sortAccountsActiveFirst,
+	usageEmptyStateMessage,
+} from "./tab-helpers";
+import { UsageHistoryChart } from "./UsageHistoryChart";
+
+// Match the ranges the endpoint accepts (getRangeConfig: 1h/6h/24h/7d/30d).
+const RANGES: TimeRange[] = ["1h", "6h", "24h", "7d", "30d"];
+
+export function UsageHistoryTab() {
+	const { data: accounts } = useAccounts();
+	const [accountId, setAccountId] = useState<string>("");
+	const [range, setRange] = useState<string>("24h");
+
+	const selected = accountId || pickDefaultAccount(accounts) || "";
+	const selectedAccount = accounts?.find((a) => a.id === selected);
+	const { data, isLoading } = useUsageHistory(selected, range);
+	const windows = data?.windows ?? [];
+
+	return (
+		<div className="space-y-4">
+			<div className="flex gap-3">
+				<Select value={selected} onValueChange={setAccountId}>
+					<SelectTrigger className="w-64">
+						<SelectValue placeholder="Select account" />
+					</SelectTrigger>
+					<SelectContent>
+						{sortAccountsActiveFirst(accounts ?? []).map((a) => (
+							<SelectItem key={a.id} value={a.id}>
+								{a.name}
+								{a.paused ? " (paused)" : ""}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+				<Select value={range} onValueChange={setRange}>
+					<SelectTrigger className="w-28">
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						{RANGES.map((r) => (
+							<SelectItem key={r} value={r}>
+								{r}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			</div>
+
+			<Card className="p-4">
+				<UsageHistoryChart
+					windows={windows}
+					rangeMs={rangeToMs(range)}
+					loading={isLoading}
+					emptyState={usageEmptyStateMessage(selectedAccount)}
+				/>
+			</Card>
+
+			{windows.length > 0 && (
+				<Card className="p-4 space-y-1 text-sm">
+					{windows.map((w) => (
+						<div key={w.window}>
+							{formatPredictionAnnotation(w, Date.now())}
+						</div>
+					))}
+				</Card>
+			)}
+		</div>
+	);
+}

--- a/packages/dashboard-web/src/components/usage-history/__tests__/chart-data.test.ts
+++ b/packages/dashboard-web/src/components/usage-history/__tests__/chart-data.test.ts
@@ -1,0 +1,349 @@
+import { describe, expect, it } from "bun:test";
+import type { UsageHistoryWindowSeries } from "@better-ccflare/types";
+import {
+	buildUsageChartData,
+	formatPredictionAnnotation,
+	resetMarkers,
+} from "../chart-data";
+
+const H = 60 * 60 * 1000;
+const NOW = 3 * H;
+
+/** Build a single-window series with an inline prediction, for annotation tests. */
+function annSeries(
+	window: string,
+	prediction: UsageHistoryWindowSeries["prediction"],
+): UsageHistoryWindowSeries {
+	return {
+		window,
+		points: [{ t: 1000, utilization: 50, resetsAt: prediction.resetsAtMs }],
+		prediction,
+	};
+}
+
+function series(): UsageHistoryWindowSeries[] {
+	return [
+		{
+			window: "five_hour",
+			points: [
+				{ t: 1000, utilization: 10, resetsAt: 5 * H },
+				{ t: 2000, utilization: 20, resetsAt: 5 * H },
+			],
+			prediction: {
+				slopePerHour: 10,
+				etaExhaustMs: 4 * H,
+				predictedAtReset: 100,
+				resetsAtMs: 5 * H,
+				willExhaustBeforeReset: true,
+				state: "rising",
+				lowConfidence: false,
+			},
+		},
+		{
+			window: "seven_day",
+			points: [{ t: 2000, utilization: 3, resetsAt: null }],
+			prediction: {
+				slopePerHour: 0,
+				etaExhaustMs: null,
+				predictedAtReset: null,
+				resetsAtMs: null,
+				willExhaustBeforeReset: false,
+				state: "stable",
+				lowConfidence: false,
+			},
+		},
+	];
+}
+
+describe("buildUsageChartData", () => {
+	it("merges actual + prediction segments into one dataset", () => {
+		const { rows, windowKeys, predictionKeys } = buildUsageChartData(
+			series(),
+			NOW,
+			24 * H,
+		);
+		expect(windowKeys).toEqual(["five_hour", "seven_day"]);
+		expect(predictionKeys).toEqual(["five_hour__pred"]); // only the rising window
+		// distinct timestamps: 1000, 2000 (actual) + 4h (eta endpoint) = 3 rows
+		expect(rows.map((r) => r.t)).toEqual([1000, 2000, 4 * H]);
+		const t2 = rows.find((r) => r.t === 2000)!;
+		expect(t2.five_hour).toBe(20);
+		expect(t2.seven_day).toBe(3);
+		expect(t2.five_hour__pred).toBe(20); // prediction anchored at last actual
+		const eta = rows.find((r) => r.t === 4 * H)!;
+		expect(eta.five_hour__pred).toBe(100); // dashed line reaches the limit
+		expect(eta.five_hour).toBeNull(); // no actual point there
+		const t1 = rows.find((r) => r.t === 1000)!;
+		expect(t1.seven_day).toBeNull(); // gap
+	});
+
+	it("caps the forecast at the reset when the ETA is beyond it", () => {
+		const windows = [
+			{
+				window: "seven_day",
+				points: [
+					{ t: 0, utilization: 40, resetsAt: 10 * H },
+					{ t: 1 * H, utilization: 42, resetsAt: 10 * H },
+				],
+				prediction: {
+					slopePerHour: 2,
+					etaExhaustMs: 30 * H, // ETA far beyond the 10h reset
+					predictedAtReset: 58,
+					resetsAtMs: 10 * H,
+					willExhaustBeforeReset: false,
+					state: "rising" as const,
+					lowConfidence: false,
+				},
+			},
+		];
+		const { rows, predictionKeys } = buildUsageChartData(windows, NOW, 24 * H);
+		expect(predictionKeys).toEqual(["seven_day__pred"]);
+		// forecast endpoint is at the reset (10h), value = predictedAtReset (58), NOT 30h/100
+		expect(rows.map((r) => r.t)).toEqual([0, 1 * H, 10 * H]);
+		expect(rows.find((r) => r.t === 10 * H)?.seven_day__pred).toBe(58);
+	});
+
+	it("threads horizonMs into markers — a far reset is dropped", () => {
+		// seven_day resets 19h out; a 6h horizon must not surface it as a marker.
+		const windows: UsageHistoryWindowSeries[] = [
+			{
+				window: "seven_day",
+				points: [{ t: 0, utilization: 40, resetsAt: 19 * H }],
+				prediction: {
+					slopePerHour: 0,
+					etaExhaustMs: null,
+					predictedAtReset: null,
+					resetsAtMs: 19 * H,
+					willExhaustBeforeReset: false,
+					state: "stable",
+					lowConfidence: false,
+				},
+			},
+		];
+		expect(buildUsageChartData(windows, 0, 6 * H).markers).toEqual([]);
+	});
+});
+
+describe("resetMarkers", () => {
+	it("returns a single marker at the nearest upcoming reset", () => {
+		// series() has a five_hour window resetting at 5h (+ a null-reset window).
+		expect(resetMarkers(series(), 3 * H, 24 * H).map((m) => m.x)).toEqual([
+			5 * H,
+		]);
+	});
+
+	it("returns [] when now is after every reset", () => {
+		expect(resetMarkers(series(), 6 * H, 24 * H)).toEqual([]);
+	});
+
+	it("keeps a reset that is within the forward horizon", () => {
+		const windows: UsageHistoryWindowSeries[] = [
+			{
+				window: "five_hour",
+				points: [{ t: 0, utilization: 20, resetsAt: 4.5 * H }],
+				prediction: {
+					slopePerHour: 0,
+					etaExhaustMs: null,
+					predictedAtReset: null,
+					resetsAtMs: 4.5 * H,
+					willExhaustBeforeReset: false,
+					state: "stable",
+					lowConfidence: false,
+				},
+			},
+		];
+		// now=0, horizon=6h → 4.5h ≤ 6h, marker kept.
+		expect(resetMarkers(windows, 0, 6 * H).map((m) => m.x)).toEqual([4.5 * H]);
+	});
+
+	it("drops a reset that is beyond the forward horizon", () => {
+		const windows: UsageHistoryWindowSeries[] = [
+			{
+				window: "seven_day",
+				points: [{ t: 0, utilization: 40, resetsAt: 19 * H }],
+				prediction: {
+					slopePerHour: 0,
+					etaExhaustMs: null,
+					predictedAtReset: null,
+					resetsAtMs: 19 * H,
+					willExhaustBeforeReset: false,
+					state: "stable",
+					lowConfidence: false,
+				},
+			},
+		];
+		// now=0, horizon=6h → 19h > 6h, marker dropped (this is the new bound).
+		expect(resetMarkers(windows, 0, 6 * H)).toEqual([]);
+	});
+
+	it("picks the earliest reset within the horizon, ignoring farther ones beyond it", () => {
+		const windows: UsageHistoryWindowSeries[] = [
+			{
+				window: "seven_day",
+				points: [{ t: 0, utilization: 40, resetsAt: 19 * H }],
+				prediction: {
+					slopePerHour: 0,
+					etaExhaustMs: null,
+					predictedAtReset: null,
+					resetsAtMs: 19 * H,
+					willExhaustBeforeReset: false,
+					state: "stable",
+					lowConfidence: false,
+				},
+			},
+			{
+				window: "five_hour",
+				points: [{ t: 0, utilization: 20, resetsAt: 4.5 * H }],
+				prediction: {
+					slopePerHour: 0,
+					etaExhaustMs: null,
+					predictedAtReset: null,
+					resetsAtMs: 4.5 * H,
+					willExhaustBeforeReset: false,
+					state: "stable",
+					lowConfidence: false,
+				},
+			},
+		];
+		// now=0, horizon=6h → 4.5h kept, 19h dropped.
+		expect(resetMarkers(windows, 0, 6 * H).map((m) => m.x)).toEqual([4.5 * H]);
+	});
+
+	it("picks the earliest future reset across multiple windows, skipping past ones", () => {
+		const windows: UsageHistoryWindowSeries[] = [
+			{
+				window: "seven_day",
+				points: [{ t: 0, utilization: 40, resetsAt: 10 * H }],
+				prediction: {
+					slopePerHour: 0,
+					etaExhaustMs: null,
+					predictedAtReset: null,
+					resetsAtMs: 10 * H,
+					willExhaustBeforeReset: false,
+					state: "stable",
+					lowConfidence: false,
+				},
+			},
+			{
+				window: "five_hour",
+				points: [{ t: 0, utilization: 20, resetsAt: 3 * H }],
+				prediction: {
+					slopePerHour: 0,
+					etaExhaustMs: null,
+					predictedAtReset: null,
+					resetsAtMs: 3 * H,
+					willExhaustBeforeReset: false,
+					state: "stable",
+					lowConfidence: false,
+				},
+			},
+		];
+		// both resets in the future (now=1h) → earliest (3h) wins
+		expect(resetMarkers(windows, 1 * H, 24 * H).map((m) => m.x)).toEqual([
+			3 * H,
+		]);
+		// now past the 3h reset → the next future reset (10h) is chosen
+		expect(resetMarkers(windows, 4 * H, 24 * H).map((m) => m.x)).toEqual([
+			10 * H,
+		]);
+	});
+});
+
+describe("formatPredictionAnnotation", () => {
+	it("summarizes a rising window that will exhaust before reset", () => {
+		const out = formatPredictionAnnotation(series()[0], 3 * H);
+		expect(out).toContain("five_hour");
+		expect(out.toLowerCase()).toContain("limit");
+	});
+	it("says stable for a stable window", () => {
+		expect(formatPredictionAnnotation(series()[1], 0).toLowerCase()).toContain(
+			"stable",
+		);
+	});
+
+	// Load-bearing guard: a rising window with NO known reset must never claim
+	// "safe until reset" (Fable M6). Pins the negative direction.
+	it("never claims safe for a rising window with no known reset", () => {
+		const out = formatPredictionAnnotation(
+			annSeries("five_hour", {
+				slopePerHour: 5,
+				etaExhaustMs: null,
+				predictedAtReset: null,
+				resetsAtMs: null,
+				willExhaustBeforeReset: false,
+				state: "rising",
+				lowConfidence: false,
+			}),
+			NOW,
+		);
+		expect(out.toLowerCase()).not.toContain("safe");
+		expect(out).toContain("five_hour");
+		expect(out.toLowerCase()).toContain("rising");
+	});
+
+	it("says collecting for insufficient_data", () => {
+		const out = formatPredictionAnnotation(
+			annSeries("seven_day", {
+				slopePerHour: 0,
+				etaExhaustMs: null,
+				predictedAtReset: null,
+				resetsAtMs: null,
+				willExhaustBeforeReset: false,
+				state: "insufficient_data",
+				lowConfidence: false,
+			}),
+			NOW,
+		);
+		expect(out.toLowerCase()).toContain("collecting");
+	});
+
+	it("says at limit for an exhausted window", () => {
+		const out = formatPredictionAnnotation(
+			annSeries("five_hour", {
+				slopePerHour: 20,
+				etaExhaustMs: NOW,
+				predictedAtReset: 100,
+				resetsAtMs: 5 * H,
+				willExhaustBeforeReset: true,
+				state: "exhausted",
+				lowConfidence: false,
+			}),
+			NOW,
+		);
+		expect(out.toLowerCase()).toContain("limit");
+	});
+
+	it("flags low confidence for a rising low-confidence window", () => {
+		const out = formatPredictionAnnotation(
+			annSeries("five_hour", {
+				slopePerHour: 8,
+				etaExhaustMs: null,
+				predictedAtReset: null,
+				resetsAtMs: 5 * H,
+				willExhaustBeforeReset: false,
+				state: "rising",
+				lowConfidence: true,
+			}),
+			NOW,
+		);
+		expect(out.toLowerCase()).toContain("low confidence");
+	});
+
+	// Positive counterpart to the guard: a rising window WITH a known reset that
+	// won't exhaust before it should say "safe". Together these pin both directions.
+	it("says safe until reset for a rising window with a known reset", () => {
+		const out = formatPredictionAnnotation(
+			annSeries("five_hour", {
+				slopePerHour: 6,
+				etaExhaustMs: 8 * H,
+				predictedAtReset: 70,
+				resetsAtMs: 5 * H,
+				willExhaustBeforeReset: false,
+				state: "rising",
+				lowConfidence: false,
+			}),
+			NOW,
+		);
+		expect(out.toLowerCase()).toContain("safe");
+	});
+});

--- a/packages/dashboard-web/src/components/usage-history/__tests__/chart-data.test.ts
+++ b/packages/dashboard-web/src/components/usage-history/__tests__/chart-data.test.ts
@@ -71,7 +71,11 @@ describe("buildUsageChartData", () => {
 		expect(t2.seven_day).toBe(3);
 		expect(t2.five_hour__pred).toBe(20); // prediction anchored at last actual
 		const eta = rows.find((r) => r.t === 4 * H)!;
-		expect(eta.five_hour__pred).toBe(100); // dashed line reaches the limit
+		// Endpoint value now interpolates the straight-line forecast at the (capped)
+		// endpoint time rather than snapping to 100. This synthetic fixture's ETA
+		// (4h) is inconsistent with its slope, so the interpolation lands below 100.
+		const expectedEta = 20 + 10 * ((4 * H - 2000) / H);
+		expect(eta.five_hour__pred).toBeCloseTo(expectedEta, 5);
 		expect(eta.five_hour).toBeNull(); // no actual point there
 		const t1 = rows.find((r) => r.t === 1000)!;
 		expect(t1.seven_day).toBeNull(); // gap
@@ -98,9 +102,82 @@ describe("buildUsageChartData", () => {
 		];
 		const { rows, predictionKeys } = buildUsageChartData(windows, NOW, 24 * H);
 		expect(predictionKeys).toEqual(["seven_day__pred"]);
-		// forecast endpoint is at the reset (10h), value = predictedAtReset (58), NOT 30h/100
+		// forecast endpoint is at the reset (10h), NOT 30h. Value now interpolates
+		// the straight line to that endpoint: 42 + slope(2) * (10h - 1h) = 60.
 		expect(rows.map((r) => r.t)).toEqual([0, 1 * H, 10 * H]);
-		expect(rows.find((r) => r.t === 10 * H)?.seven_day__pred).toBe(58);
+		expect(rows.find((r) => r.t === 10 * H)?.seven_day__pred).toBe(60);
+	});
+
+	it("caps a rising window's forecast at the nearest reset across windows", () => {
+		// Window A (five_hour) resets SOON (1h); window B (seven_day) resets FAR
+		// (10h). B's own reset/ETA are far out, but the nearest reset across ALL
+		// windows is A's 1h — B's forecast endpoint must be capped there so a
+		// far-horizon window can't stretch the x-domain right (near-term detail).
+		const HOUR = 60 * 60 * 1000;
+		const windows: UsageHistoryWindowSeries[] = [
+			{
+				window: "five_hour",
+				points: [{ t: 0, utilization: 50, resetsAt: 1 * HOUR }],
+				prediction: {
+					slopePerHour: 10,
+					etaExhaustMs: 5 * HOUR,
+					predictedAtReset: 60,
+					resetsAtMs: 1 * HOUR,
+					willExhaustBeforeReset: false,
+					state: "rising",
+					lowConfidence: false,
+				},
+			},
+			{
+				window: "seven_day",
+				points: [{ t: 0, utilization: 20, resetsAt: 10 * HOUR }],
+				prediction: {
+					slopePerHour: 2,
+					etaExhaustMs: 40 * HOUR,
+					predictedAtReset: 44,
+					resetsAtMs: 10 * HOUR,
+					willExhaustBeforeReset: false,
+					state: "rising",
+					lowConfidence: false,
+				},
+			},
+		];
+		const { rows, predictionKeys } = buildUsageChartData(windows, 0, 24 * HOUR);
+		expect(predictionKeys).toEqual(["five_hour__pred", "seven_day__pred"]);
+		// B's forecast endpoint is at A's reset (1h), NOT at B's own 10h.
+		expect(rows.find((r) => r.t === 10 * HOUR)).toBeUndefined();
+		// interpolated value at the capped endpoint: 20 + slopeB(2) * 1h = 22
+		expect(rows.find((r) => r.t === 1 * HOUR)?.seven_day__pred).toBe(22);
+		// domain not stretched: the max row t is A's reset (1h), not 10h
+		const maxT = Math.max(...rows.map((r) => r.t));
+		expect(maxT).toBe(1 * HOUR);
+		expect(maxT).toBeLessThanOrEqual(1 * HOUR);
+	});
+
+	it("leaves a single rising window's forecast endpoint at its own reset/ETA", () => {
+		// Only one window ⇒ nearestReset == its own reset ⇒ endpoint == min(own
+		// reset, ETA) exactly as before the multi-window cap was introduced.
+		const HOUR = 60 * 60 * 1000;
+		const windows: UsageHistoryWindowSeries[] = [
+			{
+				window: "five_hour",
+				points: [{ t: 0, utilization: 60, resetsAt: 5 * HOUR }],
+				prediction: {
+					slopePerHour: 10,
+					etaExhaustMs: 4 * HOUR, // ETA before the reset ⇒ endpoint at ETA
+					predictedAtReset: 100,
+					resetsAtMs: 5 * HOUR,
+					willExhaustBeforeReset: true,
+					state: "rising",
+					lowConfidence: false,
+				},
+			},
+		];
+		const { rows, predictionKeys } = buildUsageChartData(windows, 0, 24 * HOUR);
+		expect(predictionKeys).toEqual(["five_hour__pred"]);
+		// endpoint sits at the ETA (4h) — unchanged; value interpolates to 100.
+		expect(rows.find((r) => r.t === 4 * HOUR)?.five_hour__pred).toBe(100);
+		expect(Math.max(...rows.map((r) => r.t))).toBe(4 * HOUR);
 	});
 
 	it("threads horizonMs into markers — a far reset is dropped", () => {

--- a/packages/dashboard-web/src/components/usage-history/__tests__/tab-helpers.test.ts
+++ b/packages/dashboard-web/src/components/usage-history/__tests__/tab-helpers.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "bun:test";
+import {
+	type AccountLike,
+	pickDefaultAccount,
+	rangeToMs,
+	sortAccountsActiveFirst,
+	usageEmptyStateMessage,
+} from "../tab-helpers";
+
+const H = 60 * 60 * 1000;
+
+const acc = (
+	id: string,
+	name: string,
+	paused?: boolean | number | null,
+): AccountLike => ({ id, name, paused });
+
+describe("pickDefaultAccount", () => {
+	it("returns the first non-paused account's id", () => {
+		const accounts = [
+			acc("a", "A", true),
+			acc("b", "B", true),
+			acc("c", "C", false),
+		];
+		expect(pickDefaultAccount(accounts)).toBe("c");
+	});
+
+	it("falls back to the first account's id when all are paused", () => {
+		const accounts = [acc("a", "A", true), acc("b", "B", true)];
+		expect(pickDefaultAccount(accounts)).toBe("a");
+	});
+
+	it("returns undefined for an empty array", () => {
+		expect(pickDefaultAccount([])).toBeUndefined();
+	});
+
+	it("returns undefined when accounts is undefined", () => {
+		expect(pickDefaultAccount(undefined)).toBeUndefined();
+	});
+
+	it("treats numeric paused (1/0) truthiness correctly", () => {
+		const accounts = [acc("a", "A", 1), acc("b", "B", 0)];
+		expect(pickDefaultAccount(accounts)).toBe("b");
+	});
+});
+
+describe("sortAccountsActiveFirst", () => {
+	it("puts active accounts before paused ones", () => {
+		const accounts = [
+			acc("a", "A", true),
+			acc("b", "B", false),
+			acc("c", "C", true),
+			acc("d", "D", false),
+		];
+		expect(sortAccountsActiveFirst(accounts).map((a) => a.id)).toEqual([
+			"b",
+			"d",
+			"a",
+			"c",
+		]);
+	});
+
+	it("does not mutate the input array", () => {
+		const accounts = [acc("a", "A", true), acc("b", "B", false)];
+		const snapshot = accounts.map((a) => a.id);
+		const sorted = sortAccountsActiveFirst(accounts);
+		expect(accounts.map((a) => a.id)).toEqual(snapshot);
+		expect(sorted).not.toBe(accounts);
+	});
+
+	it("is stable within groups (paused keep relative order)", () => {
+		const accounts = [
+			acc("p1", "P1", true),
+			acc("p2", "P2", true),
+			acc("a1", "A1", false),
+		];
+		expect(sortAccountsActiveFirst(accounts).map((a) => a.id)).toEqual([
+			"a1",
+			"p1",
+			"p2",
+		]);
+	});
+});
+
+describe("rangeToMs", () => {
+	it("maps each known range to its millisecond span", () => {
+		expect(rangeToMs("1h")).toBe(H);
+		expect(rangeToMs("6h")).toBe(6 * H);
+		expect(rangeToMs("24h")).toBe(24 * H);
+		expect(rangeToMs("7d")).toBe(7 * 24 * H);
+		expect(rangeToMs("30d")).toBe(30 * 24 * H);
+	});
+
+	it("falls back to 24h for an unknown range (mirrors the endpoint)", () => {
+		expect(rangeToMs("")).toBe(24 * H);
+		expect(rangeToMs("bogus")).toBe(24 * H);
+		expect(rangeToMs("12h")).toBe(24 * H);
+	});
+});
+
+describe("usageEmptyStateMessage", () => {
+	it("prompts to select an account when none is given", () => {
+		expect(usageEmptyStateMessage(undefined)).toContain("Select an account");
+	});
+
+	it("explains paused accounts are not polled", () => {
+		expect(usageEmptyStateMessage(acc("a", "A", true))).toContain("paused");
+	});
+
+	it("shows the collecting message for an active account", () => {
+		expect(usageEmptyStateMessage(acc("a", "A", false))).toContain(
+			"Collecting usage data",
+		);
+	});
+});

--- a/packages/dashboard-web/src/components/usage-history/chart-data.ts
+++ b/packages/dashboard-web/src/components/usage-history/chart-data.ts
@@ -1,0 +1,132 @@
+// packages/dashboard-web/src/components/usage-history/chart-data.ts
+import type { UsageHistoryWindowSeries } from "@better-ccflare/types";
+
+export interface ChartRow {
+	t: number;
+	[key: string]: number | string | null;
+}
+
+const PRED_SUFFIX = "__pred";
+const LIMIT = 100;
+
+/**
+ * Merge per-window actual points AND a 2-point dashed prediction segment for
+ * each rising window into a single time-indexed recharts dataset. The forecast
+ * segment runs from the last actual point to whichever comes first — the ETA
+ * (endpoint 100%) or the window reset (endpoint = predictedAtReset) — so a
+ * barely-positive slope can't stretch the x-domain weeks out (Fable M2).
+ * Missing values are `null` (gaps).
+ */
+export function buildUsageChartData(
+	windows: UsageHistoryWindowSeries[],
+	now: number,
+	horizonMs: number,
+): {
+	rows: ChartRow[];
+	windowKeys: string[];
+	predictionKeys: string[];
+	markers: { x: number; label: string }[];
+} {
+	const windowKeys = windows.map((w) => w.window);
+	const predictionKeys: string[] = [];
+	const byTime = new Map<number, ChartRow>();
+	const ensureRow = (t: number): ChartRow => {
+		let row = byTime.get(t);
+		if (!row) {
+			row = { t };
+			byTime.set(t, row);
+		}
+		return row;
+	};
+
+	for (const w of windows) {
+		for (const p of w.points) ensureRow(p.t)[w.window] = p.utilization;
+
+		const { state, etaExhaustMs, resetsAtMs, predictedAtReset } = w.prediction;
+		if (state === "rising" && etaExhaustMs != null && w.points.length > 0) {
+			const predKey = `${w.window}${PRED_SUFFIX}`;
+			const last = w.points[w.points.length - 1];
+			ensureRow(last.t)[predKey] = last.utilization;
+			// Cap the drawn forecast at the reset when the ETA is beyond it.
+			if (resetsAtMs != null && etaExhaustMs > resetsAtMs) {
+				ensureRow(resetsAtMs)[predKey] = predictedAtReset ?? LIMIT;
+			} else {
+				ensureRow(etaExhaustMs)[predKey] = LIMIT;
+			}
+			predictionKeys.push(predKey);
+		}
+	}
+
+	const allKeys = [...windowKeys, ...predictionKeys];
+	const rows = [...byTime.values()].sort((a, b) => a.t - b.t);
+	for (const row of rows) {
+		for (const k of allKeys) if (!(k in row)) row[k] = null;
+	}
+
+	return {
+		rows,
+		windowKeys,
+		predictionKeys,
+		markers: resetMarkers(windows, now, horizonMs),
+	};
+}
+
+/**
+ * A single vertical marker at the nearest upcoming reset within the forward
+ * horizon — the smallest `resetsAt` with `now < resetsAt <= now + horizonMs`
+ * across all windows' points. Returns `[]` when no reset falls in that window.
+ * The upper bound keeps a far-future reset (e.g. a seven_day reset days out)
+ * from stretching the x-domain past the selected range. Picking the minimum
+ * future value sidesteps the sub-second resets_at jitter that defeated
+ * exact-value dedup and cluttered the chart with a line per window reset.
+ */
+export function resetMarkers(
+	windows: UsageHistoryWindowSeries[],
+	now: number,
+	horizonMs: number,
+): { x: number; label: string }[] {
+	const limit = now + horizonMs;
+	let next: number | null = null;
+	for (const w of windows) {
+		for (const p of w.points) {
+			if (p.resetsAt != null && p.resetsAt > now && p.resetsAt <= limit) {
+				if (next == null || p.resetsAt < next) next = p.resetsAt;
+			}
+		}
+	}
+	return next == null ? [] : [{ x: next, label: "reset" }];
+}
+
+/** Human-readable one-liner about a window's prediction. `now` is injected for determinism. */
+export function formatPredictionAnnotation(
+	series: UsageHistoryWindowSeries,
+	now: number,
+): string {
+	const { window, prediction } = series;
+	const atReset =
+		prediction.predictedAtReset != null
+			? ` (~${Math.round(prediction.predictedAtReset)}% at reset)`
+			: "";
+	// Handle terminal/stable states BEFORE lowConfidence — a stable window with a
+	// short span is "stable", not "rising" (Fable M6).
+	if (prediction.state === "insufficient_data")
+		return `${window}: collecting data…`;
+	if (prediction.state === "exhausted") return `${window}: at limit (100%+) ⛔`;
+	if (prediction.state === "stable") {
+		return `${window}: stable — no exhaustion predicted${atReset}`;
+	}
+	// Only "rising" remains.
+	if (prediction.lowConfidence) {
+		return `${window}: rising — low confidence (need >5 min of data)`;
+	}
+	if (prediction.etaExhaustMs == null) return `${window}: rising${atReset}`;
+	const hours = Math.max(0, (prediction.etaExhaustMs - now) / (60 * 60 * 1000));
+	const eta = hours < 1 ? `${Math.round(hours * 60)}m` : `${hours.toFixed(1)}h`;
+	if (prediction.willExhaustBeforeReset) {
+		return `${window}: ~${eta} to limit ⚠${atReset}`;
+	}
+	// Don't claim "safe until reset" when there is no known reset window (Fable M6).
+	return prediction.resetsAtMs == null
+		? `${window}: rising${atReset}`
+		: `${window}: rising, safe until reset${atReset}`;
+}

--- a/packages/dashboard-web/src/components/usage-history/chart-data.ts
+++ b/packages/dashboard-web/src/components/usage-history/chart-data.ts
@@ -7,15 +7,19 @@ export interface ChartRow {
 }
 
 const PRED_SUFFIX = "__pred";
-const LIMIT = 100;
+const HOUR_MS = 3_600_000;
+
+const clampPct = (v: number): number => Math.max(0, Math.min(100, v));
 
 /**
  * Merge per-window actual points AND a 2-point dashed prediction segment for
  * each rising window into a single time-indexed recharts dataset. The forecast
- * segment runs from the last actual point to whichever comes first — the ETA
- * (endpoint 100%) or the window reset (endpoint = predictedAtReset) — so a
- * barely-positive slope can't stretch the x-domain weeks out (Fable M2).
- * Missing values are `null` (gaps).
+ * segment runs from the last actual point to whichever comes first — the ETA,
+ * this window's OWN reset, or the NEAREST reset across all windows — so neither
+ * a barely-positive slope (Fable M2) nor a far-horizon window (e.g. seven_day
+ * resetting ~13h out while five_hour resets in minutes) can stretch the x-domain
+ * and squish near-term detail. The endpoint value interpolates the straight-line
+ * forecast at that (possibly capped) time. Missing values are `null` (gaps).
  */
 export function buildUsageChartData(
 	windows: UsageHistoryWindowSeries[],
@@ -39,20 +43,33 @@ export function buildUsageChartData(
 		return row;
 	};
 
+	// The single nearest reset > now across all windows (within the horizon). A
+	// far-horizon window's forecast is capped here so it can't stretch the domain.
+	const markers = resetMarkers(windows, now, horizonMs);
+	const nearestResetX = markers[0]?.x ?? null;
+
 	for (const w of windows) {
 		for (const p of w.points) ensureRow(p.t)[w.window] = p.utilization;
 
-		const { state, etaExhaustMs, resetsAtMs, predictedAtReset } = w.prediction;
+		const { state, etaExhaustMs, resetsAtMs, slopePerHour } = w.prediction;
 		if (state === "rising" && etaExhaustMs != null && w.points.length > 0) {
 			const predKey = `${w.window}${PRED_SUFFIX}`;
 			const last = w.points[w.points.length - 1];
 			ensureRow(last.t)[predKey] = last.utilization;
-			// Cap the drawn forecast at the reset when the ETA is beyond it.
-			if (resetsAtMs != null && etaExhaustMs > resetsAtMs) {
-				ensureRow(resetsAtMs)[predKey] = predictedAtReset ?? LIMIT;
-			} else {
-				ensureRow(etaExhaustMs)[predKey] = LIMIT;
-			}
+			// Endpoint time = earliest of ETA, this window's own reset, and the
+			// nearest reset across ALL windows. etaExhaustMs is non-null here, so
+			// there is always at least one candidate.
+			const endpointTime = Math.min(
+				...[etaExhaustMs, resetsAtMs, nearestResetX].filter(
+					(v): v is number => v != null,
+				),
+			);
+			// Interpolate the straight-line forecast at the (possibly capped)
+			// endpoint; an ETA endpoint yields ~100, matching the prior behaviour.
+			const endpointValue = clampPct(
+				last.utilization + slopePerHour * ((endpointTime - last.t) / HOUR_MS),
+			);
+			ensureRow(endpointTime)[predKey] = endpointValue;
 			predictionKeys.push(predKey);
 		}
 	}
@@ -67,7 +84,7 @@ export function buildUsageChartData(
 		rows,
 		windowKeys,
 		predictionKeys,
-		markers: resetMarkers(windows, now, horizonMs),
+		markers,
 	};
 }
 

--- a/packages/dashboard-web/src/components/usage-history/tab-helpers.ts
+++ b/packages/dashboard-web/src/components/usage-history/tab-helpers.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure, structural helpers for the Usage History tab. Kept decoupled from the
+ * full AccountResponse type so they stay trivially testable.
+ *
+ * Background: usage snapshots are only written for NON-paused accounts (the
+ * feature reuses the existing usage poll, which skips paused accounts). So the
+ * default selection and empty-state messaging both need to be paused-aware.
+ */
+export interface AccountLike {
+	id: string;
+	name: string;
+	paused?: boolean | number | null;
+}
+
+/** First non-paused account's id; else the first account's id; else undefined. */
+export function pickDefaultAccount(
+	accounts?: AccountLike[],
+): string | undefined {
+	if (!accounts || accounts.length === 0) return undefined;
+	const active = accounts.find((a) => !a.paused);
+	return (active ?? accounts[0]).id;
+}
+
+/** New array with non-paused accounts first (stable within each group). */
+export function sortAccountsActiveFirst<T extends AccountLike>(
+	accounts: T[],
+): T[] {
+	// Copy first: Array.prototype.sort mutates in place, and callers pass live
+	// query data. V8/Bun sort is stable, so equal-group order is preserved.
+	return [...accounts].sort((a, b) => Number(!!a.paused) - Number(!!b.paused));
+}
+
+/**
+ * Milliseconds spanned by a range string. Mirrors the endpoint's range set
+ * (getRangeConfig: 1h/6h/24h/7d/30d) and its 24h fallback for anything else,
+ * so the chart's forward horizon matches the selected range.
+ */
+export function rangeToMs(range: string): number {
+	const H = 60 * 60 * 1000;
+	switch (range) {
+		case "1h":
+			return H;
+		case "6h":
+			return 6 * H;
+		case "24h":
+			return 24 * H;
+		case "7d":
+			return 7 * 24 * H;
+		case "30d":
+			return 30 * 24 * H;
+		default:
+			return 24 * H;
+	}
+}
+
+/** Empty-state message for the chart, based on the selected account. */
+export function usageEmptyStateMessage(account?: AccountLike): string {
+	if (!account) return "Select an account to view its usage history.";
+	if (account.paused)
+		return "Account is paused — usage isn't polled while paused. Resume it to start collecting history.";
+	return "Collecting usage data… (first points appear within ~1 minute).";
+}

--- a/packages/dashboard-web/src/hooks/queries.ts
+++ b/packages/dashboard-web/src/hooks/queries.ts
@@ -228,6 +228,18 @@ export const useCacheInsights = (timeRange: string, threshold?: number) => {
 	});
 };
 
+export const useUsageHistory = (account: string, range: string) => {
+	return useQuery({
+		queryKey: queryKeys.usageHistory(account, range),
+		queryFn: () => api.getUsageHistory(account, range),
+		staleTime: 45000,
+		refetchInterval: 60000,
+		refetchIntervalInBackground: false,
+		gcTime: 15 * 60 * 1000,
+		enabled: !!account,
+	});
+};
+
 export const useContextInsights = (timeRange: string) => {
 	return useQuery({
 		queryKey: queryKeys.insightsContext(timeRange),

--- a/packages/dashboard-web/src/lib/query-keys.ts
+++ b/packages/dashboard-web/src/lib/query-keys.ts
@@ -32,4 +32,6 @@ export const queryKeys = {
 	families: () => [...queryKeys.all, "families"] as const,
 	apiKeys: () => [...queryKeys.all, "api-keys"] as const,
 	storage: () => [...queryKeys.all, "storage"] as const,
+	usageHistory: (account?: string, range?: string) =>
+		[...queryKeys.all, "usage-history", { account, range }] as const,
 } as const;

--- a/packages/database/src/database-operations.ts
+++ b/packages/database/src/database-operations.ts
@@ -36,6 +36,7 @@ import {
 } from "./repositories/request.repository";
 import { StatsRepository } from "./repositories/stats.repository";
 import { StrategyRepository } from "./repositories/strategy.repository";
+import { UsageHistoryRepository } from "./repositories/usage-history.repository";
 import { withDatabaseRetry } from "./retry";
 
 export interface DatabaseConfig {
@@ -245,6 +246,7 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 	private agentPreferences: AgentPreferenceRepository;
 	private apiKeys: ApiKeyRepository;
 	private combo: ComboRepository;
+	private usageHistory: UsageHistoryRepository;
 
 	constructor(
 		dbPath?: string,
@@ -367,6 +369,7 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 		this.agentPreferences = new AgentPreferenceRepository(this.adapter);
 		this.apiKeys = new ApiKeyRepository(this.adapter);
 		this.combo = new ComboRepository(this.adapter);
+		this.usageHistory = new UsageHistoryRepository(this.adapter);
 	}
 
 	/**
@@ -815,6 +818,32 @@ OAuth tokens will need to be re-authenticated.
 			reset,
 			remaining,
 		);
+	}
+
+	// Usage-history operations delegated to repository
+	getUsageHistoryRepository(): UsageHistoryRepository {
+		return this.usageHistory;
+	}
+
+	async recordUsageSnapshot(
+		accountId: string,
+		usage: Record<string, unknown>,
+		now: number,
+	): Promise<void> {
+		await this.usageHistory.recordSnapshot(accountId, usage, now);
+	}
+
+	async getUsageHistory(opts: {
+		accountId: string;
+		windowKey?: string;
+		since?: number;
+		until?: number;
+	}) {
+		return this.usageHistory.getSeries(opts);
+	}
+
+	async pruneUsageSnapshots(cutoffTs: number): Promise<number> {
+		return this.usageHistory.deleteOlderThan(cutoffTs);
 	}
 
 	async forceResetAccountRateLimit(accountId: string): Promise<boolean> {

--- a/packages/database/src/migrations-pg.ts
+++ b/packages/database/src/migrations-pg.ts
@@ -300,6 +300,10 @@ export async function ensureSchemaPg(adapter: BunSqlAdapter): Promise<void> {
 	await adapter.unsafe(
 		`CREATE INDEX IF NOT EXISTS idx_usage_snapshots_acct_win_time ON usage_snapshots(account_id, window_key, timestamp DESC)`,
 	);
+	// Secondary index on timestamp alone for retention pruning (see SQLite migration).
+	await adapter.unsafe(
+		`CREATE INDEX IF NOT EXISTS idx_usage_snapshots_ts ON usage_snapshots(timestamp)`,
+	);
 
 	log.info("PostgreSQL schema ensured");
 }
@@ -557,6 +561,10 @@ export async function runMigrationsPg(adapter: BunSqlAdapter): Promise<void> {
 	`);
 	await adapter.unsafe(
 		`CREATE INDEX IF NOT EXISTS idx_usage_snapshots_acct_win_time ON usage_snapshots(account_id, window_key, timestamp DESC)`,
+	);
+	// Secondary index on timestamp alone for retention pruning (see SQLite migration).
+	await adapter.unsafe(
+		`CREATE INDEX IF NOT EXISTS idx_usage_snapshots_ts ON usage_snapshots(timestamp)`,
 	);
 
 	// Rename oauth_sessions.mode 'max' → 'claude-oauth'

--- a/packages/database/src/migrations-pg.ts
+++ b/packages/database/src/migrations-pg.ts
@@ -287,6 +287,20 @@ export async function ensureSchemaPg(adapter: BunSqlAdapter): Promise<void> {
 		)
 	`);
 
+	// Create usage_snapshots table (see SQLite migration for rationale).
+	await adapter.unsafe(`
+		CREATE TABLE IF NOT EXISTS usage_snapshots (
+			account_id TEXT NOT NULL,
+			timestamp BIGINT NOT NULL,
+			window_key TEXT NOT NULL,
+			utilization DOUBLE PRECISION NOT NULL,
+			resets_at BIGINT
+		)
+	`);
+	await adapter.unsafe(
+		`CREATE INDEX IF NOT EXISTS idx_usage_snapshots_acct_win_time ON usage_snapshots(account_id, window_key, timestamp DESC)`,
+	);
+
 	log.info("PostgreSQL schema ensured");
 }
 
@@ -530,6 +544,20 @@ export async function runMigrationsPg(adapter: BunSqlAdapter): Promise<void> {
 		VALUES ('fable', NULL, 0), ('opus', NULL, 0), ('sonnet', NULL, 0), ('haiku', NULL, 0)
 		ON CONFLICT (family) DO NOTHING
 	`);
+
+	// Ensure usage_snapshots table exists (for upgrades from pre-usage-history installs)
+	await adapter.unsafe(`
+		CREATE TABLE IF NOT EXISTS usage_snapshots (
+			account_id TEXT NOT NULL,
+			timestamp BIGINT NOT NULL,
+			window_key TEXT NOT NULL,
+			utilization DOUBLE PRECISION NOT NULL,
+			resets_at BIGINT
+		)
+	`);
+	await adapter.unsafe(
+		`CREATE INDEX IF NOT EXISTS idx_usage_snapshots_acct_win_time ON usage_snapshots(account_id, window_key, timestamp DESC)`,
+	);
 
 	// Rename oauth_sessions.mode 'max' → 'claude-oauth'
 	try {

--- a/packages/database/src/migrations.ts
+++ b/packages/database/src/migrations.ts
@@ -351,6 +351,22 @@ export function ensureSchema(db: Database): void {
 		       ('sonnet', NULL, 0),
 		       ('haiku',  NULL, 0);
 	`);
+
+	// Create usage_snapshots table: time series of per-account usage-window
+	// utilization (0–100) captured on each /oauth/usage poll. Append-only, no
+	// surrogate key; queried and pruned by (account_id, window_key, timestamp).
+	db.run(`
+		CREATE TABLE IF NOT EXISTS usage_snapshots (
+			account_id TEXT NOT NULL,
+			timestamp INTEGER NOT NULL,
+			window_key TEXT NOT NULL,
+			utilization REAL NOT NULL,
+			resets_at INTEGER
+		)
+	`);
+	db.run(
+		`CREATE INDEX IF NOT EXISTS idx_usage_snapshots_acct_win_time ON usage_snapshots(account_id, window_key, timestamp DESC)`,
+	);
 }
 
 export function runMigrations(db: Database, dbPath?: string): void {

--- a/packages/database/src/migrations.ts
+++ b/packages/database/src/migrations.ts
@@ -367,6 +367,12 @@ export function ensureSchema(db: Database): void {
 	db.run(
 		`CREATE INDEX IF NOT EXISTS idx_usage_snapshots_acct_win_time ON usage_snapshots(account_id, window_key, timestamp DESC)`,
 	);
+	// Secondary index on timestamp alone so retention pruning
+	// (`DELETE ... WHERE timestamp < ?`) uses an index instead of full-scanning —
+	// the composite index above can't serve it because timestamp isn't leading.
+	db.run(
+		`CREATE INDEX IF NOT EXISTS idx_usage_snapshots_ts ON usage_snapshots(timestamp)`,
+	);
 }
 
 export function runMigrations(db: Database, dbPath?: string): void {

--- a/packages/database/src/repositories/__tests__/usage-history.repository.test.ts
+++ b/packages/database/src/repositories/__tests__/usage-history.repository.test.ts
@@ -1,0 +1,221 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, it } from "bun:test";
+import { BunSqlAdapter } from "../../adapters/bun-sql-adapter";
+import { DatabaseOperations } from "../../database-operations";
+import { ensureSchema, runMigrations } from "../../migrations";
+import { UsageHistoryRepository } from "../usage-history.repository";
+
+function makeDb(): Database {
+	const db = new Database(":memory:");
+	ensureSchema(db);
+	runMigrations(db);
+	return db;
+}
+
+describe("usage_snapshots schema", () => {
+	it("creates the usage_snapshots table", () => {
+		const db = makeDb();
+		const row = db
+			.query(
+				"SELECT name FROM sqlite_master WHERE type='table' AND name='usage_snapshots'",
+			)
+			.get() as { name: string } | null;
+		expect(row?.name).toBe("usage_snapshots");
+		db.close();
+	});
+});
+
+function makeRepo(db: Database): UsageHistoryRepository {
+	return new UsageHistoryRepository(new BunSqlAdapter(db));
+}
+
+describe("UsageHistoryRepository", () => {
+	it("records one row per usage window", async () => {
+		const db = makeDb();
+		const repo = makeRepo(db);
+		await repo.recordSnapshot(
+			"acc1",
+			{
+				five_hour: { utilization: 10, resets_at: "2026-07-05T12:00:00Z" },
+				seven_day: { utilization: 3, resets_at: null },
+				extra_usage: {
+					is_enabled: true,
+					monthly_limit: 5,
+					used_credits: 1,
+					utilization: 20,
+				},
+			},
+			1000,
+		);
+		const rows = await repo.getSeries({ accountId: "acc1" });
+		// extra_usage has no resets_at → not a window → excluded
+		expect(rows.map((r) => r.windowKey).sort()).toEqual([
+			"five_hour",
+			"seven_day",
+		]);
+		const fiveH = rows.find((r) => r.windowKey === "five_hour");
+		expect(fiveH?.utilization).toBe(10);
+		expect(fiveH?.resetsAt).toBe(new Date("2026-07-05T12:00:00Z").getTime());
+		db.close();
+	});
+
+	it("records every poll (no dedup) so flat windows stay a continuous series", async () => {
+		const db = makeDb();
+		const repo = makeRepo(db);
+		const usage = { five_hour: { utilization: 10, resets_at: null } };
+		await repo.recordSnapshot("acc1", usage, 1000);
+		await repo.recordSnapshot("acc1", usage, 2000); // same value → still stored
+		await repo.recordSnapshot(
+			"acc1",
+			{ five_hour: { utilization: 11, resets_at: null } },
+			3000,
+		);
+		const rows = await repo.getSeries({
+			accountId: "acc1",
+			windowKey: "five_hour",
+		});
+		expect(rows.map((r) => r.utilization)).toEqual([10, 10, 11]);
+		expect(rows.map((r) => r.timestamp)).toEqual([1000, 2000, 3000]);
+		db.close();
+	});
+
+	it("skips malformed resets_at (stores null, not NaN)", async () => {
+		const db = makeDb();
+		const repo = makeRepo(db);
+		await repo.recordSnapshot(
+			"acc1",
+			{ five_hour: { utilization: 5, resets_at: "not-a-date" } },
+			1000,
+		);
+		const rows = await repo.getSeries({ accountId: "acc1" });
+		expect(rows[0].resetsAt).toBeNull();
+		db.close();
+	});
+
+	it("filters getSeries by time range and orders ascending", async () => {
+		const db = makeDb();
+		const repo = makeRepo(db);
+		await repo.recordSnapshot(
+			"acc1",
+			{ five_hour: { utilization: 1, resets_at: null } },
+			1000,
+		);
+		await repo.recordSnapshot(
+			"acc1",
+			{ five_hour: { utilization: 2, resets_at: null } },
+			2000,
+		);
+		await repo.recordSnapshot(
+			"acc1",
+			{ five_hour: { utilization: 3, resets_at: null } },
+			3000,
+		);
+		const rows = await repo.getSeries({
+			accountId: "acc1",
+			since: 1500,
+			until: 2500,
+		});
+		expect(rows.map((r) => r.timestamp)).toEqual([2000]);
+		db.close();
+	});
+
+	it("deleteOlderThan prunes by timestamp", async () => {
+		const db = makeDb();
+		const repo = makeRepo(db);
+		await repo.recordSnapshot(
+			"acc1",
+			{ five_hour: { utilization: 1, resets_at: null } },
+			1000,
+		);
+		await repo.recordSnapshot(
+			"acc1",
+			{ five_hour: { utilization: 2, resets_at: null } },
+			5000,
+		);
+		const removed = await repo.deleteOlderThan(3000);
+		expect(removed).toBe(1);
+		const rows = await repo.getSeries({ accountId: "acc1" });
+		expect(rows.map((r) => r.timestamp)).toEqual([5000]);
+		db.close();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Facade smoke test: exercise the usage-history methods through a real
+// in-memory DatabaseOperations. Construction opens no background workers and
+// touches no real path when given ":memory:", so it is safe in a unit test.
+// ---------------------------------------------------------------------------
+
+describe("DatabaseOperations usage-history facade", () => {
+	it("round-trips a snapshot through recordUsageSnapshot / getUsageHistory", async () => {
+		const dbOps = new DatabaseOperations(":memory:", { walMode: false });
+		try {
+			await dbOps.recordUsageSnapshot(
+				"acc1",
+				{ five_hour: { utilization: 42, resets_at: "2026-07-05T12:00:00Z" } },
+				1000,
+			);
+			const rows = await dbOps.getUsageHistory({ accountId: "acc1" });
+			expect(rows).toHaveLength(1);
+			expect(rows[0].windowKey).toBe("five_hour");
+			expect(rows[0].utilization).toBe(42);
+			expect(rows[0].timestamp).toBe(1000);
+			expect(rows[0].resetsAt).toBe(new Date("2026-07-05T12:00:00Z").getTime());
+		} finally {
+			await dbOps.dispose();
+		}
+	});
+
+	it("getUsageHistory forwards windowKey/since/until to getSeries", async () => {
+		const dbOps = new DatabaseOperations(":memory:", { walMode: false });
+		try {
+			await dbOps.recordUsageSnapshot(
+				"acc1",
+				{ five_hour: { utilization: 1, resets_at: null } },
+				1000,
+			);
+			await dbOps.recordUsageSnapshot(
+				"acc1",
+				{ five_hour: { utilization: 2, resets_at: null } },
+				2000,
+			);
+			await dbOps.recordUsageSnapshot(
+				"acc1",
+				{ seven_day: { utilization: 9, resets_at: null } },
+				2000,
+			);
+			const rows = await dbOps.getUsageHistory({
+				accountId: "acc1",
+				windowKey: "five_hour",
+				since: 1500,
+				until: 2500,
+			});
+			expect(rows.map((r) => r.timestamp)).toEqual([2000]);
+			expect(rows[0].windowKey).toBe("five_hour");
+		} finally {
+			await dbOps.dispose();
+		}
+	});
+
+	it("pruneUsageSnapshots deletes rows older than the cutoff and returns the count", async () => {
+		const dbOps = new DatabaseOperations(":memory:", { walMode: false });
+		try {
+			await dbOps.recordUsageSnapshot(
+				"acc1",
+				{ five_hour: { utilization: 1, resets_at: null } },
+				1000,
+			);
+			await dbOps.recordUsageSnapshot(
+				"acc1",
+				{ five_hour: { utilization: 2, resets_at: null } },
+				5000,
+			);
+			const removed = await dbOps.pruneUsageSnapshots(3000);
+			expect(removed).toBe(1);
+			const rows = await dbOps.getUsageHistory({ accountId: "acc1" });
+			expect(rows.map((r) => r.timestamp)).toEqual([5000]);
+		} finally {
+			await dbOps.dispose();
+		}
+	});
+});

--- a/packages/database/src/repositories/__tests__/usage-history.repository.test.ts
+++ b/packages/database/src/repositories/__tests__/usage-history.repository.test.ts
@@ -23,6 +23,17 @@ describe("usage_snapshots schema", () => {
 		expect(row?.name).toBe("usage_snapshots");
 		db.close();
 	});
+
+	it("creates the timestamp prune index", () => {
+		const db = makeDb();
+		const row = db
+			.query(
+				"SELECT name FROM sqlite_master WHERE type='index' AND name='idx_usage_snapshots_ts'",
+			)
+			.get() as { name: string } | null;
+		expect(row?.name).toBe("idx_usage_snapshots_ts");
+		db.close();
+	});
 });
 
 function makeRepo(db: Database): UsageHistoryRepository {

--- a/packages/database/src/repositories/usage-history.repository.ts
+++ b/packages/database/src/repositories/usage-history.repository.ts
@@ -43,20 +43,31 @@ export class UsageHistoryRepository extends BaseRepository<UsageSnapshotRow> {
 		usage: Record<string, unknown>,
 		now: number,
 	): Promise<void> {
+		// Build one value tuple per window, then insert them all in a SINGLE
+		// statement. A multi-row INSERT is atomic (all-or-nothing) on both SQLite
+		// and Postgres, so a failure can no longer leave a partial snapshot the
+		// way the previous await-in-loop of per-window inserts could.
+		const params: unknown[] = [];
+		let count = 0;
 		for (const [windowKey, value] of Object.entries(usage)) {
 			if (!isWindow(value)) continue;
-			const utilization = value.utilization;
 			let resetsAt: number | null = null;
 			if (value.resets_at) {
 				const ms = new Date(value.resets_at).getTime();
 				resetsAt = Number.isFinite(ms) ? ms : null;
 			}
-			await this.run(
-				`INSERT INTO usage_snapshots (account_id, timestamp, window_key, utilization, resets_at)
-				 VALUES (?, ?, ?, ?, ?)`,
-				[accountId, now, windowKey, utilization, resetsAt],
-			);
+			params.push(accountId, now, windowKey, value.utilization, resetsAt);
+			count++;
 		}
+		if (count === 0) return;
+		const rows = Array.from({ length: count }, () => "(?, ?, ?, ?, ?)").join(
+			", ",
+		);
+		await this.run(
+			`INSERT INTO usage_snapshots (account_id, timestamp, window_key, utilization, resets_at)
+			 VALUES ${rows}`,
+			params,
+		);
 	}
 
 	async getSeries(opts: GetSeriesOptions): Promise<UsageSnapshotRow[]> {

--- a/packages/database/src/repositories/usage-history.repository.ts
+++ b/packages/database/src/repositories/usage-history.repository.ts
@@ -1,0 +1,110 @@
+import type { PredictionPoint, UsageSnapshotRow } from "@better-ccflare/types";
+import { BaseRepository } from "./base.repository";
+
+/** Duck-typed usage window: an object with a numeric `utilization` and a `resets_at` key. */
+function isWindow(
+	value: unknown,
+): value is { utilization: number; resets_at: string | null } {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		typeof (value as { utilization?: unknown }).utilization === "number" &&
+		"resets_at" in (value as object)
+	);
+}
+
+interface SnapshotDbRow {
+	account_id: string;
+	timestamp: number;
+	window_key: string;
+	utilization: number;
+	resets_at: number | null;
+}
+
+export interface GetSeriesOptions {
+	accountId: string;
+	windowKey?: string;
+	since?: number;
+	until?: number;
+}
+
+export class UsageHistoryRepository extends BaseRepository<UsageSnapshotRow> {
+	/**
+	 * Insert one row per usage window present in `usage`. One row per successful
+	 * poll (NO dedup) — the prediction fit and the chart both need a faithful,
+	 * near-uniform series; collapsing flat stretches to a single row makes idle
+	 * windows fall out of range queries and biases the regression. Volume is
+	 * bounded by retention pruning instead. `usage` is the raw UsageData-shaped
+	 * record from the provider cache; non-window fields (extra_usage, unknown
+	 * keys) are ignored. A malformed `resets_at` is stored as null, never NaN.
+	 */
+	async recordSnapshot(
+		accountId: string,
+		usage: Record<string, unknown>,
+		now: number,
+	): Promise<void> {
+		for (const [windowKey, value] of Object.entries(usage)) {
+			if (!isWindow(value)) continue;
+			const utilization = value.utilization;
+			let resetsAt: number | null = null;
+			if (value.resets_at) {
+				const ms = new Date(value.resets_at).getTime();
+				resetsAt = Number.isFinite(ms) ? ms : null;
+			}
+			await this.run(
+				`INSERT INTO usage_snapshots (account_id, timestamp, window_key, utilization, resets_at)
+				 VALUES (?, ?, ?, ?, ?)`,
+				[accountId, now, windowKey, utilization, resetsAt],
+			);
+		}
+	}
+
+	async getSeries(opts: GetSeriesOptions): Promise<UsageSnapshotRow[]> {
+		const clauses = ["account_id = ?"];
+		const params: unknown[] = [opts.accountId];
+		if (opts.windowKey) {
+			clauses.push("window_key = ?");
+			params.push(opts.windowKey);
+		}
+		if (opts.since != null) {
+			clauses.push("timestamp >= ?");
+			params.push(opts.since);
+		}
+		if (opts.until != null) {
+			clauses.push("timestamp <= ?");
+			params.push(opts.until);
+		}
+		const rows = await this.query<SnapshotDbRow>(
+			`SELECT account_id, timestamp, window_key, utilization, resets_at
+			 FROM usage_snapshots
+			 WHERE ${clauses.join(" AND ")}
+			 ORDER BY timestamp ASC`,
+			params,
+		);
+		return rows.map((r) => ({
+			accountId: r.account_id,
+			timestamp: Number(r.timestamp),
+			windowKey: r.window_key,
+			utilization: Number(r.utilization),
+			resetsAt: r.resets_at == null ? null : Number(r.resets_at),
+		}));
+	}
+
+	async deleteOlderThan(cutoffTs: number): Promise<number> {
+		return this.runWithChanges(
+			`DELETE FROM usage_snapshots WHERE timestamp < ?`,
+			[cutoffTs],
+		);
+	}
+}
+
+/** Convenience: map snapshot rows to prediction/chart points. */
+export function toPredictionPoints(
+	rows: UsageSnapshotRow[],
+): PredictionPoint[] {
+	return rows.map((r) => ({
+		t: r.timestamp,
+		utilization: r.utilization,
+		resetsAt: r.resetsAt,
+	}));
+}

--- a/packages/http-api/src/handlers/__tests__/usage-history.test.ts
+++ b/packages/http-api/src/handlers/__tests__/usage-history.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "bun:test";
+import type { UsageSnapshotRow } from "@better-ccflare/types";
+import { createUsageHistoryHandler } from "../usage-history";
+
+// Captures the opts passed to getUsageHistory so we can assert filter forwarding.
+function makeContext(rows: UsageSnapshotRow[]) {
+	const calls: Array<{
+		accountId: string;
+		windowKey?: string;
+		since?: number;
+	}> = [];
+	const context = {
+		dbOps: {
+			getUsageHistory: async (opts: {
+				accountId: string;
+				windowKey?: string;
+				since?: number;
+			}) => {
+				calls.push(opts);
+				return rows;
+			},
+		},
+	} as unknown as import("../../types").APIContext;
+	return { context, calls };
+}
+
+describe("createUsageHistoryHandler", () => {
+	it("400s when account is missing", async () => {
+		const { context } = makeContext([]);
+		const handler = createUsageHistoryHandler(context);
+		const res = await handler(new URLSearchParams(""));
+		expect(res.status).toBe(400);
+	});
+
+	it("groups rows by window and includes a prediction", async () => {
+		const H = 60 * 60 * 1000;
+		const rows: UsageSnapshotRow[] = [0, 1, 2, 3].map((h) => ({
+			accountId: "acc1",
+			timestamp: h * H,
+			windowKey: "five_hour",
+			utilization: 10 * h + 10,
+			resetsAt: 20 * H,
+		}));
+		const { context } = makeContext(rows);
+		const handler = createUsageHistoryHandler(context);
+		const res = await handler(new URLSearchParams("account=acc1&range=7d"));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			accountId: string;
+			range: string;
+			windows: {
+				window: string;
+				points: unknown[];
+				prediction: { state: string };
+			}[];
+		};
+		expect(body.accountId).toBe("acc1");
+		expect(body.windows).toHaveLength(1);
+		expect(body.windows[0].window).toBe("five_hour");
+		expect(body.windows[0].points).toHaveLength(4);
+		expect(body.windows[0].prediction.state).toBe("rising");
+	});
+
+	it("echoes the normalized range for an unknown value", async () => {
+		const { context } = makeContext([]);
+		const handler = createUsageHistoryHandler(context);
+		const res = await handler(new URLSearchParams("account=acc1&range=bogus"));
+		const body = (await res.json()) as { range: string };
+		expect(body.range).toBe("24h"); // unknown → getRangeConfig falls back to 24h
+	});
+
+	it("forwards the window filter to getUsageHistory", async () => {
+		const { context, calls } = makeContext([]);
+		const handler = createUsageHistoryHandler(context);
+		await handler(new URLSearchParams("account=acc1&window=seven_day_opus"));
+		expect(calls[0].accountId).toBe("acc1");
+		expect(calls[0].windowKey).toBe("seven_day_opus");
+	});
+
+	it("returns an empty windows array when there are no rows", async () => {
+		const { context } = makeContext([]);
+		const handler = createUsageHistoryHandler(context);
+		const res = await handler(new URLSearchParams("account=acc1"));
+		const body = (await res.json()) as { windows: unknown[] };
+		expect(body.windows).toEqual([]);
+	});
+});

--- a/packages/http-api/src/handlers/accounts.ts
+++ b/packages/http-api/src/handlers/accounts.ts
@@ -2772,6 +2772,13 @@ export function createAccountForceResetRateLimitHandler(
 				const { data: usageData } = await fetchUsageData(account.access_token);
 				if (usageData) {
 					usageCache.set(account.id, usageData);
+					dbOps
+						.recordUsageSnapshot(account.id, usageData, Date.now())
+						.catch((err) =>
+							log.warn(
+								`Failed to record usage snapshot for ${account.name}: ${err}`,
+							),
+						);
 					usagePollTriggered = true;
 				}
 			}

--- a/packages/http-api/src/handlers/usage-history.ts
+++ b/packages/http-api/src/handlers/usage-history.ts
@@ -1,0 +1,70 @@
+// packages/http-api/src/handlers/usage-history.ts
+import {
+	BadRequest,
+	errorResponse,
+	InternalServerError,
+	jsonResponse,
+} from "@better-ccflare/http-common";
+import { Logger } from "@better-ccflare/logger";
+import type {
+	PredictionPoint,
+	UsageHistoryResponse,
+	UsageHistoryWindowSeries,
+} from "@better-ccflare/types";
+import { computeUsagePrediction } from "../services/usage-prediction";
+import type { APIContext } from "../types";
+import { getRangeConfig } from "../utils/query-filters";
+
+const log = new Logger("UsageHistoryHandler");
+
+export function createUsageHistoryHandler(context: APIContext) {
+	return async (searchParams: URLSearchParams): Promise<Response> => {
+		const accountId = searchParams.get("account");
+		if (!accountId) {
+			return errorResponse(
+				BadRequest("Missing required 'account' query parameter"),
+			);
+		}
+		// getRangeConfig returns the normalized effective `range` (unknown values
+		// fall back to 24h) — echo that in the response so it matches startMs.
+		const { startMs, range } = getRangeConfig(
+			searchParams.get("range") ?? "24h",
+		);
+		const windowKey = searchParams.get("window") ?? undefined;
+
+		try {
+			const rows = await context.dbOps.getUsageHistory({
+				accountId,
+				windowKey,
+				since: startMs,
+			});
+
+			const byWindow = new Map<string, PredictionPoint[]>();
+			for (const r of rows) {
+				const arr = byWindow.get(r.windowKey) ?? [];
+				arr.push({
+					t: r.timestamp,
+					utilization: r.utilization,
+					resetsAt: r.resetsAt,
+				});
+				byWindow.set(r.windowKey, arr);
+			}
+
+			const windows: UsageHistoryWindowSeries[] = [...byWindow.entries()]
+				.sort(([a], [b]) => a.localeCompare(b))
+				.map(([window, points]) => ({
+					window,
+					points,
+					prediction: computeUsagePrediction(points),
+				}));
+
+			const response: UsageHistoryResponse = { accountId, range, windows };
+			return jsonResponse(response);
+		} catch (error) {
+			log.error("Usage history error:", error);
+			return errorResponse(
+				InternalServerError("Failed to fetch usage history"),
+			);
+		}
+	};
+}

--- a/packages/http-api/src/router.ts
+++ b/packages/http-api/src/router.ts
@@ -116,6 +116,7 @@ import {
 	createReauthNeededHandler,
 	createTokenHealthHandler,
 } from "./handlers/token-health";
+import { createUsageHistoryHandler } from "./handlers/usage-history";
 import { createVersionCheckHandler } from "./handlers/version";
 import { AuthService } from "./services/auth-service";
 import type { APIContext } from "./types";
@@ -195,6 +196,7 @@ export class APIRouter {
 		const logsStreamHandler = createLogsStreamHandler();
 		const logsHistoryHandler = createLogsHistoryHandler();
 		const analyticsHandler = createAnalyticsHandler(this.context);
+		const usageHistoryHandler = createUsageHistoryHandler(this.context);
 		const cacheInsightsHandler = createCacheInsightsHandler(this.context);
 		const anomalyInsightsHandler = createAnomalyInsightsHandler(this.context);
 		const contextInsightsHandler = createContextInsightsHandler(this.context);
@@ -389,6 +391,9 @@ export class APIRouter {
 		this.handlers.set("GET:/api/analytics", (_req, url) => {
 			return analyticsHandler(url.searchParams);
 		});
+		this.handlers.set("GET:/api/usage-history", (_req, url) =>
+			usageHistoryHandler(url.searchParams),
+		);
 		this.handlers.set("GET:/api/insights/cache", (_req, url) =>
 			cacheInsightsHandler(url.searchParams),
 		);

--- a/packages/http-api/src/services/__tests__/usage-prediction.test.ts
+++ b/packages/http-api/src/services/__tests__/usage-prediction.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "bun:test";
+import type { PredictionPoint } from "@better-ccflare/types";
+import { computeUsagePrediction } from "../usage-prediction";
+
+const H = 60 * 60 * 1000;
+
+describe("computeUsagePrediction", () => {
+	it("returns insufficient_data for < 3 points", () => {
+		const p = computeUsagePrediction([
+			{ t: 0, utilization: 10, resetsAt: null },
+			{ t: H, utilization: 20, resetsAt: null },
+		]);
+		expect(p.state).toBe("insufficient_data");
+		expect(p.etaExhaustMs).toBeNull();
+	});
+
+	it("anchors ETA at current usage and projects usage at reset", () => {
+		const reset = 20 * H;
+		// 10,20,30,40 over 0..3h → slope 10/h, current usage 40 at t=3h
+		const points: PredictionPoint[] = [0, 1, 2, 3].map((h) => ({
+			t: h * H,
+			utilization: 10 * h + 10,
+			resetsAt: reset,
+		}));
+		const p = computeUsagePrediction(points);
+		expect(p.state).toBe("rising");
+		expect(Math.round(p.slopePerHour)).toBe(10);
+		// (100 - 40) / 10 = 6h from t=3h → t=9h
+		expect(Math.round((p.etaExhaustMs ?? 0) / H)).toBe(9);
+		// projected at reset: 40 + 10*(20-3) = 210 → clamped to 100
+		expect(p.predictedAtReset).toBe(100);
+		expect(p.willExhaustBeforeReset).toBe(true);
+		expect(p.lowConfidence).toBe(false);
+	});
+
+	it("is stable (no eta) for flat usage; predictedAtReset ≈ current", () => {
+		const points: PredictionPoint[] = [0, 1, 2, 3].map((h) => ({
+			t: h * H,
+			utilization: 42,
+			resetsAt: 20 * H,
+		}));
+		const p = computeUsagePrediction(points);
+		expect(p.state).toBe("stable");
+		expect(p.etaExhaustMs).toBeNull();
+		expect(p.predictedAtReset).toBe(42);
+		expect(p.willExhaustBeforeReset).toBe(false);
+	});
+
+	it("segments at a resets_at change", () => {
+		const reset1 = 5 * H;
+		const reset2 = 25 * H;
+		const points: PredictionPoint[] = [
+			{ t: 0, utilization: 60, resetsAt: reset1 },
+			{ t: 1 * H, utilization: 90, resetsAt: reset1 },
+			{ t: 2 * H, utilization: 5, resetsAt: reset2 }, // new window
+			{ t: 3 * H, utilization: 6, resetsAt: reset2 },
+			{ t: 4 * H, utilization: 7, resetsAt: reset2 },
+		];
+		const p = computeUsagePrediction(points);
+		expect(p.state).toBe("rising");
+		expect(Math.round(p.slopePerHour)).toBe(1); // post-reset segment only
+		expect(p.resetsAtMs).toBe(reset2);
+	});
+
+	it("tolerates sub-second resets_at jitter within one window (no false segmentation)", () => {
+		// Real Anthropic data: every poll reports the SAME reset instant but the
+		// stored epoch-ms jitters by ~±1s. Exact-inequality segmentation would cut
+		// at every pair → segment length 1 → bogus "insufficient_data". A rising
+		// window with ample data must still read as "rising" across the whole span.
+		const base = 20 * H;
+		const jitter = [120, -300, 80, -50, 200]; // ms, all within ±1s
+		const points: PredictionPoint[] = [0, 1, 2, 3, 4].map((h) => ({
+			t: h * H,
+			utilization: 20 + 10 * h, // 20,30,40,50,60 → slope 10/h
+			resetsAt: base + jitter[h],
+		}));
+		const p = computeUsagePrediction(points);
+		expect(p.state).toBe("rising");
+		expect(Math.round(p.slopePerHour)).toBe(10); // whole segment, not a lone point
+	});
+
+	it("stays stable across resets_at jitter for a flat window", () => {
+		const base = 20 * H;
+		const jitter = [120, -300, 80, -50, 200];
+		const points: PredictionPoint[] = [0, 1, 2, 3, 4].map((h) => ({
+			t: h * H,
+			utilization: 51, // flat
+			resetsAt: base + jitter[h],
+		}));
+		const p = computeUsagePrediction(points);
+		expect(p.state).toBe("stable");
+	});
+
+	it("reports exhausted when the latest sample is at/over 100", () => {
+		const reset = 20 * H;
+		const points: PredictionPoint[] = [
+			{ t: 0, utilization: 80, resetsAt: reset },
+			{ t: 1 * H, utilization: 100, resetsAt: reset },
+			{ t: 2 * H, utilization: 120, resetsAt: reset }, // overage
+		];
+		const p = computeUsagePrediction(points);
+		expect(p.state).toBe("exhausted");
+		expect(p.etaExhaustMs).toBe(2 * H);
+	});
+
+	it("ignores idle null-reset points that would flatten the slope", () => {
+		const reset = 20 * H;
+		const points: PredictionPoint[] = [
+			{ t: 0, utilization: 0, resetsAt: null }, // idle
+			{ t: 1 * H, utilization: 0, resetsAt: null }, // idle
+			{ t: 2 * H, utilization: 0, resetsAt: null }, // idle
+			{ t: 3 * H, utilization: 20, resetsAt: reset },
+			{ t: 4 * H, utilization: 40, resetsAt: reset },
+			{ t: 5 * H, utilization: 60, resetsAt: reset },
+		];
+		const p = computeUsagePrediction(points);
+		expect(p.state).toBe("rising");
+		expect(Math.round(p.slopePerHour)).toBe(20); // active pace, not diluted to ~10
+	});
+
+	it("drops pre-gift data so a mid-period refund never yields a negative slope", () => {
+		const reset = 25 * H;
+		const points: PredictionPoint[] = [
+			{ t: 0, utilization: 60, resetsAt: reset },
+			{ t: 1 * H, utilization: 86, resetsAt: reset },
+			{ t: 2 * H, utilization: 7, resetsAt: reset }, // >5pp drop = refund/gift
+			{ t: 3 * H, utilization: 8, resetsAt: reset },
+			{ t: 4 * H, utilization: 9, resetsAt: reset },
+		];
+		const p = computeUsagePrediction(points);
+		expect(p.slopePerHour).toBeGreaterThan(0); // NOT the bogus negative slope
+		expect(Math.round(p.slopePerHour)).toBe(1); // post-gift trend ~1%/h
+		expect(p.predictedAtReset).not.toBeNull();
+		expect(p.predictedAtReset as number).toBeGreaterThanOrEqual(0); // never "-142%"
+	});
+
+	it("flags lowConfidence and suppresses eta for a sub-5-minute span", () => {
+		const t0 = 1_000_000;
+		const points: PredictionPoint[] = [0, 1, 2].map((i) => ({
+			t: t0 + i * 60 * 1000, // 3 points across 2 minutes
+			utilization: 10 + i * 5,
+			resetsAt: t0 + 5 * H,
+		}));
+		const p = computeUsagePrediction(points);
+		expect(p.lowConfidence).toBe(true);
+		expect(p.etaExhaustMs).toBeNull();
+		expect(p.predictedAtReset).toBeNull();
+	});
+});

--- a/packages/http-api/src/services/usage-prediction.ts
+++ b/packages/http-api/src/services/usage-prediction.ts
@@ -1,0 +1,149 @@
+// packages/http-api/src/services/usage-prediction.ts
+import type { PredictionPoint, UsagePrediction } from "@better-ccflare/types";
+
+const HOUR_MS = 60 * 60 * 1000;
+const MIN_POINTS = 3;
+const MIN_SPAN_MS = 5 * 60 * 1000; // below ~5 min the trend is not trustworthy
+const RESET_DROP_THRESHOLD = 5; // pp drop that marks a reset/refund (not jitter)
+// Real Anthropic polls report the SAME reset instant but the stored epoch-ms
+// jitters by ~±1s. Treat a resets_at change as a new-window boundary only when it
+// exceeds this tolerance — far above the ~1s jitter, far below the smallest real
+// reset shift (5h). Without this, jitter cuts a segment at every pair.
+const RESET_JITTER_TOLERANCE_MS = 60_000;
+const LIMIT = 100; // utilization is 0–100
+
+const clamp = (v: number, lo: number, hi: number) =>
+	Math.max(lo, Math.min(hi, v));
+
+/**
+ * Predict a usage window's trajectory from its recent snapshots. Ported from the
+ * battle-tested `calculate_prediction` in robsonek/claude-usage-dashboard: ETA is
+ * anchored at current usage; a ≥5 pp drop (reset/refund) segments the data; idle
+ * (resets_at == null) readings are excluded when a live window is known; a short
+ * data span is flagged low-confidence.
+ */
+export function computeUsagePrediction(
+	points: PredictionPoint[],
+): UsagePrediction {
+	const sorted = [...points].sort((a, b) => a.t - b.t);
+	const latest = sorted.length ? sorted[sorted.length - 1] : null;
+	const resetsAtMs = latest ? latest.resetsAt : null;
+
+	const base = {
+		slopePerHour: 0,
+		etaExhaustMs: null as number | null,
+		predictedAtReset: null as number | null,
+		resetsAtMs,
+		willExhaustBeforeReset: false,
+		lowConfidence: false,
+	};
+
+	// Already at/over the cap (overage). No forward extrapolation needed.
+	if (latest && latest.utilization >= LIMIT) {
+		return {
+			...base,
+			etaExhaustMs: latest.t,
+			predictedAtReset: LIMIT,
+			willExhaustBeforeReset: true,
+			state: "exhausted",
+		};
+	}
+
+	// When a current-period reset is known, idle readings (resets_at == null) are
+	// NOT part of the active window — including them flattens the slope ~10×.
+	let pts = sorted;
+	if (resetsAtMs != null) {
+		const active = sorted.filter((p) => p.resetsAt != null);
+		if (active.length >= 2) pts = active;
+	}
+
+	// Segment to the current window: cut at the last boundary — a resets_at change
+	// OR a drop larger than RESET_DROP_THRESHOLD (a reset/refund, not measurement
+	// jitter). Regressing across an 86%→7% "gift" would yield a bogus negative slope.
+	let segStart = 0;
+	for (let i = 1; i < pts.length; i++) {
+		const prev = pts[i - 1];
+		const cur = pts[i];
+		// A resets_at change marks a new window only when it moves by MORE than the
+		// jitter tolerance. A null↔value transition is always a boundary; both-null
+		// is never one.
+		const prevReset = prev.resetsAt ?? null;
+		const curReset = cur.resetsAt ?? null;
+		let resetChanged: boolean;
+		if (prevReset == null && curReset == null) {
+			resetChanged = false;
+		} else if (prevReset == null || curReset == null) {
+			resetChanged = true;
+		} else {
+			resetChanged = Math.abs(curReset - prevReset) > RESET_JITTER_TOLERANCE_MS;
+		}
+		const dropped = cur.utilization < prev.utilization - RESET_DROP_THRESHOLD;
+		if (resetChanged || dropped) segStart = i;
+	}
+	const segment = pts.slice(segStart);
+
+	if (segment.length < MIN_POINTS) {
+		return { ...base, state: "insufficient_data" };
+	}
+
+	const first = segment[0];
+	const last = segment[segment.length - 1];
+	const currentUsage = last.utilization;
+	const lowConfidence = last.t - first.t < MIN_SPAN_MS;
+
+	// Least-squares on centered, hour-scaled time (avoids float64 cancellation at
+	// epoch-ms): utilization = a*x + b, x = (t - first.t)/HOUR_MS, a is per-hour.
+	const n = segment.length;
+	let sumX = 0;
+	let sumU = 0;
+	let sumXX = 0;
+	let sumXU = 0;
+	for (const p of segment) {
+		const x = (p.t - first.t) / HOUR_MS;
+		sumX += x;
+		sumU += p.utilization;
+		sumXX += x * x;
+		sumXU += x * p.utilization;
+	}
+	const denom = n * sumXX - sumX * sumX;
+	const a = denom === 0 ? 0 : (n * sumXU - sumX * sumU) / denom; // per hour
+	const slopePerHour = a;
+
+	// "Target line": projected utilization at the reset moment, anchored at current
+	// usage. willExhaustBeforeReset is the raw (unclamped) projection crossing 100.
+	const hoursToReset =
+		resetsAtMs != null ? Math.max(0, (resetsAtMs - last.t) / HOUR_MS) : null;
+	const rawAtReset =
+		hoursToReset != null ? currentUsage + a * hoursToReset : null;
+	const predictedAtReset =
+		!lowConfidence && rawAtReset != null ? clamp(rawAtReset, 0, LIMIT) : null;
+	const willExhaustBeforeReset =
+		!lowConfidence && rawAtReset != null && rawAtReset >= LIMIT;
+
+	if (a <= 0) {
+		return {
+			...base,
+			slopePerHour,
+			predictedAtReset,
+			willExhaustBeforeReset,
+			lowConfidence,
+			state: "stable",
+		};
+	}
+
+	// ETA to 100% anchored at CURRENT usage (not the fitted intercept) — matches
+	// the real latest reading and never lands in the past for a rising trend.
+	const etaExhaustMs = lowConfidence
+		? null
+		: Math.round(last.t + ((LIMIT - currentUsage) / a) * HOUR_MS);
+
+	return {
+		...base,
+		slopePerHour,
+		etaExhaustMs,
+		predictedAtReset,
+		willExhaustBeforeReset,
+		lowConfidence,
+		state: "rising",
+	};
+}

--- a/packages/providers/src/usage-fetcher.ts
+++ b/packages/providers/src/usage-fetcher.ts
@@ -357,6 +357,10 @@ class UsageCache {
 		string,
 		(accountId: string) => void
 	>();
+	private snapshotCallbacks = new Map<
+		string,
+		(accountId: string, data: UsageData) => void
+	>();
 	private inFlightFetches = new Map<
 		string,
 		Promise<{ success: boolean; retryAfterMs: number | null }>
@@ -438,6 +442,7 @@ class UsageCache {
 		customEndpoint?: string | null,
 		onWindowReset?: (accountId: string) => void,
 		onCapacityRestored?: (accountId: string) => void,
+		onSnapshot?: (accountId: string, data: UsageData) => void,
 	) {
 		// Check if provider supports usage tracking
 		if (provider && !supportsUsageTracking(provider)) {
@@ -482,6 +487,11 @@ class UsageCache {
 			this.capacityRestoredCallbacks.set(accountId, onCapacityRestored);
 		} else {
 			this.capacityRestoredCallbacks.delete(accountId);
+		}
+		if (onSnapshot) {
+			this.snapshotCallbacks.set(accountId, onSnapshot);
+		} else {
+			this.snapshotCallbacks.delete(accountId);
 		}
 
 		// Default to 90s if not provided
@@ -546,6 +556,7 @@ class UsageCache {
 			this.failureCounts.delete(accountId);
 			this.windowResetCallbacks.delete(accountId);
 			this.capacityRestoredCallbacks.delete(accountId);
+			this.snapshotCallbacks.delete(accountId);
 			// Clean up cache entry when polling stops to prevent memory leaks
 			this.cache.delete(accountId);
 			this.usageRateLimitedUntil.delete(accountId);
@@ -739,6 +750,8 @@ class UsageCache {
 						data: result.data,
 						timestamp: Date.now(),
 					});
+					const snapshotCb = this.snapshotCallbacks.get(accountId);
+					if (snapshotCb) snapshotCb(accountId, result.data as UsageData);
 					const utilization = getRepresentativeUtilization(
 						result.data as UsageData,
 					);

--- a/packages/proxy/src/auto-refresh-scheduler.ts
+++ b/packages/proxy/src/auto-refresh-scheduler.ts
@@ -618,6 +618,13 @@ export class AutoRefreshScheduler {
 							log.info(
 								`Fetched usage data for ${accountRow.name}: 5h=${usageData.five_hour.utilization}%, 7d=${usageData.seven_day.utilization}%`,
 							);
+							this.proxyContext.dbOps
+								.recordUsageSnapshot(accountRow.id, usageData, Date.now())
+								.catch((err) =>
+									log.warn(
+										`Failed to record usage snapshot for ${accountRow.name}: ${err}`,
+									),
+								);
 						} else {
 							log.warn(
 								`Failed to fetch usage data for ${accountRow.name} after auto-refresh`,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -15,3 +15,4 @@ export * from "./logging";
 export * from "./request";
 export * from "./stats";
 export * from "./strategy";
+export * from "./usage-history";

--- a/packages/types/src/usage-history.ts
+++ b/packages/types/src/usage-history.ts
@@ -1,0 +1,39 @@
+// packages/types/src/usage-history.ts
+
+/** One persisted usage-window measurement. `utilization` is 0–100. */
+export interface UsageSnapshotRow {
+	accountId: string;
+	timestamp: number; // ms epoch — when the snapshot was taken
+	windowKey: string; // e.g. "five_hour" | "seven_day" | "seven_day_opus" | "seven_day_sonnet"
+	utilization: number; // 0–100
+	resetsAt: number | null; // ms epoch when the window resets
+}
+
+/** A single point fed to the prediction fn / chart. */
+export interface PredictionPoint {
+	t: number; // ms epoch
+	utilization: number; // 0–100
+	resetsAt: number | null;
+}
+
+export interface UsagePrediction {
+	slopePerHour: number; // fitted utilization gain per hour over the current segment (0 only when the fit is flat or has too few points)
+	etaExhaustMs: number | null; // ms epoch reaching 100%, anchored at CURRENT usage; null unless rising/exhausted
+	predictedAtReset: number | null; // clamped projected utilization (0–100) at the window reset ("target line"); null if no reset/low-confidence
+	resetsAtMs: number | null; // current window reset (ms epoch)
+	willExhaustBeforeReset: boolean; // the RAW (unclamped) projected-at-reset value >= 100
+	state: "insufficient_data" | "stable" | "rising" | "exhausted";
+	lowConfidence: boolean; // data span < ~5 min — trend not trustworthy; etaExhaustMs/predictedAtReset suppressed (slopePerHour still reported)
+}
+
+export interface UsageHistoryWindowSeries {
+	window: string;
+	points: PredictionPoint[];
+	prediction: UsagePrediction;
+}
+
+export interface UsageHistoryResponse {
+	accountId: string;
+	range: string;
+	windows: UsageHistoryWindowSeries[];
+}


### PR DESCRIPTION
## Usage History — persist usage-window utilization, predict exhaustion, chart it

Adds a per-account, per-window **usage-window utilization time series**, a server-computed **exhaustion prediction**, and a new **Usage History** dashboard tab. Fills the "historical window tracking" gap the `session-window-stats` design left out of scope.

**Reuses the existing `/oauth/usage` poll — no new calls to the Anthropic API.**

### What it does
- **`usage_snapshots` table** — dual migration (SQLite + PostgreSQL, incl. `runMigrationsPg` for PG upgrades). Append-only, no surrogate key, pruned by `(account_id, window_key, timestamp)`.
- **Capture** — an injected `onSnapshot(accountId, data)` callback fires in `UsageCache._doFetchAndCache` (Anthropic branch only), wired at the single Anthropic `startPolling` site plus the two direct-fetch paths (auto-refresh scheduler, force-reset fallback). `packages/providers` gains **no** dependency on `packages/database` — the write is callback-injected. Every write is best-effort (`.catch`, never throws into the poll/refresh path).
- **`GET /api/usage-history?account=&range=&window=`** — groups the series by window, each with a prediction.
- **Prediction** (pure, unit-tested `computeUsagePrediction`) — ETA anchored at current usage, ≥5pp gift/refund segmentation, idle-reading filtering, `predictedAtReset` target line, `lowConfidence` handling, and **tolerance for the ~±1s `resets_at` jitter the usage API reports on every poll** (exact-equality made every poll look like a new window → false "insufficient data").
- **Retention** — `USAGE_HISTORY_RETENTION_DAYS` (default 90); pruning wired into startup + the existing hourly maintenance.
- **Dashboard tab** — numeric time x-axis **bounded to the selected range**, one line per window, a dashed forecast line, a single nearest-upcoming reset marker, per-window annotations, and account (defaults to the first non-paused account) + range selectors. `BaseLineChart` extended (numeric axis, dashed lines, nullable/gap data) **backward-compatibly** — existing charts unaffected.

### Testing
- New tests: config retention, repository + `dbOps` facade, prediction (incl. `resets_at` jitter), API handler, chart-data transforms, tab helpers.
- `bun test` green for all new files; `bun run typecheck` / lint / format clean on the changed code.
- Verified end-to-end against real Anthropic usage data (the `resets_at` jitter fix turns a false `insufficient_data` into a correct `stable`/`rising`).

### Notes
- No version bump included — leaving versioning to the release system.
- Out of scope (v1): CLI readout, threshold alerts, CSV export, cross-account rollups, interactive legend toggling.
