### PR TITLE
fix: surface usage-window exhaustion in /health and account rateLimitStatus

### DIFF
--- a/packages/http-api/src/handlers/__tests__/health-runtime.test.ts
+++ b/packages/http-api/src/handlers/__tests__/health-runtime.test.ts
@@ -232,6 +232,7 @@ describe("computeHealthStatus three-state logic", () => {
 			paused: 1,
 			rate_limited: 0,
 			routable: 2,
+			usage_exhausted: 0,
 			next_available_at: null,
 		};
 
@@ -246,6 +247,7 @@ describe("computeHealthStatus three-state logic", () => {
 			paused: 0,
 			rate_limited: 2,
 			routable: 0,
+			usage_exhausted: 0,
 			next_available_at: new Date(Date.now() + 3600000).toISOString(),
 		};
 
@@ -260,6 +262,7 @@ describe("computeHealthStatus three-state logic", () => {
 			paused: 0,
 			rate_limited: 0,
 			routable: 3,
+			usage_exhausted: 0,
 			next_available_at: null,
 		};
 
@@ -274,6 +277,7 @@ describe("computeHealthStatus three-state logic", () => {
 			paused: 0,
 			rate_limited: 0,
 			routable: 0,
+			usage_exhausted: 0,
 			next_available_at: null,
 		};
 
@@ -288,6 +292,7 @@ describe("computeHealthStatus three-state logic", () => {
 			paused: 2,
 			rate_limited: 0,
 			routable: 0,
+			usage_exhausted: 0,
 			next_available_at: null,
 		};
 

--- a/packages/http-api/src/handlers/__tests__/health-usage-exhausted.test.ts
+++ b/packages/http-api/src/handlers/__tests__/health-usage-exhausted.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { usageCache } from "@better-ccflare/providers";
+import type { Account } from "@better-ccflare/types";
+import { computePoolStatus, createHealthHandler } from "../health";
+
+/**
+ * Incident 2026-07-09: /health reported `routable: 2` and the dashboard showed
+ * `rateLimitStatus: OK` for MAX_200_ALT_2 while the account's weekly usage
+ * window sat at 100% (every request 429'd upstream) and /v1/messages returned
+ * 503 pool_exhausted. `routable` must keep its meaning (unpaused + no active
+ * cooldown), but the pool status has to EXPOSE usage-exhausted accounts so the
+ * two readings stop contradicting each other.
+ */
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "acc",
+		name: "acc",
+		provider: "anthropic",
+		paused: false,
+		rate_limited_until: null,
+		...overrides,
+	} as Account;
+}
+
+describe("computePoolStatus — usage_exhausted counter", () => {
+	const now = Date.UTC(2026, 6, 9, 2, 30, 0);
+
+	it("counts unpaused accounts whose representative utilization is >= 100", () => {
+		// Incident constellation: MAIN+ALT paused, ALT_2 weekly 100%, ALT_3 41%.
+		const accounts = [
+			makeAccount({ id: "main", name: "MAX_200_MAIN", paused: true }),
+			makeAccount({ id: "alt", name: "MAX_200_ALT", paused: true }),
+			makeAccount({ id: "alt2", name: "MAX_200_ALT_2" }),
+			makeAccount({ id: "alt3", name: "MAX_200_ALT_3" }),
+		];
+		const utilization: Record<string, number> = {
+			main: 76,
+			alt: 100, // paused — already visible as paused, must not double-count
+			alt2: 100,
+			alt3: 41,
+		};
+
+		const status = computePoolStatus(accounts, now, (account) =>
+			utilization[account.id] != null
+				? { utilization: utilization[account.id], resetMs: now + 3_600_000 }
+				: null,
+		);
+
+		expect(status.usage_exhausted).toBe(1);
+		// routable keeps its existing meaning — ALT_2 has no active cooldown,
+		// so it still counts. The contradiction becomes visible instead of
+		// hidden: routable 2, of which 1 is usage-exhausted.
+		expect(status.routable).toBe(2);
+		expect(status.paused).toBe(2);
+		expect(status.rate_limited).toBe(0);
+	});
+
+	it("reports 0 when no utilization source is provided (backward compatible)", () => {
+		const status = computePoolStatus([makeAccount()], now);
+		expect(status.usage_exhausted).toBe(0);
+		expect(status.routable).toBe(1);
+	});
+
+	it("treats null usage info (no usage data) as not exhausted", () => {
+		const status = computePoolStatus([makeAccount()], now, () => null);
+		expect(status.usage_exhausted).toBe(0);
+	});
+
+	it("does NOT count an account whose known usage reset lies in the past (stale snapshot)", () => {
+		// Same staleness guard as the rateLimitStatus display — otherwise the
+		// two surfaces contradict each other for up to a cache interval after
+		// a window reset (cross-LLM review consensus finding).
+		const status = computePoolStatus([makeAccount()], now, () => ({
+			utilization: 100,
+			resetMs: now - 1,
+		}));
+		expect(status.usage_exhausted).toBe(0);
+	});
+});
+
+describe("createHealthHandler — pool.usage_exhausted in the response", () => {
+	const dbWith = (accounts: Partial<Account>[]) =>
+		({
+			getAllAccounts: async () => accounts,
+		}) as unknown as import("@better-ccflare/database").DatabaseOperations;
+	const config = {
+		getStrategy: () => "session",
+	} as unknown as import("@better-ccflare/config").Config;
+
+	afterEach(() => {
+		usageCache.delete("health-test-exhausted");
+		usageCache.delete("health-test-stale");
+	});
+
+	it("exposes usage_exhausted via an injected utilization source", async () => {
+		const handler = createHealthHandler(
+			dbWith([
+				{ id: "a1", name: "a1", provider: "anthropic", paused: false },
+				{ id: "a2", name: "a2", provider: "anthropic", paused: false },
+			]),
+			config,
+			undefined,
+			undefined,
+			undefined,
+			(account) => ({
+				utilization: account.id === "a2" ? 100 : 10,
+				resetMs: null,
+			}),
+		);
+
+		const response = await handler(new URL("http://localhost/health"));
+		const body = (await response.json()) as {
+			pool: { routable: number; usage_exhausted: number };
+		};
+
+		expect(body.pool.routable).toBe(2);
+		expect(body.pool.usage_exhausted).toBe(1);
+	});
+
+	it("defaults to the shared usageCache (no wiring changes at call sites)", async () => {
+		usageCache.set("health-test-exhausted", {
+			five_hour: { utilization: 12, resets_at: null },
+			seven_day: {
+				utilization: 100,
+				resets_at: new Date(Date.now() + 3_600_000).toISOString(),
+			},
+		});
+
+		const handler = createHealthHandler(
+			dbWith([
+				{
+					id: "health-test-exhausted",
+					name: "exhausted",
+					provider: "anthropic",
+					paused: false,
+				},
+			]),
+			config,
+		);
+
+		const response = await handler(new URL("http://localhost/health"));
+		const body = (await response.json()) as {
+			pool: { routable: number; usage_exhausted: number };
+		};
+
+		expect(body.pool.routable).toBe(1);
+		expect(body.pool.usage_exhausted).toBe(1);
+	});
+
+	it("default path applies the staleness guard (reset in the past — not exhausted)", async () => {
+		usageCache.set("health-test-stale", {
+			five_hour: { utilization: 12, resets_at: null },
+			seven_day: {
+				utilization: 100,
+				resets_at: new Date(Date.now() - 60_000).toISOString(),
+			},
+		});
+
+		const handler = createHealthHandler(
+			dbWith([
+				{
+					id: "health-test-stale",
+					name: "stale",
+					provider: "anthropic",
+					paused: false,
+				},
+			]),
+			config,
+		);
+
+		const response = await handler(new URL("http://localhost/health"));
+		const body = (await response.json()) as {
+			pool: { usage_exhausted: number };
+		};
+
+		expect(body.pool.usage_exhausted).toBe(0);
+	});
+});

--- a/packages/http-api/src/handlers/__tests__/health-usage-exhausted.test.ts
+++ b/packages/http-api/src/handlers/__tests__/health-usage-exhausted.test.ts
@@ -77,6 +77,21 @@ describe("computePoolStatus — usage_exhausted counter", () => {
 		}));
 		expect(status.usage_exhausted).toBe(0);
 	});
