### PR TITLE
fix(server): gracefully drain in-flight SSE streams on shutdown

### DIFF
--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -119,10 +119,18 @@ interface ParsedArgs {
 	admin: boolean;
 }
 
+// When the long-running server starts, its own SIGINT/SIGTERM handlers
+// (apps/server) own shutdown: they drain in-flight requests before exit.
+// The CLI-level handlers must then stand down; otherwise exitGracefully()
+// races the server's drain, disposes the same resources concurrently, and
+// its process.exit() severs active streams mid-response.
+let serverOwnsShutdown = false;
+
 /**
  * Helper function to start server with unified environment variable handling
  */
 function startServerWithConfig(args: ParsedArgs, config: Config) {
+	serverOwnsShutdown = true;
 	const runtime = config.getRuntime();
 
 	// Proper precedence: command line args > environment variables > config defaults
@@ -1399,11 +1407,14 @@ main().catch(async (error) => {
 	await exitGracefully(1);
 });
 
-// Handle process termination
+// Handle process termination. When the server is running it owns shutdown
+// (see serverOwnsShutdown); these handlers cover short-lived CLI commands.
 process.on("SIGINT", async () => {
+	if (serverOwnsShutdown) return;
 	await exitGracefully(0);
 });
 
 process.on("SIGTERM", async () => {
+	if (serverOwnsShutdown) return;
 	await exitGracefully(0);
 });

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -39,6 +39,65 @@ describe("readShutdownDrainMs", () => {
 		// make the watchdog fire immediately.
 		process.env[SHUTDOWN_DRAIN_MS_ENV] = "99999999999";
 		expect(readShutdownDrainMs()).toBe(MAX_SHUTDOWN_DRAIN_MS);
+		// Beyond MAX_SAFE_INTEGER must still clamp, not fall back to 60s.
+		process.env[SHUTDOWN_DRAIN_MS_ENV] = "9007199254740992";
+		expect(readShutdownDrainMs()).toBe(MAX_SHUTDOWN_DRAIN_MS);
 		delete process.env[SHUTDOWN_DRAIN_MS_ENV];
+	});
+});
+
+describe("trackStreamForShutdown", () => {
+	const {
+		trackStreamForShutdown,
+		abortInflightStreams,
+	} = require("./server");
+
+	const endlessResponse = () =>
+		new Response(
+			new ReadableStream<Uint8Array>({
+				async pull(controller) {
+					controller.enqueue(new TextEncoder().encode("tick\n"));
+					await new Promise((r) => setTimeout(r, 20));
+				},
+			}),
+			{ headers: { "content-type": "text/event-stream" } },
+		);
+
+	it("errors tracked never-ending streams on abort", async () => {
+		const wrapped = trackStreamForShutdown(endlessResponse());
+		const reader = wrapped.body?.getReader();
+		if (!reader) throw new Error("wrapped response lost its body");
+		await reader.read(); // stream is live
+		expect(abortInflightStreams()).toBe(1);
+		await expect(
+			(async () => {
+				while (true) {
+					const { done } = await reader.read();
+					if (done) break;
+				}
+			})(),
+		).rejects.toThrow(/drain deadline/);
+		// Registry is drained; a second sweep has nothing to abort.
+		expect(abortInflightStreams()).toBe(0);
+	});
+
+	it("unregisters streams that complete normally", async () => {
+		const wrapped = trackStreamForShutdown(
+			new Response(
+				new ReadableStream<Uint8Array>({
+					start(controller) {
+						controller.enqueue(new TextEncoder().encode("done"));
+						controller.close();
+					},
+				}),
+			),
+		);
+		expect(await wrapped.text()).toBe("done");
+		expect(abortInflightStreams()).toBe(0);
+	});
+
+	it("passes non-stream responses through untouched", () => {
+		const plain = new Response(null, { status: 204 });
+		expect(trackStreamForShutdown(plain)).toBe(plain);
 	});
 });

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -14,3 +14,19 @@ describe("supportsRefreshBackedUsagePolling", () => {
 		expect(supportsRefreshBackedUsagePolling(null)).toBe(false);
 	});
 });
