### PR TITLE
fix(proxy): recover missing Anthropic message_stop

### DIFF
--- a/packages/proxy/src/__tests__/anthropic-terminal-recovery.test.ts
+++ b/packages/proxy/src/__tests__/anthropic-terminal-recovery.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, it, mock } from "bun:test";
+import {
+	ANTHROPIC_MESSAGE_STOP_FRAME,
+	createAnthropicTerminalRecoveryStream,
+} from "../anthropic-terminal-recovery";
+
+const encoder = new TextEncoder();
+
+function bytes(text: string): Uint8Array {
+	return encoder.encode(text);
+}
+
+function immediateStream(
+	chunks: readonly Uint8Array[],
+): ReadableStream<Uint8Array> {
+	return new ReadableStream<Uint8Array>({
+		start(controller) {
+			for (const chunk of chunks) controller.enqueue(chunk);
+			controller.close();
+		},
+	});
+}
+
+function controllableStream(
+	onCancel: (reason?: unknown) => void | Promise<void> = () => undefined,
+) {
+	let controller!: ReadableStreamDefaultController<Uint8Array>;
+	const cancel = mock(onCancel);
+	const stream = new ReadableStream<Uint8Array>({
+		start(nextController) {
+			controller = nextController;
+		},
+		cancel,
+	});
+
+	return { stream, controller: () => controller, cancel };
+}
+
+const terminalDelta =
+	'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":42}}\n\n';
+const messageStop = 'event: message_stop\ndata: {"type":"message_stop"}\n\n';
+const ping = 'event: ping\ndata: {"type":"ping"}\n\n';
+
+describe("createAnthropicTerminalRecoveryStream", () => {
+	it("leaves a healthy stream byte-for-byte unchanged", async () => {
+		const original = `${terminalDelta}${messageStop}`;
+		const chunks = [
+			bytes(original.slice(0, 7)),
+			bytes(original.slice(7, 63)),
+			bytes(original.slice(63)),
+		];
+		const onRecovery = mock(() => undefined);
+
+		const body = createAnthropicTerminalRecoveryStream(
+			immediateStream(chunks),
+			{ gracePeriodMs: 10, onRecovery },
+		);
+
+		await expect(new Response(body).text()).resolves.toBe(original);
+		expect(onRecovery).not.toHaveBeenCalled();
+	});
+
+	it("parses arbitrary chunk splits and recovers a terminal delta missing message_stop", async () => {
+		const source = controllableStream();
+		const onRecovery = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(source.stream, {
+			gracePeriodMs: 20,
+			onRecovery,
+		});
+		const result = new Response(body).text();
+
+		for (const byte of bytes(terminalDelta)) {
+			source.controller().enqueue(new Uint8Array([byte]));
+		}
+		source.controller().enqueue(bytes(ping));
+
+		await expect(result).resolves.toBe(
+			`${terminalDelta}${ping}${ANTHROPIC_MESSAGE_STOP_FRAME}`,
+		);
+		expect(onRecovery).toHaveBeenCalledTimes(1);
+		expect(source.cancel).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not let ping events defer recovery", async () => {
+		const source = controllableStream();
+		const onRecovery = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(source.stream, {
+			gracePeriodMs: 25,
+			onRecovery,
+		});
+		const result = new Response(body).text();
+
+		source.controller().enqueue(bytes(terminalDelta));
+		const interval = setInterval(() => {
+			try {
+				source.controller().enqueue(bytes(ping));
+			} catch {
+				clearInterval(interval);
+			}
+		}, 3);
+
+		try {
+			const output = await result;
+			expect(output.startsWith(terminalDelta)).toBe(true);
+			expect(output.endsWith(ANTHROPIC_MESSAGE_STOP_FRAME)).toBe(true);
+			expect(onRecovery).toHaveBeenCalledTimes(1);
+		} finally {
+			clearInterval(interval);
+		}
+	});
+
+	it("separates a partial post-terminal ping before timeout recovery", async () => {
+		const source = controllableStream();
+		const onRecovery = mock(() => undefined);
+		const partialPing = ping.slice(0, -2);
+		const body = createAnthropicTerminalRecoveryStream(source.stream, {
+			gracePeriodMs: 20,
+			onRecovery,
+		});
+		const result = new Response(body).text();
+
+		source.controller().enqueue(bytes(terminalDelta));
+		source.controller().enqueue(bytes(partialPing));
+
+		await expect(result).resolves.toBe(
+			`${terminalDelta}${partialPing}\n\n${ANTHROPIC_MESSAGE_STOP_FRAME}`,
+		);
+		expect(onRecovery).toHaveBeenCalledTimes(1);
+		expect(source.cancel).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not duplicate a real message_stop buffered at the timeout boundary", async () => {
+		const source = controllableStream();
+		const onRecovery = mock(() => undefined);
+		const partialMessageStop = messageStop.slice(0, -2);
+		const body = createAnthropicTerminalRecoveryStream(source.stream, {
+			gracePeriodMs: 20,
+			onRecovery,
+		});
+		const result = new Response(body).text();
+
+		source.controller().enqueue(bytes(terminalDelta));
+		source.controller().enqueue(bytes(partialMessageStop));
+
+		await expect(result).resolves.toBe(
+			`${terminalDelta}${partialMessageStop}\n\n`,
+		);
+		expect(onRecovery).not.toHaveBeenCalled();
+		expect(source.cancel).toHaveBeenCalledTimes(1);
+	});
+
+	it("preserves a message_stop that completes shortly before the timeout", async () => {
+		const source = controllableStream();
+		const onRecovery = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(source.stream, {
+			gracePeriodMs: 50,
+			onRecovery,
+		});
+		const result = new Response(body).text();
+		const split = messageStop.length - 2;
+
+		source.controller().enqueue(bytes(terminalDelta));
+		source.controller().enqueue(bytes(messageStop.slice(0, split)));
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		source.controller().enqueue(bytes(messageStop.slice(split)));
+		source.controller().close();
+
+		await expect(result).resolves.toBe(`${terminalDelta}${messageStop}`);
+		expect(onRecovery).not.toHaveBeenCalled();
+		expect(source.cancel).not.toHaveBeenCalled();
+	});
+
+	it("never synthesizes for message_delta without a stop reason", async () => {
+		const original =
+			'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":null}}\n\n' +
+			ping;
+		const onRecovery = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(
+			immediateStream([bytes(original)]),
+			{ gracePeriodMs: 5, onRecovery },
+		);
+
+		await expect(new Response(body).text()).resolves.toBe(original);
+		expect(onRecovery).not.toHaveBeenCalled();
+	});
+
+	it("passes valid JSON null and scalar data through unchanged", async () => {
+		const original =
+			"event: ping\ndata: null\n\n" +
+			'event: message_delta\ndata: "scalar"\n\n' +
+			"data: 42\n\n";
+		const onRecovery = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(
+			immediateStream([bytes(original)]),
+			{ gracePeriodMs: 5, onRecovery },
+		);
+
+		await expect(new Response(body).text()).resolves.toBe(original);
+		expect(onRecovery).not.toHaveBeenCalled();
+	});
+
+	it("synthesizes exactly once on clean EOF after a terminal delta", async () => {
+		const onRecovery = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(
+			immediateStream([bytes(terminalDelta)]),
+			{ gracePeriodMs: 50, onRecovery },
+		);
+
+		await expect(new Response(body).text()).resolves.toBe(
+			`${terminalDelta}${ANTHROPIC_MESSAGE_STOP_FRAME}`,
+		);
+		expect(onRecovery).toHaveBeenCalledTimes(1);
+	});
+
+	it("recovers a terminal delta buffered at EOF without a blank-line delimiter", async () => {
+		const terminalDeltaWithoutDelimiter = terminalDelta.slice(0, -2);
+		const onRecovery = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(
+			immediateStream([bytes(terminalDeltaWithoutDelimiter)]),
+			{ gracePeriodMs: 50, onRecovery },
+		);
+
+		await expect(new Response(body).text()).resolves.toBe(
+			`${terminalDeltaWithoutDelimiter}\n\n${ANTHROPIC_MESSAGE_STOP_FRAME}`,
+		);
+		expect(onRecovery).toHaveBeenCalledTimes(1);
+	});
+
+	it("propagates upstream errors without masking them as successful completion", async () => {
+		const source = controllableStream();
+		const onRecovery = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(source.stream, {
+			gracePeriodMs: 20,
+			onRecovery,
+		});
+		const reader = body.getReader();
+
+		source.controller().enqueue(bytes(terminalDelta));
+		await expect(reader.read()).resolves.toMatchObject({ done: false });
+		source.controller().error(new Error("upstream failed"));
+		await expect(reader.read()).rejects.toThrow("upstream failed");
+		expect(onRecovery).not.toHaveBeenCalled();
+	});
+
+	it("cancels upstream once and disarms recovery when downstream cancels", async () => {
+		const source = controllableStream();
+		const onRecovery = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(source.stream, {
+			gracePeriodMs: 10,
+			onRecovery,
+		});
+		const reader = body.getReader();
+
+		source.controller().enqueue(bytes(terminalDelta));
+		await expect(reader.read()).resolves.toMatchObject({ done: false });
+		await reader.cancel("client disconnected");
+		await new Promise((resolve) => setTimeout(resolve, 20));
+
+		expect(source.cancel).toHaveBeenCalledTimes(1);
+		expect(onRecovery).not.toHaveBeenCalled();
+	});
+
+	it("propagates an upstream cancellation failure to downstream cancel", async () => {
+		const cancelError = new Error("upstream cancel failed");
+		const source = controllableStream(() => Promise.reject(cancelError));
+		const onCancelError = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(source.stream, {
+			gracePeriodMs: 20,
+			onCancelError,
+		});
+		const reader = body.getReader();
+
+		source.controller().enqueue(bytes(terminalDelta));
+		await expect(reader.read()).resolves.toMatchObject({ done: false });
+		await expect(reader.cancel("client disconnected")).rejects.toThrow(
+			"upstream cancel failed",
+		);
+
+		expect(source.cancel).toHaveBeenCalledTimes(1);
+		expect(onCancelError).not.toHaveBeenCalled();
+	});
+
+	it("reports a recovery cancellation failure after completing downstream", async () => {
+		const cancelError = new Error("recovery cancel failed");
+		const source = controllableStream(() => Promise.reject(cancelError));
+		const onCancelError = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(source.stream, {
+			gracePeriodMs: 20,
+			onCancelError,
+		});
+		const result = new Response(body).text();
+
+		source.controller().enqueue(bytes(terminalDelta));
+		await expect(result).resolves.toBe(
+			`${terminalDelta}${ANTHROPIC_MESSAGE_STOP_FRAME}`,
+		);
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(onCancelError).toHaveBeenCalledTimes(1);
+		expect(onCancelError).toHaveBeenCalledWith(cancelError, "timeout");
+	});
+});

