### PR TITLE
feat: migrate Anthropic usage to limits[] (display + model-aware throttling)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,6 +53,7 @@ export {
 	parseModelMappings,
 	validateAndSanitizeModelFallbacks,
 	validateAndSanitizeModelMappings,
+	weeklyScopedWindowKey,
 } from "./model-mappings";
 export {
 	CLAUDE_MODEL_IDS,

--- a/packages/core/src/model-mappings.ts
+++ b/packages/core/src/model-mappings.ts
@@ -30,6 +30,21 @@ export function getModelFamily(
 }
 
 /**
+ * Internal window key for a per-model weekly (weekly_scoped) limit, derived from
+ * the model display name. Kept byte-identical between the dashboard usage rows
+ * and the proxy throttle snapshots so the two match (throttle-window match /
+ * amber highlight). Only needs to start with `seven_day_` (so the pace marker
+ * treats it as a 7-day window) and be stable per model.
+ */
+export function weeklyScopedWindowKey(displayName: string): string {
+	const slug = displayName
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "_")
+		.replace(/^_+|_+$/g, "");
+	return `seven_day_${slug}`;
+}
+
+/**
  * Validate if a model ID is a valid Claude model
  * Accepts any model containing fable, opus, sonnet, or haiku (case-insensitive)
  * @returns true if model matches a known pattern

--- a/packages/core/src/throttle-utils.test.ts
+++ b/packages/core/src/throttle-utils.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "bun:test";
+import {
+	computeWindowStartMs,
+	FIXED_WINDOW_DURATION_MS,
+} from "@better-ccflare/core";
+
+const RESET = 1_700_000_000_000;
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+const SEVEN_DAYS = 7 * DAY;
+
+describe("computeWindowStartMs", () => {
+	it("computes start for explicitly-listed fixed windows", () => {
+		expect(computeWindowStartMs(RESET, "five_hour")).toBe(RESET - 5 * HOUR);
+		expect(computeWindowStartMs(RESET, "seven_day")).toBe(RESET - SEVEN_DAYS);
+		expect(computeWindowStartMs(RESET, "seven_day_opus")).toBe(
+			RESET - SEVEN_DAYS,
+		);
+		expect(computeWindowStartMs(RESET, "seven_day_sonnet")).toBe(
+			RESET - SEVEN_DAYS,
+		);
+		expect(computeWindowStartMs(RESET, "daily")).toBe(RESET - DAY);
+		expect(computeWindowStartMs(RESET, "tokens_limit")).toBe(RESET - 5 * HOUR);
+	});
+
+	it("treats any unlisted seven_day_* tier as a 7-day window (Fable + future tiers)", () => {
+		expect(computeWindowStartMs(RESET, "seven_day_fable")).toBe(
+			RESET - SEVEN_DAYS,
+		);
+		expect(computeWindowStartMs(RESET, "seven_day_future_model")).toBe(
+			RESET - SEVEN_DAYS,
+		);
+	});
+
+	it("stays generic — no per-tier fable entry added to the duration table", () => {
+		expect(FIXED_WINDOW_DURATION_MS.seven_day_fable).toBeUndefined();
+	});
+
+	it("computes monthly start from the preceding month's actual duration", () => {
+		// reset at 2023-03-01 UTC → preceding month is February 2023 (28 days)
+		const marchFirst = Date.UTC(2023, 2, 1);
+		const febDuration = Date.UTC(2023, 2, 1) - Date.UTC(2023, 1, 1);
+		expect(computeWindowStartMs(marchFirst, "monthly")).toBe(
+			marchFirst - febDuration,
+		);
+	});
+
+	it("returns null for unknown non-weekly windows", () => {
+		expect(computeWindowStartMs(RESET, "totally_unknown")).toBeNull();
+		// time_limit is intentionally omitted (ZAI duration unknown)
+		expect(computeWindowStartMs(RESET, "time_limit")).toBeNull();
+	});
+
+	it("returns null for non-finite resetMs", () => {
+		expect(computeWindowStartMs(Number.NaN, "seven_day")).toBeNull();
+		expect(
+			computeWindowStartMs(Number.POSITIVE_INFINITY, "seven_day_fable"),
+		).toBeNull();
+	});
+});

--- a/packages/core/src/throttle-utils.ts
+++ b/packages/core/src/throttle-utils.ts
@@ -69,6 +69,12 @@ export function computeWindowStartMs(
 		return resetMs - actualMonthDurationMs;
 	}
 
-	const durationMs = FIXED_WINDOW_DURATION_MS[window];
+	// Any Anthropic weekly model-tier window (`seven_day_*`, e.g. a new
+	// `seven_day_fable` tier or future tiers) is a 7-day window, even when not
+	// explicitly listed above. This keeps the pace marker / exhaustion
+	// projection generic instead of hardcoded per tier.
+	const durationMs =
+		FIXED_WINDOW_DURATION_MS[window] ??
+		(window.startsWith("seven_day_") ? 7 * 24 * 60 * 60 * 1000 : undefined);
 	return durationMs ? resetMs - durationMs : null;
 }

--- a/packages/dashboard-web/src/components/accounts/RateLimitProgress.test.tsx
+++ b/packages/dashboard-web/src/components/accounts/RateLimitProgress.test.tsx
@@ -35,6 +35,109 @@ describe("RateLimitProgress", () => {
 		expect(html).toContain("Usage (5-hour)");
 	});
 
+	it("renders a generic seven_day_fable tier as 'Fable (Weekly)' with a 0% bar", () => {
+		const reset = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString();
+		const html = renderToStaticMarkup(
+			<RateLimitProgress
+				resetIso={new Date(Date.now() + 60 * 60 * 1000).toISOString()}
+				usageUtilization={10}
+				usageWindow="five_hour"
+				usageData={{
+					five_hour: { utilization: 10, resets_at: reset },
+					seven_day: { utilization: 20, resets_at: reset },
+					seven_day_fable: { utilization: 0, resets_at: reset },
+				}}
+				provider="anthropic"
+				showWeekly
+			/>,
+		);
+
+		// Generic labelling: the new tier is shown without any per-tier hardcoding.
+		expect(html).toContain("Usage (Fable (Weekly))");
+		// utilization: 0 is a valid value — shows "0%", not "N/A".
+		expect(html).toContain("0%");
+		expect(html).not.toContain("N/A");
+	});
+
+	it("renders per-model weekly caps from the limits[] array (Fable red + binding)", () => {
+		const reset = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString();
+		const html = renderToStaticMarkup(
+			<RateLimitProgress
+				resetIso={new Date(Date.now() + 60 * 60 * 1000).toISOString()}
+				usageUtilization={100}
+				usageWindow="seven_day"
+				usageData={{
+					limits: [
+						{
+							kind: "session",
+							group: "session",
+							percent: 32,
+							severity: "normal",
+							resets_at: reset,
+							scope: null,
+							is_active: false,
+						},
+						{
+							kind: "weekly_all",
+							group: "weekly",
+							percent: 92,
+							severity: "critical",
+							resets_at: reset,
+							scope: null,
+							is_active: false,
+						},
+						{
+							kind: "weekly_scoped",
+							group: "weekly",
+							percent: 100,
+							severity: "critical",
+							resets_at: reset,
+							scope: {
+								model: { id: null, display_name: "Fable" },
+								surface: null,
+							},
+							is_active: true,
+						},
+					],
+				}}
+				provider="anthropic"
+				showWeekly
+			/>,
+		);
+		// limits[] rows use the explicit label directly (no "Usage (" wrapper).
+		expect(html).toContain("Fable (Weekly)");
+		expect(html).toContain("100%");
+		// severity critical -> red indicator; is_active -> "binding" marker.
+		expect(html).toContain("bg-red-500");
+		expect(html).toContain("binding");
+		// Session / Weekly group headers.
+		expect(html).toContain("Session");
+		expect(html).toContain("Weekly");
+	});
+
+	it("renders five_hour as 5-hour with N/A when its object has utilization: null", () => {
+		const reset = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+		const html = renderToStaticMarkup(
+			<RateLimitProgress
+				resetIso={reset}
+				usageUtilization={88}
+				usageWindow="five_hour"
+				usageData={{
+					// Present object with null utilization must still render as 5-hour,
+					// and the usageUtilization fallback (88) must NOT leak in.
+					five_hour: { utilization: null, resets_at: reset },
+					seven_day: { utilization: 20, resets_at: reset },
+				}}
+				provider="anthropic"
+				showWeekly
+			/>,
+		);
+
+		expect(html).toContain("Usage (5-hour)");
+		expect(html).toContain("N/A");
+		expect(html).not.toContain("88%");
+	});
+
 	it("does not display a throttled-until time past reset for over-100% usage", () => {
 		const now = Date.now();
 		const resetAt = now + 30 * 1000;
@@ -62,5 +165,92 @@ describe("RateLimitProgress", () => {
 		);
 		expect(html).not.toContain("Until");
 		expect(html).toContain("Less than 1 minute");
+	});
+
+	it("does not color the time-based fallback bar from elapsed time (m4)", () => {
+		// A provider with no usage data hits the time-based else branch, where the
+		// bar percentage is ELAPSED TIME, not usage — it must not turn amber/red.
+		const now = Date.now();
+		// ~98% elapsed of the 5-hour display window.
+		const reset = new Date(now + 5 * 60 * 1000).toISOString();
+		const html = renderToStaticMarkup(
+			<RateLimitProgress
+				resetIso={reset}
+				provider="openai-compatible"
+				showWeekly
+			/>,
+		);
+		expect(html).not.toContain("bg-amber-500");
+		expect(html).not.toContain("bg-red-500");
+	});
+
+	it("uses the model label (not the window slug) in the scoped-row tooltip (n2)", () => {
+		const reset = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString();
+		const html = renderToStaticMarkup(
+			<RateLimitProgress
+				resetIso={new Date(Date.now() + 60 * 60 * 1000).toISOString()}
+				usageUtilization={50}
+				usageWindow="seven_day"
+				usageData={{
+					limits: [
+						{
+							kind: "weekly_scoped",
+							group: "weekly",
+							percent: 50,
+							severity: "normal",
+							resets_at: reset,
+							scope: {
+								model: { id: null, display_name: "Fable 4.5" },
+								surface: null,
+							},
+							is_active: false,
+						},
+					],
+				}}
+				provider="anthropic"
+				showWeekly
+			/>,
+		);
+		// Tooltip renders `${label} usage` — must use the human label, not the
+		// slugified window key ("Fable_4_5 …").
+		expect(html).toContain("Fable 4.5 (Weekly) usage");
+	});
+
+	it("renders a real Session group-header element for limits[] rows (n5)", () => {
+		const reset = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString();
+		const html = renderToStaticMarkup(
+			<RateLimitProgress
+				resetIso={new Date(Date.now() + 60 * 60 * 1000).toISOString()}
+				usageUtilization={30}
+				usageWindow="five_hour"
+				usageData={{
+					limits: [
+						{
+							kind: "session",
+							group: "session",
+							percent: 30,
+							severity: "normal",
+							resets_at: reset,
+							scope: null,
+							is_active: false,
+						},
+						{
+							kind: "weekly_all",
+							group: "weekly",
+							percent: 40,
+							severity: "normal",
+							resets_at: reset,
+							scope: null,
+							is_active: false,
+						},
+					],
+				}}
+				provider="anthropic"
+				showWeekly
+			/>,
+		);
+		// The group header is its own element (ends in </div>), distinct from the
+		// row labels which are <span>s — pins the header markup, not just the text.
+		expect(html).toContain(">Session</div>");
 	});
 });

--- a/packages/dashboard-web/src/components/accounts/RateLimitProgress.tsx
+++ b/packages/dashboard-web/src/components/accounts/RateLimitProgress.tsx
@@ -1,5 +1,5 @@
 import { computeWindowStartMs, registerUIRefresh } from "@better-ccflare/core";
-import type { FullUsageData } from "@better-ccflare/types";
+import type { AnthropicUsageData, FullUsageData } from "@better-ccflare/types";
 import { useEffect, useState } from "react";
 import { cn } from "../../lib/utils";
 import {
@@ -9,6 +9,13 @@ import {
 	providerShowsWeeklyUsage,
 } from "../../utils/provider-utils";
 import { Progress } from "../ui/progress";
+import {
+	collectAnthropicUsageRows,
+	formatWindowName,
+	isWeeklyWindow,
+	severityColor,
+	type UsageDisplay,
+} from "./rate-limit-helpers";
 
 interface RateLimitProgressProps {
 	resetIso: string | null;
@@ -88,6 +95,17 @@ function formatThrottledUntil(throttledUntilMs: number, now: number): string {
 	});
 }
 
+// Map an Anthropic severity (or a >=100% fallback) to a Progress indicator class.
+function severityIndicatorClass(
+	severity: string | undefined,
+	utilization: number | null,
+): string | undefined {
+	const c = severityColor(severity, utilization);
+	if (c === "critical") return "bg-red-500 dark:bg-red-400";
+	if (c === "warning") return "bg-amber-500 dark:bg-amber-400";
+	return undefined;
+}
+
 function computeProjectedMessage(
 	resetTime: string | null,
 	window: string | null,
@@ -108,41 +126,6 @@ function computeProjectedMessage(
 		return `Runs out ${formatDuration(remaining - timeToExhaustMs)} before reset`;
 	}
 	return `Resets ${formatDuration(timeToExhaustMs - remaining)} before exhaustion`;
-}
-
-// Format window name for display
-function formatWindowName(window: string | null): string {
-	if (!window) return "window";
-	switch (window) {
-		case "five_hour":
-			return "5-hour";
-		case "seven_day":
-			return "Weekly";
-		case "seven_day_opus":
-			return "Opus (Weekly)";
-		case "seven_day_sonnet":
-			return "Sonnet (Weekly)";
-		case "daily":
-			return "Daily";
-		case "weekly":
-			return "Weekly";
-		case "monthly":
-			return "Monthly";
-		case "time_limit":
-			return "Time Quota";
-		case "tokens_limit":
-			return "5-hour";
-		case "credits":
-			return "Grok credits";
-		default:
-			return window.replace("_", " ");
-	}
-}
-
-interface UsageDisplay {
-	utilization: number | null;
-	window: string | null;
-	resetTime: string | null;
 }
 
 export function RateLimitProgress({
@@ -253,9 +236,11 @@ export function RateLimitProgress({
 
 	// Anthropic-style quota data is shared by Anthropic and Codex; detect by shape, not provider name.
 	const hasAnthropicStyleData =
-		usageData &&
-		"five_hour" in usageData &&
-		"seven_day" in usageData &&
+		usageData != null &&
+		// Legacy flat windows OR the new generic limits[] array. Never NanoGPT's
+		// object-shaped `limits` — disambiguated with Array.isArray.
+		(("five_hour" in usageData && "seven_day" in usageData) ||
+			Array.isArray((usageData as { limits?: unknown }).limits)) &&
 		!isAlibabaData &&
 		!isZaiData &&
 		!isNanoGPTData;
@@ -363,81 +348,14 @@ export function RateLimitProgress({
 			});
 		}
 	} else if (hasAnthropicStyleData && showWeekly) {
-		// Anthropic usage data - show 5-hour and weekly usage
-		const anthropicData = usageData as {
-			five_hour?: { utilization: number | null; resets_at: string | null };
-			seven_day?: { utilization: number | null; resets_at: string | null };
-			seven_day_opus?: { utilization: number | null; resets_at: string | null };
-			seven_day_sonnet?: {
-				utilization: number | null;
-				resets_at: string | null;
-			};
-		};
-		if (anthropicData?.five_hour) {
-			usages.push({
-				utilization: anthropicData.five_hour.utilization,
-				window: "five_hour",
-				resetTime: anthropicData.five_hour.resets_at,
-			});
-		} else {
-			// Fallback: use the most restrictive window data for 5-hour display
-			usages.push({
+		// Anthropic usage data - show 5-hour, weekly, and any per-model weekly
+		// tier (opus, sonnet, and future tiers such as Fable) generically.
+		usages.push(
+			...collectAnthropicUsageRows(usageData as unknown as AnthropicUsageData, {
 				utilization: usageUtilization ?? null,
-				window: "five_hour",
 				resetTime: resetIso,
-			});
-		}
-
-		// Check if seven_day data exists and has valid utilization
-		if (
-			anthropicData &&
-			anthropicData.seven_day &&
-			anthropicData.seven_day.utilization !== null &&
-			anthropicData.seven_day.utilization !== undefined
-		) {
-			usages.push({
-				utilization: anthropicData.seven_day.utilization,
-				window: "seven_day",
-				resetTime: anthropicData.seven_day.resets_at,
-			});
-		} else {
-			// Add weekly usage as placeholder if data is not available
-			usages.push({
-				utilization: null,
-				window: "seven_day",
-				resetTime: null,
-			});
-		}
-
-		// Check if seven_day_opus data exists, has valid utilization, and resets_at is not null
-		if (
-			anthropicData &&
-			anthropicData.seven_day_opus &&
-			anthropicData.seven_day_opus.utilization !== null &&
-			anthropicData.seven_day_opus.utilization !== undefined &&
-			anthropicData.seven_day_opus.resets_at !== null
-		) {
-			usages.push({
-				utilization: anthropicData.seven_day_opus.utilization,
-				window: "seven_day_opus",
-				resetTime: anthropicData.seven_day_opus.resets_at,
-			});
-		}
-
-		// Check if seven_day_sonnet data exists, has valid utilization, and resets_at is not null
-		if (
-			anthropicData &&
-			anthropicData.seven_day_sonnet &&
-			anthropicData.seven_day_sonnet.utilization !== null &&
-			anthropicData.seven_day_sonnet.utilization !== undefined &&
-			anthropicData.seven_day_sonnet.resets_at !== null
-		) {
-			usages.push({
-				utilization: anthropicData.seven_day_sonnet.utilization,
-				window: "seven_day_sonnet",
-				resetTime: anthropicData.seven_day_sonnet.resets_at,
-			});
-		}
+			}),
+		);
 	} else if (
 		providerShowsWeeklyUsage(provider) &&
 		usageUtilization !== null &&
@@ -507,6 +425,11 @@ export function RateLimitProgress({
 				const percentage = usage.utilization;
 				const isAvailable = percentage !== null;
 
+				// Group header shown before the first row of each group (limits[] rows).
+				const showGroupHeader =
+					usage.group != null && usage.group !== usages[_index - 1]?.group;
+				const groupTitle = usage.group === "session" ? "Session" : "Weekly";
+
 				// Calculate time remaining for this specific window
 				let windowTimeText = "";
 				if (usage.resetTime) {
@@ -523,14 +446,9 @@ export function RateLimitProgress({
 					} else {
 						windowTimeText = `${windowRemainingMinutes}m`;
 					}
-				} else if (usage.window === "seven_day") {
-					// Special handling for weekly data when reset time is not available
-					windowTimeText = "Data unavailable";
-				} else if (
-					usage.window === "seven_day_opus" ||
-					usage.window === "seven_day_sonnet"
-				) {
-					// Special handling for weekly opus/sonnet data when reset time is not available
+				} else if (usage.window && isWeeklyWindow(usage.window)) {
+					// Weekly account/tier windows (seven_day, seven_day_opus,
+					// seven_day_sonnet, seven_day_fable, …) when reset time is unavailable.
 					windowTimeText = "Data unavailable";
 				} else if (usage.window === "daily" || usage.window === "monthly") {
 					// Special handling for NanoGPT when no subscription is active (PayG mode)
@@ -543,7 +461,10 @@ export function RateLimitProgress({
 					!usage.resetTime
 				) {
 					return (
-						<div key={usage.window || "default"} className="space-y-2">
+						<div
+							key={`${usage.window ?? "row"}:${usage.label ?? "default"}`}
+							className="space-y-2"
+						>
 							<div className="flex items-center justify-between">
 								<span className="text-xs text-muted-foreground">
 									No subscription (PayG mode)
@@ -554,7 +475,15 @@ export function RateLimitProgress({
 				}
 
 				return (
-					<div key={usage.window || "default"} className="space-y-2">
+					<div
+						key={`${usage.window ?? "row"}:${usage.label ?? "default"}`}
+						className="space-y-2"
+					>
+						{showGroupHeader && (
+							<div className="pt-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+								{groupTitle}
+							</div>
+						)}
 						{(() => {
 							const expectedPct = computeExpectedPct(
 								usage.resetTime,
@@ -577,7 +506,7 @@ export function RateLimitProgress({
 							const throttleDisplayUntil =
 								windowThrottleUntil ?? usageThrottledUntil;
 							const windowLabel = usage.window
-								? formatWindowName(usage.window)
+								? (usage.label ?? formatWindowName(usage.window))
 								: "Rate limit";
 							const projectedMessage = computeProjectedMessage(
 								usage.resetTime,
@@ -590,7 +519,8 @@ export function RateLimitProgress({
 									<div className="flex items-center justify-between">
 										<span className="text-xs text-muted-foreground">
 											{usage.window
-												? `Usage (${formatWindowName(usage.window)})`
+												? (usage.label ??
+													`Usage (${formatWindowName(usage.window)})`)
 												: "Rate limit window"}
 										</span>
 										<span
@@ -601,6 +531,11 @@ export function RateLimitProgress({
 											)}
 										>
 											{isAvailable ? `${percentage?.toFixed(0)}%` : "N/A"}
+											{usage.isActive && (
+												<span className="ml-1.5 text-[10px] font-normal uppercase tracking-wide text-red-500 dark:text-red-400">
+													binding
+												</span>
+											)}
 										</span>
 									</div>
 									<div className="group relative">
@@ -631,7 +566,14 @@ export function RateLimitProgress({
 											indicatorClassName={
 												isWindowThrottled
 													? "bg-amber-500 dark:bg-amber-400"
-													: undefined
+													: severityIndicatorClass(
+															usage.severity,
+															// Time-based fallback row (window == null) uses elapsed
+															// time as its bar %, not usage -- never color it by that.
+															usage.window == null
+																? null
+																: (percentage ?? null),
+														)
 											}
 										/>
 										{expectedPct !== null && (
@@ -678,9 +620,7 @@ export function RateLimitProgress({
 										: `${windowTimeText} until refresh`}
 								</span>
 								<span className="text-xs text-muted-foreground">
-									{usage.window === "seven_day" ||
-									usage.window === "seven_day_opus" ||
-									usage.window === "seven_day_sonnet" ||
+									{(usage.window && isWeeklyWindow(usage.window)) ||
 									usage.window === "weekly" ||
 									usage.window === "monthly" ||
 									usage.window === "time_limit" ||
@@ -705,9 +645,7 @@ export function RateLimitProgress({
 							</div>
 						)}
 						{!usage.resetTime &&
-							(usage.window === "seven_day" ||
-								usage.window === "seven_day_opus" ||
-								usage.window === "seven_day_sonnet" ||
+							((usage.window && isWeeklyWindow(usage.window)) ||
 								usage.window === "daily" ||
 								usage.window === "monthly") && (
 								<div className="flex items-center justify-between">
@@ -724,6 +662,54 @@ export function RateLimitProgress({
 					</div>
 				);
 			})}
+			{hasAnthropicStyleData &&
+				(() => {
+					const spend = (
+						usageData as {
+							spend?: {
+								enabled?: boolean;
+								percent?: number | null;
+								used?: {
+									amount_minor: number;
+									currency: string;
+									exponent?: number;
+								} | null;
+								currency?: string | null;
+							};
+						}
+					).spend;
+					if (!spend?.enabled) return null;
+					const used = spend.used;
+					const exponent = used?.exponent ?? 2;
+					const rawAmount =
+						used != null ? used.amount_minor / 10 ** exponent : null;
+					const amount =
+						rawAmount != null && Number.isFinite(rawAmount) ? rawAmount : null;
+					const cur = used?.currency ?? spend.currency ?? "USD";
+					const pct = spend.percent ?? null;
+					return (
+						<div className="space-y-2">
+							<div className="flex items-center justify-between">
+								<span className="text-xs text-muted-foreground">
+									Overage credits
+								</span>
+								<span className="text-xs font-medium text-muted-foreground">
+									{amount != null
+										? `${cur} ${amount.toFixed(2)}`
+										: pct != null
+											? `${pct.toFixed(0)}%`
+											: "—"}
+								</span>
+							</div>
+							{pct != null && (
+								<Progress
+									value={Math.min(100, Math.max(0, pct))}
+									className="h-2"
+								/>
+							)}
+						</div>
+					);
+				})()}
 		</div>
 	);
 }

--- a/packages/dashboard-web/src/components/accounts/rate-limit-helpers.test.ts
+++ b/packages/dashboard-web/src/components/accounts/rate-limit-helpers.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, it } from "bun:test";
+import type { AnthropicUsageData, UsageLimit } from "@better-ccflare/types";
+import {
+	collectAnthropicLimitRows,
+	collectAnthropicUsageRows,
+	displayLabel,
+	formatWindowName,
+	isUsageWindow,
+	isWeeklyWindow,
+	severityColor,
+} from "./rate-limit-helpers";
+
+const RESET = "2030-01-01T00:00:00.000Z";
+
+// Mirrors the real /api/oauth/usage `limits[]` shape (session / weekly_all /
+// weekly_scoped Fable), taken from live data.
+const LIMITS_FIXTURE: UsageLimit[] = [
+	{
+		kind: "session",
+		group: "session",
+		percent: 32,
+		severity: "normal",
+		resets_at: RESET,
+		scope: null,
+		is_active: false,
+	},
+	{
+		kind: "weekly_all",
+		group: "weekly",
+		percent: 92,
+		severity: "critical",
+		resets_at: RESET,
+		scope: null,
+		is_active: false,
+	},
+	{
+		kind: "weekly_scoped",
+		group: "weekly",
+		percent: 100,
+		severity: "critical",
+		resets_at: RESET,
+		scope: { model: { id: null, display_name: "Fable" }, surface: null },
+		is_active: true,
+	},
+];
+
+describe("collectAnthropicLimitRows (limits[] primary)", () => {
+	it("maps session / weekly_all / weekly_scoped to the right rows", () => {
+		const rows = collectAnthropicLimitRows(LIMITS_FIXTURE);
+		expect(rows).toHaveLength(3);
+
+		expect(rows[0]).toMatchObject({
+			window: "five_hour",
+			label: "5-hour",
+			utilization: 32,
+			group: "session",
+			severity: "normal",
+			isActive: false,
+		});
+		expect(rows[1]).toMatchObject({
+			window: "seven_day",
+			label: "Weekly",
+			utilization: 92,
+			group: "weekly",
+			severity: "critical",
+		});
+		expect(rows[2]).toMatchObject({
+			window: "seven_day_fable",
+			label: "Fable (Weekly)",
+			utilization: 100,
+			group: "weekly",
+			severity: "critical",
+			isActive: true,
+		});
+		// scoped rows are weekly windows (pace marker + long-date reset apply)
+		expect(isWeeklyWindow(rows[2].window as string)).toBe(true);
+	});
+
+	it("renders multiple weekly_scoped tiers with distinct window keys", () => {
+		const rows = collectAnthropicLimitRows([
+			{
+				kind: "weekly_scoped",
+				group: "weekly",
+				percent: 10,
+				resets_at: RESET,
+				scope: { model: { id: null, display_name: "Opus" }, surface: null },
+			},
+			{
+				kind: "weekly_scoped",
+				group: "weekly",
+				percent: 20,
+				resets_at: RESET,
+				scope: { model: { id: null, display_name: "Sonnet" }, surface: null },
+			},
+		]);
+		expect(rows.map((r) => r.window)).toEqual([
+			"seven_day_opus",
+			"seven_day_sonnet",
+		]);
+		expect(rows.map((r) => r.label)).toEqual([
+			"Opus (Weekly)",
+			"Sonnet (Weekly)",
+		]);
+	});
+
+	it("treats percent 0 as valid but skips null percent", () => {
+		const rows = collectAnthropicLimitRows([
+			{ kind: "session", percent: 0, resets_at: RESET },
+			{ kind: "weekly_all", percent: null, resets_at: RESET },
+		]);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({ window: "five_hour", utilization: 0 });
+	});
+
+	it("skips a weekly_scoped entry without a model display name", () => {
+		const rows = collectAnthropicLimitRows([
+			{ kind: "weekly_scoped", percent: 50, resets_at: RESET, scope: null },
+			{
+				kind: "weekly_scoped",
+				percent: 50,
+				resets_at: RESET,
+				scope: { model: { id: null, display_name: "  " }, surface: null },
+			},
+		]);
+		expect(rows).toHaveLength(0);
+	});
+
+	it("does not render unknown limit kinds", () => {
+		const rows = collectAnthropicLimitRows([
+			{ kind: "session", percent: 5, resets_at: RESET },
+			{ kind: "some_future_kind", percent: 99, resets_at: RESET },
+		]);
+		expect(rows.map((r) => r.window)).toEqual(["five_hour"]);
+	});
+});
+
+describe("collectAnthropicUsageRows (dispatch + legacy fallback)", () => {
+	it("uses limits[] when present", () => {
+		const rows = collectAnthropicUsageRows(
+			{ limits: LIMITS_FIXTURE } as AnthropicUsageData,
+			{ utilization: null, resetTime: null },
+		);
+		expect(rows.map((r) => r.window)).toEqual([
+			"five_hour",
+			"seven_day",
+			"seven_day_fable",
+		]);
+	});
+
+	it("does NOT take the limits path for an object-shaped `limits` (NanoGPT collision)", () => {
+		// NanoGPTUsageData.limits is {daily,monthly} — must not be treated as limits[].
+		const rows = collectAnthropicUsageRows(
+			{ limits: { daily: 1, monthly: 2 } } as unknown as AnthropicUsageData,
+			{ utilization: 7, resetTime: RESET },
+		);
+		// Falls through to legacy path -> only five_hour(fallback) + seven_day placeholder.
+		expect(rows.map((r) => r.window)).toEqual(["five_hour", "seven_day"]);
+	});
+
+	it("falls back to legacy flat windows when limits[] is absent", () => {
+		const rows = collectAnthropicUsageRows(
+			{
+				five_hour: { utilization: 10, resets_at: RESET },
+				seven_day: { utilization: 20, resets_at: RESET },
+				seven_day_fable: { utilization: 55, resets_at: RESET },
+			} as AnthropicUsageData,
+			{ utilization: null, resetTime: null },
+		);
+		expect(rows.map((r) => r.window)).toEqual([
+			"five_hour",
+			"seven_day",
+			"seven_day_fable",
+		]);
+		expect(rows[2].utilization).toBe(55);
+	});
+
+	it("always includes a seven_day placeholder and a five_hour fallback", () => {
+		const rows = collectAnthropicUsageRows({} as AnthropicUsageData, {
+			utilization: 77,
+			resetTime: RESET,
+		});
+		expect(rows.map((r) => r.window)).toEqual(["five_hour", "seven_day"]);
+		expect(rows[0].utilization).toBe(77); // five_hour fallback used
+		expect(rows[1].utilization).toBeNull(); // seven_day placeholder
+	});
+});
+
+describe("severityColor", () => {
+	it("prefers the API severity", () => {
+		expect(severityColor("critical", 10)).toBe("critical");
+		expect(severityColor("warning", 10)).toBe("warning");
+		expect(severityColor("normal", 100)).toBe("normal");
+	});
+	it("derives from utilization when severity is absent", () => {
+		expect(severityColor(undefined, 100)).toBe("critical");
+		expect(severityColor(undefined, 95)).toBe("warning");
+		expect(severityColor(undefined, 40)).toBe("normal");
+		expect(severityColor(undefined, null)).toBe("normal");
+	});
+});
+
+describe("displayLabel", () => {
+	it("prefers an explicit label, else formats the window key", () => {
+		expect(
+			displayLabel({
+				utilization: 1,
+				window: "seven_day_fable",
+				resetTime: RESET,
+				label: "Fable (Weekly)",
+			}),
+		).toBe("Fable (Weekly)");
+		expect(
+			displayLabel({ utilization: 1, window: "five_hour", resetTime: RESET }),
+		).toBe("5-hour");
+	});
+});
+
+describe("isUsageWindow / isWeeklyWindow / formatWindowName (legacy helpers)", () => {
+	it("isUsageWindow requires resets_at + utilization keys", () => {
+		expect(isUsageWindow({ utilization: 0, resets_at: null })).toBe(true);
+		expect(isUsageWindow({ utilization: 5 })).toBe(false); // extra_usage-like
+		expect(isUsageWindow(null)).toBe(false);
+	});
+	it("isWeeklyWindow matches seven_day and seven_day_*", () => {
+		expect(isWeeklyWindow("seven_day")).toBe(true);
+		expect(isWeeklyWindow("seven_day_fable")).toBe(true);
+		expect(isWeeklyWindow("five_hour")).toBe(false);
+	});
+	it("formatWindowName maps generic tiers", () => {
+		expect(formatWindowName("seven_day_fable")).toBe("Fable (Weekly)");
+		expect(formatWindowName("five_hour")).toBe("5-hour");
+		expect(formatWindowName("seven_day")).toBe("Weekly");
+	});
+});
+
+describe("review fixes: limits[] fallback (M2) + group ordering (m1)", () => {
+	it("falls back to legacy flat windows when limits[] is present but empty (M2)", () => {
+		// A limits[] array that yields no rows must not blank the card — the flat
+		// windows still render, keeping the account row consistent with pool tiles.
+		const rows = collectAnthropicUsageRows(
+			{
+				limits: [],
+				five_hour: { utilization: 15, resets_at: RESET },
+				seven_day: { utilization: 25, resets_at: RESET },
+			} as unknown as AnthropicUsageData,
+			{ utilization: null, resetTime: null },
+		);
+		expect(rows.map((r) => r.window)).toEqual(["five_hour", "seven_day"]);
+		expect(rows[0].utilization).toBe(15);
+		expect(rows[1].utilization).toBe(25);
+	});
+
+	it("falls back to legacy when every limits[] entry has null percent (M2)", () => {
+		const rows = collectAnthropicUsageRows(
+			{
+				limits: [
+					{ kind: "session", percent: null, resets_at: RESET },
+					{ kind: "weekly_all", percent: null, resets_at: RESET },
+				],
+				five_hour: { utilization: 42, resets_at: RESET },
+				seven_day: { utilization: 63, resets_at: RESET },
+			} as unknown as AnthropicUsageData,
+			{ utilization: null, resetTime: null },
+		);
+		expect(rows.map((r) => r.window)).toEqual(["five_hour", "seven_day"]);
+		expect(rows[0].utilization).toBe(42);
+	});
+
+	it("orders session before weekly regardless of limits[] array order (m1)", () => {
+		const rows = collectAnthropicLimitRows([
+			{
+				kind: "weekly_all",
+				group: "weekly",
+				percent: 50,
+				resets_at: RESET,
+				scope: null,
+			},
+			{
+				kind: "session",
+				group: "session",
+				percent: 10,
+				resets_at: RESET,
+				scope: null,
+			},
+			{
+				kind: "weekly_scoped",
+				group: "weekly",
+				percent: 90,
+				resets_at: RESET,
+				scope: { model: { id: null, display_name: "Fable" }, surface: null },
+			},
+		]);
+		// session first, then the two weekly rows in their original relative order.
+		expect(rows.map((r) => r.group)).toEqual(["session", "weekly", "weekly"]);
+		expect(rows.map((r) => r.window)).toEqual([
+			"five_hour",
+			"seven_day",
+			"seven_day_fable",
+		]);
+	});
+});

--- a/packages/dashboard-web/src/components/accounts/rate-limit-helpers.test.ts
+++ b/packages/dashboard-web/src/components/accounts/rate-limit-helpers.test.ts
@@ -299,3 +299,47 @@ describe("review fixes: limits[] fallback (M2) + group ordering (m1)", () => {
 		]);
 	});
 });
+
+describe("collectAnthropicLimitRows — scoped identity (Greptile P2)", () => {
+	it("keeps the first scoped occurrence byte-stable and disambiguates duplicates by surface", () => {
+		const rows = collectAnthropicLimitRows([
+			{
+				kind: "weekly_scoped",
+				percent: 50,
+				resets_at: RESET,
+				scope: { model: { id: null, display_name: "Fable" }, surface: "api" },
+			},
+			{
+				kind: "weekly_scoped",
+				percent: 80,
+				resets_at: RESET,
+				scope: {
+					model: { id: null, display_name: "Fable" },
+					surface: "vscode",
+				},
+			},
+		]);
+		// First occurrence keeps the exact seven_day_fable key + label so the m3
+		// throttle-window match, pace marker, and snapshot tests stay stable.
+		expect(rows[0].window).toBe("seven_day_fable");
+		expect(rows[0].label).toBe("Fable (Weekly)");
+		// Same display name, different surface -> distinct window AND label
+		// (no duplicate React keys, distinguishable in projection state).
+		expect(rows[1].window).not.toBe(rows[0].window);
+		expect(rows[1].window?.startsWith("seven_day_")).toBe(true);
+		expect(rows[1].label).not.toBe(rows[0].label);
+	});
+
+	it("leaves a single scoped limit's key/label unchanged (byte-stable)", () => {
+		const rows = collectAnthropicLimitRows([
+			{
+				kind: "weekly_scoped",
+				percent: 50,
+				resets_at: RESET,
+				scope: { model: { id: null, display_name: "Opus" }, surface: "api" },
+			},
+		]);
+		expect(rows[0].window).toBe("seven_day_opus");
+		expect(rows[0].label).toBe("Opus (Weekly)");
+	});
+});

--- a/packages/dashboard-web/src/components/accounts/rate-limit-helpers.test.ts
+++ b/packages/dashboard-web/src/components/accounts/rate-limit-helpers.test.ts
@@ -330,6 +330,25 @@ describe("collectAnthropicLimitRows — scoped identity (Greptile P2)", () => {
 		expect(rows[1].label).not.toBe(rows[0].label);
 	});
 
+	it("does not collide a duplicate counter suffix with a real model slug", () => {
+		// codex/fable: seven_day_fable_1 (dup of "Fable") must not equal
+		// weeklyScopedWindowKey("Fable 1").
+		const s = (name: string): UsageLimit => ({
+			kind: "weekly_scoped",
+			percent: 50,
+			resets_at: RESET,
+			scope: { model: { id: null, display_name: name }, surface: null },
+		});
+		const rows = collectAnthropicLimitRows([
+			s("Fable"),
+			s("Fable"),
+			s("Fable 1"),
+		]);
+		const windows = rows.map((r) => r.window);
+		expect(new Set(windows).size).toBe(3); // all distinct, no collision
+		expect(windows[0]).toBe("seven_day_fable");
+	});
+
 	it("leaves a single scoped limit's key/label unchanged (byte-stable)", () => {
 		const rows = collectAnthropicLimitRows([
 			{

--- a/packages/dashboard-web/src/components/accounts/rate-limit-helpers.test.ts
+++ b/packages/dashboard-web/src/components/accounts/rate-limit-helpers.test.ts
@@ -342,4 +342,22 @@ describe("collectAnthropicLimitRows — scoped identity (Greptile P2)", () => {
 		expect(rows[0].window).toBe("seven_day_opus");
 		expect(rows[0].label).toBe("Opus (Weekly)");
 	});
+
+	it("gives every duplicate a unique window key even when surface repeats", () => {
+		// Greptile P2 re-review: surface alone is not a unique disambiguator.
+		const scoped = (surface: string): UsageLimit => ({
+			kind: "weekly_scoped",
+			percent: 50,
+			resets_at: RESET,
+			scope: { model: { id: null, display_name: "Fable" }, surface },
+		});
+		const rows = collectAnthropicLimitRows([
+			scoped("api"),
+			scoped("api"),
+			scoped("api"),
+		]);
+		const windows = rows.map((r) => r.window);
+		expect(new Set(windows).size).toBe(3); // all distinct -> no duplicate React keys
+		expect(windows[0]).toBe("seven_day_fable"); // first stays byte-stable
+	});
 });

--- a/packages/dashboard-web/src/components/accounts/rate-limit-helpers.ts
+++ b/packages/dashboard-web/src/components/accounts/rate-limit-helpers.ts
@@ -123,6 +123,9 @@ export function collectAnthropicLimitRows(
 	limits: UsageLimit[],
 ): UsageDisplay[] {
 	const rows: UsageDisplay[] = [];
+	// Track scoped window keys so two limits with the same display_name on
+	// different surfaces don't collide (duplicate React keys / indistinguishable).
+	const seenScoped = new Map<string, number>();
 	for (const limit of limits) {
 		if (!limit || limit.percent == null) continue;
 		const base = {
@@ -148,10 +151,24 @@ export function collectAnthropicLimitRows(
 		} else if (limit.kind === "weekly_scoped") {
 			const name = limit.scope?.model?.display_name?.trim();
 			if (!name) continue;
+			const baseWindow = `seven_day_${slugifyModel(name)}`;
+			const seen = seenScoped.get(baseWindow) ?? 0;
+			seenScoped.set(baseWindow, seen + 1);
+			// First occurrence keeps the byte-stable key + label (throttle-window
+			// match, pace marker, snapshot tests). Later duplicates — same
+			// display_name, different scope.surface / model.id — get a distinct
+			// suffix (still seven_day_-prefixed so the pace marker applies) and a
+			// distinct label so React keys and projection state stay unique.
+			const disambig =
+				limit.scope?.surface?.trim() ||
+				limit.scope?.model?.id?.trim() ||
+				String(seen + 1);
 			rows.push({
 				...base,
-				window: `seven_day_${slugifyModel(name)}`,
-				label: `${name} (Weekly)`,
+				window:
+					seen === 0 ? baseWindow : `${baseWindow}_${slugifyModel(disambig)}`,
+				label:
+					seen === 0 ? `${name} (Weekly)` : `${name} (Weekly, ${disambig})`,
 				group: "weekly",
 			});
 		}

--- a/packages/dashboard-web/src/components/accounts/rate-limit-helpers.ts
+++ b/packages/dashboard-web/src/components/accounts/rate-limit-helpers.ts
@@ -113,9 +113,10 @@ export function collectAnthropicLimitRows(
 	limits: UsageLimit[],
 ): UsageDisplay[] {
 	const rows: UsageDisplay[] = [];
-	// Track scoped window keys so two limits with the same display_name on
-	// different surfaces don't collide (duplicate React keys / indistinguishable).
-	const seenScoped = new Map<string, number>();
+	// Track every scoped window key already emitted so duplicates get a unique
+	// suffix that can't collide with each other OR with a real model whose slug
+	// already ends in _<n> (e.g. a "Fable" duplicate vs a model named "Fable 1").
+	const usedWindows = new Set<string>();
 	for (const limit of limits) {
 		if (!limit || limit.percent == null) continue;
 		const base = {
@@ -142,23 +143,28 @@ export function collectAnthropicLimitRows(
 			const name = limit.scope?.model?.display_name?.trim();
 			if (!name) continue;
 			const baseWindow = weeklyScopedWindowKey(name);
-			const seen = seenScoped.get(baseWindow) ?? 0;
-			seenScoped.set(baseWindow, seen + 1);
 			// First occurrence keeps the byte-stable key + label (throttle-window
-			// match, pace marker, snapshot tests). Later duplicates — same
-			// display_name, even the SAME surface/model.id — get a monotonic
-			// counter suffix (guaranteed unique, still seven_day_-prefixed so the
-			// pace marker applies) so React keys / projection state stay distinct;
-			// surface/model.id is label-only context.
+			// match, pace marker, snapshot tests). Later duplicates get the next free
+			// numeric suffix, checked against ALL used scoped keys so it can never
+			// collide with another duplicate or a real model slug; still
+			// seven_day_-prefixed so the pace marker applies. surface/model.id is
+			// label-only context.
+			let window = baseWindow;
+			let n = 0;
+			while (usedWindows.has(window)) {
+				n += 1;
+				window = `${baseWindow}_${n}`;
+			}
+			usedWindows.add(window);
 			const context =
 				limit.scope?.surface?.trim() || limit.scope?.model?.id?.trim();
 			rows.push({
 				...base,
-				window: seen === 0 ? baseWindow : `${baseWindow}_${seen}`,
+				window,
 				label:
-					seen === 0
+					window === baseWindow
 						? `${name} (Weekly)`
-						: `${name} (Weekly, ${context ?? seen + 1})`,
+						: `${name} (Weekly, ${context ?? n})`,
 				group: "weekly",
 			});
 		}

--- a/packages/dashboard-web/src/components/accounts/rate-limit-helpers.ts
+++ b/packages/dashboard-web/src/components/accounts/rate-limit-helpers.ts
@@ -1,0 +1,249 @@
+/**
+ * Pure, testable display helpers for RateLimitProgress.
+ *
+ * Anthropic's usage endpoint now reports the authoritative picture in a generic
+ * `limits[]` array (kinds `session` / `weekly_all` / `weekly_scoped`). Per-model
+ * weekly caps (Fable/Opus/Sonnet) live ONLY there as `weekly_scoped` entries;
+ * the legacy flat `seven_day_*` keys are null on current plans. We render from
+ * `limits[]` when present and fall back to the legacy flat windows otherwise.
+ */
+import type { AnthropicUsageData, UsageLimit } from "@better-ccflare/types";
+
+/** A single progress-bar row rendered by RateLimitProgress. */
+export interface UsageDisplay {
+	utilization: number | null;
+	/** Internal window key (drives pace marker + reset formatting). */
+	window: string | null;
+	resetTime: string | null;
+	/** Explicit display label (used for limits[] rows); falls back to formatWindowName(window). */
+	label?: string;
+	/** Grouping bucket for the UI ("session" | "weekly"). */
+	group?: "session" | "weekly";
+	/** Anthropic-provided severity ("normal" | "warning" | "critical") — drives bar color. */
+	severity?: string;
+	/** True when this is the currently-binding limit (from limits[].is_active). */
+	isActive?: boolean;
+}
+
+/**
+ * Runtime type guard for a legacy Anthropic usage window.
+ *
+ * Requires BOTH `resets_at` and `utilization` keys, which intentionally EXCLUDES
+ * `extra_usage` (has `utilization` but no `resets_at`) and opaque codename fields.
+ */
+export function isUsageWindow(
+	v: unknown,
+): v is { utilization: number | null; resets_at: string | null } {
+	return (
+		typeof v === "object" &&
+		v !== null &&
+		"resets_at" in v &&
+		"utilization" in v
+	);
+}
+
+/** True for the account-level weekly window and every model tier window. */
+export function isWeeklyWindow(window: string): boolean {
+	return window === "seven_day" || window.startsWith("seven_day_");
+}
+
+/**
+ * Human-friendly label for a window key (used for legacy rows that carry no
+ * explicit label). Anthropic weekly tiers map `seven_day_<tier>` -> "<Tier> (Weekly)".
+ */
+export function formatWindowName(window: string | null): string {
+	if (!window) return "window";
+	switch (window) {
+		case "five_hour":
+			return "5-hour";
+		case "seven_day":
+			return "Weekly";
+		case "daily":
+			return "Daily";
+		case "weekly":
+			return "Weekly";
+		case "monthly":
+			return "Monthly";
+		case "time_limit":
+			return "Time Quota";
+		case "tokens_limit":
+			return "5-hour";
+		case "credits":
+			return "Grok credits";
+	}
+
+	if (window.startsWith("seven_day_")) {
+		const tier = window.slice("seven_day_".length);
+		if (tier.length > 0) {
+			const label = tier.charAt(0).toUpperCase() + tier.slice(1);
+			return `${label} (Weekly)`;
+		}
+	}
+
+	return window.replace("_", " ");
+}
+
+/** Resolve the display label for a row (explicit label wins). */
+export function displayLabel(row: UsageDisplay): string {
+	return row.label ?? formatWindowName(row.window);
+}
+
+/** Map an Anthropic severity (or a >=100% fallback) to a bar-color token. */
+export function severityColor(
+	severity: string | undefined,
+	utilization: number | null,
+): "critical" | "warning" | "normal" {
+	if (severity === "critical" || severity === "warning") return severity;
+	if (severity === "normal") return "normal";
+	// No severity provided (legacy rows): derive from utilization.
+	if (utilization != null && utilization >= 100) return "critical";
+	if (utilization != null && utilization >= 90) return "warning";
+	return "normal";
+}
+
+// Slugify a model display name into an internal `seven_day_<slug>` window key.
+// The slug only needs to (a) start with `seven_day_` so the pace marker
+// (computeWindowStartMs) treats it as a 7-day window and (b) be stable per model.
+// The human label is carried separately on the row, so the slug form is cosmetic.
+function slugifyModel(name: string): string {
+	return name
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "_")
+		.replace(/^_+|_+$/g, "");
+}
+
+/**
+ * Build display rows from Anthropic's generic `limits[]` array — the primary,
+ * authoritative source. Order follows the array (session, weekly_all, then
+ * weekly_scoped). Malformed entries (no `percent`, or a scoped entry without a
+ * model display name) are skipped. `is_active` is NOT used to filter — every
+ * valid limit renders; the active one is only flagged for highlighting.
+ */
+export function collectAnthropicLimitRows(
+	limits: UsageLimit[],
+): UsageDisplay[] {
+	const rows: UsageDisplay[] = [];
+	for (const limit of limits) {
+		if (!limit || limit.percent == null) continue;
+		const base = {
+			utilization: limit.percent,
+			resetTime: limit.resets_at,
+			severity: limit.severity,
+			isActive: limit.is_active === true,
+		};
+		if (limit.kind === "session") {
+			rows.push({
+				...base,
+				window: "five_hour",
+				label: "5-hour",
+				group: "session",
+			});
+		} else if (limit.kind === "weekly_all") {
+			rows.push({
+				...base,
+				window: "seven_day",
+				label: "Weekly",
+				group: "weekly",
+			});
+		} else if (limit.kind === "weekly_scoped") {
+			const name = limit.scope?.model?.display_name?.trim();
+			if (!name) continue;
+			rows.push({
+				...base,
+				window: `seven_day_${slugifyModel(name)}`,
+				label: `${name} (Weekly)`,
+				group: "weekly",
+			});
+		}
+		// Unknown kinds are intentionally not rendered.
+	}
+	// Stable-partition session rows before weekly rows so the Session / Weekly
+	// group headers render correctly regardless of the order limits[] arrives in.
+	const sessionRows = rows.filter((r) => r.group === "session");
+	const weeklyRows = rows.filter((r) => r.group !== "session");
+	return [...sessionRows, ...weeklyRows];
+}
+
+// Legacy per-model tier keys (all null on current plans; kept only as a fallback
+// for older API versions that still populate them and omit `limits[]`).
+const LEGACY_MODEL_TIER_WINDOWS = [
+	"seven_day_opus",
+	"seven_day_sonnet",
+	"seven_day_fable",
+	"seven_day_haiku",
+] as const;
+
+/**
+ * Build the ordered list of progress-bar rows for an Anthropic-style payload.
+ *
+ * PRIMARY: when `limits[]` is present (an array — never the NanoGPT `limits`
+ * object), rows come entirely from it via collectAnthropicLimitRows.
+ * FALLBACK: otherwise, the legacy flat windows (five_hour / seven_day / the
+ * per-model allowlist) are used, matching the prior behavior.
+ */
+export function collectAnthropicUsageRows(
+	usage: AnthropicUsageData | null | undefined,
+	fallback: { utilization: number | null; resetTime: string | null },
+): UsageDisplay[] {
+	// PRIMARY path: the generic limits[] array (disambiguated from NanoGPT's
+	// object-shaped `limits` by Array.isArray).
+	if (usage && Array.isArray(usage.limits)) {
+		const rows = collectAnthropicLimitRows(usage.limits);
+		// Only take the limits[] result if it produced usable rows. An empty
+		// array, all-null percents, or scoped entries missing a display name
+		// would otherwise blank the card — fall through to the legacy flat windows
+		// instead, keeping the account row consistent with the pool tiles
+		// (pool-usage.ts also falls back per kind).
+		if (rows.length > 0) return rows;
+	}
+
+	// FALLBACK path: legacy flat windows.
+	const data = (usage ?? {}) as Record<
+		string,
+		{ utilization: number | null; resets_at: string | null } | undefined
+	>;
+	const rows: UsageDisplay[] = [];
+
+	const fiveHour = data.five_hour;
+	if (isUsageWindow(fiveHour)) {
+		rows.push({
+			utilization: fiveHour.utilization,
+			window: "five_hour",
+			resetTime: fiveHour.resets_at,
+		});
+	} else {
+		rows.push({
+			utilization: fallback.utilization,
+			window: "five_hour",
+			resetTime: fallback.resetTime,
+		});
+	}
+
+	const sevenDay = data.seven_day;
+	if (isUsageWindow(sevenDay) && sevenDay.utilization != null) {
+		rows.push({
+			utilization: sevenDay.utilization,
+			window: "seven_day",
+			resetTime: sevenDay.resets_at,
+		});
+	} else {
+		rows.push({ utilization: null, window: "seven_day", resetTime: null });
+	}
+
+	for (const key of LEGACY_MODEL_TIER_WINDOWS) {
+		const window = data[key];
+		if (
+			isUsageWindow(window) &&
+			window.utilization != null &&
+			window.resets_at !== null
+		) {
+			rows.push({
+				utilization: window.utilization,
+				window: key,
+				resetTime: window.resets_at,
+			});
+		}
+	}
+
+	return rows;
+}