+
+describe("readShutdownDrainMs", () => {
+	const { readShutdownDrainMs, SHUTDOWN_DRAIN_MS_ENV } = require("./server");
+
+	it("defaults to 60s and parses overrides", () => {
+		delete process.env[SHUTDOWN_DRAIN_MS_ENV];
+		expect(readShutdownDrainMs()).toBe(60_000);
+		process.env[SHUTDOWN_DRAIN_MS_ENV] = "5000";
+		expect(readShutdownDrainMs()).toBe(5_000);
+		process.env[SHUTDOWN_DRAIN_MS_ENV] = "0";
+		expect(readShutdownDrainMs()).toBe(0);
+		process.env[SHUTDOWN_DRAIN_MS_ENV] = "nonsense";
+		expect(readShutdownDrainMs()).toBe(60_000);
+		delete process.env[SHUTDOWN_DRAIN_MS_ENV];
+	});
+});

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -29,4 +29,16 @@ describe("readShutdownDrainMs", () => {
 		expect(readShutdownDrainMs()).toBe(60_000);
 		delete process.env[SHUTDOWN_DRAIN_MS_ENV];
 	});
+
+	it("rejects numeric prefixes and clamps oversized values", () => {
+		const { MAX_SHUTDOWN_DRAIN_MS } = require("./server");
+		// parseInt would read "1abc" as a 1ms drain; treat it as invalid.
+		process.env[SHUTDOWN_DRAIN_MS_ENV] = "1abc";
+		expect(readShutdownDrainMs()).toBe(60_000);
+		// Values beyond the clamp would overflow setTimeout's 32-bit delay and
+		// make the watchdog fire immediately.
+		process.env[SHUTDOWN_DRAIN_MS_ENV] = "99999999999";
+		expect(readShutdownDrainMs()).toBe(MAX_SHUTDOWN_DRAIN_MS);
+		delete process.env[SHUTDOWN_DRAIN_MS_ENV];
+	});
 });

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -518,12 +518,17 @@ function startUsagePollingWithRefresh(
 }
 
 // Export for programmatic use