--- a/packages/proxy/src/__tests__/anthropic-terminal-recovery.test.ts
+++ b/packages/proxy/src/__tests__/anthropic-terminal-recovery.test.ts
@@ -40,6 +40,12 @@ const terminalDelta =
 	'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":42}}\n\n';
 const messageStop = 'event: message_stop\ndata: {"type":"message_stop"}\n\n';
 const ping = 'event: ping\ndata: {"type":"ping"}\n\n';
+const contentBlockStart =
+	'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n';
+const contentBlockStop =
+	'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n';
+const overloadedError =
+	'event: error\ndata: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}\n\n';
 
 describe("createAnthropicTerminalRecoveryStream", () => {
 	it("leaves a healthy stream byte-for-byte unchanged", async () => {
@@ -149,6 +155,24 @@ describe("createAnthropicTerminalRecoveryStream", () => {
 		expect(source.cancel).toHaveBeenCalledTimes(1);
 	});
 
+	it("closes a message_stop data line that only lacks its final blank line", async () => {
+		const source = controllableStream();
+		const onRecovery = mock(() => undefined);
+		const messageStopWithoutBlankLine = messageStop.slice(0, -1);
+		const body = createAnthropicTerminalRecoveryStream(source.stream, {
+			gracePeriodMs: 20,
+			onRecovery,
+		});
+		const result = new Response(body).text();
+
+		source.controller().enqueue(bytes(terminalDelta));
+		source.controller().enqueue(bytes(messageStopWithoutBlankLine));
+
+		await expect(result).resolves.toBe(`${terminalDelta}${messageStop}`);
+		expect(onRecovery).not.toHaveBeenCalled();
+		expect(source.cancel).toHaveBeenCalledTimes(1);
+	});
+
 	it("preserves a message_stop that completes shortly before the timeout", async () => {
 		const source = controllableStream();
 		const onRecovery = mock(() => undefined);
@@ -224,6 +248,210 @@ describe("createAnthropicTerminalRecoveryStream", () => {
 			`${terminalDeltaWithoutDelimiter}\n\n${ANTHROPIC_MESSAGE_STOP_FRAME}`,
 		);
 		expect(onRecovery).toHaveBeenCalledTimes(1);
+	});
+
+	it("starts recovery for a complete terminal data line without a blank-line delimiter", async () => {
+		const source = controllableStream();
+		const onRecovery = mock(() => undefined);
+		const terminalDeltaWithoutBlankLine = terminalDelta.slice(0, -1);
+		const body = createAnthropicTerminalRecoveryStream(source.stream, {
+			gracePeriodMs: 20,
+			onRecovery,
+		});
+		const result = new Response(body).text();
+
+		source.controller().enqueue(bytes(terminalDeltaWithoutBlankLine));
+		const settled = await Promise.race([
+			result,
+			new Promise<false>((resolve) => setTimeout(() => resolve(false), 75)),
+		]);
+		if (settled === false) source.controller().close();
+
+		expect(settled).toBe(
+			`${terminalDeltaWithoutBlankLine}\n${ANTHROPIC_MESSAGE_STOP_FRAME}`,
+		);
+		expect(onRecovery).toHaveBeenCalledTimes(1);
+	});
+
+	it("never synthesizes success after an in-band error event", async () => {
+		const source = controllableStream();
+		const onRecovery = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(source.stream, {
+			gracePeriodMs: 20,
+			onRecovery,
+		});
+		const result = new Response(body).text();
+
+		source.controller().enqueue(bytes(terminalDelta));
+		source.controller().enqueue(bytes(overloadedError));
+		await new Promise((resolve) => setTimeout(resolve, 40));
+		try {
+			source.controller().close();
+		} catch {
+			// The pre-fix implementation already closed after false recovery.
+		}
+
+		await expect(result).resolves.toBe(`${terminalDelta}${overloadedError}`);
+		expect(onRecovery).not.toHaveBeenCalled();
+	});
+
+	it("treats the SSE error field as failure even when data is not JSON", async () => {
+		const source = controllableStream();
+		const plainTextError = "event: error\ndata: upstream disconnected\n\n";
+		const onRecovery = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(source.stream, {
+			gracePeriodMs: 20,
+			onRecovery,
+		});
+		const result = new Response(body).text();
+
+		source.controller().enqueue(bytes(terminalDelta));
+		source.controller().enqueue(bytes(plainTextError));
+		await new Promise((resolve) => setTimeout(resolve, 40));
+		source.controller().close();
+
+		await expect(result).resolves.toBe(`${terminalDelta}${plainTextError}`);
+		expect(onRecovery).not.toHaveBeenCalled();
+	});
+
+	it("treats a payload error type as failure without an SSE error field", async () => {
+		const payloadOnlyError =
+			'data: {"type":"error","error":{"type":"api_error","message":"failed"}}\n\n';
+		const original = `${terminalDelta}${payloadOnlyError}`;
+		const onRecovery = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(
+			immediateStream([bytes(original)]),
+			{ gracePeriodMs: 5, onRecovery },
+		);
+
+		await expect(new Response(body).text()).resolves.toBe(original);
+		expect(onRecovery).not.toHaveBeenCalled();
+	});
+
+	it("does not synthesize while a content block remains open", async () => {
+		const original = `${contentBlockStart}${terminalDelta}`;
+		const onRecovery = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(
+			immediateStream([bytes(original)]),
+			{ gracePeriodMs: 5, onRecovery },
+		);
+
+		await expect(new Response(body).text()).resolves.toBe(original);
+		expect(onRecovery).not.toHaveBeenCalled();
+	});
+
+	it("does not re-enable recovery when an open block closes after the terminal delta", async () => {
+		const original = `${contentBlockStart}${terminalDelta}${contentBlockStop}`;
+		const onRecovery = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(
+			immediateStream([bytes(original)]),
+			{ gracePeriodMs: 5, onRecovery },
+		);
+
+		await expect(new Response(body).text()).resolves.toBe(original);
+		expect(onRecovery).not.toHaveBeenCalled();
+	});
+
+	it("disables recovery after malformed content-block transitions", async () => {
+		const indexlessStart =
+			'event: content_block_start\ndata: {"type":"content_block_start","content_block":{"type":"text","text":""}}\n\n';
+		const indexlessStop =
+			'event: content_block_stop\ndata: {"type":"content_block_stop"}\n\n';
+		const cases = [
+			`${indexlessStart}${indexlessStart}${indexlessStop}${terminalDelta}`,
+			`${contentBlockStart}${contentBlockStart}${contentBlockStop}${terminalDelta}`,
+			`${contentBlockStop}${terminalDelta}`,
+		];
+
+		for (const original of cases) {
+			const onRecovery = mock(() => undefined);
+			const body = createAnthropicTerminalRecoveryStream(
+				immediateStream([bytes(original)]),
+				{ gracePeriodMs: 5, onRecovery },
+			);
+
+			await expect(new Response(body).text()).resolves.toBe(original);
+			expect(onRecovery).not.toHaveBeenCalled();
+		}
+	});
+
+	it("passes through an oversized event but disables later recovery", async () => {
+		const oversizedEvent = `data: ${"x".repeat(80 * 1024)}\n\n`;
+		const original = `${oversizedEvent}${contentBlockStart}${contentBlockStop}${terminalDelta}`;
+		const chunks: Uint8Array[] = [];
+		for (let offset = 0; offset < original.length; offset += 1024) {
+			chunks.push(bytes(original.slice(offset, offset + 1024)));
+		}
+		const onRecovery = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(
+			immediateStream(chunks),
+			{ gracePeriodMs: 5, onRecovery },
+		);
+
+		await expect(new Response(body).text()).resolves.toBe(original);
+		expect(onRecovery).not.toHaveBeenCalled();
+	});
+
+	it("does not append a delimiter to trailing data after a complete message_stop", async () => {
+		const trailingData = `data: ${"x".repeat(80 * 1024)}\n`;
+		const original = `${terminalDelta}${messageStop}${trailingData}`;
+		const onRecovery = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(
+			immediateStream([bytes(original)]),
+			{ gracePeriodMs: 5, onRecovery },
+		);
+
+		await expect(new Response(body).text()).resolves.toBe(original);
+		expect(onRecovery).not.toHaveBeenCalled();
+	});
+
+	it("disables recovery if an oversized event becomes uninspectable after the terminal delta", async () => {
+		const source = controllableStream();
+		const oversizedPendingEvent = `data: ${"x".repeat(80 * 1024)}\n`;
+		const onRecovery = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(source.stream, {
+			gracePeriodMs: 20,
+			onRecovery,
+		});
+		const result = new Response(body).text();
+
+		source.controller().enqueue(bytes(terminalDelta));
+		source.controller().enqueue(bytes(oversizedPendingEvent));
+		await new Promise((resolve) => setTimeout(resolve, 40));
+		try {
+			source.controller().close();
+		} catch {
+			// The pre-fix implementation already closed after unsafe recovery.
+		}
+
+		await expect(result).resolves.toBe(
+			`${terminalDelta}${oversizedPendingEvent}`,
+		);
+		expect(onRecovery).not.toHaveBeenCalled();
+	});
+
+	it("handles oversized events consistently across transport chunking", async () => {
+		const largeDelta = `event: content_block_delta\ndata: ${JSON.stringify({
+			type: "content_block_delta",
+			index: 0,
+			delta: { type: "text_delta", text: "x".repeat(80 * 1024) },
+		})}\n\n`;
+		const original = `${contentBlockStart}${largeDelta}${contentBlockStop}${terminalDelta}`;
+		const splitChunks: Uint8Array[] = [];
+		for (let offset = 0; offset < original.length; offset += 1024) {
+			splitChunks.push(bytes(original.slice(offset, offset + 1024)));
+		}
+
+		for (const chunks of [[bytes(original)], splitChunks]) {
+			const onRecovery = mock(() => undefined);
+			const body = createAnthropicTerminalRecoveryStream(
+				immediateStream(chunks),
+				{ gracePeriodMs: 5, onRecovery },
+			);
+
+			await expect(new Response(body).text()).resolves.toBe(original);
+			expect(onRecovery).not.toHaveBeenCalled();
+		}
 	});
 
 	it("propagates upstream errors without masking them as successful completion", async () => {

--- a/packages/proxy/src/__tests__/anthropic-terminal-recovery.test.ts
+++ b/packages/proxy/src/__tests__/anthropic-terminal-recovery.test.ts
@@ -3,6 +3,7 @@ import {
 	ANTHROPIC_MESSAGE_STOP_FRAME,
 	createAnthropicTerminalRecoveryStream,
 } from "../anthropic-terminal-recovery";
+import { teeStream } from "../stream-tee";
 
 const encoder = new TextEncoder();
 
@@ -44,6 +45,8 @@ const contentBlockStart =
 	'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n';
 const contentBlockStop =
 	'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n';
+const contentBlockDelta =
+	'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}\n\n';
 const overloadedError =
 	'event: error\ndata: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}\n\n';
 
@@ -113,6 +116,39 @@ describe("createAnthropicTerminalRecoveryStream", () => {
 		} finally {
 			clearInterval(interval);
 		}
+	});
+
+	it("does not let recovery overtake unread upstream events during downstream backpressure", async () => {
+		const source = controllableStream();
+		const realMessageStop =
+			'event: message_stop\ndata: {"type":"message_stop","marker":"real-upstream-stop"}\n\n';
+		const original = `${terminalDelta}${ping}${ping}${realMessageStop}`;
+		const recoveryBody = createAnthropicTerminalRecoveryStream(source.stream, {
+			gracePeriodMs: 25,
+		});
+		const clientBody = teeStream(recoveryBody);
+		const reader = clientBody.getReader();
+
+		source.controller().enqueue(bytes(terminalDelta));
+		source.controller().enqueue(bytes(ping));
+		source.controller().enqueue(bytes(ping));
+		source.controller().enqueue(bytes(realMessageStop));
+		source.controller().close();
+
+		const first = await reader.read();
+		expect(first.done).toBe(false);
+		expect(new TextDecoder().decode(first.value)).toBe(terminalDelta);
+		await new Promise((resolve) => setTimeout(resolve, 70));
+
+		let output = new TextDecoder().decode(first.value);
+		for (;;) {
+			const next = await reader.read();
+			if (next.done) break;
+			output += new TextDecoder().decode(next.value);
+		}
+
+		expect(output).toBe(original);
+		expect(source.cancel).not.toHaveBeenCalled();
 	});
 
 	it("separates a partial post-terminal ping before timeout recovery", async () => {
@@ -328,6 +364,40 @@ describe("createAnthropicTerminalRecoveryStream", () => {
 		expect(onRecovery).not.toHaveBeenCalled();
 	});
 
+	it("fails closed on unparseable data events but still permits explicit ping keepalives", async () => {
+		const malformedEvent =
+			'event: content_block_start\ndata: {"type":"content_block_start"\n\n';
+		for (const original of [
+			`${malformedEvent}${terminalDelta}`,
+			`${terminalDelta}${malformedEvent}`,
+		]) {
+			const onRecovery = mock(() => undefined);
+			const body = createAnthropicTerminalRecoveryStream(
+				immediateStream([bytes(original)]),
+				{ gracePeriodMs: 5, onRecovery },
+			);
+
+			await expect(new Response(body).text()).resolves.toBe(original);
+			expect(onRecovery).not.toHaveBeenCalled();
+		}
+
+		const malformedPing = "event: ping\ndata: not-json\n\n";
+		const source = controllableStream();
+		const onRecovery = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(source.stream, {
+			gracePeriodMs: 5,
+			onRecovery,
+		});
+		const result = new Response(body).text();
+		source.controller().enqueue(bytes(terminalDelta));
+		source.controller().enqueue(bytes(malformedPing));
+
+		await expect(result).resolves.toBe(
+			`${terminalDelta}${malformedPing}${ANTHROPIC_MESSAGE_STOP_FRAME}`,
+		);
+		expect(onRecovery).toHaveBeenCalledTimes(1);
+	});
+
 	it("does not synthesize while a content block remains open", async () => {
 		const original = `${contentBlockStart}${terminalDelta}`;
 		const onRecovery = mock(() => undefined);
@@ -373,6 +443,39 @@ describe("createAnthropicTerminalRecoveryStream", () => {
 			await expect(new Response(body).text()).resolves.toBe(original);
 			expect(onRecovery).not.toHaveBeenCalled();
 		}
+	});
+
+	it("validates every content-block delta against the open block lifecycle", async () => {
+		const invalidDelta =
+			'event: content_block_delta\ndata: {"type":"content_block_delta","index":-1,"delta":{"type":"text_delta","text":"bad"}}\n\n';
+		const invalidCases = [
+			`${contentBlockDelta}${terminalDelta}`,
+			`${contentBlockStart}${contentBlockStop}${contentBlockDelta}${terminalDelta}`,
+			`${terminalDelta}${contentBlockDelta}`,
+			`${invalidDelta}${terminalDelta}`,
+		];
+
+		for (const original of invalidCases) {
+			const onRecovery = mock(() => undefined);
+			const body = createAnthropicTerminalRecoveryStream(
+				immediateStream([bytes(original)]),
+				{ gracePeriodMs: 5, onRecovery },
+			);
+
+			await expect(new Response(body).text()).resolves.toBe(original);
+			expect(onRecovery).not.toHaveBeenCalled();
+		}
+
+		const valid = `${contentBlockStart}${contentBlockDelta}${contentBlockStop}${terminalDelta}`;
+		const onRecovery = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(
+			immediateStream([bytes(valid)]),
+			{ gracePeriodMs: 5, onRecovery },
+		);
+		await expect(new Response(body).text()).resolves.toBe(
+			`${valid}${ANTHROPIC_MESSAGE_STOP_FRAME}`,
+		);
+		expect(onRecovery).toHaveBeenCalledTimes(1);
 	});
 
 	it("passes through an oversized event but disables later recovery", async () => {

--- a/packages/proxy/src/__tests__/response-handler-anthropic-terminal-recovery.test.ts
+++ b/packages/proxy/src/__tests__/response-handler-anthropic-terminal-recovery.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, mock } from "bun:test";
+import { ANTHROPIC_MESSAGE_STOP_FRAME } from "../anthropic-terminal-recovery";
+import type { ProxyContext } from "../handlers";
+
+// The source worktree intentionally excludes generated database worker bundles.
+// ResponseHandler only reaches these constructors through UsageCollector, which
+// this filtered probe path never initializes or calls.
+mock.module("@better-ccflare/database", () => ({
+	AsyncDbWriter: class AsyncDbWriter {},
+	DatabaseFactory: class DatabaseFactory {},
+	DatabaseOperations: class DatabaseOperations {},
+	ModelTranslationRepository: class ModelTranslationRepository {},
+}));
+
+const { forwardToClient } = await import("../response-handler");
+
+const encoder = new TextEncoder();
+const terminalDelta =
+	'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":42}}\n\n';
+
+function bytes(text: string): Uint8Array {
+	return encoder.encode(text);
+}
+
+function immediateStream(chunk: Uint8Array): ReadableStream<Uint8Array> {
+	return new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(chunk);
+			controller.close();
+		},
+	});
+}
+
+function nativeAnthropicCtx(providerName = "anthropic"): ProxyContext {
+	return {
+		strategy: {},
+		dbOps: {},
+		runtime: { port: 8080, tlsEnabled: false },
+		config: { getStorePayloads: () => true },
+		provider: {
+			name: providerName,
+			isStreamingResponse: () => true,
+		},
+		refreshInFlight: new Map<string, Promise<string>>(),
+		asyncWriter: {},
+	} as unknown as ProxyContext;
+}
+
+async function forwardClosedStream({
+	requestHeaders,
+	providerName = "anthropic",
+	path = "/v1/messages",
+	method = "POST",
+	status = 200,
+	contentType = "text/event-stream; charset=utf-8",
+}: {
+	requestHeaders: Headers;
+	providerName?: string;
+	path?: string;
+	method?: string;
+	status?: number;
+	contentType?: string;
+}): Promise<string> {
+	const response = await forwardToClient(
+		{
+			requestId: crypto.randomUUID(),
+			method,
+			path,
+			account: null,
+			requestHeaders,
+			requestBody: bytes("{}"),
+			response: new Response(immediateStream(bytes(terminalDelta)), {
+				status,
+				headers: { "content-type": contentType },
+			}),
+			timestamp: Date.now(),
+			retryAttempt: 0,
+			failoverAttempts: 0,
+		},
+		nativeAnthropicCtx(providerName),
+	);
+
+	return response.text();
+}
+
+describe("forwardToClient Anthropic terminal recovery integration", () => {
+	it("recovers only native Anthropic Messages SSE responses", async () => {
+		const requestHeaders = new Headers({
+			"anthropic-version": "2023-06-01",
+			"x-better-ccflare-auto-refresh": "true",
+		});
+
+		await expect(forwardClosedStream({ requestHeaders })).resolves.toBe(
+			`${terminalDelta}${ANTHROPIC_MESSAGE_STOP_FRAME}`,
+		);
+	});
+
+	it("leaves non-native, non-Anthropic, and non-Messages streams unchanged", async () => {
+		const filteredHeaders = new Headers({
+			"x-better-ccflare-auto-refresh": "true",
+		});
+		const nativeHeaders = new Headers(filteredHeaders);
+		nativeHeaders.set("anthropic-version", "2023-06-01");
+
+		await expect(
+			forwardClosedStream({ requestHeaders: filteredHeaders }),
+		).resolves.toBe(terminalDelta);
+		await expect(
+			forwardClosedStream({
+				requestHeaders: nativeHeaders,
+				providerName: "anthropic-compatible",
+			}),
+		).resolves.toBe(terminalDelta);
+		await expect(
+			forwardClosedStream({
+				requestHeaders: nativeHeaders,
+				path: "/v1/complete",
+			}),
+		).resolves.toBe(terminalDelta);
+	});
+
+	it("leaves GET, non-2xx, and non-SSE Anthropic Messages responses unchanged", async () => {
+		const nativeHeaders = new Headers({
+			"anthropic-version": "2023-06-01",
+			"x-better-ccflare-auto-refresh": "true",
+		});
+
+		await expect(
+			forwardClosedStream({ requestHeaders: nativeHeaders, method: "GET" }),
+		).resolves.toBe(terminalDelta);
+		await expect(
+			forwardClosedStream({ requestHeaders: nativeHeaders, status: 500 }),
+		).resolves.toBe(terminalDelta);
+		await expect(
+			forwardClosedStream({
+				requestHeaders: nativeHeaders,
+				contentType: "application/json",
+			}),
+		).resolves.toBe(terminalDelta);
+	});
+});

--- a/packages/proxy/src/__tests__/response-handler-anthropic-terminal-recovery.test.ts
+++ b/packages/proxy/src/__tests__/response-handler-anthropic-terminal-recovery.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, mock } from "bun:test";
+import { describe, expect, it, mock, spyOn } from "bun:test";
 import { ANTHROPIC_MESSAGE_STOP_FRAME } from "../anthropic-terminal-recovery";
 import type { ProxyContext } from "../handlers";
 
@@ -12,6 +12,7 @@ mock.module("@better-ccflare/database", () => ({
 	ModelTranslationRepository: class ModelTranslationRepository {},
 }));
 
+const usageCollectorModule = await import("../usage-collector");
 const { forwardToClient } = await import("../response-handler");
 
 const encoder = new TextEncoder();
@@ -93,6 +94,70 @@ describe("forwardToClient Anthropic terminal recovery integration", () => {
 		await expect(forwardClosedStream({ requestHeaders })).resolves.toBe(
 			`${terminalDelta}${ANTHROPIC_MESSAGE_STOP_FRAME}`,
 		);
+	});
+
+	it("feeds synthesized framing through the normal usage lifecycle", async () => {
+		const chunks: Uint8Array[] = [];
+		const ends: Array<Record<string, unknown>> = [];
+		const collector = {
+			handleStart: mock(() => undefined),
+			handleChunk: mock((_requestId: string, data: Uint8Array) => {
+				chunks.push(data);
+			}),
+			handleEnd: mock((message: Record<string, unknown>) => {
+				ends.push(message);
+				return Promise.resolve();
+			}),
+		};
+		const collectorSpy = spyOn(
+			usageCollectorModule,
+			"getUsageCollector",
+		).mockReturnValue(
+			collector as unknown as usageCollectorModule.UsageCollector,
+		);
+
+		try {
+			const requestId = "normal-recovered-request";
+			const response = await forwardToClient(
+				{
+					requestId,
+					method: "POST",
+					path: "/v1/messages",
+					account: null,
+					requestHeaders: new Headers({
+						"anthropic-version": "2023-06-01",
+					}),
+					requestBody: bytes("{}"),
+					response: new Response(immediateStream(bytes(terminalDelta)), {
+						status: 200,
+						headers: { "content-type": "text/event-stream" },
+					}),
+					timestamp: Date.now(),
+					retryAttempt: 0,
+					failoverAttempts: 0,
+				},
+				nativeAnthropicCtx(),
+			);
+
+			await expect(response.text()).resolves.toBe(
+				`${terminalDelta}${ANTHROPIC_MESSAGE_STOP_FRAME}`,
+			);
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(collector.handleStart).toHaveBeenCalledTimes(1);
+			expect(Buffer.concat(chunks).toString()).toBe(
+				`${terminalDelta}${ANTHROPIC_MESSAGE_STOP_FRAME}`,
+			);
+			expect(ends).toEqual([
+				expect.objectContaining({
+					requestId,
+					success: true,
+					type: "end",
+				}),
+			]);
+		} finally {
+			collectorSpy.mockRestore();
+		}
 	});
 
 	it("leaves non-native, non-Anthropic, and non-Messages streams unchanged", async () => {

--- a/packages/proxy/src/anthropic-terminal-recovery.ts
+++ b/packages/proxy/src/anthropic-terminal-recovery.ts
@@ -1,0 +1,266 @@
+export const ANTHROPIC_MESSAGE_STOP_FRAME =
+	'event: message_stop\ndata: {"type":"message_stop"}\n\n';
+
+export const ANTHROPIC_TERMINAL_RECOVERY_GRACE_MS = 10_000;
+
+const encoder = new TextEncoder();
+const messageStopBytes = encoder.encode(ANTHROPIC_MESSAGE_STOP_FRAME);
+
+export type AnthropicTerminalRecoveryReason = "timeout" | "eof";
+
+export interface AnthropicTerminalRecoveryOptions {
+	/** @internal Override only in deterministic unit tests. */
+	gracePeriodMs?: number;
+	onRecovery?: (reason: AnthropicTerminalRecoveryReason) => void;
+	onCancelError?: (
+		error: unknown,
+		reason: AnthropicTerminalRecoveryReason,
+	) => void;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+/**
+ * Observe a native Anthropic SSE stream without rewriting its upstream bytes.
+ *
+ * A terminal `message_delta` carries the authoritative stop reason. Anthropic's
+ * protocol follows it with `message_stop`; if that final event never arrives,
+ * Claude Code waits for semantic progress until its watchdog expires. This
+ * wrapper gives the upstream a short grace period, then supplies only the
+ * protocol terminator that was already implied by the terminal delta.
+ */
+export function createAnthropicTerminalRecoveryStream(
+	upstream: ReadableStream<Uint8Array>,
+	options: AnthropicTerminalRecoveryOptions = {},
+): ReadableStream<Uint8Array> {
+	const gracePeriodMs =
+		options.gracePeriodMs ?? ANTHROPIC_TERMINAL_RECOVERY_GRACE_MS;
+	const reader = upstream.getReader();
+	const decoder = new TextDecoder();
+
+	let eventBuffer = "";
+	let terminalDeltaSeen = false;
+	let messageStopSeen = false;
+	let finalized = false;
+	let upstreamCancelPromise: Promise<void> | null = null;
+	let recoveryTimer: ReturnType<typeof setTimeout> | null = null;
+	let downstreamController:
+		| ReadableStreamDefaultController<Uint8Array>
+		| undefined;
+
+	const clearRecoveryTimer = (): void => {
+		if (recoveryTimer === null) return;
+		clearTimeout(recoveryTimer);
+		recoveryTimer = null;
+	};
+
+	const cancelUpstream = (reason: unknown): Promise<void> => {
+		if (upstreamCancelPromise) return upstreamCancelPromise;
+		try {
+			upstreamCancelPromise = reader.cancel(reason);
+		} catch (error) {
+			upstreamCancelPromise = Promise.reject(error);
+		}
+		return upstreamCancelPromise;
+	};
+
+	const reportRecovery = (reason: AnthropicTerminalRecoveryReason): void => {
+		try {
+			options.onRecovery?.(reason);
+		} catch {
+			// Observability must never interfere with client stream recovery.
+		}
+	};
+
+	const reportCancelError = (
+		error: unknown,
+		reason: AnthropicTerminalRecoveryReason,
+	): void => {
+		try {
+			options.onCancelError?.(error, reason);
+		} catch {
+			// Observability must never interfere with an already-complete stream.
+		}
+	};
+
+	const appendMissingEventDelimiter = (delimiter: string): void => {
+		if (delimiter && downstreamController) {
+			downstreamController.enqueue(encoder.encode(delimiter));
+		}
+	};
+
+	const cancelAfterForcedClose = (
+		reason: AnthropicTerminalRecoveryReason,
+		message: string,
+	): void => {
+		void cancelUpstream(new Error(message)).catch((error: unknown) => {
+			reportCancelError(error, reason);
+		});
+	};
+
+	const recover = (
+		reason: AnthropicTerminalRecoveryReason,
+		missingEventDelimiter = "",
+	): void => {
+		if (finalized || messageStopSeen || !downstreamController) return;
+
+		finalized = true;
+		clearRecoveryTimer();
+		appendMissingEventDelimiter(missingEventDelimiter);
+		downstreamController.enqueue(messageStopBytes.slice());
+		downstreamController.close();
+		reportRecovery(reason);
+		cancelAfterForcedClose(
+			reason,
+			`Anthropic stream recovered after missing message_stop (${reason})`,
+		);
+	};
+
+	const inspectEvent = (rawEvent: string): void => {
+		let eventType: string | undefined;
+		const dataLines: string[] = [];
+
+		for (const line of rawEvent.split(/\r?\n/)) {
+			if (line.length === 0 || line.startsWith(":")) continue;
+
+			const colon = line.indexOf(":");
+			const field = colon === -1 ? line : line.slice(0, colon);
+			let value = colon === -1 ? "" : line.slice(colon + 1);
+			if (value.startsWith(" ")) value = value.slice(1);
+
+			if (field === "event") eventType = value;
+			if (field === "data") dataLines.push(value);
+		}
+
+		if (dataLines.length === 0) return;
+
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(dataLines.join("\n")) as unknown;
+		} catch {
+			return;
+		}
+		if (!isRecord(parsed)) return;
+
+		const isMessageStop =
+			eventType === "message_stop" || parsed.type === "message_stop";
+		if (isMessageStop) {
+			messageStopSeen = true;
+			clearRecoveryTimer();
+			return;
+		}
+
+		const isMessageDelta =
+			eventType === "message_delta" || parsed.type === "message_delta";
+		const stopReason = isRecord(parsed.delta)
+			? parsed.delta.stop_reason
+			: undefined;
+		if (isMessageDelta && stopReason !== null && stopReason !== undefined) {
+			terminalDeltaSeen = true;
+			armRecoveryTimer();
+		}
+	};
+
+	const takeBufferedEventDelimiter = (): string => {
+		if (eventBuffer.length === 0) return "";
+		const bufferedEvent = eventBuffer;
+		eventBuffer = "";
+		inspectEvent(bufferedEvent);
+		return bufferedEvent.endsWith("\r\n")
+			? "\r\n"
+			: bufferedEvent.endsWith("\n")
+				? "\n"
+				: "\n\n";
+	};
+
+	const finalizeBufferedMessageStopAtTimeout = (
+		missingEventDelimiter: string,
+	): void => {
+		if (finalized || !downstreamController) return;
+		finalized = true;
+		clearRecoveryTimer();
+		appendMissingEventDelimiter(missingEventDelimiter);
+		downstreamController.close();
+		cancelAfterForcedClose(
+			"timeout",
+			"Anthropic stream closed after message_stop at timeout boundary",
+		);
+	};
+
+	const handleRecoveryTimeout = (): void => {
+		recoveryTimer = null;
+		if (finalized) return;
+		const missingEventDelimiter = takeBufferedEventDelimiter();
+		if (messageStopSeen) {
+			finalizeBufferedMessageStopAtTimeout(missingEventDelimiter);
+			return;
+		}
+		recover("timeout", missingEventDelimiter);
+	};
+
+	const armRecoveryTimer = (): void => {
+		if (recoveryTimer !== null || finalized || messageStopSeen) return;
+		recoveryTimer = setTimeout(handleRecoveryTimeout, gracePeriodMs);
+	};
+
+	const inspectChunk = (chunk: Uint8Array): void => {
+		eventBuffer += decoder.decode(chunk, { stream: true });
+
+		let delimiter = /\r?\n\r?\n/.exec(eventBuffer);
+		while (delimiter?.index !== undefined) {
+			const rawEvent = eventBuffer.slice(0, delimiter.index);
+			eventBuffer = eventBuffer.slice(delimiter.index + delimiter[0].length);
+			inspectEvent(rawEvent);
+			delimiter = /\r?\n\r?\n/.exec(eventBuffer);
+		}
+	};
+
+	return new ReadableStream<Uint8Array>({
+		start(controller) {
+			downstreamController = controller;
+		},
+
+		async pull(controller) {
+			if (finalized) return;
+
+			try {
+				const { value, done } = await reader.read();
+				if (finalized) return;
+
+				if (done) {
+					eventBuffer += decoder.decode();
+					const missingEventDelimiter = takeBufferedEventDelimiter();
+					if (terminalDeltaSeen && !messageStopSeen) {
+						recover("eof", missingEventDelimiter);
+						return;
+					}
+
+					finalized = true;
+					clearRecoveryTimer();
+					if (messageStopSeen) {
+						appendMissingEventDelimiter(missingEventDelimiter);
+					}
+					controller.close();
+					return;
+				}
+
+				controller.enqueue(value);
+				inspectChunk(value);
+			} catch (error) {
+				if (finalized) return;
+				finalized = true;
+				clearRecoveryTimer();
+				controller.error(error);
+			}
+		},
+
+		cancel(reason) {
+			if (finalized) return;
+			finalized = true;
+			clearRecoveryTimer();
+			return cancelUpstream(reason);
+		},
+	});
+}

--- a/packages/proxy/src/anthropic-terminal-recovery.ts
+++ b/packages/proxy/src/anthropic-terminal-recovery.ts
@@ -53,14 +53,28 @@ export function createAnthropicTerminalRecoveryStream(
 	let finalized = false;
 	let upstreamCancelPromise: Promise<void> | null = null;
 	let recoveryTimer: ReturnType<typeof setTimeout> | null = null;
+	let recoveryWaitRemainingMs = gracePeriodMs;
+	let recoveryWaitStartedAt: number | null = null;
+	let upstreamReadPending = false;
 	let downstreamController:
 		| ReadableStreamDefaultController<Uint8Array>
 		| undefined;
 
 	const clearRecoveryTimer = (): void => {
-		if (recoveryTimer === null) return;
-		clearTimeout(recoveryTimer);
+		if (recoveryTimer !== null) clearTimeout(recoveryTimer);
 		recoveryTimer = null;
+		recoveryWaitStartedAt = null;
+	};
+
+	const pauseRecoveryTimer = (): void => {
+		if (recoveryTimer !== null) clearTimeout(recoveryTimer);
+		recoveryTimer = null;
+		if (recoveryWaitStartedAt === null) return;
+		recoveryWaitRemainingMs = Math.max(
+			0,
+			recoveryWaitRemainingMs - (Date.now() - recoveryWaitStartedAt),
+		);
+		recoveryWaitStartedAt = null;
 	};
 
 	const cancelUpstream = (reason: unknown): Promise<void> => {
@@ -142,6 +156,11 @@ export function createAnthropicTerminalRecoveryStream(
 		clearRecoveryTimer();
 	};
 
+	const disableRecovery = (): void => {
+		recoveryDisabled = true;
+		clearRecoveryTimer();
+	};
+
 	const inspectEvent = (rawEvent: string, provisional = false): void => {
 		let eventType: string | undefined;
 		const dataLines: string[] = [];
@@ -163,20 +182,30 @@ export function createAnthropicTerminalRecoveryStream(
 			return;
 		}
 
-		if (dataLines.length === 0) return;
+		if (dataLines.length === 0) {
+			if (!provisional && eventType !== undefined && eventType !== "ping") {
+				disableRecovery();
+			}
+			return;
+		}
 
 		let parsed: unknown;
 		try {
 			parsed = JSON.parse(dataLines.join("\n")) as unknown;
 		} catch {
+			if (!provisional && eventType !== "ping") disableRecovery();
 			return;
 		}
-		if (!isRecord(parsed)) return;
+		if (!isRecord(parsed)) {
+			if (!provisional && eventType !== "ping") disableRecovery();
+			return;
+		}
 
 		if (parsed.type === "error") {
 			markTerminalFailure();
 			return;
 		}
+		if (eventType === "ping") return;
 
 		const isMessageStop =
 			eventType === "message_stop" || parsed.type === "message_stop";
@@ -201,6 +230,9 @@ export function createAnthropicTerminalRecoveryStream(
 			const isContentBlockStop =
 				eventType === "content_block_stop" ||
 				parsed.type === "content_block_stop";
+			const isContentBlockDelta =
+				eventType === "content_block_delta" ||
+				parsed.type === "content_block_delta";
 
 			if (isContentBlockStart) {
 				if (
@@ -237,6 +269,18 @@ export function createAnthropicTerminalRecoveryStream(
 					openContentBlocks.size === 0
 				) {
 					armRecoveryTimer();
+				}
+				return;
+			}
+
+			if (isContentBlockDelta) {
+				if (
+					contentBlockIndex === null ||
+					!openContentBlocks.has(contentBlockIndex) ||
+					terminalDeltaSeen ||
+					provisionalTerminalDeltaSeen
+				) {
+					disableRecovery();
 				}
 				return;
 			}
@@ -298,6 +342,8 @@ export function createAnthropicTerminalRecoveryStream(
 
 	const handleRecoveryTimeout = (): void => {
 		recoveryTimer = null;
+		recoveryWaitRemainingMs = 0;
+		recoveryWaitStartedAt = null;
 		if (finalized) return;
 		const missingEventDelimiter = takeBufferedEventDelimiter();
 		if (messageStopSeen) {
@@ -308,8 +354,21 @@ export function createAnthropicTerminalRecoveryStream(
 	};
 
 	const armRecoveryTimer = (): void => {
-		if (recoveryTimer !== null || finalized || messageStopSeen) return;
-		recoveryTimer = setTimeout(handleRecoveryTimeout, gracePeriodMs);
+		if (
+			recoveryTimer !== null ||
+			finalized ||
+			messageStopSeen ||
+			terminalFailureSeen ||
+			recoveryDisabled ||
+			(!terminalDeltaSeen && !provisionalTerminalDeltaSeen) ||
+			!upstreamReadPending
+		)
+			return;
+		recoveryWaitStartedAt = Date.now();
+		recoveryTimer = setTimeout(
+			handleRecoveryTimeout,
+			recoveryWaitRemainingMs,
+		);
 	};
 
 	const inspectChunk = (chunk: Uint8Array): void => {
@@ -369,7 +428,16 @@ export function createAnthropicTerminalRecoveryStream(
 			if (finalized) return;
 
 			try {
-				const { value, done } = await reader.read();
+				const { value, done } = await (async () => {
+					upstreamReadPending = true;
+					armRecoveryTimer();
+					try {
+						return await reader.read();
+					} finally {
+						upstreamReadPending = false;
+						pauseRecoveryTimer();
+					}
+				})();
 				if (finalized) return;
 
 				if (done) {

--- a/packages/proxy/src/anthropic-terminal-recovery.ts
+++ b/packages/proxy/src/anthropic-terminal-recovery.ts
@@ -5,6 +5,7 @@ export const ANTHROPIC_TERMINAL_RECOVERY_GRACE_MS = 10_000;
 
 const encoder = new TextEncoder();
 const messageStopBytes = encoder.encode(ANTHROPIC_MESSAGE_STOP_FRAME);
+const MAX_PENDING_EVENT_CHARS = 64 * 1024;
 
 export type AnthropicTerminalRecoveryReason = "timeout" | "eof";
 
@@ -41,8 +42,14 @@ export function createAnthropicTerminalRecoveryStream(
 	const decoder = new TextDecoder();
 
 	let eventBuffer = "";
+	let eventBufferTruncated = false;
 	let terminalDeltaSeen = false;
+	let provisionalTerminalDeltaSeen = false;
 	let messageStopSeen = false;
+	let terminalFailureSeen = false;
+	let recoveryDisabled = false;
+	let unknownContentBlockOpen = false;
+	const openContentBlocks = new Set<number>();
 	let finalized = false;
 	let upstreamCancelPromise: Promise<void> | null = null;
 	let recoveryTimer: ReturnType<typeof setTimeout> | null = null;
@@ -104,7 +111,17 @@ export function createAnthropicTerminalRecoveryStream(
 		reason: AnthropicTerminalRecoveryReason,
 		missingEventDelimiter = "",
 	): void => {
-		if (finalized || messageStopSeen || !downstreamController) return;
+		if (
+			finalized ||
+			messageStopSeen ||
+			terminalFailureSeen ||
+			recoveryDisabled ||
+			!terminalDeltaSeen ||
+			unknownContentBlockOpen ||
+			openContentBlocks.size > 0 ||
+			!downstreamController
+		)
+			return;
 
 		finalized = true;
 		clearRecoveryTimer();
@@ -118,7 +135,14 @@ export function createAnthropicTerminalRecoveryStream(
 		);
 	};
 
-	const inspectEvent = (rawEvent: string): void => {
+	const markTerminalFailure = (): void => {
+		terminalFailureSeen = true;
+		terminalDeltaSeen = false;
+		provisionalTerminalDeltaSeen = false;
+		clearRecoveryTimer();
+	};
+
+	const inspectEvent = (rawEvent: string, provisional = false): void => {
 		let eventType: string | undefined;
 		const dataLines: string[] = [];
 
@@ -134,6 +158,11 @@ export function createAnthropicTerminalRecoveryStream(
 			if (field === "data") dataLines.push(value);
 		}
 
+		if (eventType === "error") {
+			markTerminalFailure();
+			return;
+		}
+
 		if (dataLines.length === 0) return;
 
 		let parsed: unknown;
@@ -144,12 +173,73 @@ export function createAnthropicTerminalRecoveryStream(
 		}
 		if (!isRecord(parsed)) return;
 
+		if (parsed.type === "error") {
+			markTerminalFailure();
+			return;
+		}
+
 		const isMessageStop =
 			eventType === "message_stop" || parsed.type === "message_stop";
 		if (isMessageStop) {
+			if (provisional) return;
 			messageStopSeen = true;
+			provisionalTerminalDeltaSeen = false;
 			clearRecoveryTimer();
 			return;
+		}
+
+		if (!provisional) {
+			const contentBlockIndex =
+				typeof parsed.index === "number" &&
+				Number.isSafeInteger(parsed.index) &&
+				parsed.index >= 0
+					? parsed.index
+					: null;
+			const isContentBlockStart =
+				eventType === "content_block_start" ||
+				parsed.type === "content_block_start";
+			const isContentBlockStop =
+				eventType === "content_block_stop" ||
+				parsed.type === "content_block_stop";
+
+			if (isContentBlockStart) {
+				if (
+					contentBlockIndex === null ||
+					openContentBlocks.has(contentBlockIndex)
+				) {
+					unknownContentBlockOpen = true;
+					recoveryDisabled = true;
+				} else {
+					openContentBlocks.add(contentBlockIndex);
+				}
+				if (terminalDeltaSeen || provisionalTerminalDeltaSeen) {
+					recoveryDisabled = true;
+				}
+				clearRecoveryTimer();
+				return;
+			}
+
+			if (isContentBlockStop) {
+				if (
+					contentBlockIndex === null ||
+					!openContentBlocks.has(contentBlockIndex)
+				) {
+					unknownContentBlockOpen = true;
+					recoveryDisabled = true;
+				} else {
+					openContentBlocks.delete(contentBlockIndex);
+				}
+				if (
+					terminalDeltaSeen &&
+					!terminalFailureSeen &&
+					!recoveryDisabled &&
+					!unknownContentBlockOpen &&
+					openContentBlocks.size === 0
+				) {
+					armRecoveryTimer();
+				}
+				return;
+			}
 		}
 
 		const isMessageDelta =
@@ -158,8 +248,23 @@ export function createAnthropicTerminalRecoveryStream(
 			? parsed.delta.stop_reason
 			: undefined;
 		if (isMessageDelta && stopReason !== null && stopReason !== undefined) {
-			terminalDeltaSeen = true;
-			armRecoveryTimer();
+			if (unknownContentBlockOpen || openContentBlocks.size > 0) {
+				recoveryDisabled = true;
+				clearRecoveryTimer();
+			}
+			if (provisional) provisionalTerminalDeltaSeen = true;
+			else {
+				terminalDeltaSeen = true;
+				provisionalTerminalDeltaSeen = false;
+			}
+			if (
+				!terminalFailureSeen &&
+				!recoveryDisabled &&
+				!unknownContentBlockOpen &&
+				openContentBlocks.size === 0
+			) {
+				armRecoveryTimer();
+			}
 		}
 	};
 
@@ -167,7 +272,9 @@ export function createAnthropicTerminalRecoveryStream(
 		if (eventBuffer.length === 0) return "";
 		const bufferedEvent = eventBuffer;
 		eventBuffer = "";
-		inspectEvent(bufferedEvent);
+		provisionalTerminalDeltaSeen = false;
+		if (!eventBufferTruncated) inspectEvent(bufferedEvent);
+		eventBufferTruncated = false;
 		return bufferedEvent.endsWith("\r\n")
 			? "\r\n"
 			: bufferedEvent.endsWith("\n")
@@ -208,12 +315,48 @@ export function createAnthropicTerminalRecoveryStream(
 	const inspectChunk = (chunk: Uint8Array): void => {
 		eventBuffer += decoder.decode(chunk, { stream: true });
 
+		if (eventBufferTruncated) {
+			const resyncDelimiter = /\r?\n\r?\n/.exec(eventBuffer);
+			if (resyncDelimiter?.index === undefined) {
+				eventBuffer = eventBuffer.slice(-3);
+				return;
+			}
+			eventBuffer = eventBuffer.slice(
+				resyncDelimiter.index + resyncDelimiter[0].length,
+			);
+			eventBufferTruncated = false;
+		}
+
 		let delimiter = /\r?\n\r?\n/.exec(eventBuffer);
 		while (delimiter?.index !== undefined) {
 			const rawEvent = eventBuffer.slice(0, delimiter.index);
 			eventBuffer = eventBuffer.slice(delimiter.index + delimiter[0].length);
-			inspectEvent(rawEvent);
+			provisionalTerminalDeltaSeen = false;
+			if (eventBufferTruncated || rawEvent.length > MAX_PENDING_EVENT_CHARS) {
+				recoveryDisabled = true;
+				clearRecoveryTimer();
+			} else {
+				inspectEvent(rawEvent);
+			}
+			eventBufferTruncated = false;
 			delimiter = /\r?\n\r?\n/.exec(eventBuffer);
+		}
+
+		if (eventBuffer.length > MAX_PENDING_EVENT_CHARS) {
+			eventBuffer = eventBuffer.slice(-3);
+			eventBufferTruncated = true;
+			recoveryDisabled = true;
+			clearRecoveryTimer();
+			provisionalTerminalDeltaSeen = false;
+			return;
+		}
+
+		if (
+			!eventBufferTruncated &&
+			eventBuffer.length > 0 &&
+			/\r?\n$/.test(eventBuffer)
+		) {
+			inspectEvent(eventBuffer, true);
 		}
 	};
 
@@ -231,15 +374,25 @@ export function createAnthropicTerminalRecoveryStream(
 
 				if (done) {
 					eventBuffer += decoder.decode();
+					const messageStopSeenBeforeBufferedEvent = messageStopSeen;
 					const missingEventDelimiter = takeBufferedEventDelimiter();
-					if (terminalDeltaSeen && !messageStopSeen) {
+					const bufferedEventSuppliedMessageStop =
+						!messageStopSeenBeforeBufferedEvent && messageStopSeen;
+					if (
+						terminalDeltaSeen &&
+						!messageStopSeen &&
+						!terminalFailureSeen &&
+						!recoveryDisabled &&
+						!unknownContentBlockOpen &&
+						openContentBlocks.size === 0
+					) {
 						recover("eof", missingEventDelimiter);
 						return;
 					}
 
 					finalized = true;
 					clearRecoveryTimer();
-					if (messageStopSeen) {
+					if (bufferedEventSuppliedMessageStop) {
 						appendMissingEventDelimiter(missingEventDelimiter);
 					}
 					controller.close();

--- a/packages/proxy/src/response-handler.ts
+++ b/packages/proxy/src/response-handler.ts
@@ -5,6 +5,10 @@ import {
 } from "@better-ccflare/http-common";
 import { Logger } from "@better-ccflare/logger";
 import type { Account, RateLimitReason } from "@better-ccflare/types";
+import {
+	ANTHROPIC_TERMINAL_RECOVERY_GRACE_MS,
+	createAnthropicTerminalRecoveryStream,
+} from "./anthropic-terminal-recovery";
 import type { ProxyContext } from "./handlers";
 import { applyRateLimitCooldown } from "./handlers/rate-limit-cooldown";
 import { createSseRateLimitSniffer } from "./handlers/sse-rate-limit-sniffer";
@@ -284,7 +288,40 @@ export async function forwardToClient(
 			}
 		};
 
-		const passthroughBody = teeStream(response.body, {
+		const isNativeAnthropicMessagesStream =
+			method === "POST" &&
+			path === "/v1/messages" &&
+			ctx.provider.name === "anthropic" &&
+			requestHeaders.has("anthropic-version") &&
+			response.ok &&
+			response.headers
+				.get("content-type")
+				?.toLowerCase()
+				.includes("text/event-stream");
+		const responseBody = isNativeAnthropicMessagesStream
+			? createAnthropicTerminalRecoveryStream(response.body, {
+					onRecovery(reason) {
+						log.warn("anthropic_terminal_message_stop_recovered", {
+							requestId,
+							accountId: account?.id ?? null,
+							provider: ctx.provider.name,
+							reason,
+							gracePeriodMs: ANTHROPIC_TERMINAL_RECOVERY_GRACE_MS,
+						});
+					},
+					onCancelError(error, reason) {
+						log.warn("anthropic_terminal_upstream_cancel_failed", {
+							requestId,
+							accountId: account?.id ?? null,
+							provider: ctx.provider.name,
+							reason,
+							errorType: error instanceof Error ? error.name : typeof error,
+						});
+					},
+				})
+			: response.body;
+
+		const passthroughBody = teeStream(responseBody, {
 			onChunk,
 			onClose,
 			onError,


### PR DESCRIPTION
## Summary

Add a narrowly scoped terminal-recovery transform for successful native Anthropic `POST /v1/messages` SSE responses.

Healthy streams remain byte-for-byte unchanged. After a terminal `message_delta` with a non-null `stop_reason`, the proxy allows 10 seconds for the required `message_stop`. If it never arrives, or upstream EOF arrives first, the proxy emits exactly one valid `message_stop`, closes downstream, and cancels the stuck upstream reader.

## Root cause

We observed streams that delivered the full assistant response and usage, followed by a terminal `message_delta` with `stop_reason: "end_turn"`, then only `ping` events. The required `message_stop` never arrived, so Claude Code waited until its approximately 300-second semantic watchdog reported `Response stalled mid-stream`.

Anthropic's streaming contract ends with `message_stop`; a non-null stop reason means the model response is semantically complete. This recovery repairs missing terminal framing without inventing assistant content.

- https://platform.claude.com/docs/en/build-with-claude/streaming
- https://platform.claude.com/docs/en/build-with-claude/handling-stop-reasons

## Safety and observability

Recovery is restricted to:

- provider `anthropic`
- successful native `POST /v1/messages` responses
- requests carrying `anthropic-version`
- `text/event-stream` responses

The observer is bounded and fail-closed: in-band errors, open or malformed content-block lifecycles, and oversized/uninspectable events disable synthesis. Complete `message_stop` frames and healthy response bytes remain unchanged. Structured logs record successful recovery and upstream-cancellation failures.

## Validation

Revalidated on 2026-07-15 by merging PR head `4aa95057` into current `upstream/main` `d6e44df9` in an isolated worktree. The merge was clean and the resulting working tree remained clean after validation.

- `bun test packages/proxy/src/__tests__/anthropic-terminal-recovery.test.ts packages/proxy/src/__tests__/response-handler-anthropic-terminal-recovery.test.ts`: 33 passed, 0 failed, 100 assertions
- `bun run lint`: passed with existing repository warnings; Biome reformatted one PR file, and that uncommitted formatting-only rewrite was discarded
- `bun run format`: passed, no fixes applied
- `bun run build`: passed, dashboard and CLI built successfully
- `bun run typecheck`: initially reported the expected absent generated database worker modules in the fresh worktree, then passed after the build generated them
- `git diff --check upstream/main...HEAD`: passed

Original branch validation also included adversarial terminal-recovery coverage for downstream backpressure, accumulated grace across pings, chunk boundaries, malformed payloads, partial terminal events, error precedence, content-block lifecycle validation, oversized events, EOF, cancellation, and exact-byte preservation.