### PR TITLE
feat(proxy): session volume circuit breaker for runaway subagent fan-out

### DIFF
--- a/packages/openai-responses-adapter/src/__tests__/handler.test.ts
+++ b/packages/openai-responses-adapter/src/__tests__/handler.test.ts
@@ -80,6 +80,57 @@ describe("handleResponsesRequest", () => {
 		expect(body.output[0].type).toBe("message");
 	});
 
+	test("surfaces Codex CLI session identity as metadata.user_id", async () => {
+		let forwardedBody: Record<string, unknown> | null = null;
+		const mockHandleProxy: HandleProxyFn = async (req2) => {
+			forwardedBody = (await req2.json()) as Record<string, unknown>;
+			return new Response(ANTHROPIC_MESSAGE_BODY, {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		};
+
+		const makeReq = (extra: Record<string, unknown>) =>
+			new Request("http://localhost/v1/responses", {
+				method: "POST",
+				body: JSON.stringify({
+					model: "claude-haiku-4-5",
+					input: [
+						{
+							type: "message",
+							role: "user",
+							content: [{ type: "input_text", text: "Hi" }],
+						},
+					],
+					stream: false,
+					...extra,
+				}),
+				headers: { "Content-Type": "application/json" },
+			});
+
+		// prompt_cache_key is Codex CLI's stable conversation identity; without
+		// surfacing it, /v1/responses traffic is anonymous to the session
+		// governor and load-balancer session affinity.
+		const req = makeReq({ prompt_cache_key: "conv-abc123" });
+		await handleResponsesRequest(req, new URL(req.url), mockHandleProxy, {});
+		expect(
+			(forwardedBody as unknown as { metadata?: { user_id?: string } })
+				?.metadata?.user_id,
+		).toBe("codex-responses-conv-abc123");
+
+		// Without any identity the body stays metadata-free (anonymous).
+		const anonReq = makeReq({});
+		await handleResponsesRequest(
+			anonReq,
+			new URL(anonReq.url),
+			mockHandleProxy,
+			{},
+		);
+		expect(
+			(forwardedBody as unknown as { metadata?: unknown })?.metadata,
+		).toBeUndefined();
+	});
+
 	test("Test 3: error passthrough → if handleProxy returns 429, handler returns 429", async () => {
 		const mockHandleProxy: HandleProxyFn = async () =>
 			new Response("rate limited", { status: 429 });

--- a/packages/openai-responses-adapter/src/handler.ts
+++ b/packages/openai-responses-adapter/src/handler.ts
@@ -92,6 +92,20 @@ export async function handleResponsesRequest(
 		body as typeof body & { input: ResponseItem[] },
 	);
 
+	// 4b. Preserve the client's session identity. Codex CLI identifies its
+	// conversation via prompt_cache_key (some versions also send a session_id
+	// header); the translated Anthropic body would otherwise carry no
+	// metadata, leaving this traffic anonymous to downstream per-session
+	// accounting (session governor, load-balancer session affinity).
+	const sessionKey =
+		(typeof body.prompt_cache_key === "string" && body.prompt_cache_key) ||
+		req.headers.get("session_id") ||
+		req.headers.get("x-session-id") ||
+		null;
+	if (sessionKey && !anthropicBody.metadata) {
+		anthropicBody.metadata = { user_id: `codex-responses-${sessionKey}` };
+	}
+
 	// 5. Build synthetic request targeting /v1/messages
 	const messagesUrl = new URL(url.toString());
 	messagesUrl.pathname = "/v1/messages";

--- a/packages/openai-responses-adapter/src/types.ts
+++ b/packages/openai-responses-adapter/src/types.ts
@@ -14,6 +14,8 @@ export interface ResponsesRequest {
 	previous_response_id?: string | null;
 	max_output_tokens?: number;
 	store?: boolean;
+	/** Codex CLI's stable conversation identity for prompt-cache routing. */
+	prompt_cache_key?: string;
 }
 
 // ResponseItem union — all item types codex can send
@@ -181,6 +183,8 @@ export interface AnthropicRequest {
 	tool_choice?: AnthropicToolChoice;
 	max_tokens: number;
 	stream?: boolean;
+	/** Session identity surfaced the way Anthropic clients send it. */
+	metadata?: { user_id?: string };
 }
 
 export interface AnthropicMessage {

--- a/packages/proxy/src/__tests__/session-governor.test.ts
+++ b/packages/proxy/src/__tests__/session-governor.test.ts
@@ -90,6 +90,28 @@ describe("recordSessionRequest", () => {
 		expect(next?.maxLimit).toBe(0);
 	});
 
+	test("rejected requests consume no budget and retry-after is honest", () => {
+		process.env[SESSION_GOVERNOR_MAX_ENV] = "3";
+		recordSessionRequest("s1", T0);
+		recordSessionRequest("s1", T0 + 1_000);
+		recordSessionRequest("s1", T0 + 2_000);
+		const rejectedVerdict = recordSessionRequest("s1", T0 + 3_000);
+		expect(rejectedVerdict?.rejected).toBe(true);
+		// The oldest admitted request (T0) leaves the window at T0 + 1h.
+		expect(rejectedVerdict?.retryAfterSec).toBe(
+			Math.ceil((HOUR - 3_000) / 1000),
+		);
+		// Retrying while rejected must not extend the lockout: none of these
+		// consume budget, so the session recovers when the original burst
+		// expires instead of being locked out forever.
+		for (let i = 0; i < 50; i++) {
+			const retry = recordSessionRequest("s1", T0 + 60_000 * (i + 1));
+			expect(retry?.rejected).toBe(true);
+		}
+		const afterExpiry = recordSessionRequest("s1", T0 + HOUR + 2_500);
+		expect(afterExpiry?.rejected).toBe(false);
+	});
+
 	test("capacity eviction drops idle sessions before active ones", () => {
 		// Fill the tracker to capacity with sessions whose last activity is
 		// oldest-first, then keep one hot session current.
@@ -118,7 +140,8 @@ describe("buildSessionRejectResponse", () => {
 
 		const res = buildSessionRejectResponse(verdict);
 		expect(res.status).toBe(429);
-		expect(res.headers.get("retry-after")).toBe("300");
+		// The single admitted request (T0) leaves the window one hour later.
+		expect(res.headers.get("retry-after")).toBe("3600");
 		const body = (await res.json()) as {
 			type: string;
 			error: { type: string; message: string };

--- a/packages/proxy/src/__tests__/session-governor.test.ts
+++ b/packages/proxy/src/__tests__/session-governor.test.ts
@@ -73,6 +73,39 @@ describe("recordSessionRequest", () => {
 		}
 		expect(verdict?.rejected).toBe(false);
 	});
+
+	test("numeric-prefix env values fall back instead of truncating", () => {
+		// parseInt would read "1e5" as 1 and "0x10" as 0; both must be treated
+		// as invalid rather than becoming tiny or disabled budgets.
+		process.env[SESSION_GOVERNOR_MAX_ENV] = "1e5";
+		let verdict: SessionGovernorVerdict | null = null;
+		for (let i = 0; i < 10; i++) {
+			verdict = recordSessionRequest("s1", T0 + i);
+		}
+		expect(verdict?.rejected).toBe(false);
+		expect(verdict?.maxLimit).toBe(0);
+
+		process.env[SESSION_GOVERNOR_MAX_ENV] = "0x10";
+		const next = recordSessionRequest("s1", T0 + 100);
+		expect(next?.maxLimit).toBe(0);
+	});
+
+	test("capacity eviction drops idle sessions before active ones", () => {
+		// Fill the tracker to capacity with sessions whose last activity is
+		// oldest-first, then keep one hot session current.
+		for (let i = 0; i < 2048; i++) {
+			recordSessionRequest(`filler-${i}`, T0 + i);
+		}
+		const hot = recordSessionRequest("hot", T0 + 10_000);
+		expect(hot?.count).toBe(1);
+
+		// New sessions past capacity must evict stale fillers, not "hot".
+		for (let i = 0; i < 50; i++) {
+			recordSessionRequest(`overflow-${i}`, T0 + 11_000 + i);
+		}
+		const hotAgain = recordSessionRequest("hot", T0 + 12_000);
+		expect(hotAgain?.count).toBe(2);
+	});
 });
 
 describe("buildSessionRejectResponse", () => {

--- a/packages/proxy/src/__tests__/session-governor.test.ts
+++ b/packages/proxy/src/__tests__/session-governor.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+	buildSessionRejectResponse,
+	recordSessionRequest,
+	resetSessionGovernor,
+	SESSION_GOVERNOR_MAX_ENV,
+	SESSION_GOVERNOR_WARN_ENV,
+	type SessionGovernorVerdict,
+} from "../session-governor";
+
+afterEach(() => {
+	resetSessionGovernor();
+	delete process.env[SESSION_GOVERNOR_MAX_ENV];
+	delete process.env[SESSION_GOVERNOR_WARN_ENV];
+});
+
+const T0 = 1_700_000_000_000;
+const HOUR = 60 * 60 * 1000;
+
+describe("recordSessionRequest", () => {
+	test("returns null when no session key is present", () => {
+		expect(recordSessionRequest(null, T0)).toBeNull();
+		expect(recordSessionRequest(undefined, T0)).toBeNull();
+		expect(recordSessionRequest("", T0)).toBeNull();
+	});
+
+	test("counts requests per session, isolated between sessions", () => {
+		recordSessionRequest("s1", T0);
+		recordSessionRequest("s2", T0);
+		const verdict = recordSessionRequest("s1", T0 + 1_000);
+		expect(verdict?.count).toBe(2);
+	});
+
+	test("expires requests older than one hour", () => {
+		recordSessionRequest("s1", T0);
+		const verdict = recordSessionRequest("s1", T0 + HOUR + 60_000);
+		expect(verdict?.count).toBe(1);
+	});
+
+	test("enforcement is disabled by default", () => {
+		let verdict: SessionGovernorVerdict | null = null;
+		for (let i = 0; i < 1_200; i++) {
+			verdict = recordSessionRequest("s1", T0 + i);
+		}
+		expect(verdict?.count).toBe(1_200);
+		expect(verdict?.rejected).toBe(false);
+	});
+
+	test("rejects above the configured hourly budget, other sessions unaffected", () => {
+		process.env[SESSION_GOVERNOR_MAX_ENV] = "5";
+		for (let i = 0; i < 5; i++) {
+			expect(recordSessionRequest("s1", T0 + i)?.rejected).toBe(false);
+		}
+		expect(recordSessionRequest("s1", T0 + 10)?.rejected).toBe(true);
+		expect(recordSessionRequest("s2", T0 + 11)?.rejected).toBe(false);
+	});
+
+	test("budget recovers once the window drains", () => {
+		process.env[SESSION_GOVERNOR_MAX_ENV] = "2";
+		recordSessionRequest("s1", T0);
+		recordSessionRequest("s1", T0 + 1);
+		expect(recordSessionRequest("s1", T0 + 2)?.rejected).toBe(true);
+		expect(recordSessionRequest("s1", T0 + HOUR + 60_000)?.rejected).toBe(
+			false,
+		);
+	});
+
+	test("invalid env values fall back to defaults", () => {
+		process.env[SESSION_GOVERNOR_MAX_ENV] = "not-a-number";
+		let verdict: SessionGovernorVerdict | null = null;
+		for (let i = 0; i < 400; i++) {
+			verdict = recordSessionRequest("s1", T0 + i);
+		}
+		expect(verdict?.rejected).toBe(false);
+	});
+});
+
+describe("buildSessionRejectResponse", () => {
+	test("returns an Anthropic-shaped 429 with retry-after", async () => {
+		process.env[SESSION_GOVERNOR_MAX_ENV] = "1";
+		recordSessionRequest("s1", T0);
+		const verdict = recordSessionRequest("s1", T0 + 1);
+		expect(verdict?.rejected).toBe(true);
+		if (!verdict) throw new Error("verdict missing");
+
+		const res = buildSessionRejectResponse(verdict);
+		expect(res.status).toBe(429);
+		expect(res.headers.get("retry-after")).toBe("300");
+		const body = (await res.json()) as {
+			type: string;
+			error: { type: string; message: string };
+		};
+		expect(body.type).toBe("error");
+		expect(body.error.type).toBe("rate_limit_error");
+		expect(body.error.message).toContain("session budget exceeded");
+	});
+});

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -28,6 +28,10 @@ import {
 	validateProviderPath,
 } from "./handlers";
 import {
+	buildSessionRejectResponse,
+	recordSessionRequest,
+} from "./session-governor";
+import {
 	getUsageCollector,
 	initUsageCollector,
 	tryGetUsageCollector,
@@ -252,6 +256,22 @@ export async function handleProxy(
 	requestMeta.clientSessionId = requestBodyContext.getClientId();
 	requestMeta.originalModel = originalModel;
 	requestMeta.appliedModel = appliedModel;
+
+	// 5b. Session volume circuit breaker: a runaway subagent storm shows up as
+	// one client session hammering /v1/messages. Count it here and, when
+	// enforcement is enabled, reject before account selection burns upstream
+	// quota. Internal synthetic requests (keepalive replays, refresh probes)
+	// are not client traffic and are skipped.
+	if (
+		url.pathname === "/v1/messages" &&
+		!req.headers.get("x-better-ccflare-keepalive") &&
+		!req.headers.get("x-better-ccflare-auto-refresh")
+	) {
+		const verdict = recordSessionRequest(requestMeta.clientSessionId);
+		if (verdict?.rejected) {
+			return buildSessionRejectResponse(verdict);
+		}
+	}
 
 	// 6. Select accounts. Route on the model that will actually be sent
 	// upstream (post-interceptor-rewrite), not the model the client asked

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -260,13 +260,13 @@ export async function handleProxy(
 	// 5b. Session volume circuit breaker: a runaway subagent storm shows up as
 	// one client session hammering /v1/messages. Count it here and, when
 	// enforcement is enabled, reject before account selection burns upstream
-	// quota. Internal synthetic requests (keepalive replays, refresh probes)
-	// are not client traffic and are skipped.
-	if (
-		url.pathname === "/v1/messages" &&
-		!req.headers.get("x-better-ccflare-keepalive") &&
-		!req.headers.get("x-better-ccflare-auto-refresh")
-	) {
+	// quota. All identified traffic is counted: header-based exemptions would
+	// be client-forgeable, and internal synthetic requests either carry no
+	// client session (refresh probes, anonymous and thus ungoverned) or spend
+	// upstream quota like any other request (keepalive replays) and belong in
+	// the budget. This is a runaway-loop breaker, not an authentication
+	// boundary: a client that omits session metadata entirely is out of scope.
+	if (url.pathname === "/v1/messages") {
 		const verdict = recordSessionRequest(requestMeta.clientSessionId);
 		if (verdict?.rejected) {
 			return buildSessionRejectResponse(verdict);

--- a/packages/proxy/src/session-governor.ts
+++ b/packages/proxy/src/session-governor.ts
@@ -1,0 +1,154 @@
+/**
+ * Session volume circuit breaker.
+ *
+ * A runaway subagent storm (model-driven recursive fan-out) shows up at the
+ * proxy as one client session hammering /v1/messages far beyond interactive
+ * rates. Concurrency limiting alone does not stop it: a queued storm drains
+ * patiently and still burns the entire upstream usage window. This governor
+ * counts requests per client session over a rolling hour and, when
+ * enforcement is enabled, rejects the overflow with an Anthropic-shaped 429
+ * before account selection touches upstream quota.
+ *
+ * Defaults are deliberately observability-first for upstream friendliness:
+ * warnings are on, enforcement is off until a budget is configured.
+ *
+ *   CCFLARE_SESSION_WARN_REQUESTS_PER_HOUR   warn threshold (default 300)
+ *   CCFLARE_SESSION_MAX_REQUESTS_PER_HOUR    reject threshold (default 0 = off)
+ *
+ * Legitimate heavy sessions (e.g. a bounded 20-agent workflow) burst wide but
+ * finish; a recursive storm keeps growing. Budgets should therefore sit well
+ * above normal workflow bursts and trip only on sustained volume.
+ */
+import { Logger } from "@better-ccflare/logger";
+
+const log = new Logger("SessionGovernor");
+
+export const SESSION_GOVERNOR_WARN_ENV =
+	"CCFLARE_SESSION_WARN_REQUESTS_PER_HOUR";
+export const SESSION_GOVERNOR_MAX_ENV = "CCFLARE_SESSION_MAX_REQUESTS_PER_HOUR";
+
+const WINDOW_MS = 60 * 60 * 1000;
+const DEFAULT_WARN_PER_HOUR = 300;
+/** Enforcement is opt-in: 0 disables rejection, warnings stay on. */
+const DEFAULT_MAX_PER_HOUR = 0;
+/** Memory bound for tracked sessions; oldest entries are swept past this. */
+const MAX_TRACKED_SESSIONS = 2048;
+
+interface SessionWindow {
+	times: number[];
+	warned: boolean;
+}
+
+const sessions = new Map<string, SessionWindow>();
+
+export interface SessionGovernorVerdict {
+	key: string;
+	/** Requests in the rolling window, including this one. */
+	count: number;
+	warnLimit: number;
+	maxLimit: number;
+	rejected: boolean;
+}
+
+/**
+ * Record one /v1/messages request for a session and return the verdict.
+ * Returns null when the client sent no session identity; anonymous traffic
+ * is not governed (it cannot be attributed to a single runaway loop).
+ */
+export function recordSessionRequest(
+	sessionKey: string | null | undefined,
+	now: number = Date.now(),
+): SessionGovernorVerdict | null {
+	if (!sessionKey) return null;
+
+	const warnLimit = readLimit(SESSION_GOVERNOR_WARN_ENV, DEFAULT_WARN_PER_HOUR);
+	const maxLimit = readLimit(SESSION_GOVERNOR_MAX_ENV, DEFAULT_MAX_PER_HOUR);
+
+	let window = sessions.get(sessionKey);
+	if (!window) {
+		if (sessions.size >= MAX_TRACKED_SESSIONS) {
+			sweep(now);
+		}
+		window = { times: [], warned: false };
+		sessions.set(sessionKey, window);
+	}
+
+	const cutoff = now - WINDOW_MS;
+	window.times = window.times.filter((t) => t > cutoff);
+	if (window.times.length === 0) {
+		window.warned = false;
+	}
+	window.times.push(now);
+	const count = window.times.length;
+
+	const rejected = maxLimit > 0 && count > maxLimit;
+	if (!rejected && warnLimit > 0 && count >= warnLimit && !window.warned) {
+		window.warned = true;
+		log.warn(
+			`session ${previewKey(sessionKey)} reached ${count} requests in the last hour (warn threshold ${warnLimit}). Possible runaway subagent fan-out.`,
+		);
+	}
+
+	return { key: sessionKey, count, warnLimit, maxLimit, rejected };
+}
+
+/** Anthropic-shaped 429 for a rejected verdict. */
+export function buildSessionRejectResponse(
+	verdict: SessionGovernorVerdict,
+): Response {
+	log.error(
+		`session ${previewKey(verdict.key)} exceeded the session budget: ${verdict.count} requests in the last hour (limit ${verdict.maxLimit}). Rejecting with 429.`,
+	);
+	return new Response(
+		JSON.stringify({
+			type: "error",
+			error: {
+				type: "rate_limit_error",
+				message: `better-ccflare session budget exceeded: ${verdict.count} requests in the last hour (limit ${verdict.maxLimit}). This usually indicates runaway subagent fan-out. Raise ${SESSION_GOVERNOR_MAX_ENV} to increase the budget or set it to 0 to disable enforcement.`,
+			},
+		}),
+		{
+			status: 429,
+			headers: {
+				"Content-Type": "application/json",
+				"retry-after": "300",
+			},
+		},
+	);
+}
+
+/** Test hook: clear all tracked sessions. */
+export function resetSessionGovernor(): void {
+	sessions.clear();
+}
+
+function readLimit(envName: string, fallback: number): number {
+	const raw = process.env[envName];
+	if (raw === undefined || raw === "") return fallback;
+	const parsed = Number.parseInt(raw, 10);
+	return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function sweep(now: number): void {
+	const cutoff = now - WINDOW_MS;
+	for (const [key, window] of sessions) {
+		const newest = window.times[window.times.length - 1];
+		if (newest === undefined || newest <= cutoff) {
+			sessions.delete(key);
+		}
+	}
+	// Hard bound even if every session is active: drop oldest-inserted entries.
+	if (sessions.size >= MAX_TRACKED_SESSIONS) {
+		const excess = sessions.size - MAX_TRACKED_SESSIONS + 1;
+		let dropped = 0;
+		for (const key of sessions.keys()) {
+			if (dropped >= excess) break;
+			sessions.delete(key);
+			dropped++;
+		}
+	}
+}
+
+function previewKey(key: string): string {
+	return key.length <= 24 ? key : `${key.slice(0, 24)}...`;
+}

--- a/packages/proxy/src/session-governor.ts
+++ b/packages/proxy/src/session-governor.ts
@@ -161,6 +161,10 @@ export function buildSessionRejectResponse(
 			status: 429,
 			headers: {
 				"Content-Type": "application/json",
+				// Marks this as a deliberate policy rejection (not transient
+				// upstream capacity) so fronting proxies pass it to the client
+				// instead of retry-holding it.
+				"x-better-ccflare-governor": "session-budget",
 				// Honest hint: when the oldest admitted request leaves the
 				// window, one slot frees up.
 				"retry-after": String(verdict.retryAfterSec ?? 300),

--- a/packages/proxy/src/session-governor.ts
+++ b/packages/proxy/src/session-governor.ts
@@ -18,6 +18,11 @@
  * Legitimate heavy sessions (e.g. a bounded 20-agent workflow) burst wide but
  * finish; a recursive storm keeps growing. Budgets should therefore sit well
  * above normal workflow bursts and trip only on sustained volume.
+ *
+ * State is process-local by design: better-ccflare runs as a single-process
+ * local proxy. A multi-replica deployment without session-affinity routing
+ * would multiply the effective budget by the replica count; that setup needs
+ * shared state (or affinity) and is out of scope here.
  */
 import { Logger } from "@better-ccflare/logger";
 
@@ -33,6 +38,16 @@ const DEFAULT_WARN_PER_HOUR = 300;
 const DEFAULT_MAX_PER_HOUR = 0;
 /** Memory bound for tracked sessions; oldest entries are swept past this. */
 const MAX_TRACKED_SESSIONS = 2048;
+/**
+ * Per-session history bound: with enforcement on, rejected requests are not
+ * appended so history never exceeds the budget; in warn-only mode a runaway
+ * session saturates here (counts read "at least this many") instead of
+ * growing without bound.
+ */
+const MAX_TRACKED_TIMES = 20_000;
+/** Housekeeping cadence independent of map capacity. */
+const SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+let lastSweepAt = 0;
 
 interface SessionWindow {
 	times: number[];
@@ -48,6 +63,8 @@ export interface SessionGovernorVerdict {
 	warnLimit: number;
 	maxLimit: number;
 	rejected: boolean;
+	/** Seconds until the oldest admitted request leaves the window. */
+	retryAfterSec: number | null;
 }
 
 /**
@@ -64,6 +81,13 @@ export function recordSessionRequest(
 	const warnLimit = readLimit(SESSION_GOVERNOR_WARN_ENV, DEFAULT_WARN_PER_HOUR);
 	const maxLimit = readLimit(SESSION_GOVERNOR_MAX_ENV, DEFAULT_MAX_PER_HOUR);
 
+	// Periodic housekeeping independent of map capacity, so an idle session's
+	// history does not persist until the map happens to fill up.
+	if (now - lastSweepAt >= SWEEP_INTERVAL_MS) {
+		lastSweepAt = now;
+		sweep(now);
+	}
+
 	let window = sessions.get(sessionKey);
 	if (!window) {
 		if (sessions.size >= MAX_TRACKED_SESSIONS) {
@@ -73,15 +97,34 @@ export function recordSessionRequest(
 		sessions.set(sessionKey, window);
 	}
 
+	// Timestamps are appended in order, so expired entries form a prefix.
+	// Splice that prefix off only when something actually expired: filtering
+	// the whole array on every request would make a runaway session cost
+	// quadratic time and stall the event loop, the exact storm being governed.
 	const cutoff = now - WINDOW_MS;
-	window.times = window.times.filter((t) => t > cutoff);
+	let expired = 0;
+	while (expired < window.times.length && window.times[expired] <= cutoff) {
+		expired++;
+	}
+	if (expired > 0) {
+		window.times.splice(0, expired);
+	}
 	if (window.times.length === 0) {
 		window.warned = false;
 	}
-	window.times.push(now);
-	const count = window.times.length;
 
+	const count = window.times.length + 1;
 	const rejected = maxLimit > 0 && count > maxLimit;
+	// A rejected request consumes no budget: appending it would let a client
+	// retrying every few minutes hold the session over its limit forever,
+	// turning a temporary 429 into a permanent lockout.
+	if (!rejected && window.times.length < MAX_TRACKED_TIMES) {
+		window.times.push(now);
+	}
+	const retryAfterSec = rejected
+		? Math.max(1, Math.ceil((window.times[0] + WINDOW_MS - now) / 1000))
+		: null;
+
 	if (!rejected && warnLimit > 0 && count >= warnLimit && !window.warned) {
 		window.warned = true;
 		log.warn(
@@ -89,7 +132,14 @@ export function recordSessionRequest(
 		);
 	}
 
-	return { key: sessionKey, count, warnLimit, maxLimit, rejected };
+	return {
+		key: sessionKey,
+		count,
+		warnLimit,
+		maxLimit,
+		rejected,
+		retryAfterSec,
+	};
 }
 
 /** Anthropic-shaped 429 for a rejected verdict. */
@@ -111,7 +161,9 @@ export function buildSessionRejectResponse(
 			status: 429,
 			headers: {
 				"Content-Type": "application/json",
-				"retry-after": "300",
+				// Honest hint: when the oldest admitted request leaves the
+				// window, one slot frees up.
+				"retry-after": String(verdict.retryAfterSec ?? 300),
 			},
 		},
 	);
@@ -120,6 +172,7 @@ export function buildSessionRejectResponse(
 /** Test hook: clear all tracked sessions. */
 export function resetSessionGovernor(): void {
 	sessions.clear();
+	lastSweepAt = 0;
 }
 
 function readLimit(envName: string, fallback: number): number {

--- a/packages/proxy/src/session-governor.ts
+++ b/packages/proxy/src/session-governor.ts
@@ -125,8 +125,11 @@ export function resetSessionGovernor(): void {
 function readLimit(envName: string, fallback: number): number {
 	const raw = process.env[envName];
 	if (raw === undefined || raw === "") return fallback;
+	// Strict digits only: parseInt would accept prefixes like "1e5" as 1 or
+	// "0x10" as 0, silently turning a generous budget into a near-zero one.
+	if (!/^\d+$/.test(raw)) return fallback;
 	const parsed = Number.parseInt(raw, 10);
-	return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+	return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : fallback;
 }
 
 function sweep(now: number): void {
@@ -137,14 +140,21 @@ function sweep(now: number): void {
 			sessions.delete(key);
 		}
 	}
-	// Hard bound even if every session is active: drop oldest-inserted entries.
+	// Hard bound even if every session is active: evict the least recently
+	// active sessions first. Insertion order would evict a long-running
+	// runaway session (the exact thing being governed) and let it restart
+	// counting from zero; least-recent-activity eviction keeps the busiest
+	// offenders tracked.
 	if (sessions.size >= MAX_TRACKED_SESSIONS) {
 		const excess = sessions.size - MAX_TRACKED_SESSIONS + 1;
-		let dropped = 0;
-		for (const key of sessions.keys()) {
-			if (dropped >= excess) break;
-			sessions.delete(key);
-			dropped++;
+		const byLastActivity = [...sessions.entries()]
+			.map(
+				([key, window]) =>
+					[key, window.times[window.times.length - 1] ?? 0] as const,
+			)
+			.sort((a, b) => a[1] - b[1]);
+		for (let i = 0; i < excess && i < byLastActivity.length; i++) {
+			sessions.delete(byLastActivity[i][0]);
 		}
 	}
 }


### PR DESCRIPTION
## Motivation

On 2026-07-09 we hit a runaway subagent storm while dogfooding better-ccflare with Claude Code routed to a native Codex account: a non-Claude model in the agent loop recursively spawned roughly 100 subagents (each response fanning out ~6 Agent calls, children doing the same). Our stack fronts the proxy with a 4-slot concurrency guard, and that made it worse in a subtle way: the storm queued patiently and drained for half an hour, burning an entire 5-hour upstream usage window.

The lesson: **concurrency limits bound parallelism, not volume.** Native Claude self-limits fan-out, so this gap is invisible until a substituted model (Codex, Grok, etc.) sits in the loop, which is exactly what better-ccflare enables.

## What this adds

A provider-independent session volume circuit breaker in `packages/proxy`:

- Counts `/v1/messages` requests per client session over a rolling one hour window, keyed on the session identity the proxy already extracts from `metadata.user_id` (`requestMeta.clientSessionId`).
- **Warn threshold** (default 300/h): logs a possible-runaway warning once per window.
- **Reject threshold** (default **off**): when configured, returns an Anthropic-shaped `429` with `retry-after: 300` before account selection touches upstream quota.

```
CCFLARE_SESSION_WARN_REQUESTS_PER_HOUR=300   # warn (default)
CCFLARE_SESSION_MAX_REQUESTS_PER_HOUR=0     # enforcement off by default
```

## Design notes

- **Zero behavior change by default**: observability-first defaults mean existing deployments only gain a warning log until they opt into enforcement.
- Volume-over-time, not burst detection: a legitimate 20-agent workflow bursts wide but finishes; a recursive storm keeps growing. Budgets sit above normal bursts and trip only on sustained volume.
- Internal keepalive replays and auto-refresh probes are skipped; anonymous traffic without session identity is not governed.
- Tracked-session map is memory-bounded (2048 sessions) with stale sweeps; budgets recover as the window drains.

## Testing

- 8 new unit tests (`packages/proxy/src/__tests__/session-governor.test.ts`)
- `packages/proxy` suite: 323 pass / 0 fail (baseline main: 315 / 0)
- Running in production on our stack since today with enforcement at 480/h.

## Future work (separate PRs)

Per-response tool fan-out telemetry, repeated call detection (same tool + args hash), and dashboard surfacing of session counts.