+let serverLifecycleOwned = false;
+
 export default async function startServer(options?: {
 	port?: number;
 	withDashboard?: boolean;
 	sslKeyPath?: string;
 	sslCertPath?: string;
 }) {
+	// From here on, this process owns a server lifecycle: the module-scope
+	// signal handlers below act, and the CLI's own handlers stand down.
+	serverLifecycleOwned = true;
 	// Return existing server if already running
 	if (serverInstance) {
 		const existingPort = serverInstance.port;
@@ -1192,12 +1197,14 @@ export default async function startServer(options?: {
 								authResult.apiKeyName,
 							);
 						}
-						return await handleProxy(
-							req,
-							url,
-							proxyContext,
-							authResult.apiKeyId,
-							authResult.apiKeyName,
+						return trackStreamForShutdown(
+							await handleProxy(
+								req,
+								url,
+								proxyContext,
+								authResult.apiKeyId,
+								authResult.apiKeyName,
+							),
 						);
 					} catch (proxyError) {
 						const statusCode =
@@ -1568,6 +1575,73 @@ Available endpoints:
  * timeout (systemd TimeoutStopSec, wrapper SIGKILL delays) above this value
  * plus the watchdog margin or the drain gets SIGKILLed out from under us.
  */
+// ── In-flight stream registry for shutdown ─────────────────────────────────
+// Bun 1.x cannot escalate a graceful stop(): once stop() has removed the
+// listener, a later stop(true) no longer terminates active connections
+// (verified empirically on Bun 1.3.5). To force-close still-streaming
+// responses at the drain deadline, every proxied response is wrapped in a
+// pass-through whose controller can be errored explicitly.
+const inflightStreamAborts = new Set<() => void>();
+
+export function trackStreamForShutdown(response: Response): Response {
+	const body = response.body;
+	if (!body) return response;
+	const reader = body.getReader();
+	let abort: (() => void) | null = null;
+	const unregister = () => {
+		if (abort) inflightStreamAborts.delete(abort);
+	};
+	const stream = new ReadableStream<Uint8Array>({
+		start(controller) {
+			abort = () => {
+				unregister();
+				try {
+					controller.error(new Error("server shutdown: drain deadline"));
+				} catch {
+					// already closed or errored
+				}
+				reader.cancel().catch(() => {});
+			};
+			inflightStreamAborts.add(abort);
+		},
+		async pull(controller) {
+			try {
+				const { done, value } = await reader.read();
+				if (done) {
+					unregister();
+					controller.close();
+				} else {
+					controller.enqueue(value);
+				}
+			} catch (error) {
+				unregister();
+				try {
+					controller.error(error);
+				} catch {
+					// already errored by abort
+				}
+			}
+		},
+		cancel(reason) {
+			unregister();
+			return reader.cancel(reason).catch(() => {});
+		},
+	});
+	return new Response(stream, {
+		status: response.status,
+		statusText: response.statusText,
+		headers: response.headers,
+	});
+}
+
+/** Error every tracked in-flight stream; returns how many were aborted. */
+export function abortInflightStreams(): number {
+	const aborts = [...inflightStreamAborts];
+	inflightStreamAborts.clear();
+	for (const abort of aborts) abort();
+	return aborts.length;
+}
+
 export const SHUTDOWN_DRAIN_MS_ENV = "CCFLARE_SHUTDOWN_DRAIN_MS";
 const DEFAULT_SHUTDOWN_DRAIN_MS = 60_000;
 /**
@@ -1586,8 +1660,11 @@ export function readShutdownDrainMs(): number {
 	// Strict digits only: parseInt accepts numeric prefixes like "1abc" as 1,
 	// which would silently shrink the drain budget to a millisecond.
 	if (!/^\d+$/.test(raw)) return DEFAULT_SHUTDOWN_DRAIN_MS;
-	const parsed = Number.parseInt(raw, 10);
-	if (!Number.isSafeInteger(parsed) || parsed < 0) {
+	// Number (not parseInt) so digit strings beyond MAX_SAFE_INTEGER still
+	// compare correctly and clamp to the maximum instead of falling back to
+	// the shorter default the operator did not ask for.
+	const parsed = Number(raw);
+	if (!Number.isFinite(parsed) || parsed < 0) {
 		return DEFAULT_SHUTDOWN_DRAIN_MS;
 	}
 	return Math.min(parsed, MAX_SHUTDOWN_DRAIN_MS);
@@ -1714,7 +1791,15 @@ async function handleGracefulShutdown(signal: string) {
 				console.error(
 					`Drain budget exhausted; force-closing ${remaining} in-flight request(s)`,
 				);
+				// stop(true) cannot escalate an earlier graceful stop() on Bun 1.x
+				// (verified on 1.3.5), so error the tracked response streams
+				// directly; the call stays as belt-and-braces for Bun versions
+				// where escalation works.
 				serverInstance.stop(true);
+				const aborted = abortInflightStreams();
+				if (aborted > 0) {
+					console.error(`Errored ${aborted} tracked response stream(s)`);
+				}
 				// Force-cancelled streams still have queued close/error handlers
 				// that record their final usage. Yield briefly so those callbacks
 				// run before the usage collector drains and the async DB writer
@@ -1736,8 +1821,18 @@ async function handleGracefulShutdown(signal: string) {
 }
 
 // Register signal handlers
-process.on("SIGINT", () => handleGracefulShutdown("SIGINT"));
-process.on("SIGTERM", () => handleGracefulShutdown("SIGTERM"));
+// Only act once this process actually owns a server lifecycle: for
+// short-lived CLI commands (which import this module without starting a
+// server) the CLI's own handlers own shutdown, and a second concurrent
+// shutdown path could exit while the first is still disposing resources.
+process.on("SIGINT", () => {
+	if (!serverLifecycleOwned) return;
+	handleGracefulShutdown("SIGINT");
+});
+process.on("SIGTERM", () => {
+	if (!serverLifecycleOwned) return;
+	handleGracefulShutdown("SIGTERM");
+});
 
 // Export helper to get the current protocol
 export function getProtocol(): string {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1570,16 +1570,27 @@ Available endpoints:
  */
 export const SHUTDOWN_DRAIN_MS_ENV = "CCFLARE_SHUTDOWN_DRAIN_MS";
 const DEFAULT_SHUTDOWN_DRAIN_MS = 60_000;
+/**
+ * Upper clamp for the drain budget: keeps the watchdog setTimeout well
+ * inside its 32-bit millisecond range (an overflowed delay fires
+ * immediately, which would cut off the very streams being drained) and
+ * keeps shutdown inside any sane service-manager stop timeout.
+ */
+export const MAX_SHUTDOWN_DRAIN_MS = 15 * 60 * 1000;
 /** Budget for post-drain cleanup (DB writer, disposables) before force exit. */
 const SHUTDOWN_WATCHDOG_MARGIN_MS = 15_000;
 
 export function readShutdownDrainMs(): number {
 	const raw = process.env[SHUTDOWN_DRAIN_MS_ENV];
 	if (raw === undefined || raw === "") return DEFAULT_SHUTDOWN_DRAIN_MS;
+	// Strict digits only: parseInt accepts numeric prefixes like "1abc" as 1,
+	// which would silently shrink the drain budget to a millisecond.
+	if (!/^\d+$/.test(raw)) return DEFAULT_SHUTDOWN_DRAIN_MS;
 	const parsed = Number.parseInt(raw, 10);
-	return Number.isFinite(parsed) && parsed >= 0
-		? parsed
-		: DEFAULT_SHUTDOWN_DRAIN_MS;
+	if (!Number.isSafeInteger(parsed) || parsed < 0) {
+		return DEFAULT_SHUTDOWN_DRAIN_MS;
+	}
+	return Math.min(parsed, MAX_SHUTDOWN_DRAIN_MS);
 }
 
 // Deduplicates concurrent shutdown invocations (e.g. SIGINT arriving while
@@ -1704,6 +1715,12 @@ async function handleGracefulShutdown(signal: string) {
 					`Drain budget exhausted; force-closing ${remaining} in-flight request(s)`,
 				);
 				serverInstance.stop(true);
+				// Force-cancelled streams still have queued close/error handlers
+				// that record their final usage. Yield briefly so those callbacks
+				// run before the usage collector drains and the async DB writer
+				// is disposed; otherwise the cancelled streams' last usage events
+				// are lost.
+				await new Promise((resolve) => setTimeout(resolve, 250));
 			}
 		}
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1560,9 +1560,27 @@ Available endpoints:
 	};
 }
 