--- a/packages/dashboard-web/src/components/accounts/rate-limit-helpers.ts
+++ b/packages/dashboard-web/src/components/accounts/rate-limit-helpers.ts
@@ -7,6 +7,7 @@
  * the legacy flat `seven_day_*` keys are null on current plans. We render from
  * `limits[]` when present and fall back to the legacy flat windows otherwise.
  */
+import { weeklyScopedWindowKey } from "@better-ccflare/core";
 import type { AnthropicUsageData, UsageLimit } from "@better-ccflare/types";
 
 /** A single progress-bar row rendered by RateLimitProgress. */
@@ -101,17 +102,6 @@ export function severityColor(
 	return "normal";
 }
 
-// Slugify a model display name into an internal `seven_day_<slug>` window key.
-// The slug only needs to (a) start with `seven_day_` so the pace marker
-// (computeWindowStartMs) treats it as a 7-day window and (b) be stable per model.
-// The human label is carried separately on the row, so the slug form is cosmetic.
-function slugifyModel(name: string): string {
-	return name
-		.toLowerCase()
-		.replace(/[^a-z0-9]+/g, "_")
-		.replace(/^_+|_+$/g, "");
-}
-
 /**
  * Build display rows from Anthropic's generic `limits[]` array — the primary,
  * authoritative source. Order follows the array (session, weekly_all, then
@@ -151,7 +141,7 @@ export function collectAnthropicLimitRows(
 		} else if (limit.kind === "weekly_scoped") {
 			const name = limit.scope?.model?.display_name?.trim();
 			if (!name) continue;
-			const baseWindow = `seven_day_${slugifyModel(name)}`;
+			const baseWindow = weeklyScopedWindowKey(name);
 			const seen = seenScoped.get(baseWindow) ?? 0;
 			seenScoped.set(baseWindow, seen + 1);
 			// First occurrence keeps the byte-stable key + label (throttle-window

--- a/packages/dashboard-web/src/components/accounts/rate-limit-helpers.ts
+++ b/packages/dashboard-web/src/components/accounts/rate-limit-helpers.ts
@@ -156,19 +156,19 @@ export function collectAnthropicLimitRows(
 			seenScoped.set(baseWindow, seen + 1);
 			// First occurrence keeps the byte-stable key + label (throttle-window
 			// match, pace marker, snapshot tests). Later duplicates — same
-			// display_name, different scope.surface / model.id — get a distinct
-			// suffix (still seven_day_-prefixed so the pace marker applies) and a
-			// distinct label so React keys and projection state stay unique.
-			const disambig =
-				limit.scope?.surface?.trim() ||
-				limit.scope?.model?.id?.trim() ||
-				String(seen + 1);
+			// display_name, even the SAME surface/model.id — get a monotonic
+			// counter suffix (guaranteed unique, still seven_day_-prefixed so the
+			// pace marker applies) so React keys / projection state stay distinct;
+			// surface/model.id is label-only context.
+			const context =
+				limit.scope?.surface?.trim() || limit.scope?.model?.id?.trim();
 			rows.push({
 				...base,
-				window:
-					seen === 0 ? baseWindow : `${baseWindow}_${slugifyModel(disambig)}`,
+				window: seen === 0 ? baseWindow : `${baseWindow}_${seen}`,
 				label:
-					seen === 0 ? `${name} (Weekly)` : `${name} (Weekly, ${disambig})`,
+					seen === 0
+						? `${name} (Weekly)`
+						: `${name} (Weekly, ${context ?? seen + 1})`,
 				group: "weekly",
 			});
 		}

--- a/packages/dashboard-web/src/lib/__tests__/pool-usage.test.ts
+++ b/packages/dashboard-web/src/lib/__tests__/pool-usage.test.ts
@@ -719,3 +719,73 @@ describe("computePoolUsage", () => {
 		expect(sevenDay.earliestResetAccountName).toBe("five-hour-exhausted");
 	});
 });
+
+describe("Anthropic limits[] primary (pool usage)", () => {
+	const RESET_ISO = "2030-01-01T00:00:00.000Z";
+
+	it("isAnthropicStyleShape is true for a limits[]-only payload", () => {
+		expect(
+			isAnthropicStyleShape({
+				limits: [{ kind: "session", percent: 10, resets_at: RESET_ISO }],
+			} as never),
+		).toBe(true);
+	});
+
+	it("reads five_hour / seven_day from limits[] when no flat windows exist", () => {
+		const acc = mkAccount({
+			provider: "anthropic",
+			usageData: {
+				limits: [
+					{ kind: "session", percent: 40, resets_at: RESET_ISO, scope: null },
+					{
+						kind: "weekly_all",
+						percent: 70,
+						resets_at: RESET_ISO,
+						scope: null,
+					},
+				],
+			} as never,
+		});
+		const five = computePoolUsage([acc], "five_hour", NOW);
+		expect(five.contributing[0]?.pct).toBe(40);
+		const seven = computePoolUsage([acc], "seven_day", NOW);
+		expect(seven.contributing[0]?.pct).toBe(70);
+	});
+
+	it("classifies a weekly_all >= 100 from limits[] as seven_day_exhausted", () => {
+		const acc = mkAccount({
+			name: "fable-capped",
+			provider: "anthropic",
+			usageData: {
+				limits: [
+					{ kind: "session", percent: 10, resets_at: RESET_ISO, scope: null },
+					{
+						kind: "weekly_all",
+						percent: 100,
+						resets_at: RESET_ISO,
+						scope: null,
+					},
+				],
+			} as never,
+		});
+		const seven = computePoolUsage([acc], "seven_day", NOW);
+		expect(seven.exhausted.map((e) => e.reason)).toContain(
+			"seven_day_exhausted",
+		);
+	});
+
+	it("falls back to the flat window when the matching kind is absent from limits[]", () => {
+		const acc = mkAccount({
+			provider: "anthropic",
+			usageData: {
+				// limits[] has only a session entry; seven_day must come from the flat window.
+				limits: [
+					{ kind: "session", percent: 20, resets_at: RESET_ISO, scope: null },
+				],
+				seven_day: { utilization: 55, resets_at: RESET_ISO },
+			} as never,
+		});
+		const seven = computePoolUsage([acc], "seven_day", NOW);
+		expect(seven.contributing[0]?.pct).toBe(55);
+	});
+});

--- a/packages/dashboard-web/src/lib/__tests__/pool-usage.test.ts
+++ b/packages/dashboard-web/src/lib/__tests__/pool-usage.test.ts
@@ -788,4 +788,19 @@ describe("Anthropic limits[] primary (pool usage)", () => {
 		const seven = computePoolUsage([acc], "seven_day", NOW);
 		expect(seven.contributing[0]?.pct).toBe(55);
 	});
+
+	it("falls back to the flat window when the limits[] entry exists but percent is null", () => {
+		const acc = mkAccount({
+			provider: "anthropic",
+			usageData: {
+				// session limit present but percent null -> must NOT shadow the flat window.
+				limits: [
+					{ kind: "session", percent: null, resets_at: RESET_ISO, scope: null },
+				],
+				five_hour: { utilization: 33, resets_at: RESET_ISO },
+			} as never,
+		});
+		const five = computePoolUsage([acc], "five_hour", NOW);
+		expect(five.contributing[0]?.pct).toBe(33);
+	});
 });

--- a/packages/dashboard-web/src/lib/pool-usage.ts
+++ b/packages/dashboard-web/src/lib/pool-usage.ts
@@ -110,12 +110,35 @@ export function isAnthropicStyleShape(
 	if (isNanoGPTShape(usageData)) return false;
 	if (isAlibabaShape(usageData)) return false;
 	if (isZaiShape(usageData)) return false;
-	return "five_hour" in usageData && "seven_day" in usageData;
+	return (
+		("five_hour" in usageData && "seven_day" in usageData) ||
+		Array.isArray((usageData as { limits?: unknown }).limits)
+	);
 }
 
 interface ExtractedValue {
 	pct: number | null;
 	resetMs: number | null;
+}
+
+// Read a session / weekly_all entry from Anthropic's generic limits[] array
+// (the authoritative source). NanoGPT's `limits` is an object, so we guard with
+// Array.isArray. Returns null when limits[] is absent -> caller falls back to
+// the legacy flat five_hour / seven_day windows.
+function extractAnthropicLimit(
+	usageData: FullUsageData,
+	kind: "session" | "weekly_all",
+): ExtractedValue | null {
+	const limits = (usageData as { limits?: unknown }).limits;
+	if (!Array.isArray(limits)) return null;
+	const entry = limits.find(
+		(l) => l && typeof l === "object" && (l as { kind?: string }).kind === kind,
+	) as { percent?: number | null; resets_at?: string | null } | undefined;
+	if (!entry) return null;
+	return {
+		pct: entry.percent ?? null,
+		resetMs: normalizeResetMs(entry.resets_at ?? null),
+	};
 }
 
 function extractFiveHour(usageData: FullUsageData): ExtractedValue | null {
@@ -146,6 +169,9 @@ function extractFiveHour(usageData: FullUsageData): ExtractedValue | null {
 		};
 	}
 	if (isAnthropicStyleShape(usageData)) {
+		// PRIMARY: the generic limits[] session entry; FALLBACK: legacy five_hour.
+		const fromLimits = extractAnthropicLimit(usageData, "session");
+		if (fromLimits) return fromLimits;
 		const data = usageData as {
 			five_hour?: { utilization: number | null; resets_at: string | null };
 		};
@@ -176,6 +202,9 @@ function extractSevenDay(usageData: FullUsageData): ExtractedValue | null {
 		return null;
 	}
 	if (isAnthropicStyleShape(usageData)) {
+		// PRIMARY: the generic limits[] weekly_all entry; FALLBACK: legacy seven_day.
+		const fromLimits = extractAnthropicLimit(usageData, "weekly_all");
+		if (fromLimits) return fromLimits;
 		const data = usageData as {
 			seven_day?: { utilization: number | null; resets_at: string | null };
 		};

--- a/packages/dashboard-web/src/lib/pool-usage.ts
+++ b/packages/dashboard-web/src/lib/pool-usage.ts
@@ -134,9 +134,11 @@ function extractAnthropicLimit(
 	const entry = limits.find(
 		(l) => l && typeof l === "object" && (l as { kind?: string }).kind === kind,
 	) as { percent?: number | null; resets_at?: string | null } | undefined;
-	if (!entry) return null;
+	// Absent OR present-but-null percent -> return null so the caller falls back to
+	// the legacy flat window instead of excluding the account as no_usage_data.
+	if (!entry || entry.percent == null) return null;
 	return {
-		pct: entry.percent ?? null,
+		pct: entry.percent,
 		resetMs: normalizeResetMs(entry.resets_at ?? null),
 	};
 }

--- a/packages/http-api/src/handlers/accounts.ts
+++ b/packages/http-api/src/handlers/accounts.ts
@@ -342,7 +342,8 @@ export function createAccountsListHandler(
 					usageData
 				) {
 					const isAnthropicStyleData =
-						"five_hour" in usageData && "seven_day" in usageData;
+						("five_hour" in usageData && "seven_day" in usageData) ||
+						Array.isArray((usageData as { limits?: unknown }).limits);
 					if (isAnthropicStyleData) {
 						try {
 							usageUtilization = getRepresentativeUtilization(

--- a/packages/http-api/src/handlers/accounts.ts
+++ b/packages/http-api/src/handlers/accounts.ts
@@ -69,25 +69,24 @@ function toRateLimitReason(v: string | null): RateLimitReason | null {
 }
 
 function normalizeCodexUsageData(usage: UsageData): UsageData | null {
-	const normalized: UsageData = {
-		five_hour: { ...usage.five_hour },
-		seven_day: { ...usage.seven_day },
-	};
+	// Codex payloads carry the flat windows; default to empty windows if a
+	// limits-only shape ever reaches here (five_hour/seven_day are now optional).
+	let five_hour = usage.five_hour ?? { utilization: 0, resets_at: null };
+	let seven_day = usage.seven_day ?? { utilization: 0, resets_at: null };
 	if (
-		normalized.five_hour.resets_at &&
-		new Date(normalized.five_hour.resets_at).getTime() <= Date.now()
+		five_hour.resets_at &&
+		new Date(five_hour.resets_at).getTime() <= Date.now()
 	) {
-		normalized.five_hour = { utilization: 0, resets_at: null };
+		five_hour = { utilization: 0, resets_at: null };
 	}
 	if (
-		normalized.seven_day.resets_at &&
-		new Date(normalized.seven_day.resets_at).getTime() <= Date.now()
+		seven_day.resets_at &&
+		new Date(seven_day.resets_at).getTime() <= Date.now()
 	) {
-		normalized.seven_day = { utilization: 0, resets_at: null };
+		seven_day = { utilization: 0, resets_at: null };
 	}
-	return normalized.five_hour.resets_at !== null ||
-		normalized.seven_day.resets_at !== null
-		? normalized
+	return five_hour.resets_at !== null || seven_day.resets_at !== null
+		? { five_hour, seven_day }
 		: null;
 }
 

--- a/packages/http-api/src/handlers/accounts.ts
+++ b/packages/http-api/src/handlers/accounts.ts
@@ -71,8 +71,12 @@ function toRateLimitReason(v: string | null): RateLimitReason | null {
 function normalizeCodexUsageData(usage: UsageData): UsageData | null {
 	// Codex payloads carry the flat windows; default to empty windows if a
 	// limits-only shape ever reaches here (five_hour/seven_day are now optional).
-	let five_hour = usage.five_hour ?? { utilization: 0, resets_at: null };
-	let seven_day = usage.seven_day ?? { utilization: 0, resets_at: null };
+	let five_hour = usage.five_hour
+		? { ...usage.five_hour }
+		: { utilization: 0, resets_at: null };
+	let seven_day = usage.seven_day
+		? { ...usage.seven_day }
+		: { utilization: 0, resets_at: null };
 	if (
 		five_hour.resets_at &&
 		new Date(five_hour.resets_at).getTime() <= Date.now()

--- a/packages/http-api/src/handlers/accounts.ts
+++ b/packages/http-api/src/handlers/accounts.ts
@@ -474,6 +474,9 @@ export function createAccountsListHandler(
 						fullUsageData as AnyUsageData,
 						usageThrottleSettings,
 						now,
+						// Display path: surface ALL per-model caps (m3 amber highlight);
+						// routing-side model matching happens in proxy.ts only.
+						{ scopedMode: "all" },
 					);
 					usageThrottledUntil = usageThrottleStatus.throttleUntil;
 					usageThrottledWindows = usageThrottleStatus.throttledWindows;

--- a/packages/providers/src/__tests__/usage-fetcher-limits.test.ts
+++ b/packages/providers/src/__tests__/usage-fetcher-limits.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import type { UsageData } from "../usage-fetcher";
+import {
+	getRepresentativeUtilization,
+	getRepresentativeUtilizationForProvider,
+	getRepresentativeWindow,
+} from "../usage-fetcher";
+
+const R = "2030-01-01T00:00:00.000Z";
+
+// A limits[]-only Anthropic payload (no flat five_hour/seven_day) — the shape
+// Anthropic moves toward. The account-level number must come from limits[]:
+// weekly_all 70 is the hard account cap; the Fable 100% weekly_scoped is a
+// per-model cap and must NOT count as the account-level utilization.
+const limitsOnly = {
+	limits: [
+		{ kind: "session", percent: 40, resets_at: R, scope: null },
+		{ kind: "weekly_all", percent: 70, resets_at: R, scope: null },
+		{
+			kind: "weekly_scoped",
+			percent: 100,
+			resets_at: R,
+			scope: { model: { id: null, display_name: "Fable" }, surface: null },
+		},
+	],
+} as unknown as UsageData;
+
+describe("getRepresentativeUtilization — limits[] (P1)", () => {
+	it("reads account-level session/weekly_all from limits[], ignoring weekly_scoped", () => {
+		expect(getRepresentativeUtilization(limitsOnly)).toBe(70);
+	});
+
+	it("returns null (not 0) when no usable window is present", () => {
+		expect(
+			getRepresentativeUtilization({ limits: [] } as unknown as UsageData),
+		).toBeNull();
+	});
+
+	it("still reads legacy flat windows when limits[] is absent", () => {
+		const flat = {
+			five_hour: { utilization: 30, resets_at: R },
+			seven_day: { utilization: 20, resets_at: R },
+		} as UsageData;
+		expect(getRepresentativeUtilization(flat)).toBe(30);
+	});
+});
+
+describe("getRepresentativeWindow — limits[] (P1)", () => {
+	it("maps the most-restrictive account-level limit to a canonical window key", () => {
+		// weekly_all (70) beats session (40) -> canonical "seven_day".
+		expect(getRepresentativeWindow(limitsOnly)).toBe("seven_day");
+	});
+});
+
+describe("getRepresentativeUtilizationForProvider — limits[] (P1)", () => {
+	it("anthropic reads account-level limits[] (max session/weekly_all)", () => {
+		expect(
+			getRepresentativeUtilizationForProvider(limitsOnly, "anthropic"),
+		).toBe(70);
+	});
+});

--- a/packages/providers/src/__tests__/window-reset-detection.test.ts
+++ b/packages/providers/src/__tests__/window-reset-detection.test.ts
@@ -45,6 +45,18 @@ describe("extractWindowResetTime", () => {
 		expect(extractWindowResetTime(data, "anthropic")).toBeNull();
 	});
 
+	it("falls back to limits[] session resets_at for anthropic limits-only payloads", () => {
+		const resetIso = "2030-03-01T00:00:00.000Z";
+		const data = {
+			limits: [
+				{ kind: "session", percent: 40, resets_at: resetIso, scope: null },
+			],
+		} as unknown as UsageData;
+		expect(extractWindowResetTime(data, "anthropic")).toBe(
+			new Date(resetIso).getTime(),
+		);
+	});
+
 	it("returns parsed credits reset for xai provider", () => {
 		const resetIso = "2030-02-01T00:00:00.000Z";
 		const data: XaiUsageData = {

--- a/packages/providers/src/usage-fetcher.ts
+++ b/packages/providers/src/usage-fetcher.ts
@@ -107,16 +107,15 @@ export function extractWindowResetTime(
 		const zai = data as ZaiUsageData;
 		return zai.tokens_limit?.resetAt ?? null;
 	}
-	if (provider === "anthropic") {
-		const anthropic = data as UsageData;
-		const resetsAt = anthropic.five_hour?.resets_at;
-		if (!resetsAt) return null;
-		const ms = new Date(resetsAt).getTime();
-		return Number.isFinite(ms) ? ms : null;
-	}
-	if (provider === "codex") {
-		const codex = data as UsageData;
-		const resetsAt = codex.five_hour?.resets_at;
+	if (provider === "anthropic" || provider === "codex") {
+		const d = data as UsageData;
+		// Prefer the flat five_hour window; fall back to the limits[] session
+		// entry so limits-only payloads still expose a session reset time.
+		const resetsAt =
+			d.five_hour?.resets_at ??
+			(Array.isArray(d.limits)
+				? (d.limits.find((l) => l?.kind === "session")?.resets_at ?? null)
+				: null);
 		if (!resetsAt) return null;
 		const ms = new Date(resetsAt).getTime();
 		return Number.isFinite(ms) ? ms : null;
@@ -236,6 +235,24 @@ export async function fetchUsageData(
  * Returns the highest utilization across all windows
  * Dynamically handles any usage window fields in the response
  */
