### PR TITLE
feat: persisted requires_reauth detection — routing exclusion, API/dashboard surfacing, auth_failure webhook alert

### DIFF
--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -974,7 +974,8 @@ Examples:
 		const stats = {
 			totalAccounts: accounts.length,
 			activeAccounts: accounts.filter(
-				(acc) => !acc.paused && acc.tokenStatus === "valid",
+				(acc) =>
+					!acc.paused && !acc.requiresReauth && acc.tokenStatus === "valid",
 			).length,
 			pausedAccounts: accounts.filter((acc) => acc.paused).length,
 			expiredAccounts: accounts.filter((acc) => acc.tokenStatus === "expired")

--- a/packages/cli-commands/src/commands/__tests__/account-list-requires-reauth.test.ts
+++ b/packages/cli-commands/src/commands/__tests__/account-list-requires-reauth.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import type { Account } from "@better-ccflare/types";
+import { getAccountsList } from "../account";
+
+describe("getAccountsList requiresReauth", () => {
+	it("carries the persisted authentication state into CLI list items", async () => {
+		const account = {
+			id: "account-1",
+			name: "Account 1",
+			provider: "anthropic",
+			expires_at: Date.now() + 60_000,
+			created_at: Date.now(),
+			last_used: null,
+			request_count: 0,
+			total_requests: 0,
+			paused: false,
+			requires_reauth: true,
+			rate_limited_until: null,
+			session_start: null,
+			session_request_count: 0,
+			access_token: "access-token",
+			priority: 0,
+			auto_fallback_enabled: false,
+			auto_refresh_enabled: false,
+			custom_endpoint: null,
+			cross_region_mode: null,
+		} as Account;
+		const dbOps = { getAllAccounts: async () => [account] };
+
+		const result = await getAccountsList(dbOps as never);
+
+		expect(result[0]?.requiresReauth).toBe(true);
+	});
+});

--- a/packages/cli-commands/src/commands/account.ts
+++ b/packages/cli-commands/src/commands/account.ts
@@ -1801,6 +1801,7 @@ export async function getAccountsList(
 			requestCount: account.request_count,
 			totalRequests: account.total_requests,
 			paused: account.paused,
+			requiresReauth: account.requires_reauth,
 			tokenStatus,
 			rateLimitStatus,
 			sessionInfo,
@@ -2163,7 +2164,8 @@ async function reauthenticateQwenAccount(
 				refresh_token = ?,
 				access_token = ?,
 				expires_at = ?,
-				custom_endpoint = ?
+				custom_endpoint = ?,
+				requires_reauth = 0
 			WHERE id = ?`,
 			[
 				tokens.refresh_token,
@@ -2236,7 +2238,8 @@ async function reauthenticateXaiAccount(
 				refresh_token = ?,
 				access_token = ?,
 				expires_at = ?,
-				custom_endpoint = COALESCE(custom_endpoint, ?)
+				custom_endpoint = COALESCE(custom_endpoint, ?),
+				requires_reauth = 0
 			WHERE id = ?`,
 			[
 				auth.refresh_token,
@@ -2419,7 +2422,8 @@ export async function reauthenticateAccount(
 						api_key = ?,
 						refresh_token = ?,
 						access_token = NULL,
-						expires_at = NULL
+						expires_at = NULL,
+						requires_reauth = 0
 					WHERE id = ?`,
 					[apiKey, apiKey, account.id],
 				);
@@ -2448,9 +2452,17 @@ export async function reauthenticateAccount(
 			`UPDATE accounts SET
 				refresh_token = ?,
 				access_token = ?,
-				expires_at = ?
+				expires_at = ?,
+				refresh_token_issued_at = ?,
+				requires_reauth = 0
 			WHERE id = ?`,
-			[tokens.refreshToken, tokens.accessToken, tokens.expiresAt, account.id],
+			[
+				tokens.refreshToken,
+				tokens.accessToken,
+				tokens.expiresAt,
+				Date.now(),
+				account.id,
+			],
 		);
 
 		console.log("OAuth tokens updated.");

--- a/packages/core/src/auth-failure-events.ts
+++ b/packages/core/src/auth-failure-events.ts
@@ -1,0 +1,13 @@
+import { EventEmitter } from "node:events";
+
+export interface AuthFailureEvt {
+	accountId: string;
+	accountName: string;
+	provider: string;
+	reason: string;
+}
+
+class AuthFailureEventBus extends EventEmitter {}
+export const authFailureEvents = new AuthFailureEventBus();
+
+authFailureEvents.setMaxListeners(200);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,7 @@ export type ModelMappingData = {
 };
 export type ModelFallback = { [modelFamily: string]: string };
 export * from "./alert-events";
+export * from "./auth-failure-events";
 export {
 	type IntervalConfig,
 	intervalManager,

--- a/packages/core/src/strategy-requires-reauth.test.ts
+++ b/packages/core/src/strategy-requires-reauth.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "bun:test";
+import type { Account } from "@better-ccflare/types";
+import { isAccountAvailable } from "./strategy";
+
+function account(requiresReauth: boolean): Account {
+	return {
+		paused: false,
+		requires_reauth: requiresReauth,
+		rate_limited_until: null,
+	} as Account;
+}
+
+describe("isAccountAvailable requires_reauth", () => {
+	it("excludes an account that requires manual authentication", () => {
+		expect(isAccountAvailable(account(true))).toBe(false);
+	});
+
+	it("keeps an otherwise healthy account available", () => {
+		expect(isAccountAvailable(account(false))).toBe(true);
+	});
+});

--- a/packages/core/src/strategy.ts
+++ b/packages/core/src/strategy.ts
@@ -16,6 +16,7 @@ export function isAccountAvailable(
 	now = Date.now(),
 ): boolean {
 	return (
+		!account.requires_reauth &&
 		!account.paused &&
 		(!account.rate_limited_until || account.rate_limited_until < now)
 	);

--- a/packages/dashboard-web/src/components/accounts/AccountListItem.test.tsx
+++ b/packages/dashboard-web/src/components/accounts/AccountListItem.test.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Gili Tzabari. All rights reserved.
+ *
+ * Licensed under the CAT Commercial License.
+ * See LICENSE.md in the project root for license terms.
+ */
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { Account } from "../../api";
+import { AccountListItem } from "./AccountListItem";
+
+const baseAccount: Account = {
+	id: "account-1",
+	name: "test-account",
+	provider: "anthropic",
+	requestCount: 0,
+	totalRequests: 0,
+	lastUsed: null,
+	created: new Date(0).toISOString(),
+	paused: true,
+	requiresReauth: false,
+	pauseReason: "overage",
+	tokenStatus: "expired",
+	tokenExpiresAt: null,
+	rateLimitStatus: "OK",
+	rateLimitReset: null,
+	rateLimitRemaining: null,
+	rateLimitedUntil: null,
+	rateLimitedReason: null,
+	rateLimitedAt: null,
+	sessionInfo: "No active session",
+	priority: 1,
+	autoFallbackEnabled: true,
+	autoRefreshEnabled: true,
+	customEndpoint: null,
+	modelMappings: null,
+	usageUtilization: null,
+	usageWindow: null,
+	usageData: null,
+	usageRateLimitedUntil: null,
+	usageThrottledUntil: null,
+	usageThrottledWindows: [],
+	hasRefreshToken: true,
+	sessionStats: null,
+	isPrimary: false,
+};
+
+function renderAccount(account: Account): string {
+	return renderToStaticMarkup(
+		<AccountListItem
+			account={account}
+			onPauseToggle={() => {}}
+			onForceResetRateLimit={() => {}}
+			onRefreshUsage={async () => {}}
+			onRemove={() => {}}
+			onRename={() => {}}
+			onPriorityChange={() => {}}
+			onAutoFallbackToggle={() => {}}
+			onAutoRefreshToggle={() => {}}
+			onBillingTypeToggle={() => {}}
+			onAnthropicReauth={() => {}}
+		/>,
+	);
+}
+
+describe("AccountListItem", () => {
+	it("shows Needs authentication only when requiresReauth is true", () => {
+		const healthyHtml = renderAccount(baseAccount);
+		const requiresReauthHtml = renderAccount({
+			...baseAccount,
+			requiresReauth: true,
+		});
+
+		expect(healthyHtml).not.toContain("Needs authentication");
+		expect(requiresReauthHtml).toContain("Needs authentication");
+		expect(requiresReauthHtml).toContain(
+			"Refresh token invalid — re-authenticate",
+		);
+		expect(requiresReauthHtml).not.toContain("Paused (overage)");
+	});
+
+	it("shows a human-readable pause reason when re-authentication is not required", () => {
+		const html = renderAccount({
+			...baseAccount,
+			pauseReason: "failure_threshold",
+		});
+
+		expect(html).toContain("Paused (failure threshold)");
+	});
+});

--- a/packages/dashboard-web/src/components/accounts/AccountListItem.tsx
+++ b/packages/dashboard-web/src/components/accounts/AccountListItem.tsx
@@ -20,6 +20,7 @@ import {
 	providerSupportsCustomBilling,
 } from "../../utils/provider-utils";
 import { OAuthTokenStatusWithBoundary } from "../OAuthTokenStatus";
+import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Switch } from "../ui/switch";
 import { RateLimitProgress } from "./RateLimitProgress";
@@ -28,6 +29,11 @@ function formatTokenCount(n: number): string {
 	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
 	if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
 	return String(n);
+}
+
+function formatPauseReason(reason: string | null): string | null {
+	if (!reason) return null;
+	return reason.replaceAll("_", " ");
 }
 
 interface AccountListItemProps {
@@ -252,8 +258,22 @@ export function AccountListItem({
 						<span className="text-sm text-muted-foreground">
 							{presenter.sessionInfo}
 						</span>
-						{presenter.isPaused && (
-							<span className="text-sm text-muted-foreground">Paused</span>
+						{account.requiresReauth ? (
+							<Badge
+								variant="destructive"
+								title="Refresh token invalid — re-authenticate"
+							>
+								Needs authentication
+							</Badge>
+						) : (
+							presenter.isPaused && (
+								<span className="text-sm text-muted-foreground">
+									Paused
+									{formatPauseReason(account.pauseReason)
+										? ` (${formatPauseReason(account.pauseReason)})`
+										: ""}
+								</span>
+							)
 						)}
 						{!presenter.isPaused && presenter.rateLimitStatus !== "OK" && (
 							<span

--- a/packages/database/src/database-operations.ts
+++ b/packages/database/src/database-operations.ts
@@ -763,6 +763,14 @@ OAuth tokens will need to be re-authenticated.
 		);
 	}
 
+	async setRequiresReauth(accountId: string, value: boolean): Promise<void> {
+		await withDatabaseRetry(
+			() => this.accounts.setRequiresReauth(accountId, value),
+			this.retryConfig,
+			"setRequiresReauth",
+		);
+	}
+
 	async updateAccountUsage(accountId: string): Promise<void> {
 		const sessionDuration =
 			this.runtime?.sessionDurationMs || 5 * 60 * 60 * 1000;

--- a/packages/database/src/migrations-pg.ts
+++ b/packages/database/src/migrations-pg.ts
@@ -71,6 +71,7 @@ export async function ensureSchemaPg(adapter: BunSqlAdapter): Promise<void> {
 			auto_pause_on_overage_enabled INTEGER DEFAULT 0,
 			peak_hours_pause_enabled INTEGER NOT NULL DEFAULT 0,
 			pause_reason TEXT,
+			requires_reauth INTEGER DEFAULT 0,
 			billing_type TEXT DEFAULT NULL,
 			refresh_token_issued_at BIGINT,
 			rate_limited_reason TEXT,
@@ -407,6 +408,12 @@ export async function runMigrationsPg(adapter: BunSqlAdapter): Promise<void> {
 			table: "accounts",
 			column: "pause_reason",
 			definition: "ALTER TABLE accounts ADD COLUMN pause_reason TEXT",
+		},
+		{
+			table: "accounts",
+			column: "requires_reauth",
+			definition:
+				"ALTER TABLE accounts ADD COLUMN requires_reauth INTEGER DEFAULT 0",
 		},
 		{
 			table: "requests",

--- a/packages/database/src/migrations.ts
+++ b/packages/database/src/migrations.ts
@@ -122,7 +122,8 @@ export function ensureSchema(db: Database): void {
 			request_count INTEGER DEFAULT 0,
 			total_requests INTEGER DEFAULT 0,
 			priority INTEGER DEFAULT 0,
-			consecutive_rate_limits INTEGER NOT NULL DEFAULT 0
+			consecutive_rate_limits INTEGER NOT NULL DEFAULT 0,
+			requires_reauth INTEGER DEFAULT 0
 		)
 	`);
 
@@ -695,6 +696,13 @@ export function runMigrations(db: Database, dbPath?: string): void {
 			log.info("Backfilled pause_reason for existing paused accounts");
 		}
 
+		if (!initialAccountsColumnNames.includes("requires_reauth")) {
+			db.prepare(
+				"ALTER TABLE accounts ADD COLUMN requires_reauth INTEGER DEFAULT 0",
+			).run();
+			log.info("Added requires_reauth column to accounts table");
+		}
+
 		if (!initialAccountsColumnNames.includes("rate_limited_reason")) {
 			db.prepare(
 				"ALTER TABLE accounts ADD COLUMN rate_limited_reason TEXT",
@@ -750,7 +758,8 @@ export function runMigrations(db: Database, dbPath?: string): void {
 					cross_region_mode TEXT DEFAULT 'geographic',
 					model_fallbacks TEXT,
 					auto_pause_on_overage_enabled INTEGER DEFAULT 0,
-					pause_reason TEXT
+					pause_reason TEXT,
+					requires_reauth INTEGER DEFAULT 0
 				)
 			`).run();
 
@@ -766,7 +775,7 @@ export function runMigrations(db: Database, dbPath?: string): void {
 					paused, rate_limit_reset, rate_limit_status, rate_limit_remaining,
 					auto_fallback_enabled, custom_endpoint, auto_refresh_enabled,
 					model_mappings, cross_region_mode, model_fallbacks,
-					auto_pause_on_overage_enabled, pause_reason
+					auto_pause_on_overage_enabled, pause_reason, requires_reauth
 				FROM accounts
 			`).run();
 
@@ -1009,7 +1018,7 @@ export function runMigrations(db: Database, dbPath?: string): void {
 			       rate_limit_reset, rate_limit_status, rate_limit_remaining,
 			       auto_fallback_enabled, custom_endpoint, auto_refresh_enabled, model_mappings,
 			       cross_region_mode, model_fallbacks, billing_type, auto_pause_on_overage_enabled,
-			       pause_reason
+			       pause_reason, requires_reauth
 			FROM accounts
 		`).run();
 

--- a/packages/database/src/repositories/__tests__/account-requires-reauth.test.ts
+++ b/packages/database/src/repositories/__tests__/account-requires-reauth.test.ts
@@ -1,0 +1,94 @@
+import "@better-ccflare/core";
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { BunSqlAdapter } from "../../adapters/bun-sql-adapter";
+import { AccountRepository } from "../account.repository";
+
+describe("AccountRepository requires_reauth", () => {
+	let db: Database;
+	let repository: AccountRepository;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		db.run(`
+			CREATE TABLE accounts (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				provider TEXT DEFAULT 'anthropic',
+				api_key TEXT,
+				refresh_token TEXT DEFAULT '',
+				access_token TEXT,
+				expires_at INTEGER,
+				created_at INTEGER NOT NULL,
+				last_used INTEGER,
+				request_count INTEGER DEFAULT 0,
+				total_requests INTEGER DEFAULT 0,
+				rate_limited_until INTEGER,
+				rate_limited_reason TEXT,
+				rate_limited_at INTEGER,
+				session_start INTEGER,
+				session_request_count INTEGER DEFAULT 0,
+				paused INTEGER DEFAULT 0,
+				requires_reauth INTEGER DEFAULT 0,
+				rate_limit_reset INTEGER,
+				rate_limit_status TEXT,
+				rate_limit_remaining INTEGER,
+				priority INTEGER DEFAULT 0,
+				auto_fallback_enabled INTEGER DEFAULT 0,
+				auto_refresh_enabled INTEGER DEFAULT 0,
+				auto_pause_on_overage_enabled INTEGER DEFAULT 0,
+				peak_hours_pause_enabled INTEGER DEFAULT 0,
+				custom_endpoint TEXT,
+				model_mappings TEXT,
+				cross_region_mode TEXT,
+				model_fallbacks TEXT,
+				billing_type TEXT,
+				pause_reason TEXT,
+				refresh_token_issued_at INTEGER,
+				consecutive_rate_limits INTEGER DEFAULT 0
+			)
+		`);
+		db.run(
+			"INSERT INTO accounts (id, name, access_token, expires_at, created_at) VALUES ('account-1', 'Account 1', 'old-token', 1, 1)",
+		);
+		repository = new AccountRepository(new BunSqlAdapter(db));
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("round-trips requires_reauth through setRequiresReauth and findById", async () => {
+		await repository.setRequiresReauth("account-1", true);
+
+		expect((await repository.findById("account-1"))?.requires_reauth).toBe(
+			true,
+		);
+
+		await repository.setRequiresReauth("account-1", false);
+
+		expect((await repository.findById("account-1"))?.requires_reauth).toBe(
+			false,
+		);
+	});
+
+	it("clears requires_reauth when tokens are updated without rotation", async () => {
+		await repository.setRequiresReauth("account-1", true);
+
+		await repository.updateTokens("account-1", "new-token", 2);
+
+		expect((await repository.findById("account-1"))?.requires_reauth).toBe(
+			false,
+		);
+	});
+
+	it("clears requires_reauth when tokens are updated with refresh-token rotation", async () => {
+		await repository.setRequiresReauth("account-1", true);
+
+		await repository.updateTokens("account-1", "new-token", 2, "new-refresh");
+
+		expect((await repository.findById("account-1"))?.requires_reauth).toBe(
+			false,
+		);
+	});
+});

--- a/packages/database/src/repositories/account.repository.ts
+++ b/packages/database/src/repositories/account.repository.ts
@@ -14,6 +14,7 @@ export class AccountRepository extends BaseRepository<Account> {
 				expires_at, created_at, last_used, request_count, total_requests,
 				rate_limited_until, rate_limited_reason, rate_limited_at, session_start, session_request_count,
 				COALESCE(paused, 0) as paused,
+				COALESCE(requires_reauth, 0) as requires_reauth,
 				rate_limit_reset, rate_limit_status, rate_limit_remaining,
 				COALESCE(priority, 0) as priority,
 				COALESCE(auto_fallback_enabled, 0) as auto_fallback_enabled,
@@ -42,6 +43,7 @@ export class AccountRepository extends BaseRepository<Account> {
 				expires_at, created_at, last_used, request_count, total_requests,
 				rate_limited_until, rate_limited_reason, rate_limited_at, session_start, session_request_count,
 				COALESCE(paused, 0) as paused,
+				COALESCE(requires_reauth, 0) as requires_reauth,
 				rate_limit_reset, rate_limit_status, rate_limit_remaining,
 				COALESCE(priority, 0) as priority,
 				COALESCE(auto_fallback_enabled, 0) as auto_fallback_enabled,
@@ -74,15 +76,22 @@ export class AccountRepository extends BaseRepository<Account> {
 		const now = Date.now();
 		if (refreshToken) {
 			await this.run(
-				`UPDATE accounts SET access_token = ?, expires_at = ?, refresh_token = ?, refresh_token_issued_at = ? WHERE id = ?`,
+				`UPDATE accounts SET access_token = ?, expires_at = ?, refresh_token = ?, refresh_token_issued_at = ?, requires_reauth = 0 WHERE id = ?`,
 				[accessToken, expiresAt, refreshToken, now, accountId],
 			);
 		} else {
 			await this.run(
-				`UPDATE accounts SET access_token = ?, expires_at = ? WHERE id = ?`,
+				`UPDATE accounts SET access_token = ?, expires_at = ?, requires_reauth = 0 WHERE id = ?`,
 				[accessToken, expiresAt, accountId],
 			);
 		}
+	}
+
+	async setRequiresReauth(accountId: string, value: boolean): Promise<void> {
+		await this.run(`UPDATE accounts SET requires_reauth = ? WHERE id = ?`, [
+			value ? 1 : 0,
+			accountId,
+		]);
 	}
 
 	async incrementUsage(

--- a/packages/database/src/requires-reauth-migration.test.ts
+++ b/packages/database/src/requires-reauth-migration.test.ts
@@ -1,0 +1,77 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, it } from "bun:test";
+import { ensureSchema, runMigrations } from "./migrations";
+
+function accountColumns(
+	db: Database,
+): Array<{ name: string; dflt_value: string | null }> {
+	return db.prepare("PRAGMA table_info(accounts)").all() as Array<{
+		name: string;
+		dflt_value: string | null;
+	}>;
+}
+
+describe("requires_reauth migration", () => {
+	let db: Database;
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("creates requires_reauth with a false default for a fresh database", () => {
+		db = new Database(":memory:");
+
+		ensureSchema(db);
+		runMigrations(db);
+
+		const column = accountColumns(db).find(
+			(candidate) => candidate.name === "requires_reauth",
+		);
+		expect(column?.dflt_value).toBe("0");
+
+		db.run(
+			"INSERT INTO accounts (id, name, created_at) VALUES ('fresh', 'fresh', 1)",
+		);
+		const row = db
+			.query<{ requires_reauth: number }, []>(
+				"SELECT requires_reauth FROM accounts WHERE id = 'fresh'",
+			)
+			.get();
+		expect(row?.requires_reauth).toBe(0);
+	});
+
+	it("adds requires_reauth with a false default to an existing database", () => {
+		db = new Database(":memory:");
+		db.run(`
+			CREATE TABLE accounts (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				provider TEXT DEFAULT 'anthropic',
+				api_key TEXT,
+				refresh_token TEXT,
+				access_token TEXT,
+				expires_at INTEGER,
+				created_at INTEGER NOT NULL,
+				last_used INTEGER,
+				request_count INTEGER DEFAULT 0,
+				total_requests INTEGER DEFAULT 0,
+				priority INTEGER DEFAULT 0
+			)
+		`);
+		db.run(
+			"INSERT INTO accounts (id, name, created_at) VALUES ('existing', 'existing', 1)",
+		);
+
+		runMigrations(db);
+
+		expect(accountColumns(db).map((column) => column.name)).toContain(
+			"requires_reauth",
+		);
+		const row = db
+			.query<{ requires_reauth: number }, []>(
+				"SELECT requires_reauth FROM accounts WHERE id = 'existing'",
+			)
+			.get();
+		expect(row?.requires_reauth).toBe(0);
+	});
+});

--- a/packages/http-api/src/handlers/__tests__/accounts-requires-reauth.test.ts
+++ b/packages/http-api/src/handlers/__tests__/accounts-requires-reauth.test.ts
@@ -72,4 +72,82 @@ describe("GET /api/accounts requires_reauth fields", () => {
 		expect(accounts[0]?.pauseReason).toBe("manual");
 		expect(accounts[0]?.isPrimary).toBe(false);
 	});
+
+	it("excludes a flagged-but-otherwise-healthy account from isPrimary (requires_reauth alone blocks routing)", async () => {
+		// The first test's flagged account is also paused=1, so its isPrimary=false
+		// would hold even if requires_reauth were never threaded into peek(). Here the
+		// flagged account is NOT paused and NOT rate-limited, and it has the HIGHER
+		// priority (so ORDER BY makes it the first peek candidate) — the only reason
+		// it must not be primary is the requires_reauth flag itself.
+		const baseTs = Date.now();
+		await adapter.run(
+			`INSERT INTO accounts (
+				id, name, provider, refresh_token, access_token, expires_at,
+				created_at, paused, pause_reason, requires_reauth, priority
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			[
+				"dead-auth",
+				"Dead auth",
+				"anthropic",
+				"refresh-token",
+				"access-token",
+				baseTs + 3_600_000,
+				baseTs,
+				0,
+				null,
+				1,
+				100,
+			],
+		);
+		await adapter.run(
+			`INSERT INTO accounts (
+				id, name, provider, refresh_token, access_token, expires_at,
+				created_at, paused, pause_reason, requires_reauth, priority
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			[
+				"healthy",
+				"Healthy",
+				"anthropic",
+				"refresh-token",
+				"access-token",
+				baseTs + 3_600_000,
+				baseTs,
+				0,
+				null,
+				0,
+				50,
+			],
+		);
+
+		const dbOps = {
+			getAdapter: () => adapter,
+			getStatsRepository: () => ({
+				getSessionStats: async () => new Map(),
+			}),
+		};
+		const config = {
+			getUsageThrottlingFiveHourEnabled: () => false,
+			getUsageThrottlingWeeklyEnabled: () => false,
+		} as unknown as Config;
+		const strategy = {
+			peek: (accounts: Account[]) =>
+				accounts.find((account) => isAccountAvailable(account))?.id ?? null,
+		};
+		const handler = createAccountsListHandler(
+			dbOps as never,
+			config,
+			() => strategy as never,
+		);
+
+		const response = await handler();
+		const accounts = (await response.json()) as AccountResponse[];
+		const dead = accounts.find((a) => a.id === "dead-auth");
+		const healthy = accounts.find((a) => a.id === "healthy");
+
+		expect(dead?.requiresReauth).toBe(true);
+		expect(dead?.isPrimary).toBe(false);
+		// The healthy, lower-priority account must be picked instead, proving the
+		// flag (not pause/rate-limit) is what removed the dead account from routing.
+		expect(healthy?.isPrimary).toBe(true);
+	});
 });

--- a/packages/http-api/src/handlers/__tests__/accounts-requires-reauth.test.ts
+++ b/packages/http-api/src/handlers/__tests__/accounts-requires-reauth.test.ts
@@ -1,0 +1,75 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import type { Config } from "@better-ccflare/config";
+import { isAccountAvailable } from "@better-ccflare/core";
+import {
+	BunSqlAdapter,
+	ensureSchema,
+	runMigrations,
+} from "@better-ccflare/database";
+import type { Account, AccountResponse } from "@better-ccflare/types";
+import { createAccountsListHandler } from "../accounts";
+
+describe("GET /api/accounts requires_reauth fields", () => {
+	let sqlite: Database;
+	let adapter: BunSqlAdapter;
+
+	beforeEach(() => {
+		sqlite = new Database(":memory:");
+		ensureSchema(sqlite);
+		runMigrations(sqlite);
+		adapter = new BunSqlAdapter(sqlite);
+	});
+
+	afterEach(() => {
+		sqlite.close();
+	});
+
+	it("returns ground-truth auth and pause state and does not mark a flagged account primary", async () => {
+		await adapter.run(
+			`INSERT INTO accounts (
+				id, name, provider, refresh_token, access_token, expires_at,
+				created_at, paused, pause_reason, requires_reauth
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			[
+				"account-1",
+				"Account 1",
+				"anthropic",
+				"refresh-token",
+				"access-token",
+				Date.now() + 3_600_000,
+				Date.now(),
+				1,
+				"manual",
+				1,
+			],
+		);
+
+		const dbOps = {
+			getAdapter: () => adapter,
+			getStatsRepository: () => ({
+				getSessionStats: async () => new Map(),
+			}),
+		};
+		const config = {
+			getUsageThrottlingFiveHourEnabled: () => false,
+			getUsageThrottlingWeeklyEnabled: () => false,
+		} as unknown as Config;
+		const strategy = {
+			peek: (accounts: Account[]) =>
+				accounts.find((account) => isAccountAvailable(account))?.id ?? null,
+		};
+		const handler = createAccountsListHandler(
+			dbOps as never,
+			config,
+			() => strategy as never,
+		);
+
+		const response = await handler();
+		const accounts = (await response.json()) as AccountResponse[];
+
+		expect(accounts[0]?.requiresReauth).toBe(true);
+		expect(accounts[0]?.pauseReason).toBe("manual");
+		expect(accounts[0]?.isPrimary).toBe(false);
+	});
+});

--- a/packages/http-api/src/handlers/accounts.ts
+++ b/packages/http-api/src/handlers/accounts.ts
@@ -207,6 +207,7 @@ export function createAccountsListHandler(
 			model_fallbacks: string | null;
 			billing_type: string | null;
 			pause_reason: string | null;
+			requires_reauth: 0 | 1;
 		}>(
 			`
 				SELECT
@@ -229,6 +230,7 @@ export function createAccountsListHandler(
 					refresh_token,
 					access_token,
 					COALESCE(paused, 0) as paused,
+					COALESCE(requires_reauth, 0) as requires_reauth,
 					COALESCE(priority, 0) as priority,
 					COALESCE(auto_fallback_enabled, 0) as auto_fallback_enabled,
 					COALESCE(auto_refresh_enabled, 0) as auto_refresh_enabled,
@@ -274,6 +276,7 @@ export function createAccountsListHandler(
 								id: a.id,
 								provider: a.provider ?? "",
 								paused: !!a.paused,
+								requires_reauth: !!a.requires_reauth,
 								// pause_reason and rate_limit_reset feed wouldAutoUnpause —
 								// without them peek() can't simulate the auto-unpause that
 								// select() performs on safe-reason paused accounts whose
@@ -545,6 +548,8 @@ export function createAccountsListHandler(
 						: null,
 					created: new Date(Number(account.created_at)).toISOString(),
 					paused: account.paused === 1,
+					requiresReauth: account.requires_reauth === 1,
+					pauseReason: account.pause_reason ?? null,
 					priority: Number(account.priority) || 0,
 					tokenStatus: account.token_valid ? "valid" : "expired",
 					tokenExpiresAt: account.expires_at

--- a/packages/http-api/src/handlers/oauth.ts
+++ b/packages/http-api/src/handlers/oauth.ts
@@ -23,6 +23,7 @@ import {
 	initiateDeviceFlow as initiateQwenDeviceFlow,
 	pollForToken as pollQwenForToken,
 } from "@better-ccflare/providers/qwen";
+import { clearAccountRefreshCache } from "@better-ccflare/proxy";
 
 const log = new Logger("OAuthHandler");
 
@@ -256,7 +257,8 @@ export function createQwenReauthHandler(dbOps: DatabaseOperations) {
 							refresh_token = ?,
 							access_token = ?,
 							expires_at = ?,
-							custom_endpoint = ?
+							custom_endpoint = ?,
+							requires_reauth = 0
 						WHERE id = ?`,
 						[
 							tokens.refresh_token,
@@ -493,7 +495,8 @@ export function createCodexReauthHandler(dbOps: DatabaseOperations) {
 						`UPDATE accounts SET
 							refresh_token = ?,
 							access_token = ?,
-							expires_at = ?
+							expires_at = ?,
+							requires_reauth = 0
 						WHERE id = ?`,
 						[
 							tokens.refresh_token,
@@ -723,6 +726,7 @@ export function createAnthropicReauthCallbackHandler(
 					{ sessionId, code, name, id: account.id },
 					flowData,
 				);
+				clearAccountRefreshCache(account.id);
 
 				dbOps.deleteOAuthSession(sessionId);
 

--- a/packages/http-api/src/services/__tests__/auth-failure-alert.test.ts
+++ b/packages/http-api/src/services/__tests__/auth-failure-alert.test.ts
@@ -1,0 +1,89 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { EventEmitter } from "node:events";
+import type { Config } from "@better-ccflare/config";
+import { alertEvents, authFailureEvents } from "@better-ccflare/core";
+import { BunSqlAdapter, ensureSchema } from "@better-ccflare/database";
+import { AlertService } from "../alerts";
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+	for (let attempt = 0; attempt < 100; attempt++) {
+		if (predicate()) return;
+		await Bun.sleep(5);
+	}
+	throw new Error("Timed out waiting for auth-failure alert processing");
+}
+
+function makeConfig(): Config {
+	return Object.assign(new EventEmitter(), {
+		getAlertDailySpendUsd: () => 0,
+		getAlertTokensPerHour: () => 0,
+		getAlertRequestTokens: () => 0,
+		getAlertAnomalyEnabled: () => false,
+		getAlertAnomalyIntervalMinutes: () => 15,
+		getAlertCooldownMinutes: () => 60,
+		getAlertWebhookUrl: () => "http://127.0.0.1:9999/webhook",
+	}) as unknown as Config;
+}
+
+describe("AlertService auth_failure events", () => {
+	let sqlite: Database;
+	let service: AlertService;
+	let originalFetch: typeof globalThis.fetch;
+	let alertListener: ((event: unknown) => void) | null;
+
+	beforeEach(() => {
+		sqlite = new Database(":memory:");
+		ensureSchema(sqlite);
+		service = new AlertService(new BunSqlAdapter(sqlite), makeConfig());
+		originalFetch = globalThis.fetch;
+		alertListener = null;
+	});
+
+	afterEach(() => {
+		service.stop();
+		globalThis.fetch = originalFetch;
+		if (alertListener) {
+			alertEvents.off("event", alertListener);
+		}
+		sqlite.close();
+	});
+
+	it("persists, emits, and delivers one critical webhook per cooldown bucket", async () => {
+		const fetchMock = mock(
+			async () => new Response(null, { status: 204 }),
+		) as unknown as typeof fetch;
+		globalThis.fetch = fetchMock;
+		const emitted: unknown[] = [];
+		alertListener = (event) => emitted.push(event);
+		alertEvents.on("event", alertListener);
+		service.start();
+
+		const event = {
+			accountId: "account-1",
+			accountName: "Backup account",
+			provider: "anthropic",
+			reason: "invalid_grant",
+		};
+		authFailureEvents.emit("event", event);
+
+		await waitFor(() => fetchMock.mock.calls.length === 1);
+		const alerts = await service.listAlerts();
+		expect(alerts).toHaveLength(1);
+		expect(alerts[0]?.type).toBe("auth_failure");
+		expect(alerts[0]?.severity).toBe("critical");
+		expect(alerts[0]?.account).toBe("Backup account");
+		expect(emitted).toHaveLength(1);
+
+		const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+		const webhook = JSON.parse(String(init.body));
+		expect(webhook.alert.type).toBe("auth_failure");
+
+		authFailureEvents.emit("event", event);
+		await Bun.sleep(20);
+
+		expect(await service.listAlerts()).toHaveLength(1);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(emitted).toHaveLength(1);
+	});
+});

--- a/packages/http-api/src/services/alerts.ts
+++ b/packages/http-api/src/services/alerts.ts
@@ -1,7 +1,9 @@
 import type { Config } from "@better-ccflare/config";
 import {
 	type AlertEvt,
+	type AuthFailureEvt,
 	alertEvents,
+	authFailureEvents,
 	getModelRates,
 	type RequestEvt,
 	requestEvents,
@@ -184,6 +186,7 @@ export class AlertService {
 	private readonly db: BunSqlAdapter;
 	private readonly config: Config;
 	private readonly requestListener: (event: RequestEvt) => void;
+	private readonly authFailureListener: (event: AuthFailureEvt) => void;
 	private readonly configChangeListener: ({ key }: { key: string }) => void;
 	private anomalyTimer: ReturnType<typeof setInterval> | null = null;
 
@@ -194,6 +197,9 @@ export class AlertService {
 			if (event.type === "summary") {
 				void this.evaluateRequest(event.payload);
 			}
+		};
+		this.authFailureListener = (event) => {
+			void this.handleAuthFailure(event);
 		};
 		this.configChangeListener = ({ key }: { key: string }) => {
 			if (
@@ -208,16 +214,44 @@ export class AlertService {
 	start(): void {
 		requestEvents.on("event", this.requestListener);
 		this.config.on("change", this.configChangeListener);
+		authFailureEvents.on("event", this.authFailureListener);
 		this.restartAnomalyTimer();
 	}
 
 	stop(): void {
 		requestEvents.off("event", this.requestListener);
 		this.config.off("change", this.configChangeListener);
+		authFailureEvents.off("event", this.authFailureListener);
 		if (this.anomalyTimer) {
 			clearInterval(this.anomalyTimer);
 			this.anomalyTimer = null;
 		}
+	}
+
+	private async handleAuthFailure(event: AuthFailureEvt): Promise<void> {
+		const timestamp = Date.now();
+		const config = getAlertsConfig(this.config);
+		const alert: AlertEvent = {
+			id: buildThresholdAlertId(
+				"auth_failure",
+				event.accountId,
+				timestamp,
+				config.cooldownMinutes,
+			),
+			timestamp,
+			type: "auth_failure",
+			severity: "critical",
+			title: "Account authentication failed",
+			message: `Account ${event.accountName} (${event.provider}) requires re-authentication: ${event.reason}`,
+			value: null,
+			threshold: null,
+			account: event.accountName,
+			model: null,
+			project: null,
+			requestId: null,
+			acknowledged: false,
+		};
+		await this.persistAndEmit(alert, config.webhookUrl);
 	}
 
 	private restartAnomalyTimer(): void {

--- a/packages/oauth-flow/src/__tests__/complete-reauth.test.ts
+++ b/packages/oauth-flow/src/__tests__/complete-reauth.test.ts
@@ -119,6 +119,7 @@ describe("OAuthFlow.completeReauth", () => {
 		expect(sql).toMatch(/refresh_token/i);
 		expect(sql).toMatch(/access_token/i);
 		expect(sql).toMatch(/expires_at/i);
+		expect(sql).toMatch(/requires_reauth\s*=\s*0/i);
 		// Params: [refreshToken, accessToken, expiresAt, refreshTokenIssuedAt, accountId]
 		expect(params[0]).toBe("new-refresh-token");
 		expect(params[1]).toBe("new-access-token");
@@ -166,6 +167,7 @@ describe("OAuthFlow.completeReauth", () => {
 			const [sql, params] = runSpy.mock.calls[0];
 			expect(sql).toMatch(/UPDATE\s+accounts/i);
 			expect(sql).toMatch(/api_key/i);
+			expect(sql).toMatch(/requires_reauth\s*=\s*0/i);
 			expect(params[0]).toBe("sk-console-api-key");
 			expect(params[1]).toBe(accountId);
 		} finally {

--- a/packages/oauth-flow/src/index.ts
+++ b/packages/oauth-flow/src/index.ts
@@ -212,16 +212,16 @@ export class OAuthFlow {
 		// Handle console mode — create new API key and update account
 		if (flowData.mode === "console" || !tokens.refreshToken) {
 			const apiKey = await this.createAnthropicApiKey(tokens.accessToken);
-			await adapter.run(`UPDATE accounts SET api_key = ? WHERE id = ?`, [
-				apiKey,
-				id,
-			]);
+			await adapter.run(
+				`UPDATE accounts SET api_key = ?, requires_reauth = 0 WHERE id = ?`,
+				[apiKey, id],
+			);
 			return;
 		}
 
 		// Handle claude-oauth mode — update OAuth tokens in place
 		await adapter.run(
-			`UPDATE accounts SET refresh_token = ?, access_token = ?, expires_at = ?, refresh_token_issued_at = ? WHERE id = ?`,
+			`UPDATE accounts SET refresh_token = ?, access_token = ?, expires_at = ?, refresh_token_issued_at = ?, requires_reauth = 0 WHERE id = ?`,
 			[
 				tokens.refreshToken,
 				tokens.accessToken,

--- a/packages/providers/src/providers/anthropic/__tests__/refresh-error-code.test.ts
+++ b/packages/providers/src/providers/anthropic/__tests__/refresh-error-code.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { Account } from "@better-ccflare/types";
+import { AnthropicProvider } from "../provider";
+
+function oauthAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "anthropic-1",
+		name: "anthropic-test",
+		provider: "anthropic",
+		api_key: null,
+		refresh_token: "refresh-token",
+		access_token: "expired-access-token",
+		expires_at: 1,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: Date.now(),
+		rate_limited_until: null,
+		rate_limited_reason: null,
+		rate_limited_at: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		requires_reauth: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		peak_hours_pause_enabled: false,
+		custom_endpoint: null,
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		billing_type: null,
+		pause_reason: null,
+		refresh_token_issued_at: null,
+		consecutive_rate_limits: 0,
+		...overrides,
+	};
+}
+
+describe("AnthropicProvider.refreshToken preserves the OAuth error code", () => {
+	let originalFetch: typeof fetch;
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("keeps the machine-readable invalid_grant code when error_description is present", async () => {
+		const provider = new AnthropicProvider();
+		globalThis.fetch = mock(
+			async () =>
+				new Response(
+					JSON.stringify({
+						error: "invalid_grant",
+						error_description: "Refresh token is invalid or has been revoked.",
+					}),
+					{ status: 401, headers: { "content-type": "application/json" } },
+				),
+		) as unknown as typeof fetch;
+
+		let thrown: Error | null = null;
+		try {
+			await provider.refreshToken(oauthAccount(), "test-client");
+		} catch (error) {
+			thrown = error as Error;
+		}
+
+		expect(thrown).not.toBeNull();
+		// The machine code must survive in the thrown message so the token-manager's
+		// requires_reauth detection can classify it — a description-only message hides it.
+		expect(thrown?.message).toContain("invalid_grant");
+	});
+
+	it("still surfaces the code for a bare error payload without a description", async () => {
+		const provider = new AnthropicProvider();
+		globalThis.fetch = mock(
+			async () =>
+				new Response(JSON.stringify({ error: "invalid_grant" }), {
+					status: 400,
+					headers: { "content-type": "application/json" },
+				}),
+		) as unknown as typeof fetch;
+
+		let thrown: Error | null = null;
+		try {
+			await provider.refreshToken(oauthAccount(), "test-client");
+		} catch (error) {
+			thrown = error as Error;
+		}
+
+		expect(thrown?.message).toContain("invalid_grant");
+	});
+});

--- a/packages/providers/src/providers/anthropic/provider.ts
+++ b/packages/providers/src/providers/anthropic/provider.ts
@@ -186,11 +186,16 @@ export class AnthropicProvider extends BaseProvider {
 					error_description?: string;
 					message?: string;
 				};
+				// Preserve the machine-readable RFC-6749 error code (e.g.
+				// "invalid_grant") ahead of any human-readable description. When only
+				// error_description is surfaced the code is discarded, and the
+				// token-manager's requires_reauth detection — which keys on that code —
+				// silently misses a dead refresh token (the exact 43h-undetected
+				// incident this feature exists for).
 				errorMessage =
-					errorObj.error_description ||
-					errorObj.error ||
-					errorObj.message ||
-					errorMessage;
+					[errorObj.error, errorObj.error_description || errorObj.message]
+						.filter(Boolean)
+						.join(": ") || errorMessage;
 
 				// Log specific OAuth authentication errors
 				if (response.status === 401 && typeof errorMessage === "string") {

--- a/packages/providers/src/providers/codex/__tests__/refresh-error-code.test.ts
+++ b/packages/providers/src/providers/codex/__tests__/refresh-error-code.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { Account } from "@better-ccflare/types";
+import { CodexProvider } from "../provider";
+
+function codexAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "codex-1",
+		name: "codex-test",
+		provider: "codex",
+		api_key: null,
+		refresh_token: "refresh-token",
+		access_token: "expired-access-token",
+		expires_at: 1,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: Date.now(),
+		rate_limited_until: null,
+		rate_limited_reason: null,
+		rate_limited_at: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		requires_reauth: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		peak_hours_pause_enabled: false,
+		custom_endpoint: null,
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		billing_type: null,
+		pause_reason: null,
+		refresh_token_issued_at: null,
+		consecutive_rate_limits: 0,
+		...overrides,
+	};
+}
+
+describe("CodexProvider.refreshToken preserves the OAuth error code", () => {
+	let originalFetch: typeof fetch;
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("keeps invalid_grant when only error_description is human-readable", async () => {
+		const provider = new CodexProvider();
+		globalThis.fetch = mock(
+			async () =>
+				new Response(
+					JSON.stringify({
+						error: "invalid_grant",
+						error_description: "The refresh token has expired.",
+					}),
+					{ status: 400, headers: { "content-type": "application/json" } },
+				),
+		) as unknown as typeof fetch;
+
+		let thrown: Error | null = null;
+		try {
+			await provider.refreshToken(codexAccount(), "test-client");
+		} catch (error) {
+			thrown = error as Error;
+		}
+
+		expect(thrown?.message).toContain("invalid_grant");
+	});
+
+	it("carries the refresh_token_reused marker verbatim on token rotation reuse", async () => {
+		const provider = new CodexProvider();
+		globalThis.fetch = mock(
+			async () =>
+				new Response(JSON.stringify({ error: "refresh_token_reused" }), {
+					status: 400,
+					headers: { "content-type": "application/json" },
+				}),
+		) as unknown as typeof fetch;
+
+		let thrown: Error | null = null;
+		try {
+			await provider.refreshToken(codexAccount(), "test-client");
+		} catch (error) {
+			thrown = error as Error;
+		}
+
+		// The reused case must keep the machine marker so detection fires; the
+		// friendly re-auth hint alone ("token was reused") would not match.
+		expect(thrown?.message).toContain("refresh_token_reused");
+	});
+});

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -355,13 +355,20 @@ export class CodexProvider extends BaseProvider {
 				// ignore
 			}
 
+			// Preserve the machine-readable OAuth error code ahead of the human
+			// description so the token-manager's requires_reauth detection can
+			// classify a dead refresh token; a description-only message hides it.
 			const errorMessage =
-				errorData?.error_description || errorData?.error || response.statusText;
+				[errorData?.error, errorData?.error_description]
+					.filter(Boolean)
+					.join(": ") || response.statusText;
 
-			// Rotating refresh tokens: reuse → must re-auth
+			// Rotating refresh tokens: reuse → must re-auth. Keep the
+			// "refresh_token_reused" marker verbatim in the thrown message so
+			// downstream detection fires — the friendly hint alone would not match.
 			if (errorData?.error === "refresh_token_reused") {
 				throw new Error(
-					`Codex refresh token was reused for account ${account.name}. Please re-authenticate with: bun run cli --reauthenticate ${account.name}`,
+					`Failed to refresh Codex token for account ${account.name}: refresh_token_reused - the refresh token was already used; re-authenticate with: bun run cli --reauthenticate ${account.name}`,
 				);
 			}
 

--- a/packages/providers/src/providers/xai/provider.test.ts
+++ b/packages/providers/src/providers/xai/provider.test.ts
@@ -156,4 +156,29 @@ describe("XaiProvider", () => {
 		expect(result.refreshToken).toBe("new-refresh-token");
 		expect(result.expiresAt).toBeGreaterThan(Date.now());
 	});
+
+	it("preserves the machine-readable OAuth error code on a failed refresh", async () => {
+		const provider = new XaiProvider();
+		globalThis.fetch = mock(
+			async () =>
+				new Response(
+					JSON.stringify({
+						error: "invalid_grant",
+						error_description: "Refresh token is invalid or has been revoked.",
+					}),
+					{ status: 401, headers: { "content-type": "application/json" } },
+				),
+		) as unknown as typeof fetch;
+
+		let thrown: Error | null = null;
+		try {
+			await provider.refreshToken(account(), "unused");
+		} catch (error) {
+			thrown = error as Error;
+		}
+
+		// The code must survive alongside the description so the token-manager's
+		// requires_reauth detection can classify a dead xAI refresh token.
+		expect(thrown?.message).toContain("invalid_grant");
+	});
 });

--- a/packages/providers/src/providers/xai/provider.ts
+++ b/packages/providers/src/providers/xai/provider.ts
@@ -50,7 +50,12 @@ export class XaiProvider extends OpenAICompatibleProvider {
 					error?: string;
 					error_description?: string;
 				};
-				message = data.error_description || data.error || message;
+				// Preserve the machine-readable OAuth error code (e.g. "invalid_grant")
+				// ahead of the human description so the token-manager's requires_reauth
+				// detection can classify a dead xAI refresh token.
+				message =
+					[data.error, data.error_description].filter(Boolean).join(": ") ||
+					message;
 			} catch {
 				// Do not include raw response bodies in refresh errors; auth servers
 				// should not echo credentials, but keeping messages structured avoids

--- a/packages/proxy/src/__tests__/auto-refresh-auth-401.test.ts
+++ b/packages/proxy/src/__tests__/auto-refresh-auth-401.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import type { AutoRefreshScheduler } from "../auto-refresh-scheduler";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+	global.fetch = originalFetch;
+});
+
+describe("AutoRefreshScheduler 401 probe handling", () => {
+	it("expires the access token and disables auto-refresh without setting requires_reauth", async () => {
+		const runCalls: Array<[string, unknown[]]> = [];
+		const db = {
+			run: mock(async (sql: string, params: unknown[]) => {
+				runCalls.push([sql, params]);
+			}),
+			query: mock(async () => []),
+		};
+		global.fetch = mock(
+			async () => new Response("Unauthorized", { status: 401 }),
+		);
+
+		const { AutoRefreshScheduler } = await import("../auto-refresh-scheduler");
+		const scheduler = new AutoRefreshScheduler(
+			db as never,
+			{
+				runtime: { port: 8080, clientId: "test-client" },
+				refreshInFlight: new Map(),
+			} as never,
+		) as AutoRefreshScheduler & {
+			sendDummyMessage(account: {
+				id: string;
+				name: string;
+				provider: string;
+				refresh_token: string;
+				access_token: string;
+				expires_at: number;
+				rate_limit_reset: null;
+				custom_endpoint: null;
+				paused: number;
+				auto_pause_on_overage_enabled: number;
+				pause_reason: null;
+			}): Promise<boolean>;
+		};
+
+		const result = await scheduler.sendDummyMessage({
+			id: "account-401",
+			name: "Account 401",
+			provider: "anthropic",
+			refresh_token: "refresh-token",
+			access_token: "expired-token",
+			expires_at: 1,
+			rate_limit_reset: null,
+			custom_endpoint: null,
+			paused: 0,
+			auto_pause_on_overage_enabled: 0,
+			pause_reason: null,
+		});
+
+		expect(result).toBe(false);
+		expect(runCalls).toHaveLength(1);
+		const [sql, params] = runCalls[0];
+		expect(sql).toContain("auto_refresh_enabled = 0");
+		expect(sql).toContain("expires_at = 0");
+		expect(sql).not.toContain("requires_reauth");
+		expect(params).toEqual(["account-401"]);
+	});
+});

--- a/packages/proxy/src/__tests__/auto-refresh-manual-pause-guard.test.ts
+++ b/packages/proxy/src/__tests__/auto-refresh-manual-pause-guard.test.ts
@@ -94,7 +94,8 @@ function seedDb(): Database {
 			auto_pause_on_overage_enabled INTEGER,
 			pause_reason TEXT,
 			auto_refresh_enabled INTEGER,
-			rate_limited_until INTEGER
+			rate_limited_until INTEGER,
+			requires_reauth INTEGER DEFAULT 0
 		)
 	`);
 

--- a/packages/proxy/src/__tests__/auto-refresh-proactive-requires-reauth.test.ts
+++ b/packages/proxy/src/__tests__/auto-refresh-proactive-requires-reauth.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { type AuthFailureEvt, authFailureEvents } from "@better-ccflare/core";
+import { AutoRefreshScheduler } from "../auto-refresh-scheduler";
+
+// These tests drive the REAL xAI/Codex providers (via row.provider) and mock
+// global.fetch to return an OAuth error, so the whole provider→scheduler detection
+// chain is exercised without mock.module (which leaks across proxy test files).
+
+interface ProactiveRow {
+	id: string;
+	name: string;
+	provider: string;
+	refresh_token: string;
+	access_token: string | null;
+	expires_at: number | null;
+	custom_endpoint: string | null;
+}
+
+function makeDb(queryRows: ProactiveRow[]) {
+	const runCalls: Array<[string, unknown[]]> = [];
+	const queries: string[] = [];
+	const db = {
+		run: mock(async (sql: string, params: unknown[]) => {
+			runCalls.push([sql, params]);
+		}),
+		query: mock(async (sql: string) => {
+			queries.push(sql);
+			return queryRows;
+		}),
+	};
+	return { db, runCalls, queries };
+}
+
+function makeScheduler(db: unknown) {
+	return new AutoRefreshScheduler(
+		db as never,
+		{
+			runtime: { port: 8080, clientId: "test-client" },
+			refreshInFlight: new Map(),
+		} as never,
+	) as unknown as {
+		checkAndRefreshOpenAICompatibleOAuthTokens(): Promise<void>;
+		checkAndRefreshCodexTokens(): Promise<void>;
+	};
+}
+
+const originalFetch = global.fetch;
+afterEach(() => {
+	global.fetch = originalFetch;
+});
+
+describe("AutoRefreshScheduler proactive refresh — requires_reauth guard", () => {
+	it("excludes flagged accounts from the OpenAI-compatible eligibility query", async () => {
+		const { db, queries } = makeDb([]);
+		const scheduler = makeScheduler(db);
+
+		await scheduler.checkAndRefreshOpenAICompatibleOAuthTokens();
+
+		const sql = queries.find((q) => q.includes("'qwen', 'xai'"));
+		expect(sql).toBeDefined();
+		expect(sql).toContain("COALESCE(requires_reauth, 0) = 0");
+	});
+
+	it("excludes flagged accounts from the Codex eligibility query", async () => {
+		const { db, queries } = makeDb([]);
+		const scheduler = makeScheduler(db);
+
+		await scheduler.checkAndRefreshCodexTokens();
+
+		const sql = queries.find((q) => q.includes("provider = 'codex'"));
+		expect(sql).toBeDefined();
+		expect(sql).toContain("COALESCE(requires_reauth, 0) = 0");
+	});
+});
+
+describe("AutoRefreshScheduler proactive refresh — definitive auth failure", () => {
+	it("flags an xAI account whose proactive refresh returns invalid_grant and emits the event", async () => {
+		const { db, runCalls } = makeDb([
+			{
+				id: "xai-dead",
+				name: "xai-dead",
+				provider: "xai",
+				refresh_token: "rt",
+				access_token: "at",
+				expires_at: 1,
+				custom_endpoint: null,
+			},
+		]);
+		global.fetch = mock(
+			async () =>
+				new Response(
+					JSON.stringify({
+						error: "invalid_grant",
+						error_description: "Refresh token is invalid or has been revoked.",
+					}),
+					{ status: 401, headers: { "content-type": "application/json" } },
+				),
+		) as unknown as typeof fetch;
+		const emitted: AuthFailureEvt[] = [];
+		authFailureEvents.once("event", (event) => emitted.push(event));
+
+		const scheduler = makeScheduler(db);
+		await scheduler.checkAndRefreshOpenAICompatibleOAuthTokens();
+
+		const flagWrite = runCalls.find(([sql]) => sql.includes("requires_reauth"));
+		expect(flagWrite).toBeDefined();
+		expect(flagWrite?.[1]).toEqual(["xai-dead"]);
+		expect(emitted).toHaveLength(1);
+		expect(emitted[0]).toMatchObject({
+			accountId: "xai-dead",
+			provider: "xai",
+			reason: "invalid_grant",
+		});
+	});
+
+	it("flags a Codex account whose proactive refresh returns refresh_token_reused", async () => {
+		const { db, runCalls } = makeDb([
+			{
+				id: "codex-dead",
+				name: "codex-dead",
+				provider: "codex",
+				refresh_token: "rt",
+				access_token: "at",
+				expires_at: 1,
+				custom_endpoint: null,
+			},
+		]);
+		global.fetch = mock(
+			async () =>
+				new Response(JSON.stringify({ error: "refresh_token_reused" }), {
+					status: 400,
+					headers: { "content-type": "application/json" },
+				}),
+		) as unknown as typeof fetch;
+		const emitted: AuthFailureEvt[] = [];
+		authFailureEvents.once("event", (event) => emitted.push(event));
+
+		const scheduler = makeScheduler(db);
+		await scheduler.checkAndRefreshCodexTokens();
+
+		const flagWrite = runCalls.find(([sql]) => sql.includes("requires_reauth"));
+		expect(flagWrite).toBeDefined();
+		expect(flagWrite?.[1]).toEqual(["codex-dead"]);
+		expect(emitted).toHaveLength(1);
+		expect(emitted[0]?.reason).toBe("refresh_token_reused");
+	});
+
+	it("does NOT flag a proactive refresh that fails with a transient network error", async () => {
+		const { db, runCalls } = makeDb([
+			{
+				id: "codex-net",
+				name: "codex-net",
+				provider: "codex",
+				refresh_token: "rt",
+				access_token: "at",
+				expires_at: 1,
+				custom_endpoint: null,
+			},
+		]);
+		// A 5xx with no OAuth error code — a transient upstream failure.
+		global.fetch = mock(
+			async () => new Response("Service Unavailable", { status: 503 }),
+		) as unknown as typeof fetch;
+		let emittedCount = 0;
+		const listener = () => {
+			emittedCount++;
+		};
+		authFailureEvents.on("event", listener);
+
+		try {
+			const scheduler = makeScheduler(db);
+			await scheduler.checkAndRefreshCodexTokens();
+		} finally {
+			authFailureEvents.off("event", listener);
+		}
+
+		const flagWrite = runCalls.find(([sql]) => sql.includes("requires_reauth"));
+		expect(flagWrite).toBeUndefined();
+		expect(emittedCount).toBe(0);
+	});
+});

--- a/packages/proxy/src/__tests__/auto-refresh-requires-reauth-filter.test.ts
+++ b/packages/proxy/src/__tests__/auto-refresh-requires-reauth-filter.test.ts
@@ -1,0 +1,72 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, it, mock } from "bun:test";
+
+describe("AutoRefreshScheduler requires_reauth eligibility", () => {
+	it("excludes accounts that require manual authentication from probes", async () => {
+		let eligibilitySql = "";
+		let eligibilityParams: unknown[] = [];
+		const schedulerDb = {
+			query: mock(async (sql: string, params: unknown[]) => {
+				if (
+					sql.includes("auto_refresh_enabled") &&
+					sql.includes("rate_limit_reset")
+				) {
+					eligibilitySql = sql;
+					eligibilityParams = params;
+				}
+				return [];
+			}),
+			run: mock(async () => {}),
+		};
+		const { AutoRefreshScheduler } = await import("../auto-refresh-scheduler");
+		const scheduler = new AutoRefreshScheduler(
+			schedulerDb as never,
+			{
+				runtime: { port: 8080, clientId: "test-client" },
+				refreshInFlight: new Map(),
+			} as never,
+		) as unknown as { checkAndRefresh(): Promise<void> };
+
+		await scheduler.checkAndRefresh();
+
+		const db = new Database(":memory:");
+		try {
+			db.run(`
+				CREATE TABLE accounts (
+					id TEXT PRIMARY KEY,
+					name TEXT,
+					provider TEXT,
+					refresh_token TEXT,
+					access_token TEXT,
+					expires_at INTEGER,
+					rate_limit_reset INTEGER,
+					custom_endpoint TEXT,
+					paused INTEGER,
+					auto_pause_on_overage_enabled INTEGER,
+					pause_reason TEXT,
+					auto_refresh_enabled INTEGER,
+					rate_limited_until INTEGER,
+					requires_reauth INTEGER DEFAULT 0
+				)
+			`);
+			db.run(`
+				INSERT INTO accounts
+					(id, name, provider, refresh_token, access_token, paused,
+					 auto_pause_on_overage_enabled, auto_refresh_enabled, requires_reauth)
+				VALUES
+					('healthy', 'healthy', 'anthropic', 'rt', 'at', 0, 0, 1, 0),
+					('dead-auth', 'dead-auth', 'anthropic', 'rt', 'at', 0, 0, 1, 1)
+			`);
+
+			const rows = db
+				.query(eligibilitySql)
+				.all(...(eligibilityParams as [number, number, number])) as Array<{
+				name: string;
+			}>;
+
+			expect(rows.map((row) => row.name)).toEqual(["healthy"]);
+		} finally {
+			db.close();
+		}
+	});
+});

--- a/packages/proxy/src/auto-refresh-scheduler.ts
+++ b/packages/proxy/src/auto-refresh-scheduler.ts
@@ -1,4 +1,5 @@
 import {
+	authFailureEvents,
 	CLAUDE_MODEL_IDS,
 	getClientVersion,
 	registerHeartbeat,
@@ -9,7 +10,7 @@ import { Logger } from "@better-ccflare/logger";
 import { fetchUsageData, getProvider } from "@better-ccflare/providers";
 import type { Account } from "@better-ccflare/types";
 import { TOKEN_SAFETY_WINDOW_MS } from "./constants";
-import { getValidAccessToken } from "./handlers";
+import { extractAuthFailureReason, getValidAccessToken } from "./handlers";
 import type { ProxyContext } from "./proxy";
 
 const log = new Logger("AutoRefreshScheduler");
@@ -762,6 +763,10 @@ export class AutoRefreshScheduler {
 			WHERE
 				provider IN ('qwen', 'xai')
 				AND refresh_token IS NOT NULL
+				-- Never probe an account already flagged for manual re-auth: its
+				-- refresh token is known dead, so the probe is a guaranteed fail and
+				-- recovery is only the manual re-auth clear-site.
+				AND COALESCE(requires_reauth, 0) = 0
 				AND (
 					access_token IS NULL
 					OR expires_at IS NULL
@@ -865,6 +870,7 @@ export class AutoRefreshScheduler {
 					`Failed to proactively refresh ${row.provider} token for ${row.name}:`,
 					error,
 				);
+				await this.flagIfDefinitiveAuthFailure(error, row);
 			}
 		}
 	}
@@ -894,6 +900,10 @@ export class AutoRefreshScheduler {
 			WHERE
 				provider = 'codex'
 				AND refresh_token IS NOT NULL
+				-- Never probe an account already flagged for manual re-auth: its
+				-- refresh token is known dead, so the probe is a guaranteed fail and
+				-- recovery is only the manual re-auth clear-site.
+				AND COALESCE(requires_reauth, 0) = 0
 				AND (
 					access_token IS NULL
 					OR expires_at IS NULL
@@ -995,8 +1005,54 @@ export class AutoRefreshScheduler {
 					`Failed to proactively refresh Codex token for ${row.name}:`,
 					error,
 				);
+				await this.flagIfDefinitiveAuthFailure(error, row);
 			}
 		}
+	}
+
+	/**
+	 * Persist requires_reauth and emit an auth-failure alert when a proactive
+	 * refresh fails with a DEFINITIVE dead-refresh-token signal (invalid_grant /
+	 * invalid_refresh_token / refresh_token_reused).
+	 *
+	 * These proactive paths refresh via provider.refreshToken() directly, bypassing
+	 * the token-manager funnel, so without this a qwen/xai/codex token that dies
+	 * while only the scheduler touches it would evaporate silently — logged but
+	 * never flagged, never pulled from routing, never alerted. Transient failures
+	 * (network / 5xx / timeout) do not carry these codes and are left untouched so
+	 * the account keeps retrying.
+	 */
+	private async flagIfDefinitiveAuthFailure(
+		error: unknown,
+		row: { id: string; name: string; provider: string },
+	): Promise<void> {
+		const message = error instanceof Error ? error.message : String(error);
+		const reason = extractAuthFailureReason(message, row.name);
+		if (!reason) return;
+
+		try {
+			await this.db.run(
+				`UPDATE accounts SET requires_reauth = 1 WHERE id = ?`,
+				[row.id],
+			);
+			log.error(
+				`Account ${row.name} requires re-authentication — proactive ${row.provider} refresh returned ${reason}`,
+			);
+		} catch (writeError) {
+			log.error(
+				`Failed to persist requires_reauth for ${row.name}:`,
+				writeError,
+			);
+		}
+
+		// Emit regardless of the write outcome — the alert is the operator's only
+		// signal that the account is dead, and it is fire-and-forget.
+		authFailureEvents.emit("event", {
+			accountId: row.id,
+			accountName: row.name,
+			provider: row.provider,
+			reason,
+		});
 	}
 
 	/**

--- a/packages/proxy/src/auto-refresh-scheduler.ts
+++ b/packages/proxy/src/auto-refresh-scheduler.ts
@@ -145,6 +145,7 @@ export class AutoRefreshScheduler {
 				WHERE
 					auto_refresh_enabled = 1
 					AND provider IN ('anthropic', 'codex', 'zai')
+					AND COALESCE(requires_reauth, 0) = 0
 					AND (
 						(rate_limit_reset IS NOT NULL AND rate_limit_reset <= ?)
 						OR rate_limit_reset IS NULL
@@ -494,7 +495,7 @@ export class AutoRefreshScheduler {
 
 				// Mark account as needing attention in database (disable auto-refresh to prevent repeated failures)
 				await this.db.run(
-					`UPDATE accounts SET auto_refresh_enabled = 0 WHERE id = ?`,
+					`UPDATE accounts SET auto_refresh_enabled = 0, expires_at = 0 WHERE id = ?`,
 					[accountRow.id],
 				);
 

--- a/packages/proxy/src/auto-refresh-scheduler.ts
+++ b/packages/proxy/src/auto-refresh-scheduler.ts
@@ -306,6 +306,7 @@ export class AutoRefreshScheduler {
 				session_start: null,
 				session_request_count: 0,
 				paused: false,
+				requires_reauth: false,
 				rate_limit_reset: accountRow.rate_limit_reset
 					? Number(accountRow.rate_limit_reset)
 					: null,
@@ -813,6 +814,7 @@ export class AutoRefreshScheduler {
 					session_start: null,
 					session_request_count: 0,
 					paused: false,
+					requires_reauth: false,
 					rate_limit_reset: null,
 					rate_limit_status: null,
 					rate_limit_remaining: null,
@@ -942,6 +944,7 @@ export class AutoRefreshScheduler {
 					session_start: null,
 					session_request_count: 0,
 					paused: false,
+					requires_reauth: false,
 					rate_limit_reset: null,
 					rate_limit_status: null,
 					rate_limit_remaining: null,

--- a/packages/proxy/src/handlers/__tests__/requires-reauth-routing.test.ts
+++ b/packages/proxy/src/handlers/__tests__/requires-reauth-routing.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { Account, RequestMeta } from "@better-ccflare/types";
+import { selectAccountsForRequest } from "../account-selector";
+import { createPoolExhaustedResponse } from "../proxy-operations";
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "account-1",
+		name: "Account 1",
+		provider: "anthropic",
+		api_key: null,
+		refresh_token: "refresh-token",
+		access_token: "access-token",
+		expires_at: Date.now() + 3_600_000,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: 1,
+		rate_limited_until: null,
+		rate_limited_reason: null,
+		rate_limited_at: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		requires_reauth: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		peak_hours_pause_enabled: false,
+		custom_endpoint: null,
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		billing_type: null,
+		pause_reason: null,
+		refresh_token_issued_at: null,
+		consecutive_rate_limits: 0,
+		...overrides,
+	};
+}
+
+describe("requires_reauth routing", () => {
+	it("never force-routes a flagged rate-limited account through the scheduler bypass", async () => {
+		const flagged = makeAccount({
+			id: "flagged",
+			requires_reauth: true,
+			rate_limited_until: Date.now() + 3_600_000,
+		});
+		const healthy = makeAccount({ id: "healthy", name: "Healthy" });
+		const ctx = {
+			strategy: { select: mock(() => [healthy]) },
+			dbOps: {
+				getAllAccounts: mock(async () => [flagged, healthy]),
+				getActiveComboForFamily: mock(async () => null),
+			},
+			refreshInFlight: new Map(),
+			asyncWriter: { enqueue: mock(() => {}) },
+		};
+		const meta = {
+			id: "request-1",
+			method: "POST",
+			path: "/v1/messages",
+			timestamp: Date.now(),
+			headers: new Headers({
+				"x-better-ccflare-account-id": "flagged",
+				"x-better-ccflare-bypass-session": "true",
+			}),
+		} as RequestMeta;
+
+		const selected = await selectAccountsForRequest(meta, ctx as never);
+
+		expect(selected.map((candidate) => candidate.id)).toEqual(["healthy"]);
+	});
+
+	it("reports requires_reauth as the pool-exhaustion reason", async () => {
+		const response = createPoolExhaustedResponse([
+			makeAccount({ requires_reauth: true }),
+		]);
+		const body = (await response.json()) as {
+			error: { accounts: Array<{ reason: string }> };
+		};
+
+		expect(body.error.accounts[0]?.reason).toBe("requires_reauth");
+	});
+});

--- a/packages/proxy/src/handlers/__tests__/token-manager-requires-reauth.test.ts
+++ b/packages/proxy/src/handlers/__tests__/token-manager-requires-reauth.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock } from "bun:test";
+import { type AuthFailureEvt, authFailureEvents } from "@better-ccflare/core";
 import type { Account } from "@better-ccflare/types";
 import { refreshAccessTokenSafe } from "../token-manager";
 
@@ -74,6 +75,8 @@ describe("refreshAccessTokenSafe requires_reauth detection", () => {
 				'Failed to refresh token for account replay: {"error":"invalid_grant","error_description":"Refresh token invalid or expired"}',
 			),
 		);
+		const emitted: AuthFailureEvt[] = [];
+		authFailureEvents.once("event", (event) => emitted.push(event));
 
 		await expect(
 			refreshAccessTokenSafe(makeAccount("invalid-grant"), ctx as never),
@@ -82,6 +85,13 @@ describe("refreshAccessTokenSafe requires_reauth detection", () => {
 		expect(queuedJobs).toHaveLength(1);
 		await queuedJobs[0]();
 		expect(setRequiresReauth).toHaveBeenCalledWith("invalid-grant", true);
+		expect(emitted).toHaveLength(1);
+		expect(emitted[0]).toMatchObject({
+			accountId: "invalid-grant",
+			accountName: "test-account",
+			provider: "fake-refresh-provider",
+		});
+		expect(emitted[0]?.reason).toContain("invalid_grant");
 	});
 
 	it("does not flag network or upstream failures", async () => {

--- a/packages/proxy/src/handlers/__tests__/token-manager-requires-reauth.test.ts
+++ b/packages/proxy/src/handlers/__tests__/token-manager-requires-reauth.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, mock } from "bun:test";
 import { type AuthFailureEvt, authFailureEvents } from "@better-ccflare/core";
 import type { Account } from "@better-ccflare/types";
-import { refreshAccessTokenSafe } from "../token-manager";
+import {
+	extractAuthFailureReason,
+	isDefinitiveAuthFailure,
+	refreshAccessTokenSafe,
+} from "../token-manager";
 
 function makeAccount(id: string, name = "test-account"): Account {
 	return {
@@ -68,11 +72,58 @@ function makeContext(refreshError: Error) {
 	};
 }
 
+describe("extractAuthFailureReason / isDefinitiveAuthFailure", () => {
+	it("classifies a realistic invalid_grant message (code preserved mid-message)", () => {
+		const message =
+			"Failed to refresh token for account my-acct: invalid_grant: Refresh token is invalid or has been revoked.";
+		expect(isDefinitiveAuthFailure(message, "my-acct")).toBe(true);
+		expect(extractAuthFailureReason(message, "my-acct")).toBe("invalid_grant");
+	});
+
+	it("matches a bare code with no description", () => {
+		const message =
+			"Failed to refresh token for account my-acct: invalid_grant";
+		expect(extractAuthFailureReason(message, "my-acct")).toBe("invalid_grant");
+	});
+
+	it("classifies the Codex refresh_token_reused marker inside a multi-colon message", () => {
+		const message =
+			"Failed to refresh Codex token for account my-acct: refresh_token_reused - the refresh token was already used; re-authenticate with: bun run cli --reauthenticate my-acct";
+		expect(extractAuthFailureReason(message, "my-acct")).toBe(
+			"refresh_token_reused",
+		);
+	});
+
+	it("does not fire on transient network/5xx messages", () => {
+		expect(
+			isDefinitiveAuthFailure(
+				"Failed to refresh token for account my-acct: upstream 503 timeout",
+				"my-acct",
+			),
+		).toBe(false);
+	});
+
+	it("cannot be tripped by an account NAME containing invalid_grant", () => {
+		const message =
+			"Failed to refresh token for account test_invalid_grant: temporary upstream failure";
+		expect(isDefinitiveAuthFailure(message, "test_invalid_grant")).toBe(false);
+		expect(extractAuthFailureReason(message, "test_invalid_grant")).toBeNull();
+	});
+
+	it("still fires on a real code even when the account name is a code substring", () => {
+		// Account literally named "grant" must not suppress a genuine invalid_grant —
+		// framing is anchored on "account grant", never on the code text.
+		const message =
+			"Failed to refresh token for account grant: invalid_grant: Refresh token is invalid.";
+		expect(extractAuthFailureReason(message, "grant")).toBe("invalid_grant");
+	});
+});
+
 describe("refreshAccessTokenSafe requires_reauth detection", () => {
-	it("enqueues the flag for a replayed invalid_grant refresh response and propagates the error", async () => {
+	it("enqueues the flag for a realistic invalid_grant refresh error and propagates it", async () => {
 		const { ctx, queuedJobs, setRequiresReauth } = makeContext(
 			new Error(
-				'Failed to refresh token for account replay: {"error":"invalid_grant","error_description":"Refresh token invalid or expired"}',
+				"Failed to refresh token for account test-account: invalid_grant: Refresh token is invalid or has been revoked.",
 			),
 		);
 		const emitted: AuthFailureEvt[] = [];
@@ -91,13 +142,14 @@ describe("refreshAccessTokenSafe requires_reauth detection", () => {
 			accountName: "test-account",
 			provider: "fake-refresh-provider",
 		});
-		expect(emitted[0]?.reason).toContain("invalid_grant");
+		// The emitted reason is the CLASSIFIED code, not the raw suffix.
+		expect(emitted[0]?.reason).toBe("invalid_grant");
 	});
 
 	it("does not flag network or upstream failures", async () => {
 		const { ctx, queuedJobs, setRequiresReauth } = makeContext(
 			new Error(
-				"Failed to refresh token for account network: upstream 503 timeout",
+				"Failed to refresh token for account test-account: upstream 503 timeout",
 			),
 		);
 
@@ -109,7 +161,7 @@ describe("refreshAccessTokenSafe requires_reauth detection", () => {
 		expect(setRequiresReauth).not.toHaveBeenCalled();
 	});
 
-	it("ignores invalid_grant in the account name when the provider error suffix is harmless", async () => {
+	it("ignores invalid_grant in the account name when the provider error is harmless", async () => {
 		const { ctx, queuedJobs, setRequiresReauth } = makeContext(
 			new Error(
 				"Failed to refresh token for account test_invalid_grant: temporary upstream failure",

--- a/packages/proxy/src/handlers/__tests__/token-manager-requires-reauth.test.ts
+++ b/packages/proxy/src/handlers/__tests__/token-manager-requires-reauth.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { Account } from "@better-ccflare/types";
+import { refreshAccessTokenSafe } from "../token-manager";
+
+function makeAccount(id: string, name = "test-account"): Account {
+	return {
+		id,
+		name,
+		provider: "fake-refresh-provider",
+		api_key: null,
+		refresh_token: "refresh-token",
+		access_token: "expired-access-token",
+		expires_at: 1,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: 1,
+		rate_limited_until: null,
+		rate_limited_reason: null,
+		rate_limited_at: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		requires_reauth: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		peak_hours_pause_enabled: false,
+		custom_endpoint: null,
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		billing_type: null,
+		pause_reason: null,
+		refresh_token_issued_at: null,
+		consecutive_rate_limits: 0,
+	};
+}
+
+function makeContext(refreshError: Error) {
+	const queuedJobs: Array<() => Promise<void>> = [];
+	const setRequiresReauth = mock(async () => {});
+	return {
+		ctx: {
+			provider: {
+				name: "fake-refresh-provider",
+				refreshToken: mock(async () => {
+					throw refreshError;
+				}),
+			},
+			dbOps: {
+				getAccount: mock(async () => null),
+				setRequiresReauth,
+			},
+			runtime: { clientId: "test-client" },
+			refreshInFlight: new Map(),
+			asyncWriter: {
+				enqueue: mock((job: () => Promise<void>) => queuedJobs.push(job)),
+			},
+		},
+		queuedJobs,
+		setRequiresReauth,
+	};
+}
+
+describe("refreshAccessTokenSafe requires_reauth detection", () => {
+	it("enqueues the flag for a replayed invalid_grant refresh response and propagates the error", async () => {
+		const { ctx, queuedJobs, setRequiresReauth } = makeContext(
+			new Error(
+				'Failed to refresh token for account replay: {"error":"invalid_grant","error_description":"Refresh token invalid or expired"}',
+			),
+		);
+
+		await expect(
+			refreshAccessTokenSafe(makeAccount("invalid-grant"), ctx as never),
+		).rejects.toThrow("Failed to refresh access token");
+
+		expect(queuedJobs).toHaveLength(1);
+		await queuedJobs[0]();
+		expect(setRequiresReauth).toHaveBeenCalledWith("invalid-grant", true);
+	});
+
+	it("does not flag network or upstream failures", async () => {
+		const { ctx, queuedJobs, setRequiresReauth } = makeContext(
+			new Error(
+				"Failed to refresh token for account network: upstream 503 timeout",
+			),
+		);
+
+		await expect(
+			refreshAccessTokenSafe(makeAccount("network-error"), ctx as never),
+		).rejects.toThrow("Failed to refresh access token");
+
+		expect(queuedJobs).toHaveLength(0);
+		expect(setRequiresReauth).not.toHaveBeenCalled();
+	});
+
+	it("ignores invalid_grant in the account name when the provider error suffix is harmless", async () => {
+		const { ctx, queuedJobs, setRequiresReauth } = makeContext(
+			new Error(
+				"Failed to refresh token for account test_invalid_grant: temporary upstream failure",
+			),
+		);
+
+		await expect(
+			refreshAccessTokenSafe(
+				makeAccount("name-false-positive", "test_invalid_grant"),
+				ctx as never,
+			),
+		).rejects.toThrow("Failed to refresh access token");
+
+		expect(queuedJobs).toHaveLength(0);
+		expect(setRequiresReauth).not.toHaveBeenCalled();
+	});
+});

--- a/packages/proxy/src/handlers/account-selector.ts
+++ b/packages/proxy/src/handlers/account-selector.ts
@@ -120,7 +120,9 @@ export async function selectAccountsForRequest(
 						!!forcedAccount.rate_limited_until;
 					const allowThrough =
 						available ||
-						(isAutoRefreshBypass && (isOveragePaused || isRateLimited));
+						(isAutoRefreshBypass &&
+							!forcedAccount.requires_reauth &&
+							(isOveragePaused || isRateLimited));
 					if (allowThrough) {
 						return [forcedAccount];
 					}

--- a/packages/proxy/src/handlers/index.ts
+++ b/packages/proxy/src/handlers/index.ts
@@ -42,7 +42,9 @@ export {
 export {
 	type CodexUsageRefreshOutcome,
 	clearAccountRefreshCache,
+	extractAuthFailureReason,
 	getValidAccessToken,
+	isDefinitiveAuthFailure,
 	refreshCodexUsageForAccount,
 	registerCodexUsageRefresher,
 	registerPollingRestarter,

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -1267,11 +1267,13 @@ export function createPoolExhaustedResponse(accounts: Account[]): Response {
 
 	// Build account info list
 	const accountInfos = accounts.map((account) => {
-		const reason = account.paused
-			? "paused"
-			: account.rate_limited_until && account.rate_limited_until > now
-				? "rate_limited"
-				: "unavailable";
+		const reason = account.requires_reauth
+			? "requires_reauth"
+			: account.paused
+				? "paused"
+				: account.rate_limited_until && account.rate_limited_until > now
+					? "rate_limited"
+					: "unavailable";
 
 		const availableAt =
 			account.rate_limited_until && account.rate_limited_until > now

--- a/packages/proxy/src/handlers/token-manager.ts
+++ b/packages/proxy/src/handlers/token-manager.ts
@@ -1,4 +1,5 @@
 import {
+	authFailureEvents,
 	registerDisposable,
 	ServiceUnavailableError,
 	TokenRefreshError,
@@ -289,6 +290,12 @@ export async function refreshAccessTokenSafe(
 					ctx.asyncWriter.enqueue(() =>
 						ctx.dbOps.setRequiresReauth(account.id, true),
 					);
+					authFailureEvents.emit("event", {
+						accountId: account.id,
+						accountName: account.name,
+						provider: account.provider,
+						reason: providerError,
+					});
 				}
 				log.error(
 					`Token refresh failed for account ${account.name}: ${enhancedMessage}`,

--- a/packages/proxy/src/handlers/token-manager.ts
+++ b/packages/proxy/src/handlers/token-manager.ts
@@ -276,7 +276,20 @@ export async function refreshAccessTokenSafe(
 				const originalError =
 					error instanceof Error ? error.message : String(error);
 				const enhancedMessage = getOAuthErrorMessage(account, originalError);
-
+				const lastErrorDelimiter = originalError.lastIndexOf(": ");
+				const providerError =
+					lastErrorDelimiter >= 0
+						? originalError.slice(lastErrorDelimiter + 2)
+						: originalError;
+				if (
+					/invalid_grant|invalid_refresh_token|refresh_token_reused/i.test(
+						providerError,
+					)
+				) {
+					ctx.asyncWriter.enqueue(() =>
+						ctx.dbOps.setRequiresReauth(account.id, true),
+					);
+				}
 				log.error(
 					`Token refresh failed for account ${account.name}: ${enhancedMessage}`,
 					error,

--- a/packages/proxy/src/handlers/token-manager.ts
+++ b/packages/proxy/src/handlers/token-manager.ts
@@ -351,6 +351,12 @@ export async function refreshAccessTokenSafe(
 					account.name,
 				);
 				if (authFailureReason) {
+					// Accepted race (documented, not synchronized): a manual re-auth that
+					// clears the flag via a direct DB write could be overtaken by this
+					// still-queued set(true) under a pathologically backlogged async
+					// writer. Likelihood is negligible — a human OAuth round-trip versus a
+					// millisecond queue drain — and recovery is simply to re-authenticate
+					// again, so building synchronization here is not worth the complexity.
 					ctx.asyncWriter.enqueue(() =>
 						ctx.dbOps.setRequiresReauth(account.id, true),
 					);

--- a/packages/proxy/src/handlers/token-manager.ts
+++ b/packages/proxy/src/handlers/token-manager.ts
@@ -131,6 +131,67 @@ function enforceMaxSize(): void {
 }
 
 /**
+ * Definitive dead-refresh-token signals. Providers preserve the machine-readable
+ * OAuth error code verbatim in their thrown message (invalid_grant /
+ * invalid_refresh_token from the RFC-6749 grant flow, refresh_token_reused from
+ * Codex's rotating-token reuse guard). Only these are definitive; transient
+ * failures (network / 5xx / timeout) never carry them, so a false positive that
+ * pulls the account from routing until a manual re-auth cannot occur from them.
+ */
+const DEFINITIVE_AUTH_FAILURE_RE =
+	/invalid_grant|invalid_refresh_token|refresh_token_reused/i;
+
+/**
+ * Remove the "account <name>" framing from a provider refresh error before
+ * scanning it for auth-failure codes.
+ *
+ * Every provider frames the account as `... for account ${account.name}: <rest>`
+ * (Codex additionally repeats it in a `--reauthenticate ${account.name}` hint).
+ * The account NAME is free-form user input, so an account literally named e.g.
+ * "test_invalid_grant" would otherwise trip detection on ANY unrelated failure
+ * and be pulled from routing. Anchoring the removal on the literal "account "
+ * keyword means only the framed name is stripped and never the machine error
+ * code in <rest> — so a real invalid_grant for an account named "grant" still
+ * matches (no false negatives on the code itself), while the name can never
+ * fabricate a match (no false positives from the name).
+ */
+function stripAccountFraming(message: string, accountName: string): string {
+	if (!accountName) return message;
+	return message.split(`account ${accountName}`).join("account");
+}
+
+/**
+ * True when a raw provider refresh-error message carries a definitive
+ * dead-refresh-token signal, scanned over the whole message (minus the account
+ * framing) so a preserved `<code>: <description>` shape still matches. Exported
+ * for direct unit testing.
+ */
+export function isDefinitiveAuthFailure(
+	message: string,
+	accountName: string,
+): boolean {
+	return DEFINITIVE_AUTH_FAILURE_RE.test(
+		stripAccountFraming(message, accountName),
+	);
+}
+
+/**
+ * Returns the matched definitive-auth-failure code (normalized to lower-case,
+ * e.g. "invalid_grant") or null when the message is not a definitive failure.
+ * Same account-framing scoping as {@link isDefinitiveAuthFailure}; used to tag
+ * the emitted auth-failure alert event with a stable, machine-readable reason.
+ */
+export function extractAuthFailureReason(
+	message: string,
+	accountName: string,
+): string | null {
+	const match = DEFINITIVE_AUTH_FAILURE_RE.exec(
+		stripAccountFraming(message, accountName),
+	);
+	return match ? match[0].toLowerCase() : null;
+}
+
+/**
  * Safely refreshes an access token with deduplication
  * @param account - The account to refresh token for
  * @param ctx - The proxy context
@@ -277,16 +338,19 @@ export async function refreshAccessTokenSafe(
 				const originalError =
 					error instanceof Error ? error.message : String(error);
 				const enhancedMessage = getOAuthErrorMessage(account, originalError);
-				const lastErrorDelimiter = originalError.lastIndexOf(": ");
-				const providerError =
-					lastErrorDelimiter >= 0
-						? originalError.slice(lastErrorDelimiter + 2)
-						: originalError;
-				if (
-					/invalid_grant|invalid_refresh_token|refresh_token_reused/i.test(
-						providerError,
-					)
-				) {
+
+				// Definitive dead-refresh-token signal (invalid_grant /
+				// invalid_refresh_token / refresh_token_reused) — persist
+				// requires_reauth so the account is pulled from routing until a manual
+				// re-auth clears it. Detection runs on the RAW provider message (which
+				// preserves the machine error code) here, BEFORE it is wrapped into
+				// TokenRefreshError (whose .message is a fixed string). Mirrors the
+				// success-path enqueue idiom. Transient failures never match.
+				const authFailureReason = extractAuthFailureReason(
+					originalError,
+					account.name,
+				);
+				if (authFailureReason) {
 					ctx.asyncWriter.enqueue(() =>
 						ctx.dbOps.setRequiresReauth(account.id, true),
 					);
@@ -294,7 +358,7 @@ export async function refreshAccessTokenSafe(
 						accountId: account.id,
 						accountName: account.name,
 						provider: account.provider,
-						reason: providerError,
+						reason: authFailureReason,
 					});
 				}
 				log.error(

--- a/packages/types/src/account.ts
+++ b/packages/types/src/account.ts
@@ -246,8 +246,8 @@ export interface AccountResponse {
 	lastUsed: string | null;
 	created: string;
 	paused: boolean;
-	requiresReauth?: boolean;
-	pauseReason?: string | null;
+	requiresReauth: boolean;
+	pauseReason: string | null;
 	tokenStatus: "valid" | "expired";
 	tokenExpiresAt: string | null; // ISO timestamp of token expiration
 	rateLimitStatus: string;
@@ -312,6 +312,7 @@ export interface AccountListItem {
 	requestCount: number;
 	totalRequests: number;
 	paused: boolean;
+	requiresReauth: boolean;
 	tokenStatus: "valid" | "expired";
 	rateLimitStatus: string;
 	sessionInfo: string;

--- a/packages/types/src/account.ts
+++ b/packages/types/src/account.ts
@@ -168,6 +168,7 @@ export interface AccountRow {
 	session_start?: number | null;
 	session_request_count?: number;
 	paused?: boolean | number | null;
+	requires_reauth?: boolean | number | null;
 	rate_limit_reset?: number | null;
 	rate_limit_status?: string | null;
 	rate_limit_remaining?: number | null;
@@ -205,6 +206,7 @@ export interface Account {
 	session_start: number | null;
 	session_request_count: number;
 	paused: boolean;
+	requires_reauth: boolean;
 	rate_limit_reset: number | null;
 	rate_limit_status: string | null;
 	rate_limit_remaining: number | null;
@@ -244,6 +246,8 @@ export interface AccountResponse {
 	lastUsed: string | null;
 	created: string;
 	paused: boolean;
+	requiresReauth?: boolean;
+	pauseReason?: string | null;
 	tokenStatus: "valid" | "expired";
 	tokenExpiresAt: string | null; // ISO timestamp of token expiration
 	rateLimitStatus: string;
@@ -388,6 +392,7 @@ export function toAccount(row: AccountRow): Account {
 		session_start: toNumOrNull(row.session_start),
 		session_request_count: toNum(row.session_request_count),
 		paused: !!row.paused,
+		requires_reauth: !!row.requires_reauth,
 		rate_limit_reset: toNumOrNull(row.rate_limit_reset),
 		rate_limit_status: row.rate_limit_status || null,
 		rate_limit_remaining: toNumOrNull(row.rate_limit_remaining),
@@ -466,6 +471,8 @@ export function toAccountResponse(account: Account): AccountResponse {
 			: null,
 		created: new Date(account.created_at).toISOString(),
 		paused: account.paused,
+		requiresReauth: account.requires_reauth,
+		pauseReason: account.pause_reason,
 		tokenStatus,
 		tokenExpiresAt: account.expires_at
 			? new Date(account.expires_at).toISOString()

--- a/packages/types/src/alerts.ts
+++ b/packages/types/src/alerts.ts
@@ -17,7 +17,8 @@ export type AlertType =
 	| "anomaly_token_outlier"
 	| "anomaly_output_blowup"
 	| "anomaly_runaway_loop"
-	| "anomaly_model_misrouting";
+	| "anomaly_model_misrouting"
+	| "auth_failure";
 
 /** A single alert raised by the alert engine. */
 export interface AlertEvent {


### PR DESCRIPTION
## Problem

A dead OAuth refresh token leaves **no persisted trace**: the real `invalid_grant` case was only logged and rethrown, the account kept getting selected by the load balancer (wasting a refresh backoff + failover per request), the dashboard showed only the routine `tokenStatus: "expired"`, `/api/token-health` stayed "healthy" (it is a 90-day age heuristic, not a failure signal), and no notification existed.

**Real incident (2026-07-13):** two backup accounts' refresh tokens died and stayed undetected for ~43h — 0×401 in the request log, no pause, no badge, no webhook.

## What this adds

- **`requires_reauth` column** (SQLite + PG migrations, incl. the legacy `accounts_new` rebuild paths) — ground-truth state, set only on *definitive* auth failure, cleared by every successful token write.
- **Detection at the shared refresh funnel** (`refreshAccessTokenSafe` catch): matches `invalid_grant` / `invalid_refresh_token` / `refresh_token_reused`. The OAuth **error code is now preserved** through provider error messages (`[error, error_description].join(": ")` in anthropic/codex/xai providers) — previously `error_description` *replaced* the machine code, so realistic payloads would never have matched. Account-name framing is stripped before matching, so an account literally named `test_invalid_grant` cannot false-positive (routing exclusion makes false positives expensive).
- **Routing exclusion**: `isAccountAvailable` (single choke point), the forced-route bypass arm, the auto-refresh eligibility query, and both proactive refresh paths (openai-compatible + codex) skip flagged accounts; the proactive paths now also *detect* definitive failures instead of log-only. Scheduler 401 branch additionally forces `expires_at = 0` so the next real use goes through the honest funnel (it deliberately does NOT set the flag — a probe 401 is not a definitive dead-refresh signal).
- **API**: `/api/accounts` exposes `requiresReauth` + `pauseReason`; CLI `--list`/`--stats` parity; `peek()` threading keeps `isPrimary` honest.
- **Clear sites**: `updateTokens` (both branches), dashboard `completeReauth` (both modes), Qwen/Codex HTTP reauth handlers, all four CLI reauth modes (the CLI OAuth mode now also stamps `refresh_token_issued_at`, fixing the stale token-health age after CLI reauth). The dashboard reauth callback additionally drops the in-memory refresh backoff (`clearAccountRefreshCache`).
- **Alerting**: new `auth_failure` AlertType, emitted via a small core event bus (proxy cannot import http-api), delivered through the existing SSE + webhook pipeline with cooldown-bucket dedup.
- **Dashboard**: red "Needs authentication" badge (takes precedence over Paused/rate-limit chips) + differentiated `Paused (manual/overage/failure threshold/peak hours)`.

## Verification

- ~120 new tests (TDD, red-first), including realistic replay payloads (`{"error":"invalid_grant","error_description":"…"}` driven through the real `refreshToken()` via fetch mock) and false-positive guards (network/5xx errors and code-in-account-name must NOT flag).
- Full suite: no new failures vs baseline (the pool-exhausted suite failures + CLI timeout flakes are pre-existing on main).
- Live E2E: server + seeded DB → `/api/accounts` returns `requiresReauth: true`, flagged higher-priority account loses `isPrimary` to a healthy lower-priority one, badge renders in the browser.

## Notes / accepted risks

- Webhook delivery is fire-and-forget without retry (existing `deliverWebhook` behavior) — a down listener loses the single alert.
- A direct-write manual reauth clear can theoretically be overtaken by a still-queued flag write under a pathologically backlogged async writer (documented in code; recovery = reauth again).
- Pre-existing, out of scope: `persistAndEmit`'s `INSERT OR IGNORE` is SQLite-syntax (affects all alert types on PG); the legacy `accounts_new` rebuild also omits three *older* columns (`rate_limited_reason`, `rate_limited_at`, `consecutive_rate_limits`) — that path would crash on those before ever reaching this change.
