### PR TITLE
feat(codex): opt-in OpenAI prompt_cache_key with per-conversation partitioning

### DIFF
--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { fetchCodexUsageOnDemand } from "./on-demand-fetch";
-import { CodexProvider } from "./provider";
+import {
+	CODEX_CACHE_KEY_MODE_ENV,
+	CODEX_PROMPT_CACHE_KEY_ENV,
+	CodexProvider,
+} from "./provider";
 import { parseCodexUsageHeaders } from "./usage";
 
 const sseBody = (lines: string[]) => `${lines.join("\n")}\n`;
@@ -1843,6 +1847,111 @@ describe("CodexProvider.transformRequestBody", () => {
 		const body = await transformed.json();
 
 		expect(body.model).toBe("gpt-5.4-mini");
+	});
+});
+
+describe("CodexProvider prompt_cache_key derivation", () => {
+	afterEach(() => {
+		delete process.env[CODEX_PROMPT_CACHE_KEY_ENV];
+		delete process.env[CODEX_CACHE_KEY_MODE_ENV];
+	});
+
+	const transform = async (payload: Record<string, unknown>) => {
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-5-sonnet-20241022",
+				max_tokens: 10,
+				metadata: {
+					user_id: JSON.stringify({
+						session_id: "11111111-1111-4111-8111-111111111111",
+					}),
+				},
+				messages: [{ role: "user", content: "hello" }],
+				...payload,
+			}),
+		});
+		return new CodexProvider()
+			.transformRequestBody(request, undefined)
+			.then((r) => r.json());
+	};
+
+	it("omits prompt_cache_key unless enabled", async () => {
+		const body = await transform({});
+		expect(body.prompt_cache_key).toBeUndefined();
+	});
+
+	it("conversation keys are stable across turns and distinct across conversations", async () => {
+		process.env[CODEX_PROMPT_CACHE_KEY_ENV] = "1";
+		const turn1 = await transform({
+			system: "main loop system prompt",
+			messages: [{ role: "user", content: "task A" }],
+		});
+		// Same conversation one turn later: identical first message, longer tail.
+		const turn2 = await transform({
+			system: "main loop system prompt",
+			messages: [
+				{ role: "user", content: "task A" },
+				{ role: "assistant", content: "working on it" },
+				{ role: "user", content: "continue" },
+			],
+		});
+		// Sibling subagent: same session and system, different first message.
+		const sibling = await transform({
+			system: "main loop system prompt",
+			messages: [{ role: "user", content: "task B" }],
+		});
+		// Different agent type: same first message, different system prompt.
+		const otherAgent = await transform({
+			system: "subagent system prompt",
+			messages: [{ role: "user", content: "task A" }],
+		});
+
+		expect(turn1.prompt_cache_key).toMatch(/^ccflare-convo-[0-9a-f]{48}$/);
+		expect((turn1.prompt_cache_key as string).length).toBeLessThanOrEqual(64);
+		expect(turn1.prompt_cache_key).not.toContain("11111111");
+		expect(turn2.prompt_cache_key).toBe(turn1.prompt_cache_key);
+		expect(sibling.prompt_cache_key).not.toBe(turn1.prompt_cache_key);
+		expect(otherAgent.prompt_cache_key).not.toBe(turn1.prompt_cache_key);
+	});
+
+	it("session mode keys the whole session identically", async () => {
+		process.env[CODEX_PROMPT_CACHE_KEY_ENV] = "1";
+		process.env[CODEX_CACHE_KEY_MODE_ENV] = "session";
+		const first = await transform({
+			messages: [{ role: "user", content: "task A" }],
+		});
+		const other = await transform({
+			messages: [{ role: "user", content: "completely different task" }],
+		});
+		expect(first.prompt_cache_key).toMatch(/^ccflare-session-[0-9a-f]{48}$/);
+		expect(other.prompt_cache_key).toBe(first.prompt_cache_key);
+	});
+
+	it("differing session ids produce differing keys, case-insensitively", async () => {
+		process.env[CODEX_PROMPT_CACHE_KEY_ENV] = "1";
+		const withSession = (sessionId: string) =>
+			transform({
+				metadata: { user_id: JSON.stringify({ session_id: sessionId }) },
+			});
+		const lower = await withSession("11111111-1111-4111-8111-111111111111");
+		const upper = await withSession(
+			"11111111-1111-4111-8111-111111111111".toUpperCase(),
+		);
+		const different = await withSession("22222222-2222-4222-8222-222222222222");
+		expect(upper.prompt_cache_key).toBe(lower.prompt_cache_key);
+		expect(different.prompt_cache_key).not.toBe(lower.prompt_cache_key);
+	});
+
+	it("omits prompt_cache_key for malformed session metadata", async () => {
+		process.env[CODEX_PROMPT_CACHE_KEY_ENV] = "1";
+		const noMeta = await transform({ metadata: { user_id: "not-json" } });
+		expect(noMeta.prompt_cache_key).toBeUndefined();
+		const badUuid = await transform({
+			metadata: { user_id: JSON.stringify({ session_id: "not-a-uuid" }) },
+		});
+		expect(badUuid.prompt_cache_key).toBeUndefined();
 	});
 });
 

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import type { Account } from "@better-ccflare/types";
 import { fetchCodexUsageOnDemand } from "./on-demand-fetch";
 import {
 	CODEX_CACHE_KEY_MODE_ENV,
@@ -6,6 +7,43 @@ import {
 	CodexProvider,
 } from "./provider";
 import { parseCodexUsageHeaders } from "./usage";
+
+const codexAccount = (overrides: Partial<Account> = {}): Account => ({
+	id: "codex-1",
+	name: "codex-test",
+	provider: "codex",
+	api_key: null,
+	refresh_token: "refresh-token",
+	access_token: "access-token",
+	expires_at: Date.now() + 60_000,
+	request_count: 0,
+	total_requests: 0,
+	last_used: null,
+	created_at: Date.now(),
+	rate_limited_until: null,
+	rate_limited_reason: null,
+	rate_limited_at: null,
+	session_start: null,
+	session_request_count: 0,
+	paused: false,
+	rate_limit_reset: null,
+	rate_limit_status: null,
+	rate_limit_remaining: null,
+	priority: 50,
+	auto_fallback_enabled: true,
+	auto_refresh_enabled: true,
+	auto_pause_on_overage_enabled: false,
+	peak_hours_pause_enabled: false,
+	custom_endpoint: null,
+	model_mappings: null,
+	cross_region_mode: null,
+	model_fallbacks: null,
+	billing_type: null,
+	pause_reason: null,
+	refresh_token_issued_at: null,
+	consecutive_rate_limits: 0,
+	...overrides,
+});
 
 const sseBody = (lines: string[]) => `${lines.join("\n")}\n`;
 const eventLine = (name: string, data: unknown) => [
@@ -1856,7 +1894,10 @@ describe("CodexProvider prompt_cache_key derivation", () => {
 		delete process.env[CODEX_CACHE_KEY_MODE_ENV];
 	});
 
-	const transform = async (payload: Record<string, unknown>) => {
+	const transform = async (
+		payload: Record<string, unknown>,
+		account?: Account,
+	) => {
 		const request = new Request("https://example.com/v1/messages", {
 			method: "POST",
 			headers: { "content-type": "application/json" },
@@ -1873,12 +1914,36 @@ describe("CodexProvider prompt_cache_key derivation", () => {
 			}),
 		});
 		return new CodexProvider()
-			.transformRequestBody(request, undefined)
+			.transformRequestBody(request, account)
 			.then((r) => r.json());
 	};
 
 	it("omits prompt_cache_key unless enabled", async () => {
 		const body = await transform({});
+		expect(body.prompt_cache_key).toBeUndefined();
+	});
+
+	it("attaches prompt_cache_key when the account targets OpenAI's real endpoint", async () => {
+		process.env[CODEX_PROMPT_CACHE_KEY_ENV] = "1";
+		const noAccount = await transform({});
+		const openaiAccount = await transform(
+			{},
+			codexAccount({ custom_endpoint: "https://api.openai.com/v1" }),
+		);
+		expect(noAccount.prompt_cache_key).toMatch(/^ccflare-convo-[0-9a-f]{48}$/);
+		expect(openaiAccount.prompt_cache_key).toMatch(
+			/^ccflare-convo-[0-9a-f]{48}$/,
+		);
+	});
+
+	it("omits prompt_cache_key for custom/self-hosted OpenAI-compatible endpoints even when enabled", async () => {
+		process.env[CODEX_PROMPT_CACHE_KEY_ENV] = "1";
+		const body = await transform(
+			{},
+			codexAccount({
+				custom_endpoint: "https://my-openai-proxy.example.com/v1",
+			}),
+		);
 		expect(body.prompt_cache_key).toBeUndefined();
 	});
 

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
 	mapModelName,
 	ValidationError,
@@ -11,6 +12,15 @@ import { BaseProvider } from "../../base";
 import type { RateLimitInfo, TokenRefreshResult } from "../../types";
 
 const log = new Logger("CodexProvider");
+
+/**
+ * Opt-in: set to "1" to attach an OpenAI prompt_cache_key to converted
+ * requests. OpenAI documents that on GPT-5.6-family models this key is
+ * required for reliable prompt-cache matching.
+ */
+export const CODEX_PROMPT_CACHE_KEY_ENV = "CCFLARE_CODEX_PROMPT_CACHE_KEY";
+/** "conversation" (default) or "session"; see derivePromptCacheKey. */
+export const CODEX_CACHE_KEY_MODE_ENV = "CCFLARE_CODEX_CACHE_KEY_MODE";
 
 const INTERNAL_HEADERS = [
 	"x-better-ccflare-request-id",
@@ -120,6 +130,7 @@ interface CodexRequest {
 	reasoning?: { effort: string };
 	instructions?: string;
 	tools?: CodexTool[];
+	prompt_cache_key?: string;
 }
 
 // ── Anthropic request types ───────────────────────────────────────────────────
@@ -166,6 +177,8 @@ interface AnthropicRequest {
 	stream?: boolean;
 	tools?: AnthropicTool[];
 	reasoning?: { effort?: string };
+	/** Claude Code sends a JSON-encoded object with a session_id here. */
+	metadata?: { user_id?: string };
 	[key: string]: unknown;
 }
 
@@ -848,6 +861,80 @@ export class CodexProvider extends BaseProvider {
 		}
 	}
 
+	private extractSessionId(body: AnthropicRequest): string | undefined {
+		const rawUserId = body.metadata?.user_id;
+		if (typeof rawUserId !== "string") return undefined;
+		try {
+			const metadata = JSON.parse(rawUserId) as unknown;
+			if (!metadata || typeof metadata !== "object") return undefined;
+			const sessionId = (metadata as Record<string, unknown>).session_id;
+			if (
+				typeof sessionId !== "string" ||
+				!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+					sessionId,
+				)
+			) {
+				return undefined;
+			}
+			return sessionId.toLowerCase();
+		} catch {
+			return undefined;
+		}
+	}
+
+	/**
+	 * OpenAI routes each request to a cache machine by hashing the prompt's
+	 * initial tokens together with prompt_cache_key, and documents that one key
+	 * should stay under ~15 requests/minute or "some requests may miss the
+	 * cache". A Claude Code session multiplexes the main loop plus every
+	 * subagent conversation over one session id, so keying on the session
+	 * alone funnels an entire fan-out burst onto one cache machine and
+	 * thrashes it (measured in production traces: turns 1-8 of subagent
+	 * conversations cached no better than cold starts while one session key
+	 * carried 170+ conversations in five minutes).
+	 *
+	 * Default "conversation" mode therefore partitions the key by conversation
+	 * identity: session id + instructions + first input item, all stable
+	 * across the turns of one conversation and distinct across concurrent
+	 * subagents. Each conversation is sequential, so per-key traffic stays far
+	 * below the documented rate bound. CCFLARE_CODEX_CACHE_KEY_MODE=session
+	 * restores the coarse per-session key.
+	 */
+	private derivePromptCacheKey(
+		body: AnthropicRequest,
+		instructions: string,
+		input: readonly unknown[],
+	): string | undefined {
+		if (process.env[CODEX_PROMPT_CACHE_KEY_ENV] !== "1") return undefined;
+		const sessionId = this.extractSessionId(body);
+		if (!sessionId) return undefined;
+		// Digests are truncated to 48 hex chars so the full key fits the API's
+		// 64-char key bound. Session ids and content never appear in the key.
+		if (
+			process.env[CODEX_CACHE_KEY_MODE_ENV] === "session" ||
+			input.length === 0
+		) {
+			return `ccflare-session-${createHash("sha256")
+				.update(sessionId)
+				.digest("hex")
+				.slice(0, 48)}`;
+		}
+		let firstItem = "";
+		try {
+			firstItem = JSON.stringify(input[0]) ?? "";
+		} catch {
+			// Non-serializable first item: fall back to instructions-only identity.
+		}
+		return `ccflare-convo-${createHash("sha256")
+			.update(sessionId)
+			.update("\0")
+			.update(instructions)
+			.update("\0")
+			.update(firstItem)
+			.digest("hex")
+			.slice(0, 48)}`;
+	}
+
 	private convertToCodexFormat(
 		body: AnthropicRequest,
 		account?: Account,
@@ -931,6 +1018,14 @@ export class CodexProvider extends BaseProvider {
 		};
 
 		codexRequest.instructions = instructions || "You are a helpful assistant.";
+		const promptCacheKey = this.derivePromptCacheKey(
+			body,
+			codexRequest.instructions,
+			input,
+		);
+		if (promptCacheKey) {
+			codexRequest.prompt_cache_key = promptCacheKey;
+		}
 		if (tools) {
 			codexRequest.tools = tools;
 		}

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -17,6 +17,10 @@ const log = new Logger("CodexProvider");
  * Opt-in: set to "1" to attach an OpenAI prompt_cache_key to converted
  * requests. OpenAI documents that on GPT-5.6-family models this key is
  * required for reliable prompt-cache matching.
+ *
+ * Only enable this when Codex accounts point at OpenAI's own Responses API.
+ * A strict OpenAI-compatible endpoint that does not know the field may
+ * reject requests carrying it; that is why the flag defaults to off.
  */
 export const CODEX_PROMPT_CACHE_KEY_ENV = "CCFLARE_CODEX_PROMPT_CACHE_KEY";
 /** "conversation" (default) or "session"; see derivePromptCacheKey. */

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -18,9 +18,11 @@ const log = new Logger("CodexProvider");
  * requests. OpenAI documents that on GPT-5.6-family models this key is
  * required for reliable prompt-cache matching.
  *
- * Only enable this when Codex accounts point at OpenAI's own Responses API.
- * A strict OpenAI-compatible endpoint that does not know the field may
- * reject requests carrying it; that is why the flag defaults to off.
+ * Attaching the key is also gated on the resolved account endpoint (see
+ * isOpenAiPromptCacheEndpoint): it is only sent when the account targets
+ * OpenAI's own chatgpt.com / api.openai.com hosts. Custom or self-hosted
+ * OpenAI-compatible endpoints may reject the unknown field, so the key is
+ * skipped for those even when this flag is enabled.
  */
 export const CODEX_PROMPT_CACHE_KEY_ENV = "CCFLARE_CODEX_PROMPT_CACHE_KEY";
 /** "conversation" (default) or "session"; see derivePromptCacheKey. */
@@ -43,6 +45,8 @@ const TOKEN_URL = "https://auth.openai.com/oauth/token";
 const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 export const CODEX_DEFAULT_ENDPOINT =
 	"https://chatgpt.com/backend-api/codex/responses";
+/** Hosts that are OpenAI's own Codex/Responses API, not a custom endpoint. */
+const OPENAI_PROMPT_CACHE_HOSTS = new Set(["chatgpt.com", "api.openai.com"]);
 export const CODEX_VERSION = "0.144.1";
 export const CODEX_USER_AGENT = `codex-cli/${CODEX_VERSION} (Windows 10.0.26100; x64)`;
 export const CODEX_PING_MODEL = "gpt-5-codex";
@@ -228,6 +232,38 @@ interface StreamState {
 		code?: string;
 		status?: string;
 	};
+}
+
+/**
+ * Resolves the endpoint a Codex request would be sent to, mirroring
+ * CodexProvider.buildUrl's fallback (invalid/missing custom_endpoint falls
+ * back to CODEX_DEFAULT_ENDPOINT). Read-only: unlike buildUrl it never logs,
+ * since it may be called on every request just to decide prompt_cache_key
+ * eligibility.
+ */
+function resolveCodexPromptCacheEndpoint(account?: Account): string {
+	if (account?.custom_endpoint) {
+		try {
+			return validateEndpointUrl(account.custom_endpoint, "custom_endpoint");
+		} catch {
+			return CODEX_DEFAULT_ENDPOINT;
+		}
+	}
+	return CODEX_DEFAULT_ENDPOINT;
+}
+
+/**
+ * prompt_cache_key is an OpenAI-specific Responses API field. Custom or
+ * self-hosted OpenAI-compatible endpoints may reject the unknown field, so
+ * only attach it when the account resolves to OpenAI's own hosts.
+ */
+function isOpenAiPromptCacheEndpoint(account?: Account): boolean {
+	try {
+		const { hostname } = new URL(resolveCodexPromptCacheEndpoint(account));
+		return OPENAI_PROMPT_CACHE_HOSTS.has(hostname);
+	} catch {
+		return false;
+	}
 }
 
 export class CodexProvider extends BaseProvider {
@@ -908,8 +944,10 @@ export class CodexProvider extends BaseProvider {
 		body: AnthropicRequest,
 		instructions: string,
 		input: readonly unknown[],
+		account?: Account,
 	): string | undefined {
 		if (process.env[CODEX_PROMPT_CACHE_KEY_ENV] !== "1") return undefined;
+		if (!isOpenAiPromptCacheEndpoint(account)) return undefined;
 		const sessionId = this.extractSessionId(body);
 		if (!sessionId) return undefined;
 		// Digests are truncated to 48 hex chars so the full key fits the API's
@@ -1026,6 +1064,7 @@ export class CodexProvider extends BaseProvider {
 			body,
 			codexRequest.instructions,
 			input,
+			account,
 		);
 		if (promptCacheKey) {
 			codexRequest.prompt_cache_key = promptCacheKey;


### PR DESCRIPTION
## Why

OpenAI's [prompt caching docs](https://platform.openai.com/docs/guides/prompt-caching) now state three things that matter for the Codex provider:

1. On GPT-5.6-family models, `prompt_cache_key` **must** be set to get the more reliable cache matching (implicit and explicit).
2. Requests are routed to a cache machine by hashing the prompt prefix **combined with the key**.
3. Each key should stay under **~15 requests/minute**, otherwise "some requests may miss the cache"; higher-volume workloads should "partition traffic across more keys and use a stable mapping".

Claude Code multiplexes the main agent loop plus every subagent conversation over a single `metadata.user_id` session id. In our production dogfood traces, one session pushed **170+ distinct conversations through what would be a single cache key in five minutes**, and turns 1-8 of subagent conversations cached no better than cold starts (16-27% hit where a prefix cache should approach 100% on later turns).

## What

Opt-in via `CCFLARE_CODEX_PROMPT_CACHE_KEY=1` (default off, zero behavior change otherwise):

- Attaches `prompt_cache_key` to converted Codex requests.
- Default **conversation mode** derives the key from session id + instructions + first input item: stable across the turns of one conversation, distinct across concurrent subagents, and sequential per key, so per-key traffic stays far below the documented rate bound.
- `CCFLARE_CODEX_CACHE_KEY_MODE=session` selects a coarse per-session key instead, for comparison or simpler workloads.
- Keys are truncated sha256 digests (`ccflare-convo-<48 hex>`, 62 chars, under the API's 64-char bound). Session ids and prompt content never appear in the key.

## Testing

- 5 new unit tests: default-off, turn stability, sibling/agent-type distinctness, session mode, case-insensitive session ids, malformed-metadata fallbacks. Full codex provider suite passes (64 tests), typecheck and biome clean.
- Running in production on our fork now; happy to follow up with before/after hit-rate numbers from live telemetry once a full day accumulates.