+// Account-level utilization from Anthropic's generic limits[] array: session ->
+// five_hour, weekly_all -> seven_day. Per-model (weekly_scoped) caps are excluded
+// — they are mutual fallbacks, not hard account limits.
+function accountLevelLimitWindows(
+	usage: UsageData,
+): Array<{ window: string; util: number }> {
+	if (!Array.isArray(usage.limits)) return [];
+	const out: Array<{ window: string; util: number }> = [];
+	for (const limit of usage.limits) {
+		if (!limit || typeof limit.percent !== "number") continue;
+		if (limit.kind === "session")
+			out.push({ window: "five_hour", util: limit.percent });
+		else if (limit.kind === "weekly_all")
+			out.push({ window: "seven_day", util: limit.percent });
+	}
+	return out;
+}
+
 export function getRepresentativeUtilization(
 	usage: UsageData | null,
 ): number | null {
@@ -266,7 +283,14 @@ export function getRepresentativeUtilization(
 		}
 	}
 
-	return utilizations.length > 0 ? Math.max(...utilizations) : 0;
+	// Fold in Anthropic's generic limits[] account-level caps (session / weekly_all).
+	for (const { util } of accountLevelLimitWindows(usage)) {
+		utilizations.push(util);
+	}
+
+	// Return null (not 0) when nothing was found: 0 reads as "fully available" and
+	// would falsely un-bench an exhausted account (capacity guard) and mis-rank it.
+	return utilizations.length > 0 ? Math.max(...utilizations) : null;
 }
 
 /**
@@ -301,6 +325,10 @@ export function getRepresentativeWindow(
 		) {
 			windows.push({ name: key, util: value.utilization });
 		}
+	}
+
+	for (const { window, util } of accountLevelLimitWindows(usage)) {
+		windows.push({ name: window, util });
 	}
 
 	if (windows.length === 0) return null;
@@ -339,6 +367,8 @@ export function getRepresentativeUtilizationForProvider(
 			// extra_usage has utilization: number | null
 			if (d.extra_usage?.utilization != null)
 				utils.push(d.extra_usage.utilization);
+			// Account-level limits[] caps (session / weekly_all) for limits-only payloads.
+			for (const { util } of accountLevelLimitWindows(d)) utils.push(util);
 			return utils.length > 0 ? Math.max(...utils) : null;
 		}
 		case "nanogpt": {

--- a/packages/providers/src/usage-fetcher.ts
+++ b/packages/providers/src/usage-fetcher.ts
@@ -68,9 +68,10 @@ export interface UsageSpend {
 }
 
 export interface UsageData {
-	// Core windows (always present in older API versions)
-	five_hour: UsageWindow;
-	seven_day: UsageWindow;
+	// Core windows — present on legacy payloads but ABSENT on limits[]-only
+	// payloads (Anthropic is migrating the flat windows into the generic limits[]).
+	five_hour?: UsageWindow;
+	seven_day?: UsageWindow;
 	seven_day_oauth_apps?: UsageWindow;
 	seven_day_opus?: UsageWindow | null;
 	// New fields from 2025-11 API update (all optional for backward compatibility)

--- a/packages/providers/src/usage-fetcher.ts
+++ b/packages/providers/src/usage-fetcher.ts
@@ -40,6 +40,33 @@ export interface ExtraUsage {
 	utilization: number | null;
 }
 
+// Anthropic's generic per-limit representation (2026 usage API). Session and
+// all-models weekly come as kind "session" / "weekly_all"; per-model weekly caps
+// (Fable/Opus/Sonnet) come ONLY as kind "weekly_scoped" with scope.model.
+export interface UsageLimit {
+	kind: string; // "session" | "weekly_all" | "weekly_scoped" | ...
+	group?: string; // "session" | "weekly"
+	percent: number | null;
+	severity?: "normal" | "warning" | "critical" | string;
+	resets_at: string | null;
+	scope?: {
+		model?: { id: string | null; display_name: string } | null;
+		surface?: string | null;
+	} | null;
+	is_active?: boolean;
+}
+
+// Overage / pay-as-you-go credit spend block from the usage payload.
+export interface UsageSpend {
+	used?: { amount_minor: number; currency: string; exponent: number } | null;
+	limit?: unknown;
+	percent?: number | null;
+	severity?: string;
+	enabled?: boolean;
+	currency?: string | null;
+	disabled_reason?: string | null;
+}
+
 export interface UsageData {
 	// Core windows (always present in older API versions)
 	five_hour: UsageWindow;
@@ -48,10 +75,15 @@ export interface UsageData {
 	seven_day_opus?: UsageWindow | null;
 	// New fields from 2025-11 API update (all optional for backward compatibility)
 	seven_day_sonnet?: UsageWindow | null;
+	seven_day_fable?: UsageWindow | null;
 	iguana_necktie?: unknown; // Unknown purpose, keep as flexible type
 	extra_usage?: ExtraUsage;
+	// New generic representation (2026 API): session/weekly_all/weekly_scoped
+	// entries. Per-model weekly caps (Fable/Opus/Sonnet) live ONLY here.
+	limits?: UsageLimit[];
+	spend?: UsageSpend;
 	// Allow any additional fields Anthropic might add in the future
-	[key: string]: UsageWindow | ExtraUsage | unknown;
+	[key: string]: UsageWindow | ExtraUsage | UsageLimit[] | UsageSpend | unknown;
 }
 
 // Union type for all provider usage data

--- a/packages/proxy/src/auto-refresh-scheduler.ts
+++ b/packages/proxy/src/auto-refresh-scheduler.ts
@@ -616,7 +616,7 @@ export class AutoRefreshScheduler {
 						const { data: usageData } = await fetchUsageData(accessToken);
 						if (usageData) {
 							log.info(
-								`Fetched usage data for ${accountRow.name}: 5h=${usageData.five_hour.utilization}%, 7d=${usageData.seven_day.utilization}%`,
+								`Fetched usage data for ${accountRow.name}: 5h=${usageData.five_hour?.utilization ?? "?"}%, 7d=${usageData.seven_day?.utilization ?? "?"}%`,
 							);
 						} else {
 							log.warn(

--- a/packages/proxy/src/handlers/__tests__/usage-throttling.test.ts
+++ b/packages/proxy/src/handlers/__tests__/usage-throttling.test.ts
@@ -220,7 +220,7 @@ describe("model-aware limits[] throttling (Phase 2a)", () => {
 		expect(status.throttledWindows).toContain("seven_day_fable_4_5");
 	});
 
-	it("reads limits[] instead of the flat windows for hybrid payloads (no double-count)", () => {
+	it("prefers limits[] for the windows it carries (weekly_all -> seven_day)", () => {
 		const data = {
 			five_hour: { utilization: 5, resets_at: weekReset },
 			seven_day: { utilization: 5, resets_at: weekReset },
@@ -231,8 +231,9 @@ describe("model-aware limits[] throttling (Phase 2a)", () => {
 		const status = getUsageThrottleStatus(data, settings, NOW, {
 			scopedMode: "all",
 		});
+		// seven_day comes from the limits[] weekly_all (50%, over pace).
 		expect(status.throttledWindows).toContain("seven_day");
-		// flat five_hour is NOT emitted because the limits[] branch wins.
+		// the low flat five_hour (5%) is below pace, so it is not throttled.
 		expect(status.throttledWindows).not.toContain("five_hour");
 	});
 });
@@ -306,6 +307,46 @@ describe("review fixes (codex/grok/fable)", () => {
 			getUsageThrottleStatus(data, settings, NOW, { scopedMode: "all" })
 				.throttledWindows,
 		).toContain("seven_day_mystery");
+	});
+
+	it("does not double-count five_hour when limits[] session and flat five_hour both exist", () => {
+		const data = {
+			five_hour: { utilization: 90, resets_at: fiveReset },
+			limits: [
+				{ kind: "session", percent: 90, resets_at: fiveReset, scope: null },
+			],
+		} as never;
+		const status = getUsageThrottleStatus(data, settings, NOW, {
+			scopedMode: "all",
+		});
+		// five_hour comes from the limits[] session; the flat five_hour is NOT re-added.
+		expect(
+			status.throttledWindows.filter((w) => w === "five_hour"),
+		).toHaveLength(1);
+	});
+
+	it("still evaluates the flat account cap when limits[] carries only a scoped row (Greptile hybrid)", () => {
+		// limits[] has ONLY a per-model Fable cap; the flat five_hour account cap is
+		// exhausted and NOT represented in limits[].
+		const data = {
+			five_hour: { utilization: 95, resets_at: fiveReset },
+			limits: [
+				{
+					kind: "weekly_scoped",
+					percent: 50,
+					resets_at: weekReset,
+					scope: { model: { id: null, display_name: "Fable" }, surface: null },
+				},
+			],
+		} as never;
+		// A Sonnet request: the Fable scoped cap is skipped (family mismatch), but
+		// the exhausted flat five_hour ACCOUNT cap must still throttle.
+		expect(
+			getUsageThrottleUntil(data, settings, NOW, {
+				requestModel: "claude-sonnet-4-5",
+				scopedMode: "match",
+			}),
+		).not.toBeNull();
 	});
 });
 

--- a/packages/proxy/src/handlers/__tests__/usage-throttling.test.ts
+++ b/packages/proxy/src/handlers/__tests__/usage-throttling.test.ts
@@ -140,6 +140,103 @@ describe("getUsageThrottleUntil", () => {
 	});
 });
 
+describe("model-aware limits[] throttling (Phase 2a)", () => {
+	const NOW = Date.UTC(2026, 3, 28, 12, 0, 0);
+	const settings = { fiveHourEnabled: true, weeklyEnabled: true };
+	// A weekly window that started ~1h ago -> any utilization is over the pacing line.
+	const weekReset = new Date(
+		NOW + 7 * 24 * 60 * 60 * 1000 - 60 * 60 * 1000,
+	).toISOString();
+
+	const scoped = (percent: number, displayName = "Fable") =>
+		({
+			limits: [
+				{
+					kind: "weekly_scoped",
+					percent,
+					resets_at: weekReset,
+					scope: {
+						model: { id: null, display_name: displayName },
+						surface: null,
+					},
+				},
+			],
+		}) as never;
+
+	it("reads weekly_scoped from limits[] and throttles it (scopedMode 'all')", () => {
+		const status = getUsageThrottleStatus(scoped(50), settings, NOW, {
+			scopedMode: "all",
+		});
+		expect(status.throttledWindows).toContain("seven_day_fable");
+		expect(status.throttleUntil).not.toBeNull();
+	});
+
+	it("throttles a scoped Fable cap only for the matching request family (match mode)", () => {
+		expect(
+			getUsageThrottleUntil(scoped(50), settings, NOW, {
+				requestModel: "claude-fable-5",
+				scopedMode: "match",
+			}),
+		).not.toBeNull();
+		// An Opus request over the same account is NOT throttled by the Fable cap.
+		expect(
+			getUsageThrottleUntil(scoped(50), settings, NOW, {
+				requestModel: "claude-opus-4-8",
+				scopedMode: "match",
+			}),
+		).toBeNull();
+	});
+
+	it("skips scoped windows when the request model is unknown/combo (null) in match mode", () => {
+		expect(
+			getUsageThrottleUntil(scoped(50), settings, NOW, {
+				requestModel: null,
+				scopedMode: "match",
+			}),
+		).toBeNull();
+	});
+
+	it("throttles weekly_all regardless of the request model", () => {
+		const data = {
+			limits: [
+				{ kind: "weekly_all", percent: 50, resets_at: weekReset, scope: null },
+			],
+		} as never;
+		expect(
+			getUsageThrottleUntil(data, settings, NOW, {
+				requestModel: "claude-opus-4-8",
+				scopedMode: "match",
+			}),
+		).not.toBeNull();
+	});
+
+	it("throttles a dynamic seven_day_<slug> window (isWindowThrottlingEnabled default)", () => {
+		const status = getUsageThrottleStatus(
+			scoped(50, "Fable 4.5"),
+			settings,
+			NOW,
+			{ scopedMode: "all" },
+		);
+		expect(status.throttledWindows).toContain("seven_day_fable_4_5");
+	});
+
+	it("reads limits[] instead of the flat windows for hybrid payloads (no double-count)", () => {
+		const data = {
+			five_hour: { utilization: 5, resets_at: weekReset },
+			seven_day: { utilization: 5, resets_at: weekReset },
+			limits: [
+				{ kind: "weekly_all", percent: 50, resets_at: weekReset, scope: null },
+			],
+		} as never;
+		const status = getUsageThrottleStatus(data, settings, NOW, {
+			scopedMode: "all",
+		});
+		expect(status.throttledWindows).toContain("seven_day");
+		// flat five_hour is NOT emitted because the limits[] branch wins.
+		expect(status.throttledWindows).not.toContain("five_hour");
+	});
+});
+
 describe("createUsageThrottledResponse", () => {
 	it("returns HTTP 529 with Retry-After and an Anthropic-style overload body", async () => {
 		const response = createUsageThrottledResponse([

--- a/packages/proxy/src/handlers/__tests__/usage-throttling.test.ts
+++ b/packages/proxy/src/handlers/__tests__/usage-throttling.test.ts
@@ -237,6 +237,78 @@ describe("model-aware limits[] throttling (Phase 2a)", () => {
 	});
 });
 
+describe("review fixes (codex/grok/fable)", () => {
+	const NOW = Date.UTC(2026, 3, 28, 12, 0, 0);
+	const settings = { fiveHourEnabled: true, weeklyEnabled: true };
+	const weekReset = new Date(
+		NOW + 7 * 24 * 60 * 60 * 1000 - 60 * 60 * 1000,
+	).toISOString();
+	const fiveReset = new Date(
+		NOW + 5 * 60 * 60 * 1000 - 60 * 60 * 1000,
+	).toISOString();
+
+	it("falls back to flat windows when limits[] is present but empty", () => {
+		const data = {
+			limits: [],
+			five_hour: { utilization: 50, resets_at: fiveReset },
+			seven_day: { utilization: 50, resets_at: weekReset },
+		} as never;
+		const status = getUsageThrottleStatus(data, settings, NOW, {
+			scopedMode: "all",
+		});
+		expect(status.throttledWindows).toContain("five_hour");
+	});
+
+	it("falls back to flat windows when every limits[] entry has null percent", () => {
+		const data = {
+			limits: [
+				{ kind: "session", percent: null, resets_at: fiveReset, scope: null },
+				{
+					kind: "weekly_all",
+					percent: null,
+					resets_at: weekReset,
+					scope: null,
+				},
+			],
+			five_hour: { utilization: 50, resets_at: fiveReset },
+			seven_day: { utilization: 50, resets_at: weekReset },
+		} as never;
+		const status = getUsageThrottleStatus(data, settings, NOW, {
+			scopedMode: "all",
+		});
+		expect(status.throttledWindows).toContain("five_hour");
+	});
+
+	it("does NOT throttle a scoped cap with an unmapped model family in match mode", () => {
+		// "Mystery" contains no fable/opus/sonnet/haiku -> modelFamily undefined.
+		const data = {
+			limits: [
+				{
+					kind: "weekly_scoped",
+					percent: 50,
+					resets_at: weekReset,
+					scope: {
+						model: { id: null, display_name: "Mystery" },
+						surface: null,
+					},
+				},
+			],
+		} as never;
+		// match mode with any model -> scoped skipped (cannot attribute) -> no throttle.
+		expect(
+			getUsageThrottleUntil(data, settings, NOW, {
+				requestModel: "claude-opus-4-8",
+				scopedMode: "match",
+			}),
+		).toBeNull();
+		// all mode (display) still surfaces the cap.
+		expect(
+			getUsageThrottleStatus(data, settings, NOW, { scopedMode: "all" })
+				.throttledWindows,
+		).toContain("seven_day_mystery");
+	});
+});
+
 describe("createUsageThrottledResponse", () => {
 	it("returns HTTP 529 with Retry-After and an Anthropic-style overload body", async () => {
 		const response = createUsageThrottledResponse([

--- a/packages/proxy/src/handlers/response-processor.ts
+++ b/packages/proxy/src/handlers/response-processor.ts
@@ -118,7 +118,7 @@ export function updateAccountMetadata(
 
 			usageCache.set(account.id, codexUsage);
 			log.debug(
-				`Updated Codex usage cache for ${account.name}: 5h=${codexUsage.five_hour.utilization}%, 7d=${codexUsage.seven_day.utilization}%`,
+				`Updated Codex usage cache for ${account.name}: 5h=${codexUsage.five_hour?.utilization ?? "?"}%, 7d=${codexUsage.seven_day?.utilization ?? "?"}%`,
 			);
 
 			// Update rate_limit_reset from usage headers so auto-refresh can track windows

--- a/packages/proxy/src/handlers/usage-throttling.ts
+++ b/packages/proxy/src/handlers/usage-throttling.ts
@@ -72,13 +72,17 @@ function collectWindows(data: AnyUsageData | null): UsageWindowSnapshot[] {
 	// (with modelFamily so throttling can be scoped to the request's model).
 	if (Array.isArray((data as { limits?: unknown }).limits)) {
 		const limits = (data as { limits: AnthropicLimit[] }).limits;
+		let hasSession = false;
+		let hasWeeklyAll = false;
 		for (const l of limits) {
 			if (!l || typeof l.percent !== "number") continue;
 			const resetMs = l.resets_at ? new Date(l.resets_at).getTime() : null;
 			if (l.kind === "session") {
 				pushWindow("five_hour", l.percent, resetMs);
+				hasSession = true;
 			} else if (l.kind === "weekly_all") {
 				pushWindow("seven_day", l.percent, resetMs);
+				hasWeeklyAll = true;
 			} else if (l.kind === "weekly_scoped") {
 				const name = l.scope?.model?.display_name?.trim();
 				if (!name) continue;
@@ -91,9 +95,34 @@ function collectWindows(data: AnyUsageData | null): UsageWindowSnapshot[] {
 				);
 			}
 		}
-		// If limits[] yielded no usable windows (empty array, all percent null,
-		// unknown kinds), fall through to the legacy flat windows — mirroring the
-		// dashboard (rate-limit-helpers) so the proxy and UI agree on such payloads.
+		// Supplement the account-level windows (five_hour / seven_day) from the flat
+		// payload whenever limits[] did NOT carry them (per-kind, so no double-count):
+		// a payload with only per-model scoped rows must still throttle on an
+		// exhausted flat ACCOUNT cap, and an empty limits[] falls back to flat too.
+		const flat = data as {
+			five_hour?: { utilization?: number | null; resets_at?: string | null };
+			seven_day?: { utilization?: number | null; resets_at?: string | null };
+		};
+		if (!hasSession && flat.five_hour) {
+			pushWindow(
+				"five_hour",
+				flat.five_hour.utilization,
+				flat.five_hour.resets_at
+					? new Date(flat.five_hour.resets_at).getTime()
+					: null,
+			);
+		}
+		if (!hasWeeklyAll && flat.seven_day) {
+			pushWindow(
+				"seven_day",
+				flat.seven_day.utilization,
+				flat.seven_day.resets_at
+					? new Date(flat.seven_day.resets_at).getTime()
+					: null,
+			);
+		}
+		// Return unless nothing usable was collected (empty limits[] AND no flat
+		// account windows), in which case fall through to the other shape branches.
 		if (windows.length > 0) return windows;
 	}
 

--- a/packages/proxy/src/handlers/usage-throttling.ts
+++ b/packages/proxy/src/handlers/usage-throttling.ts
@@ -14,6 +14,8 @@ interface UsageWindowSnapshot {
 	window: string;
 	/** Set for per-model weekly caps (weekly_scoped); drives model-aware throttling. */
 	modelFamily?: string;
