### PR TITLE
fix(codex): align subscription request token contract

### DIFF
--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -1843,6 +1843,109 @@ describe("CodexProvider.transformRequestBody", () => {
 		);
 	});
 
+	it("maps max_tokens according to the resolved Codex endpoint contract", async () => {
+		const cases = [
+			{
+				name: "custom endpoint",
+				endpoint: "https://codex.example.com/v1/responses",
+				expectedMaxOutputTokens: 4096,
+			},
+			{
+				name: "canonical subscription endpoint",
+				endpoint: "https://chatgpt.com/backend-api/codex/responses",
+				expectedMaxOutputTokens: undefined,
+			},
+			{
+				name: "canonical subscription endpoint with trailing slash",
+				endpoint: "https://chatgpt.com/backend-api/codex/responses/",
+				expectedMaxOutputTokens: undefined,
+			},
+			{
+				name: "canonical subscription endpoint with query",
+				endpoint:
+					"https://chatgpt.com/backend-api/codex/responses?feature=request-contract",
+				expectedMaxOutputTokens: undefined,
+			},
+		] as const;
+
+		for (const testCase of cases) {
+			const provider = new CodexProvider();
+			const account = codexAccount({ custom_endpoint: testCase.endpoint });
+			const request = new Request(testCase.endpoint, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					model: "claude-3-7-sonnet",
+					max_tokens: 4096,
+					messages: [{ role: "user", content: "hello" }],
+				}),
+			});
+
+			const transformed = await provider.transformRequestBody(request, account);
+			const body = await transformed.json();
+
+			expect(body.max_output_tokens, testCase.name).toBe(
+				testCase.expectedMaxOutputTokens,
+			);
+		}
+	});
+
+	it("preserves custom endpoint max_tokens: 0 as max_output_tokens: 1", async () => {
+		const provider = new CodexProvider();
+		const endpoint = "https://codex.example.com/v1/responses";
+		const request = new Request(endpoint, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-7-sonnet",
+				max_tokens: 0,
+				messages: [{ role: "user", content: "hello" }],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(
+			request,
+			codexAccount({ custom_endpoint: endpoint }),
+		);
+		const body = await transformed.json();
+
+		expect(body.max_output_tokens).toBe(1);
+	});
+
+	it("rejects max_tokens: 0 locally for the canonical subscription endpoint", async () => {
+		const provider = new CodexProvider();
+		const endpoint = "https://chatgpt.com/backend-api/codex/responses";
+		const request = new Request(endpoint, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-7-sonnet",
+				max_tokens: 0,
+				messages: [{ role: "user", content: "hello" }],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(
+			request,
+			codexAccount({ custom_endpoint: endpoint }),
+		);
+		const body = await transformed.json();
+
+		expect(transformed.headers.get("x-better-ccflare-synthetic-response")).toBe(
+			"true",
+		);
+		expect(transformed.headers.get("x-better-ccflare-synthetic-status")).toBe(
+			"400",
+		);
+		expect(body).toEqual({
+			type: "error",
+			error: {
+				type: "invalid_request_error",
+				message: "Codex subscription endpoint does not support max_tokens: 0.",
+			},
+		});
+	});
+
 	it("maps sonnet-family models to the default Codex model", async () => {
 		const provider = new CodexProvider();
 		const request = new Request("https://example.com/v1/messages", {

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -167,6 +167,7 @@ interface CodexRequest {
 	input: (CodexMessage | CodexFunctionCallItem | CodexFunctionCallOutputItem)[];
 	stream: boolean;
 	store: false;
+	max_output_tokens?: number;
 	reasoning?: { effort: string };
 	instructions?: string;
 	tools?: CodexTool[];
@@ -293,6 +294,19 @@ function isOpenAiPromptCacheEndpoint(account?: Account): boolean {
 	try {
 		const { hostname } = new URL(resolveCodexPromptCacheEndpoint(account));
 		return OPENAI_PROMPT_CACHE_HOSTS.has(hostname);
+	} catch {
+		return false;
+	}
+}
+
+function isCodexSubscriptionEndpoint(account?: Account): boolean {
+	try {
+		const endpoint = new URL(resolveCodexPromptCacheEndpoint(account));
+		const normalizedPath = endpoint.pathname.replace(/\/+$/, "");
+		return (
+			endpoint.origin === "https://chatgpt.com" &&
+			normalizedPath === "/backend-api/codex/responses"
+		);
 	} catch {
 		return false;
 	}
@@ -454,6 +468,14 @@ export class CodexProvider extends BaseProvider {
 			const body = (await request.json()) as AnthropicRequest;
 			if (isSyntheticCountTokens) {
 				return this.createSyntheticCountTokensResponse(request, body);
+			}
+			if (isCodexSubscriptionEndpoint(account) && body.max_tokens === 0) {
+				return this.createSyntheticErrorResponse(
+					request,
+					400,
+					"invalid_request_error",
+					"Codex subscription endpoint does not support max_tokens: 0.",
+				);
 			}
 
 			const requestId = request.headers.get("x-better-ccflare-request-id");
@@ -1090,6 +1112,17 @@ export class CodexProvider extends BaseProvider {
 			store: false,
 			reasoning: { effort: reasoningResolution.effort ?? "medium" },
 		};
+		if (
+			!isCodexSubscriptionEndpoint(account) &&
+			typeof body.max_tokens === "number" &&
+			Number.isFinite(body.max_tokens)
+		) {
+			if (body.max_tokens > 0) {
+				codexRequest.max_output_tokens = Math.floor(body.max_tokens);
+			} else if (body.max_tokens === 0) {
+				codexRequest.max_output_tokens = 1;
+			}
+		}
 
 		codexRequest.instructions = instructions || "You are a helpful assistant.";
 		const promptCacheKey = this.derivePromptCacheKey(


### PR DESCRIPTION
## Summary

- forward finite positive Anthropic `max_tokens` as `max_output_tokens` for custom Codex-compatible endpoints
- omit `max_output_tokens` for the canonical ChatGPT subscription endpoint, including trailing-slash and query variants
- reject subscription requests with `max_tokens: 0` locally as an Anthropic-compatible synthetic 400
- preserve the existing custom-endpoint zero-token behavior by sending `max_output_tokens: 1`

## Why this is focused

This extracts one request-contract correction from conflicted PR #302 onto current upstream `main`. It intentionally excludes tracing, pacing, orchestration, model support, prompt caching, tool-result translation, terminal streaming changes, and usage refresh behavior.

The implementation is limited to:

- `packages/providers/src/providers/codex/provider.ts`
- `packages/providers/src/providers/codex/provider.test.ts`

Source behavior was developed in StartupBros commits `574905913de33c626f383002f0ee411a93306060` and `42e962861e6931604478ecaffc7eb0a03e299e83`, then rebuilt test-first on current upstream rather than cherry-picked wholesale.

## Test evidence

Before the production change, focused characterization tests failed as expected:

- custom endpoint expected `max_output_tokens: 4096`, received `undefined`
- subscription `max_tokens: 0` expected a synthetic response, received no synthetic marker
- result: 0 passed, 2 failed

After the change:

- focused `max_tokens` tests: 3 passed
- complete Codex provider suite: 72 passed, 202 assertions
- `bun run build`: passed
- `bun run lint`: passed with 211 existing warnings
- `bun run typecheck`: passed
- `bun run format`: passed, no additional changes
- `git diff --check`: passed

No real provider or network endpoint was called.

## Review notes

Endpoint classification requires the exact HTTPS origin `https://chatgpt.com` and normalized path `/backend-api/codex/responses`. Query strings are ignored and trailing slashes are normalized. Other origins and paths retain custom-endpoint behavior.

This PR is opened as a draft while it receives final upstream-facing review. It is intended to supersede only this narrow portion of #302, not the entire PR.