-// most in-flight streaming responses complete; short enough that systemd's
-// default TimeoutStopSec (90s) doesn't have to escalate to SIGKILL.
-const SHUTDOWN_WATCHDOG_MS = 30_000;
+/**
+ * How long shutdown waits for in-flight requests to complete before
+ * force-closing them. Agent SSE streams can run for minutes, and a
+ * mid-stream close is unrecoverable for the client (tokens were already
+ * streamed), so this defaults generously. Supervisors must keep their stop
+ * timeout (systemd TimeoutStopSec, wrapper SIGKILL delays) above this value
+ * plus the watchdog margin or the drain gets SIGKILLed out from under us.
+ */
+export const SHUTDOWN_DRAIN_MS_ENV = "CCFLARE_SHUTDOWN_DRAIN_MS";
+const DEFAULT_SHUTDOWN_DRAIN_MS = 60_000;
+/** Budget for post-drain cleanup (DB writer, disposables) before force exit. */
+const SHUTDOWN_WATCHDOG_MARGIN_MS = 15_000;
+
+export function readShutdownDrainMs(): number {
+	const raw = process.env[SHUTDOWN_DRAIN_MS_ENV];
+	if (raw === undefined || raw === "") return DEFAULT_SHUTDOWN_DRAIN_MS;
+	const parsed = Number.parseInt(raw, 10);
+	return Number.isFinite(parsed) && parsed >= 0
+		? parsed
+		: DEFAULT_SHUTDOWN_DRAIN_MS;
+}
 
 // Deduplicates concurrent shutdown invocations (e.g. SIGINT arriving while
 // SIGTERM is still awaiting serverInstance.stop()). Without this, the second