+	/** True for a weekly_scoped (per-model) cap — even when its family is unknown. */
+	scoped?: boolean;
 }
 
 // Minimal shape of Anthropic's generic limits[] entries (see providers UsageLimit).
@@ -44,6 +46,7 @@ function collectWindows(data: AnyUsageData | null): UsageWindowSnapshot[] {
 		utilization: number | null | undefined,
 		resetAtMs: number | null | undefined,
 		modelFamily?: string,
+		scoped?: boolean,
 	) => {
 		if (
 			typeof utilization !== "number" ||
@@ -59,6 +62,7 @@ function collectWindows(data: AnyUsageData | null): UsageWindowSnapshot[] {
 			resetAtMs,
 			window,
 			modelFamily,
+			scoped,
 		});
 	};
 
@@ -83,10 +87,14 @@ function collectWindows(data: AnyUsageData | null): UsageWindowSnapshot[] {
 					l.percent,
 					resetMs,
 					getModelFamily(name) ?? undefined,
+					true,
 				);
 			}
 		}
-		return windows;
+		// If limits[] yielded no usable windows (empty array, all percent null,
+		// unknown kinds), fall through to the legacy flat windows — mirroring the
+		// dashboard (rate-limit-helpers) so the proxy and UI agree on such payloads.
+		if (windows.length > 0) return windows;
 	}
 
 	if ("five_hour" in data && "seven_day" in data) {
@@ -228,12 +236,14 @@ export function getUsageThrottleStatus(
 	const throttledWindows: string[] = [];
 
 	for (const window of windows) {
-		// A per-model weekly cap only throttles in "all" mode or on a family match;
-		// a null/unknown/combo request family therefore never throttles a scoped cap.
+		// A per-model (scoped) cap only throttles in "all" mode, or in "match" mode
+		// when its family is KNOWN and equals the request's. An unmapped scoped cap
+		// (modelFamily undefined) is skipped in match mode rather than throttling
+		// every model; whole-account windows (not scoped) always throttle.
 		if (
-			window.modelFamily != null &&
+			window.scoped &&
 			scopedMode !== "all" &&
-			window.modelFamily !== requestFamily
+			(window.modelFamily == null || window.modelFamily !== requestFamily)
 		) {
 			continue;
 		}

--- a/packages/proxy/src/handlers/usage-throttling.ts
+++ b/packages/proxy/src/handlers/usage-throttling.ts
@@ -1,6 +1,7 @@
 import {
 	computeWindowStartMs,
-	type SupportedWindow,
+	getModelFamily,
+	weeklyScopedWindowKey,
 } from "@better-ccflare/core";
 import type { AnyUsageData } from "@better-ccflare/providers";
 import type { Account } from "@better-ccflare/types";
@@ -10,7 +11,17 @@ const RETRY_AFTER_SECONDS = 60;
 interface UsageWindowSnapshot {
 	utilization: number;
 	resetAtMs: number;
-	window: SupportedWindow;
+	window: string;
+	/** Set for per-model weekly caps (weekly_scoped); drives model-aware throttling. */
+	modelFamily?: string;
+}
+
+// Minimal shape of Anthropic's generic limits[] entries (see providers UsageLimit).
+interface AnthropicLimit {
+	kind?: string;
+	percent?: number | null;
+	resets_at?: string | null;
+	scope?: { model?: { display_name?: string } | null } | null;
 }
 
 export interface UsageThrottleSettings {
@@ -20,7 +31,7 @@ export interface UsageThrottleSettings {
 
 export interface UsageThrottleStatus {
 	throttleUntil: number | null;
-	throttledWindows: SupportedWindow[];
+	throttledWindows: string[];
 }
 
 function collectWindows(data: AnyUsageData | null): UsageWindowSnapshot[] {
@@ -29,9 +40,10 @@ function collectWindows(data: AnyUsageData | null): UsageWindowSnapshot[] {
 	const windows: UsageWindowSnapshot[] = [];
 
 	const pushWindow = (
-		window: SupportedWindow,
+		window: string,
 		utilization: number | null | undefined,
 		resetAtMs: number | null | undefined,
+		modelFamily?: string,
 	) => {
 		if (
 			typeof utilization !== "number" ||
@@ -46,8 +58,36 @@ function collectWindows(data: AnyUsageData | null): UsageWindowSnapshot[] {
 			utilization,
 			resetAtMs,
 			window,
+			modelFamily,
 		});
 	};
+
+	// PRIMARY: Anthropic's generic limits[] array. Checked FIRST — current payloads
+	// carry BOTH the flat windows and limits[], and per-model caps live only here.
+	// session -> five_hour, weekly_all -> seven_day, weekly_scoped -> seven_day_<slug>
+	// (with modelFamily so throttling can be scoped to the request's model).
+	if (Array.isArray((data as { limits?: unknown }).limits)) {
+		const limits = (data as { limits: AnthropicLimit[] }).limits;
+		for (const l of limits) {
+			if (!l || typeof l.percent !== "number") continue;
+			const resetMs = l.resets_at ? new Date(l.resets_at).getTime() : null;
+			if (l.kind === "session") {
+				pushWindow("five_hour", l.percent, resetMs);
+			} else if (l.kind === "weekly_all") {
+				pushWindow("seven_day", l.percent, resetMs);
+			} else if (l.kind === "weekly_scoped") {
+				const name = l.scope?.model?.display_name?.trim();
+				if (!name) continue;
+				pushWindow(
+					weeklyScopedWindowKey(name),
+					l.percent,
+					resetMs,
+					getModelFamily(name) ?? undefined,
+				);
+			}
+		}
+		return windows;
+	}
 
 	if ("five_hour" in data && "seven_day" in data) {
 		const anthropicLike = data as {
@@ -155,33 +195,48 @@ function collectWindows(data: AnyUsageData | null): UsageWindowSnapshot[] {
 }
 
 function isWindowThrottlingEnabled(
-	window: SupportedWindow,
+	window: string,
 	settings: UsageThrottleSettings,
 ): boolean {
-	switch (window) {
-		case "five_hour":
-		case "daily":
-		case "tokens_limit":
-			return settings.fiveHourEnabled;
-		case "seven_day":
-		case "seven_day_opus":
-		case "seven_day_sonnet":
-		case "weekly":
-		case "monthly":
-			return settings.weeklyEnabled;
+	// Five-hour-class windows gate on the 5h setting; everything else — seven_day,
+	// any per-model seven_day_<slug>, weekly, monthly, and unknown future windows —
+	// gates on the weekly setting (so a dynamic scoped window never silently no-ops).
+	if (
+		window === "five_hour" ||
+		window === "daily" ||
+		window === "tokens_limit"
+	) {
+		return settings.fiveHourEnabled;
 	}
+	return settings.weeklyEnabled;
 }
 
 export function getUsageThrottleStatus(
 	data: AnyUsageData | null,
 	settings: UsageThrottleSettings,
 	now = Date.now(),
+	opts?: { requestModel?: string | null; scopedMode?: "match" | "all" },
 ): UsageThrottleStatus {
+	// scopedMode "all" (default, display path) surfaces every per-model cap;
+	// "match" (routing path) only counts a scoped cap when the request's model
+	// family matches it.
+	const scopedMode = opts?.scopedMode ?? "all";
+	const requestFamily =
+		opts?.requestModel != null ? getModelFamily(opts.requestModel) : null;
 	const windows = collectWindows(data);
 	let throttleUntil: number | null = null;
-	const throttledWindows: SupportedWindow[] = [];
+	const throttledWindows: string[] = [];
 
 	for (const window of windows) {
+		// A per-model weekly cap only throttles in "all" mode or on a family match;
+		// a null/unknown/combo request family therefore never throttles a scoped cap.
+		if (
+			window.modelFamily != null &&
+			scopedMode !== "all" &&
+			window.modelFamily !== requestFamily
+		) {
+			continue;
+		}
 		if (!isWindowThrottlingEnabled(window.window, settings)) continue;
 		if (window.resetAtMs <= now) continue;
 		const startMs = computeWindowStartMs(window.resetAtMs, window.window);
@@ -215,8 +270,9 @@ export function getUsageThrottleUntil(
 	data: AnyUsageData | null,
 	settings: UsageThrottleSettings,
 	now = Date.now(),
+	opts?: { requestModel?: string | null; scopedMode?: "match" | "all" },
 ): number | null {
-	return getUsageThrottleStatus(data, settings, now).throttleUntil;
+	return getUsageThrottleStatus(data, settings, now, opts).throttleUntil;
 }
 
 export function createUsageThrottledResponse(accounts: Account[]): Response {

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -263,11 +263,22 @@ export async function handleProxy(
 		const available: Account[] = [];
 		const throttled: Account[] = [];
 
+		// Model-aware throttling: a per-model weekly cap should only throttle
+		// requests for that model. Use the effective (post-intercept) request
+		// model; combo-routed requests assign per-slot models later, so skip
+		// scoped caps (null) and rely on the flat windows + reactive out_of_credits.
+		const comboRouted = getComboSlotInfo(requestMeta) != null;
+		const effectiveModel = appliedModel ?? requestModel ?? null;
+
 		for (const account of accounts) {
 			const throttleUntil = getUsageThrottleUntil(
 				usageCache.get(account.id),
 				settings,
 				now,
+				{
+					requestModel: comboRouted ? null : effectiveModel,
+					scopedMode: "match",
+				},
 			);
 			if (throttleUntil && throttleUntil > now) {
 				throttled.push(account);

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -267,7 +267,11 @@ export async function handleProxy(
 		// requests for that model. Use the effective (post-intercept) request
 		// model; combo-routed requests assign per-slot models later, so skip
 		// scoped caps (null) and rely on the flat windows + reactive out_of_credits.
-		const comboRouted = getComboSlotInfo(requestMeta) != null;
+		// combo routing sets meta.comboName during selection and CLEARS it on the
+		// step-10 fallback; use it (not the stale comboSlotInfo WeakMap, which the
+		// fallback does not clear) so fallback routing still applies per-model scoped
+		// throttling for its now-known single model.
+		const comboRouted = requestMeta.comboName != null;
 		const effectiveModel = appliedModel ?? requestModel ?? null;
 
 		for (const account of accounts) {

--- a/packages/types/src/account.ts
+++ b/packages/types/src/account.ts
@@ -23,11 +23,45 @@ export interface UsageWindowData {
 	resets_at: string | null;
 }
 
+// Anthropic's generic per-limit representation (2026 usage API). Session and
+// all-models weekly come as kind "session" / "weekly_all"; per-model weekly caps
+// (Fable/Opus/Sonnet) come ONLY as kind "weekly_scoped" with scope.model.
+export interface UsageLimit {
+	kind: string;
+	group?: string;
+	percent: number | null;
+	severity?: "normal" | "warning" | "critical" | string;
+	resets_at: string | null;
+	scope?: {
+		model?: { id: string | null; display_name: string } | null;
+		surface?: string | null;
+	} | null;
+	is_active?: boolean;
+}
+
+// Overage / pay-as-you-go credit spend block.
+export interface UsageSpend {
+	used?: { amount_minor: number; currency: string; exponent: number } | null;
+	limit?: unknown;
+	percent?: number | null;
+	severity?: string;
+	enabled?: boolean;
+	currency?: string | null;
+	disabled_reason?: string | null;
+}
+
 export interface AnthropicUsageData {
 	five_hour?: UsageWindowData;
 	seven_day?: UsageWindowData;
 	seven_day_oauth_apps?: UsageWindowData;
 	seven_day_opus?: UsageWindowData;
+	seven_day_sonnet?: UsageWindowData;
+	seven_day_fable?: UsageWindowData;
+	// Generic limits[] (2026 API) — authoritative source for per-model weekly
+	// caps. NOTE: NanoGPTUsageData.limits is a different (object) shape; ALWAYS
+	// disambiguate with Array.isArray(usageData.limits).
+	limits?: UsageLimit[];
+	spend?: UsageSpend;
 }
 
 // Usage data types for NanoGPT accounts


### PR DESCRIPTION
## What & why

Anthropic's `GET /api/oauth/usage` moved the usage picture into a generic `limits[]` array (kinds `session` / `weekly_all` / `weekly_scoped`). Per-model weekly caps (Fable/Opus/Sonnet) live **only** there — the flat `seven_day_<model>` keys are null, and Anthropic is migrating the flat account windows into `limits[]` too. better-ccflare read `limits[]` nowhere, so per-model caps (e.g. the **Fable** weekly limit) were neither rendered nor throttled.

This PR migrates the whole usage path to `limits[]` — **display, account summaries / load-balancer ranking, and proactive throttling** — keeping the legacy flat windows as a fallback.

<img width="2274" height="633" alt="image" src="https://github.com/user-attachments/assets/8083940c-79eb-4408-b176-7d1398a9f92d" />

<img width="2275" height="579" alt="image" src="https://github.com/user-attachments/assets/a12fcf37-8471-4a0e-88ce-57382a71ac69" />

## What's in it

**Display (Phase 1)**
- Reads `limits[]` as the primary source; one bar per limit: `session` → "5-hour", `weekly_all` → "Weekly", `weekly_scoped` → per-model "(Weekly)" rows (generic — Fable is a limited-time promo, nothing is hardcoded). Disambiguated from NanoGPT's object-shaped `limits` via `Array.isArray`.
- Richer info from the payload: `severity` → bar color, `is_active` → binding marker, Session / Weekly group headers, and an overage-credits meter.

**Account read path (P1 cascade)**
- `getRepresentativeUtilization` / `…Window` / `…ForProvider` and `extractWindowResetTime` now read the account-level `limits[]` (session → five_hour, weekly_all → seven_day; weekly_scoped excluded — a per-model, not hard account, cap). Fixes a limits-only account being reported as 0 % / unused, wrongly un-benched by the capacity guard, and mis-ranked by the load balancer; the util helper returns `null` (not `0`) when nothing is found.
- Scoped-row identity: duplicate `weekly_scoped` rows get a unique suffix that cannot collide with each other or with a real model slug.

**Model-aware throttling (Phase 2a)**
- `collectWindows` reads `limits[]` first (before the flat branch; falls back to flat when `limits[]` yields nothing usable, mirroring the display). Per-model caps become throttle windows carrying the model family.
- `getUsageThrottleStatus/Until` gained `{ requestModel, scopedMode }`: a per-model cap only throttles the **matching** model's requests — a Fable-100 % account still serves Opus/Sonnet — fixing per-model 429 storms **without** over-throttling. `/api/accounts` uses `scopedMode:"all"` so every cap is surfaced for the amber highlight; the router uses `scopedMode:"match"` with the effective post-intercept model and skips scoped caps for combo-routed requests. Ranking stays whole-account.
- A shared `weeklyScopedWindowKey` (core) keeps the dashboard row key byte-identical to the throttle window key.

**Type safety (Phase 2b / m5)**
- `UsageData.five_hour` / `seven_day` are now optional (a limits-only payload omits them); every flat-window access the compiler then surfaced was guarded.

## Review

Reviewed by **Greptile** (P1 "limits → 0" and P2 scoped-identity — both addressed) and independently by **codex**, **grok**, and **fable** on the routing/throttling changes. All findings incorporated — notably: `limits[]`-empty fallback on both the display and throttle paths; scoped caps with an unknown model family no longer over-throttle; combo-fallback no longer disables scoped throttling; and the duplicate-key collision fix.

## Tests

New / updated unit tests across the display helpers, pool usage, the usage-fetcher read path, and model-aware throttling (Fable-throttles-only-Fable, weekly_all-always, null/combo skip, dynamic per-model slug, hybrid / empty `limits[]` fallback). `bun run lint && typecheck && format` clean; the affected test dirs are green.