+
+	it("does NOT count an account under an active cooldown — usage_exhausted is a subset of routable", () => {
+		// Greptile P2 on PR #299: a benched account was counted in BOTH
+		// rate_limited and usage_exhausted, so usage_exhausted could exceed
+		// routable, contradicting the documented semantics in stats.ts.
+		const benched = makeAccount({ rate_limited_until: now + 60_000 });
+		const status = computePoolStatus([benched], now, () => ({
+			utilization: 100,
+			resetMs: now + 3_600_000,
+		}));
+		expect(status.rate_limited).toBe(1);
+		expect(status.routable).toBe(0);
+		expect(status.usage_exhausted).toBe(0);
+		expect(status.usage_exhausted).toBeLessThanOrEqual(status.routable);
+	});
 });
 
 describe("createHealthHandler — pool.usage_exhausted in the response", () => {
@@ -91,6 +106,8 @@ describe("createHealthHandler — pool.usage_exhausted in the response", () => {
 	afterEach(() => {
 		usageCache.delete("health-test-exhausted");
 		usageCache.delete("health-test-stale");
+		usageCache.delete("health-test-zai-stale");
+		usageCache.delete("health-test-zai-fresh");
 	});
 
 	it("exposes usage_exhausted via an injected utilization source", async () => {
@@ -175,5 +192,74 @@ describe("createHealthHandler — pool.usage_exhausted in the response", () => {
 		};
 
 		expect(body.pool.usage_exhausted).toBe(0);
+	});
+
+	it("default path applies the staleness guard for NON-anthropic providers too (zai, reset in the past)", async () => {
+		// Greptile P2 on PR #299: the default getter extracted resetMs only for
+		// anthropic-shaped payloads, so a zai account at 100% with an already
+		// reset window stayed "exhausted" on /health while the accounts API
+		// (which extracts the reset for every provider) said "OK" — the exact
+		// split-brain the shared guard is supposed to prevent.
+		usageCache.set("health-test-zai-stale", {
+			time_limit: null,
+			tokens_limit: {
+				used: 100,
+				remaining: 0,
+				percentage: 100,
+				resetAt: Date.now() - 60_000,
+				type: "tokens",
+			},
+		});
+
+		const handler = createHealthHandler(
+			dbWith([
+				{
+					id: "health-test-zai-stale",
+					name: "zai-stale",
+					provider: "zai",
+					paused: false,
+				},
+			]),
+			config,
+		);
+
+		const response = await handler(new URL("http://localhost/health"));
+		const body = (await response.json()) as {
+			pool: { usage_exhausted: number };
+		};
+
+		expect(body.pool.usage_exhausted).toBe(0);
+	});
+
+	it("default path still counts a genuinely exhausted non-anthropic account (zai, reset in the future)", async () => {
+		usageCache.set("health-test-zai-fresh", {
+			time_limit: null,
+			tokens_limit: {
+				used: 100,
+				remaining: 0,
+				percentage: 100,
+				resetAt: Date.now() + 3_600_000,
+				type: "tokens",
+			},
+		});
+
+		const handler = createHealthHandler(
+			dbWith([
+				{
+					id: "health-test-zai-fresh",
+					name: "zai-fresh",
+					provider: "zai",
+					paused: false,
+				},
+			]),
+			config,
+		);
+
+		const response = await handler(new URL("http://localhost/health"));
+		const body = (await response.json()) as {
+			pool: { usage_exhausted: number };
+		};
+
+		expect(body.pool.usage_exhausted).toBe(1);
 	});
 });

--- a/packages/http-api/src/handlers/__tests__/rate-limit-status.test.ts
+++ b/packages/http-api/src/handlers/__tests__/rate-limit-status.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
 	computeRateLimitStatusDisplay,
 	extractUsageResetMs,
+	getRepresentativeUsageResetMs,
 	isUsageExhausted,
 } from "../rate-limit-status";
 
@@ -140,6 +141,57 @@ describe("computeRateLimitStatusDisplay — existing behavior (parity)", () => {
 
 	it("returns OK when nothing is known", () => {
 		expect(computeRateLimitStatusDisplay(base, NOW)).toBe("OK");
+	});
+});
+
+describe("getRepresentativeUsageResetMs — shared provider-aware reset derivation", () => {
+	it("zai: reads the reset from the tokens_limit payload key despite the five_hour display label", () => {
+		const resetAt = NOW + 3_600_000;
+		const data = {
+			time_limit: null,
+			tokens_limit: {
+				used: 100,
+				remaining: 0,
+				percentage: 100,
+				resetAt,
+				type: "tokens",
+			},
+		};
+		expect(getRepresentativeUsageResetMs(data, "zai")).toBe(resetAt);
+	});
+
+	it("anthropic: uses the representative (max-utilization) window's resets_at", () => {
+		const data = {
+			five_hour: { utilization: 10, resets_at: null },
+			seven_day: { utilization: 100, resets_at: "2026-07-11T08:00:00.000Z" },
+		};
+		expect(getRepresentativeUsageResetMs(data, "anthropic")).toBe(
+			Date.UTC(2026, 6, 11, 8, 0, 0),
+		);
+	});
+
+	it("nanogpt: uses the busier window's resetAt", () => {
+		const resetAt = NOW + 7_200_000;
+		const data = {
+			active: true,
+			limits: { daily: 1, monthly: 1 },
+			enforceDailyLimit: true,
+			daily: { used: 1, remaining: 0, percentUsed: 1, resetAt },
+			monthly: {
+				used: 0,
+				remaining: 1,
+				percentUsed: 0.1,
+				resetAt: NOW + 30 * 86_400_000,
+			},
+			state: "active",
+			graceUntil: null,
+		};
+		expect(getRepresentativeUsageResetMs(data, "nanogpt")).toBe(resetAt);
+	});
+
+	it("returns null for unknown providers or missing data", () => {
+		expect(getRepresentativeUsageResetMs(null, "zai")).toBeNull();
+		expect(getRepresentativeUsageResetMs({}, "openai-compatible")).toBeNull();
 	});
 });
 

--- a/packages/http-api/src/handlers/__tests__/rate-limit-status.test.ts
+++ b/packages/http-api/src/handlers/__tests__/rate-limit-status.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "bun:test";
+import {
+	computeRateLimitStatusDisplay,
+	extractUsageResetMs,
+	isUsageExhausted,
+} from "../rate-limit-status";
+
+/**
+ * Incident 2026-07-09: MAX_200_ALT_2 showed `rateLimitStatus: "OK"` on the
+ * dashboard while its weekly usage window sat at 100% (is_active, critical)
+ * and every upstream request 429'd. The status string only reflected the last
+ * unified-header snapshot (`rate_limit_status`, NULL for ALT_2) and an active
+ * cooldown — usage exhaustion was invisible. These tests pin the desired
+ * behavior: an exhausted usage window must take precedence over "OK" and over
+ * stale "allowed*" header snapshots.
+ */
+
+const NOW = Date.UTC(2026, 6, 9, 2, 30, 0);
+
+const base = {
+	rate_limit_status: null as string | null,
+	rate_limit_reset: null as number | null,
+	rate_limited_until: null as number | null,
+	usageUtilization: null as number | null,
+	usageResetMs: null as number | null,
+};
+
+describe("computeRateLimitStatusDisplay — usage exhaustion (incident fix)", () => {
+	it("reports usage_exhausted instead of OK when the representative window is at 100%", () => {
+		// ALT_2 during the incident: no unified header snapshot, weekly 100%.
+		const resetMs = NOW + 60 * 60000;
+		const status = computeRateLimitStatusDisplay(
+			{ ...base, usageUtilization: 100, usageResetMs: resetMs },
+			NOW,
+		);
+		expect(status).toBe("usage_exhausted (60m)");
+	});
+
+	it("reports usage_exhausted without minutes when no reset time is known", () => {
+		const status = computeRateLimitStatusDisplay(
+			{ ...base, usageUtilization: 100 },
+			NOW,
+		);
+		expect(status).toBe("usage_exhausted");
+	});
+
+	it("outranks a stale allowed_warning header snapshot", () => {
+		// MAX_200_ALT during the incident: allowed_warning with far-future
+		// reset, but the weekly window was already at 100%.
+		const status = computeRateLimitStatusDisplay(
+			{
+				...base,
+				rate_limit_status: "allowed_warning",
+				rate_limit_reset: NOW + 2907 * 60000,
+				usageUtilization: 100,
+				usageResetMs: NOW + 2907 * 60000,
+			},
+			NOW,
+		);
+		expect(status).toBe("usage_exhausted (2907m)");
+	});
+
+	it("does NOT claim exhaustion when the known reset lies in the past (stale usage snapshot)", () => {
+		const status = computeRateLimitStatusDisplay(
+			{ ...base, usageUtilization: 100, usageResetMs: NOW - 1 },
+			NOW,
+		);
+		expect(status).toBe("OK");
+	});
+
+	it("does not fire below 100%", () => {
+		const status = computeRateLimitStatusDisplay(
+			{ ...base, usageUtilization: 99 },
+			NOW,
+		);
+		expect(status).toBe("OK");
+	});
+
+	it("outranks an active cooldown lock (usage exhaustion is the harder fact)", () => {
+		const status = computeRateLimitStatusDisplay(
+			{
+				...base,
+				rate_limited_until: NOW + 30_000,
+				usageUtilization: 100,
+				usageResetMs: NOW + 120 * 60000,
+			},
+			NOW,
+		);
+		expect(status).toBe("usage_exhausted (120m)");
+	});
+});
+
+describe("isUsageExhausted — shared staleness guard", () => {
+	it("is exhausted at 100% with unknown reset", () => {
+		expect(isUsageExhausted(100, null, NOW)).toBe(true);
+	});
+
+	it("is exhausted at 100% with a future reset", () => {
+		expect(isUsageExhausted(100, NOW + 60_000, NOW)).toBe(true);
+	});
+
+	it("is NOT exhausted when the known reset lies in the past (stale snapshot)", () => {
+		expect(isUsageExhausted(100, NOW - 1, NOW)).toBe(false);
+	});
+
+	it("is NOT exhausted below 100% or without data", () => {
+		expect(isUsageExhausted(99, null, NOW)).toBe(false);
+		expect(isUsageExhausted(null, null, NOW)).toBe(false);
+	});
+});
+
+describe("computeRateLimitStatusDisplay — existing behavior (parity)", () => {
+	it("shows the unified header status with minutes until reset", () => {
+		const status = computeRateLimitStatusDisplay(
+			{
+				...base,
+				rate_limit_status: "allowed",
+				rate_limit_reset: NOW + 67 * 60000,
+			},
+			NOW,
+		);
+		expect(status).toBe("allowed (67m)");
+	});
+
+	it("shows the unified header status without minutes when reset already passed", () => {
+		const status = computeRateLimitStatusDisplay(
+			{ ...base, rate_limit_status: "allowed", rate_limit_reset: NOW - 1000 },
+			NOW,
+		);
+		expect(status).toBe("allowed");
+	});
+
+	it("falls back to the legacy cooldown display", () => {
+		const status = computeRateLimitStatusDisplay(
+			{ ...base, rate_limited_until: NOW + 30_000 },
+			NOW,
+		);
+		expect(status).toBe("Rate limited (1m)");
+	});
+
+	it("returns OK when nothing is known", () => {
+		expect(computeRateLimitStatusDisplay(base, NOW)).toBe("OK");
+	});
+});
+
+describe("extractUsageResetMs", () => {
+	it("reads ISO resets_at from anthropic-style windows", () => {
+		const data = {
+			five_hour: { utilization: 10, resets_at: null },
+			seven_day: { utilization: 100, resets_at: "2026-07-11T08:00:00.000Z" },
+		};
+		expect(extractUsageResetMs(data, "seven_day")).toBe(
+			Date.UTC(2026, 6, 11, 8, 0, 0),
+		);
+	});
+
+	it("reads numeric resetAt from zai/nanogpt-style windows", () => {
+		const resetAt = NOW + 3_600_000;
+		const data = { tokens_limit: { percentage: 100, resetAt } };
+		expect(extractUsageResetMs(data, "tokens_limit")).toBe(resetAt);
+	});
+
+	it("returns null for unknown windows or missing data", () => {
+		expect(extractUsageResetMs(null, "seven_day")).toBeNull();
+		expect(extractUsageResetMs({}, "seven_day")).toBeNull();
+		expect(extractUsageResetMs({ seven_day: {} }, null)).toBeNull();
+	});
+});

--- a/packages/http-api/src/handlers/accounts.ts
+++ b/packages/http-api/src/handlers/accounts.ts
@@ -47,7 +47,7 @@ import { requiresSessionDurationTracking } from "@better-ccflare/types";
 import type { AccountResponse } from "../types";
 import {
 	computeRateLimitStatusDisplay,
-	extractUsageResetMs,
+	getRepresentativeUsageResetMs,
 } from "./rate-limit-status";
 
 const log = new Logger("AccountsHandler");
@@ -476,7 +476,14 @@ export function createAccountsListHandler(
 							? Number(account.rate_limited_until)
 							: null,
 						usageUtilization,
-						usageResetMs: extractUsageResetMs(fullUsageData, usageWindow),
+						// Shared provider-aware derivation (same as /health) — a plain
+						// extractUsageResetMs(fullUsageData, usageWindow) silently loses
+						// the zai reset because usageWindow is the display label
+						// ("five_hour"), not the payload key ("tokens_limit").
+						usageResetMs: getRepresentativeUsageResetMs(
+							fullUsageData,
+							account.provider ?? "anthropic",
+						),
 					},
 					now,
 				);

--- a/packages/http-api/src/handlers/accounts.ts
+++ b/packages/http-api/src/handlers/accounts.ts
@@ -45,6 +45,10 @@ import type {
 } from "@better-ccflare/types";
 import { requiresSessionDurationTracking } from "@better-ccflare/types";
 import type { AccountResponse } from "../types";
+import {
+	computeRateLimitStatusDisplay,
+	extractUsageResetMs,
+} from "./rate-limit-status";
 
 const log = new Logger("AccountsHandler");
 
@@ -300,25 +304,6 @@ export function createAccountsListHandler(
 
 		const response: AccountResponse[] = await Promise.all(
 			accounts.map(async (account) => {
-				let rateLimitStatus = "OK";
-
-				// Use unified rate limit status if available
-				if (account.rate_limit_status) {
-					rateLimitStatus = account.rate_limit_status;
-					const resetMs = Number(account.rate_limit_reset);
-					if (resetMs && resetMs > now) {
-						const minutesLeft = Math.ceil((resetMs - now) / 60000);
-						rateLimitStatus = `${account.rate_limit_status} (${minutesLeft}m)`;
-					}
-				} else if (account.rate_limited && account.rate_limited_until) {
-					// Fall back to legacy rate limit check
-					const limitedMs = Number(account.rate_limited_until);
-					if (limitedMs > now) {
-						const minutesLeft = Math.ceil((limitedMs - now) / 60000);
-						rateLimitStatus = `Rate limited (${minutesLeft}m)`;
-					}
-				}
-
 				// Get usage data from cache for providers that expose account-page quota or credit data
 				const cachedUsageData = usageCache.get(account.id);
 				let usageData: FullUsageData | null =
@@ -477,6 +462,24 @@ export function createAccountsListHandler(
 					usageThrottledUntil = usageThrottleStatus.throttleUntil;
 					usageThrottledWindows = usageThrottleStatus.throttledWindows;
 				}
+
+				// Computed after usage resolution so an exhausted usage window can
+				// outrank stale header snapshots and the bare "OK" default
+				// (incident 2026-07-09: 100% weekly utilization displayed as "OK").
+				const rateLimitStatus = computeRateLimitStatusDisplay(
+					{
+						rate_limit_status: account.rate_limit_status ?? null,
+						rate_limit_reset: account.rate_limit_reset
+							? Number(account.rate_limit_reset)
+							: null,
+						rate_limited_until: account.rate_limited_until
+							? Number(account.rate_limited_until)
+							: null,
+						usageUtilization,
+						usageResetMs: extractUsageResetMs(fullUsageData, usageWindow),
+					},
+					now,
+				);
 
 				// Parse model mappings for OpenAI-compatible, Anthropic-compatible, NanoGPT, and OpenRouter providers
 				let modelMappings: { [key: string]: string } | null = null;

--- a/packages/http-api/src/handlers/health.ts
+++ b/packages/http-api/src/handlers/health.ts
@@ -4,13 +4,14 @@ import type { DatabaseOperations } from "@better-ccflare/database";
 import { jsonResponse } from "@better-ccflare/http-common";
 import {
 	getRepresentativeUtilizationForProvider,
-	getRepresentativeWindow,
-	type UsageData,
 	usageCache,
 } from "@better-ccflare/providers";
 import type { Account } from "@better-ccflare/types";
 import type { HealthResponse, IntegrityStatus, PoolStatus } from "../types";
-import { extractUsageResetMs, isUsageExhausted } from "./rate-limit-status";
+import {
+	getRepresentativeUsageResetMs,
+	isUsageExhausted,
+} from "./rate-limit-status";
 
 /**
  * Usage snapshot for exhaustion accounting: representative utilization
@@ -25,25 +26,17 @@ export type AccountUsageInfoFn = (account: Account) => AccountUsageInfo | null;
 const usageCacheUsageInfo: AccountUsageInfoFn = (account) => {
 	const data = usageCache.get(account.id);
 	if (!data) return null;
-	const utilization = getRepresentativeUtilizationForProvider(
-		data,
-		account.provider ?? "anthropic",
-	);
+	const provider = account.provider ?? "anthropic";
+	const utilization = getRepresentativeUtilizationForProvider(data, provider);
 	if (utilization === null) return null;
-	// Reset time of the representative window (anthropic-style payloads only;
-	// other providers fall back to null = trust the fresh cache).
-	let resetMs: number | null = null;
-	if ("five_hour" in data && "seven_day" in data) {
-		try {
-			resetMs = extractUsageResetMs(
-				data,
-				getRepresentativeWindow(data as UsageData),
-			);
-		} catch {
-			resetMs = null;
-		}
-	}
-	return { utilization, resetMs };
+	// Same provider-aware reset derivation as the accounts handler, so the
+	// staleness guard sees identical inputs on both surfaces (PR #299 review
+	// finding: guarding only anthropic-shaped payloads recreated the /health
+	// vs accounts split-brain for the other providers).
+	return {
+		utilization,
+		resetMs: getRepresentativeUsageResetMs(data, provider),
+	};
 };
 
 type AsyncWriterHealthFn = () => {
@@ -77,12 +70,15 @@ export function computePoolStatus(
 	);
 	const rate_limited = rateLimitedAccounts.length;
 	const routable = accounts.filter((a) => isAccountAvailable(a, now)).length;
-	// Counted independently of `routable`: an account at 100% usage has no
-	// active cooldown (it stays routable) yet upstream rejects its requests,
-	// so `routable > 0` alone can mask an effectively exhausted pool
-	// (incident 2026-07-09).
+	// Subset of `routable`: accounts with no pause and no active cooldown
+	// whose usage window sits at 100% — they look available locally, yet
+	// upstream rejects their requests, so `routable > 0` alone can mask an
+	// effectively exhausted pool (incident 2026-07-09). Benched accounts are
+	// excluded — they are already visible via `rate_limited`, and counting
+	// them here would let usage_exhausted exceed routable (PR #299 review
+	// finding).
 	const usage_exhausted = accounts.filter((a) => {
-		if (a.paused) return false;
+		if (!isAccountAvailable(a, now)) return false;
 		const usage = getUsageInfo(a);
 		return (
 			usage !== null && isUsageExhausted(usage.utilization, usage.resetMs, now)

--- a/packages/http-api/src/handlers/health.ts
+++ b/packages/http-api/src/handlers/health.ts
@@ -2,8 +2,49 @@ import type { Config } from "@better-ccflare/config";
 import { isAccountAvailable, TtlCache } from "@better-ccflare/core";
 import type { DatabaseOperations } from "@better-ccflare/database";
 import { jsonResponse } from "@better-ccflare/http-common";
+import {
+	getRepresentativeUtilizationForProvider,
+	getRepresentativeWindow,
+	type UsageData,
+	usageCache,
+} from "@better-ccflare/providers";
 import type { Account } from "@better-ccflare/types";
 import type { HealthResponse, IntegrityStatus, PoolStatus } from "../types";
+import { extractUsageResetMs, isUsageExhausted } from "./rate-limit-status";
+
+/**
+ * Usage snapshot for exhaustion accounting: representative utilization
+ * (0-100) plus the representative window's reset time when known.
+ */
+export interface AccountUsageInfo {
+	utilization: number;
+	resetMs: number | null;
+}
+export type AccountUsageInfoFn = (account: Account) => AccountUsageInfo | null;
+
+const usageCacheUsageInfo: AccountUsageInfoFn = (account) => {
+	const data = usageCache.get(account.id);
+	if (!data) return null;
+	const utilization = getRepresentativeUtilizationForProvider(
+		data,
+		account.provider ?? "anthropic",
+	);
+	if (utilization === null) return null;
+	// Reset time of the representative window (anthropic-style payloads only;
+	// other providers fall back to null = trust the fresh cache).
+	let resetMs: number | null = null;
+	if ("five_hour" in data && "seven_day" in data) {
+		try {
+			resetMs = extractUsageResetMs(
+				data,
+				getRepresentativeWindow(data as UsageData),
+			);
+		} catch {
+			resetMs = null;
+		}
+	}
+	return { utilization, resetMs };
+};
 
 type AsyncWriterHealthFn = () => {
 	healthy: boolean;
@@ -27,6 +68,7 @@ type IntegrityStatusFn = () => IntegrityStatus;
 export function computePoolStatus(
 	accounts: Account[],
 	now: number,
+	getUsageInfo: AccountUsageInfoFn = () => null,
 ): PoolStatus {
 	const configured = accounts.length;
 	const paused = accounts.filter((a) => a.paused).length;
@@ -35,6 +77,17 @@ export function computePoolStatus(
 	);
 	const rate_limited = rateLimitedAccounts.length;
 	const routable = accounts.filter((a) => isAccountAvailable(a, now)).length;
+	// Counted independently of `routable`: an account at 100% usage has no
+	// active cooldown (it stays routable) yet upstream rejects its requests,
+	// so `routable > 0` alone can mask an effectively exhausted pool
+	// (incident 2026-07-09).
+	const usage_exhausted = accounts.filter((a) => {
+		if (a.paused) return false;
+		const usage = getUsageInfo(a);
+		return (
+			usage !== null && isUsageExhausted(usage.utilization, usage.resetMs, now)
+		);
+	}).length;
 
 	const earliestRateLimit = rateLimitedAccounts.reduce<number | null>(
 		(min, account) => {
@@ -55,6 +108,7 @@ export function computePoolStatus(
 		paused,
 		rate_limited,
 		routable,
+		usage_exhausted,
 		next_available_at,
 	};
 }
@@ -91,6 +145,7 @@ export function createHealthHandler(
 	getAsyncWriterHealth?: AsyncWriterHealthFn,
 	getUsageWorkerHealth?: UsageWorkerHealthFn,
 	getIntegrityStatus?: IntegrityStatusFn,
+	getAccountUsageInfo: AccountUsageInfoFn = usageCacheUsageInfo,
 ) {
 	const normalCache = new TtlCache<HealthResponse>(2000);
 	const detailCache = new TtlCache<HealthResponse>(2000);
@@ -106,7 +161,7 @@ export function createHealthHandler(
 
 		const accounts = await dbOps.getAllAccounts();
 		const now = Date.now();
-		const pool = computePoolStatus(accounts, now);
+		const pool = computePoolStatus(accounts, now, getAccountUsageInfo);
 
 		// Call each health function once and store results
 		const asyncWriterHealth = getAsyncWriterHealth

--- a/packages/http-api/src/handlers/rate-limit-status.ts
+++ b/packages/http-api/src/handlers/rate-limit-status.ts
@@ -1,0 +1,103 @@
+/**
+ * Display-string computation for an account's rate-limit state.
+ *
+ * Extracted from the accounts list handler so the precedence rules are
+ * testable in isolation. Precedence (highest first):
+ *
+ *   1. usage exhaustion — the representative usage window is at 100% and its
+ *      reset (when known) lies in the future. This outranks unified-header
+ *      snapshots because those go stale on idle accounts: during the
+ *      2026-07-09 incident an account at 100% weekly utilization kept showing
+ *      "OK" (no snapshot stored) while every upstream request 429'd.
+ *   2. the last unified rate-limit header snapshot (`rate_limit_status`),
+ *      with minutes until `rate_limit_reset` when that is in the future.
+ *   3. the legacy cooldown lock (`rate_limited_until`).
+ *   4. "OK".
+ */
+
+export interface RateLimitStatusInput {
+	/** Last `anthropic-ratelimit-unified-status` snapshot, if any. */
+	rate_limit_status: string | null;
+	/** Reset time (ms epoch) accompanying the unified snapshot. */
+	rate_limit_reset: number | null;
+	/** Local cooldown lock (ms epoch), set by 429-driven backoff. */
+	rate_limited_until: number | null;
+	/** Representative usage-window utilization in percent (0-100), or null. */
+	usageUtilization: number | null;
+	/** Reset time (ms epoch) of the representative usage window, if known. */
+	usageResetMs?: number | null;
+}
+
+function minutesLeft(untilMs: number, now: number): number {
+	return Math.ceil((untilMs - now) / 60000);
+}
+
+/**
+ * Shared exhaustion predicate for BOTH the rateLimitStatus display and the
+ * /health `usage_exhausted` counter — keeping the two surfaces from
+ * contradicting each other. A known reset in the past means the snapshot
+ * predates the window reset: do not claim exhaustion from stale data. An
+ * unknown reset trusts the (max 10-minute-old) usage cache.
+ */
+export function isUsageExhausted(
+	utilization: number | null,
+	resetMs: number | null | undefined,
+	now: number,
+): boolean {
+	return (
+		utilization !== null &&
+		utilization >= 100 &&
+		(resetMs == null || resetMs > now)
+	);
+}
+
+export function computeRateLimitStatusDisplay(
+	input: RateLimitStatusInput,
+	now: number,
+): string {
+	const { usageUtilization, usageResetMs } = input;
+
+	if (isUsageExhausted(usageUtilization, usageResetMs, now)) {
+		if (usageResetMs != null && usageResetMs > now) {
+			return `usage_exhausted (${minutesLeft(usageResetMs, now)}m)`;
+		}
+		return "usage_exhausted";
+	}
+
+	if (input.rate_limit_status) {
+		if (input.rate_limit_reset && input.rate_limit_reset > now) {
+			return `${input.rate_limit_status} (${minutesLeft(input.rate_limit_reset, now)}m)`;
+		}
+		return input.rate_limit_status;
+	}
+
+	if (input.rate_limited_until && input.rate_limited_until > now) {
+		return `Rate limited (${minutesLeft(input.rate_limited_until, now)}m)`;
+	}
+
+	return "OK";
+}
+
+/**
+ * Pull the reset timestamp (ms epoch) of a named usage window out of raw
+ * provider usage data. Handles both timestamp shapes in use:
+ * anthropic-style `resets_at` (ISO string) and zai/nanogpt-style `resetAt`
+ * (ms number).
+ */
+export function extractUsageResetMs(
+	usageData: unknown,
+	windowName: string | null,
+): number | null {
+	if (!usageData || typeof usageData !== "object" || !windowName) return null;
+	const window = (usageData as Record<string, unknown>)[windowName];
+	if (!window || typeof window !== "object") return null;
+	const w = window as { resets_at?: unknown; resetAt?: unknown };
+	if (typeof w.resets_at === "string") {
+		const ms = new Date(w.resets_at).getTime();
+		return Number.isFinite(ms) ? ms : null;
+	}
+	if (typeof w.resetAt === "number" && Number.isFinite(w.resetAt)) {
+		return w.resetAt;
+	}
+	return null;
+}

--- a/packages/http-api/src/handlers/rate-limit-status.ts
+++ b/packages/http-api/src/handlers/rate-limit-status.ts
@@ -15,6 +15,23 @@
  *   4. "OK".
  */
 
+import type {
+	AlibabaCodingPlanUsageData,
+	AnyUsageData,
+	KiloUsageData,
+	NanoGPTUsageData,
+	UsageData,
+	XaiUsageData,
+	ZaiUsageData,
+} from "@better-ccflare/providers";
+import {
+	getRepresentativeAlibabaCodingPlanWindow,
+	getRepresentativeKiloWindow,
+	getRepresentativeNanoGPTWindow,
+	getRepresentativeWindow,
+	getRepresentativeXaiWindow,
+} from "@better-ccflare/providers";
+
 export interface RateLimitStatusInput {
 	/** Last `anthropic-ratelimit-unified-status` snapshot, if any. */
 	rate_limit_status: string | null;
@@ -76,6 +93,66 @@ export function computeRateLimitStatusDisplay(
 	}
 
 	return "OK";
+}
+
+/**
+ * Reset time (ms epoch) of the representative usage window, derived the same
+ * way for every provider — the single source BOTH the /health usage_exhausted
+ * counter and the accounts rateLimitStatus display use, so their staleness
+ * guards cannot diverge (PR #299 review finding). Note zai: the display
+ * window is labeled "five_hour" (Claude terminology), but the payload key
+ * carrying the reset is `tokens_limit` — extraction must use the payload key,
+ * not the display label.
+ */
+export function getRepresentativeUsageResetMs(
+	usageData: unknown,
+	provider: string,
+): number | null {
+	if (!usageData || typeof usageData !== "object") return null;
+	try {
+		const data = usageData as AnyUsageData;
+		switch (provider) {
+			case "anthropic":
+			case "codex":
+				return "five_hour" in data && "seven_day" in data
+					? extractUsageResetMs(
+							data,
+							getRepresentativeWindow(data as UsageData),
+						)
+					: null;
+			case "zai":
+				return extractUsageResetMs(
+					data,
+					(data as ZaiUsageData).tokens_limit ? "tokens_limit" : null,
+				);
+			case "nanogpt":
+				return extractUsageResetMs(
+					data,
+					getRepresentativeNanoGPTWindow(data as NanoGPTUsageData),
+				);
+			case "kilo":
+				return extractUsageResetMs(
+					data,
+					getRepresentativeKiloWindow(data as KiloUsageData),
+				);
+			case "alibaba-coding-plan":
+				return extractUsageResetMs(
+					data,
+					getRepresentativeAlibabaCodingPlanWindow(
+						data as AlibabaCodingPlanUsageData,
+					),
+				);
+			case "xai":
+				return extractUsageResetMs(
+					data,
+					getRepresentativeXaiWindow(data as XaiUsageData),
+				);
+			default:
+				return null;
+		}
+	} catch {
+		return null;
+	}
 }
 
 /**

--- a/packages/proxy/src/__tests__/incident-2026-07-09-health-flap.test.ts
+++ b/packages/proxy/src/__tests__/incident-2026-07-09-health-flap.test.ts
@@ -1,0 +1,227 @@
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	mock,
+	spyOn,
+} from "bun:test";
+import {
+	computeRateLimitBackoffMs,
+	isAccountAvailable,
+} from "@better-ccflare/core";
+import type { Account } from "@better-ccflare/types";
+import type { ProxyContext } from "../handlers";
+import { applyRateLimitCooldown } from "../handlers/rate-limit-cooldown";
+import { handleProxy } from "../proxy";
+import * as usageCollectorModule from "../usage-collector";
+
+/**
+ * Characterization tests for the 2026-07-09 incident: upstream 429s on every
+ * unpaused account (no model fallbacks configured) benched the whole pool via
+ * account-wide cooldowns, so NEW sessions received 503 pool_exhausted while
+ * /health flipped back to `routable: N` as soon as each short backoff lapsed —
+ * even though nothing upstream had changed.
+ *
+ * The per-account 429 → model_fallback_429 → cooldown path itself is covered
+ * by proxy-operations-failover.test.ts ("429 failover" / "rate limit audit
+ * trail"). These tests pin the cross-cutting pool/health behavior on top.
+ */
+
+// 2026-07-09T02:27:38Z — first pool_exhausted of the incident window
+const T0 = Date.UTC(2026, 6, 9, 2, 27, 38);
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "acc-1",
+		name: "test-account",
+		provider: "anthropic",
+		api_key: null,
+		refresh_token: null,
+		access_token: null,
+		expires_at: null,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: T0,
+		rate_limited_until: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		custom_endpoint: null,
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		billing_type: null,
+		pause_reason: null,
+		refresh_token_issued_at: null,
+		consecutive_rate_limits: 0,
+		...overrides,
+	} as Account;
+}
+
+function makeContext(accounts: Account[]): ProxyContext {
+	return {
+		strategy: {
+			// Mirrors the real availability predicate (core isAccountAvailable):
+			// unpaused and no active cooldown.
+			select: (accs: Account[]) => {
+				const now = Date.now();
+				return accs.filter(
+					(acc) =>
+						!acc.paused &&
+						(!acc.rate_limited_until || acc.rate_limited_until <= now),
+				);
+			},
+		} as never,
+		dbOps: {
+			getAllAccounts: mock(async () => accounts),
+			getActiveComboForFamily: mock(async () => null),
+			markAccountRateLimited: mock(async () => 1),
+		} as never,
+		runtime: { port: 8080, clientId: "test" } as never,
+		config: {
+			getUsageThrottlingFiveHourEnabled: () => false,
+			getUsageThrottlingWeeklyEnabled: () => false,
+			getSystemPromptCacheTtl1h: () => false,
+		} as never,
+		provider: {
+			name: "anthropic",
+			canHandle: () => true,
+		} as never,
+		refreshInFlight: new Map(),
+		asyncWriter: { enqueue: mock(() => {}) } as never,
+	};
+}
+
+function makeRequest(): Request {
+	return new Request("https://proxy.local/v1/messages", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			model: "claude-sonnet-5",
+			messages: [{ role: "user", content: "spawn subagent" }],
+			max_tokens: 16,
+		}),
+	});
+}
+
+const ENV_KEYS = [
+	"CCFLARE_RATE_LIMIT_BACKOFF_BASE_MS",
+	"CCFLARE_RATE_LIMIT_BACKOFF_MAX_MS",
+	"CCFLARE_PASSTHROUGH_ON_EMPTY_POOL",
+] as const;
+let savedEnv: Record<string, string | undefined>;
+const realDateNow = Date.now;
+
+beforeEach(() => {
+	savedEnv = {};
+	for (const key of ENV_KEYS) {
+		savedEnv[key] = process.env[key];
+		delete process.env[key];
+	}
+});
+
+afterEach(() => {
+	Date.now = realDateNow;
+	for (const key of ENV_KEYS) {
+		if (savedEnv[key] === undefined) delete process.env[key];
+		else process.env[key] = savedEnv[key];
+	}
+});
+
+describe("incident 2026-07-09 — account-wide cooldown from a scoped upstream 429", () => {
+	it("model_fallback_429 benches the WHOLE account, even though the upstream 429 may only affect new sessions or one model", () => {
+		Date.now = () => T0;
+		const account = makeAccount({ id: "alt-3", name: "MAX_200_ALT_3" });
+		const ctx = makeContext([account]);
+
+		applyRateLimitCooldown(account, { reason: "model_fallback_429" }, ctx);
+
+		const expectedUntil = T0 + computeRateLimitBackoffMs(1);
+		expect(account.rate_limited_until).toBe(expectedUntil);
+		// The predicate shared by the router AND /health's `routable` counter
+		// (packages/core/src/strategy.ts) now excludes the account for EVERY
+		// model and session — the bench is account-wide.
+		expect(isAccountAvailable(account, T0)).toBe(false);
+	});
+
+	it("with every unpaused account benched, a new-session request gets 503 pool_exhausted", async () => {
+		Date.now = () => T0;
+		const alt3 = makeAccount({ id: "alt-3", name: "MAX_200_ALT_3" });
+		const alt2 = makeAccount({ id: "alt-2", name: "MAX_200_ALT_2" });
+		const ctx = makeContext([alt3, alt2]);
+
+		// The pool-exhausted path logs to the usage collector singleton, which
+		// is not initialized in unit tests (same pattern as
+		// auto-refresh-probe-filter.test.ts, site 3).
+		const collectorSpy = spyOn(
+			usageCollectorModule,
+			"getUsageCollector",
+		).mockReturnValue({
+			handleStart: mock(() => {}),
+			handleEnd: mock(() => Promise.resolve()),
+		} as unknown as usageCollectorModule.UsageCollector);
+
+		try {
+			// Incident sequence: the spawn request 429'd on ALT_3, failed over to
+			// ALT_2, 429'd again — each attempt benched its account.
+			applyRateLimitCooldown(alt3, { reason: "model_fallback_429" }, ctx);
+			applyRateLimitCooldown(alt2, { reason: "model_fallback_429" }, ctx);
+
+			const response = await handleProxy(
+				makeRequest(),
+				new URL("https://proxy.local/v1/messages"),
+				ctx,
+			);
+
+			expect(response.status).toBe(503);
+			const body = (await response.json()) as Record<string, unknown>;
+			const error = body.error as Record<string, unknown>;
+			expect(error.type).toBe("pool_exhausted");
+
+			// Recovery time advertised to the client = end of the 30s backoff …
+			const expectedUntil = T0 + computeRateLimitBackoffMs(1);
+			expect(error.next_available_at).toBe(
+				new Date(expectedUntil).toISOString(),
+			);
+		} finally {
+			collectorSpy.mockRestore();
+		}
+	});
+
+	it("FLAP: once the backoff lapses, the /health predicate counts the accounts as routable again although upstream never recovered", () => {
+		Date.now = () => T0;
+		const alt3 = makeAccount({ id: "alt-3", name: "MAX_200_ALT_3" });
+		const alt2 = makeAccount({ id: "alt-2", name: "MAX_200_ALT_2" });
+		const ctx = makeContext([alt3, alt2]);
+
+		applyRateLimitCooldown(alt3, { reason: "model_fallback_429" }, ctx);
+		applyRateLimitCooldown(alt2, { reason: "model_fallback_429" }, ctx);
+
+		const accounts = [alt3, alt2];
+		const routableAt = (now: number) =>
+			accounts.filter((a) => isAccountAvailable(a, now)).length;
+
+		// During the bench window: pool is empty (health: routable 0 / 503s).
+		expect(routableAt(T0)).toBe(0);
+
+		// One millisecond after the backoff lapses, /health's routable counter
+		// (computePoolStatus in packages/http-api/src/handlers/health.ts uses
+		// exactly this predicate) reports full capacity again — but the local
+		// bookkeeping learned NOTHING about the upstream limit having cleared.
+		// This is the observed incident state: `/health` said `routable: 2`
+		// while the very next new-session request 429'd on both accounts and
+		// surfaced as 503 pool_exhausted again.
+		const afterBackoff = T0 + computeRateLimitBackoffMs(1) + 1;
+		expect(routableAt(afterBackoff)).toBe(2);
+	});
+});

--- a/packages/types/src/stats.ts
+++ b/packages/types/src/stats.ts
@@ -189,6 +189,11 @@ export interface PoolStatus {
 	routable: number; // Available for routing
 	paused: number; // Manually or automatically paused
 	rate_limited: number; // Temporarily rate-limited
+	// Unpaused accounts whose usage window sits at 100%: they still count as
+	// routable (no active cooldown), but upstream will reject their requests.
+	// Surfaced separately so `routable > 0` stops masking an exhausted pool
+	// (incident 2026-07-09).
+	usage_exhausted: number;
 	next_available_at: string | null; // ISO timestamp when earliest rate-limit expires
 }
 


### PR DESCRIPTION
## What & why — incident 2026-07-09

During the night of 2026-07-09 (02:20–02:46 UTC) every Claude Code **subagent spawn** behind a better-ccflare pool died with the client-side message *"There's an issue with the selected model (X). It may not exist or you may not have access to it."* — for every model — while the sticky main session kept working.

**The actual chain (reconstructed from the request DB, session transcripts, and live `/api/accounts` data):**

1. Anthropic 429'd every **new** session on the two unpaused accounts: one had its weekly window at 100% (account-wide), the other rejected only new sessions while serving the ongoing sticky session 200s — same model, same account, same second.
2. With no model fallbacks configured, each upstream 429 benches the whole account (`applyRateLimitCooldown`, reason `model_fallback_429`, 30s–5min backoff) → failover → 429 again → **29× HTTP 503 `pool_exhausted`**, each preceded by paired 429 rows. Claude Code renders that as the misleading "selected model" error.
3. Diagnosis was needlessly slow because the proxy's own bookkeeping contradicted reality: `/health` reported `routable: 2` in parallel to the 503s (the short backoffs kept lapsing → availability "flap"), and the dashboard showed `rateLimitStatus: "OK"` for the account sitting at 100% weekly utilization — the status string only reflected the last unified-header snapshot and active cooldowns, never usage-window data.

Layers 1 (upstream quota/session limits) and the misleading client message (Claude Code rendering) are outside this repo. **This PR fixes layer 3: the observability gap.** It deliberately does not touch routing.

## What this changes (observability only)

- **`PoolStatus.usage_exhausted`** — counts unpaused accounts whose representative usage utilization is ≥ 100%. `routable` semantics are deliberately unchanged; the new counter makes `routable > 0` stop masking an effectively exhausted pool. Wired through the existing in-memory `usageCache` with **no call-site changes** (optional injector on `createHealthHandler` for tests).
- **`rateLimitStatus`** — extracted into a pure helper (`rate-limit-status.ts`) with test-pinned precedence: **usage exhaustion > unified header snapshot > legacy cooldown > "OK"**. The incident account now renders as `usage_exhausted (Xm)` (red badge + Rate Limit Info card on the dashboard) instead of `OK`.
- **Shared staleness guard** (`isUsageExhausted`) used by *both* surfaces: a known window reset in the past is never reported as exhausted, so `/health` and the accounts API cannot contradict each other on stale snapshots. (Cross-LLM review consensus finding — codex + grok.)
- **Characterization tests** (`incident-2026-07-09-health-flap.test.ts`) pin the incident chain against the real code paths: account-wide bench → pool-wide 503 → the routable **flap** after each backoff. The flap is documented as *structural* (reactive cooldowns cannot know upstream state), not "fixed". The file runs standalone via the established `getUsageCollector` spy pattern.

## Non-goals

- Does **not** prevent the spawn failures — upstream quota is upstream quota; the proxy's 503 was correct.
- Does **not** change routing, cooldown, or 503 semantics (usage-aware routing gates would need their own design; stale cache → falsely excluded accounts).
- Does **not** detect session-scoped upstream limits on a non-exhausted account (locally unobservable by definition — that's what the flap test documents).

## Review & tests

- Cross-reviewed by **codex** (gpt-5.5, xhigh) and **grok**; unanimous on diagnosis and scope. The consensus WARNING (staleness split-brain between the two surfaces) is fixed in-branch; codex's second WARNING (dropped `account.rate_limited` guard) was verified a false positive (`rate_limited` is a SQL-computed `rate_limited_until > now` — the helper checks the identical predicate).
- TDD throughout: desired-behavior tests written first (red), then implemented. 53 tests across 4 files; `bun run lint && typecheck && format` clean; full http-api+proxy suites show no new failures vs. main (identical pre-existing ordering-dependent failures).