@@ -1579,17 +1597,20 @@ async function handleGracefulShutdown(signal: string) {
 
 	console.log(`\n👋 Received ${signal}, shutting down gracefully...`);
 
-	// Hard upper bound on shutdown duration. unref'd so it doesn't itself
-	// prevent a clean exit if everything else finishes first. Exits with 0
-	// because the watchdog only fires on an expected SIGTERM that ran long,
-	// not on a failure — code 1 would make systemd Restart=on-failure
-	// auto-restart the unit instead of treating it as a normal stop.
+	// Hard upper bound on shutdown duration: the drain budget plus a margin
+	// for the remaining cleanup. unref'd so it doesn't itself prevent a clean
+	// exit if everything else finishes first. Exits with 0 because the
+	// watchdog only fires on an expected SIGTERM that ran long, not on a
+	// failure — code 1 would make systemd Restart=on-failure auto-restart
+	// the unit instead of treating it as a normal stop.
+	const drainMs = readShutdownDrainMs();
+	const watchdogMs = drainMs + SHUTDOWN_WATCHDOG_MARGIN_MS;
 	const watchdog = setTimeout(() => {
 		console.error(
-			`⚠️ Shutdown watchdog (${SHUTDOWN_WATCHDOG_MS}ms) expired, forcing exit`,
+			`⚠️ Shutdown watchdog (${watchdogMs}ms) expired, forcing exit`,
 		);
 		process.exit(0);
-	}, SHUTDOWN_WATCHDOG_MS);
+	}, watchdogMs);
 	watchdog.unref();
 
 	try {
@@ -1658,6 +1679,32 @@ async function handleGracefulShutdown(signal: string) {
 				clearTimeout(timeoutId);
 			}
 			usagePollingRetryTimeouts.clear();
+		}
+
+		// Drain in-flight requests before tearing down shared resources.
+		// stop() without arguments stops accepting new connections while
+		// letting active ones (including agent SSE streams) run to
+		// completion; wait for pendingRequests to reach zero within the
+		// drain budget, then force-close whatever remains.
+		if (serverInstance) {
+			serverInstance.stop();
+			const deadline = Date.now() + drainMs;
+			const initialPending = serverInstance.pendingRequests;
+			if (initialPending > 0) {
+				console.log(
+					`Draining ${initialPending} in-flight request(s) (budget ${drainMs}ms)...`,
+				);
+			}
+			while (serverInstance.pendingRequests > 0 && Date.now() < deadline) {
+				await new Promise((resolve) => setTimeout(resolve, 250));
+			}
+			const remaining = serverInstance.pendingRequests;
+			if (remaining > 0) {
+				console.error(
+					`Drain budget exhausted; force-closing ${remaining} in-flight request(s)`,
+				);
+				serverInstance.stop(true);
+			}
 		}
 
 		usageCache.clear(); // Stop all usage polling


### PR DESCRIPTION
## Motivation

During a routine better-ccflare deploy, an active Claude Code subagent failed with:

> API Error: Connection closed mid-response. The response above may be incomplete.

The restart had severed its in-flight SSE stream. Agent clients can often recover on their next turn, but the current response is irretrievably incomplete because tokens were already streamed.

Two shutdown defects compounded:

1. **Competing signal handlers.** The CLI and server both registered SIGINT/SIGTERM handlers. The CLI's `exitGracefully()` raced the server's shutdown sequence, disposed shared resources concurrently, and called `process.exit()` as soon as its own path finished, killing active streams even while the server thought it was draining.
2. **No wait for in-flight requests.** The server called `stop()` but never observed `pendingRequests` before tearing down the rest of the process.

## What changes

- When long-running serve mode starts, CLI-level signal handlers stand down and the server exclusively owns shutdown. CLI handlers still cover short-lived commands.
- Server shutdown calls `serverInstance.stop()` to refuse new connections, then polls `pendingRequests` until zero within a configurable drain budget:

```
CCFLARE_SHUTDOWN_DRAIN_MS=60000  # default 60s, 0 disables waiting
```

- If the budget expires, only then `stop(true)` force-closes remaining requests.
- Shutdown watchdog now scales to `drain + 15s` so cleanup gets time after draining.

## Supervisor requirement

The supervisor stop timeout (e.g. systemd `TimeoutStopSec`) must exceed `CCFLARE_SHUTDOWN_DRAIN_MS + 15s`; otherwise the supervisor's SIGKILL defeats the drain. This PR documents that invariant but does not modify deployment files.

## Testing / dogfood

- Server tests: 3 pass / 0 fail (includes drain-budget env parsing)
- Build and full typecheck pass
- Dogfooded live with 60s server drain, 75s outer guard grace, and 90s systemd stop timeout; health + GPT-5.6 smoke probe pass after restart.
