### PR TITLE
feat(proxy): track project and agent attribution sources

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "ccflare",
@@ -12,7 +13,7 @@
     },
     "apps/cli": {
       "name": "better-ccflare",
-      "version": "3.5.32",
+      "version": "3.5.35",
       "bin": {
         "better-ccflare": "dist/better-ccflare",
       },
@@ -164,6 +165,7 @@
         "@better-ccflare/database": "workspace:*",
         "@better-ccflare/oauth-flow": "workspace:*",
         "@better-ccflare/providers": "workspace:*",
+        "@better-ccflare/proxy": "workspace:*",
         "@better-ccflare/types": "workspace:*",
       },
     },

--- a/docs/plans/2026-07-08-001-feature-attribution-source-tags-plan.md
+++ b/docs/plans/2026-07-08-001-feature-attribution-source-tags-plan.md
@@ -1,0 +1,344 @@
+---
+title: Attribution Source Tags - Plan
+type: feat
+date: 2026-07-08
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-brainstorm
+execution: code
+---
+
+# Attribution Source Tags - Plan
+
+## Goal Capsule
+
+| Field | Value |
+|---|---|
+| Objective | Add first-class source tags for existing `project` and `agent_used` attribution so better-ccflare can distinguish explicit caller labels from heuristic extraction without storing prompts or secrets. |
+| Active scope | First upstream OSS PR: shared project extraction helper, project source tags, agent source tags, runtime propagation, and optional persistence of only the two source columns. |
+| Authority order | Product Contract requirements, repo `CLAUDE.md`, existing proxy/database patterns, then implementation judgment. |
+| Stop conditions | Stop if implementing this requires broad caller/job/campaign lineage, dashboard redesign, budget policy, or prompt-body persistence. Those are follow-up work. |
+| Execution profile | Test-first for new helper/source behavior, then implementation, then targeted Bun tests plus repo lint/typecheck/format checks. |
+| Tail ownership | The implementer updates this plan only if scope changes; execution progress is tracked in git and the PR, not in this document. |
+
+---
+
+## Product Contract
+
+### Summary
+
+This plan implements the first upstreamable attribution improvement for better-ccflare: source tags for the existing `project` and `agent_used` fields.
+It keeps current behavior compatible while making provenance explicit, so future cost spikes can tell whether labels came from headers, workspace-path heuristics, prompt headings, or agent prompt detection.
+
+Product Contract preservation: Product Contract unchanged in intent, narrowed for execution to PR 1; broader caller/job/campaign, dashboard, budgets, failover grouping, and producer instrumentation remain deferred follow-up work.
+
+### Problem Frame
+
+better-ccflare records useful request data, including `project`, `agent_used`, model, account, token fields, cost, status, and failover attempts.
+During the recent `Harness` and `gpt-5.5` spend investigation, those fields identified the cost bucket but not the label provenance.
+A value such as `project=Harness` could have come from an explicit header, a workspace path, or a prompt heading.
+
+Today, answering that provenance question requires database archaeology and source inspection.
+The first fix should be maintainer-friendly and small: keep existing attribution values, add source labels, and centralize duplicated extraction logic.
+It must not store request bodies, prompt text, tool inputs, auth headers, cookies, raw trace IDs, or private harness-specific metadata.
+
+### Requirements
+
+**Source tagging**
+
+- R1. Every persisted or emitted `project` value produced by the proxy flow must carry a low-cardinality source label: `header_project`, `path_project`, `heading_project`, or `none`.
+- R2. Every persisted or emitted `agent_used` value produced by the agent interceptor flow must carry a low-cardinality source label: `header_agent`, `prompt_agent`, or `none`. For PR 1, registry-assisted matches intentionally share `prompt_agent` because they still originate from prompt or known-agent prompt detection rather than an explicit caller header.
+- R3. Source labels must describe provenance only, never raw header names, prompt excerpts, request bodies, full paths, or tool input content. Each label describes the winning source for the final persisted or emitted value, not every source consulted during extraction.
+
+**Compatibility and behavior preservation**
+
+- R4. Existing callers that send only `x-project` or `x-anthropic-agent-id` must continue to work unchanged.
+- R5. Existing project extraction precedence must remain compatible: explicit project header, workspace path inference, eligible markdown heading, then no project.
+- R6. Existing agent attribution precedence must remain compatible: explicit agent header, prompt or registry detection, then no agent.
+- R7. The proxy and usage collector must not maintain divergent copies of project extraction rules after this change.
+
+**Privacy and safety**
+
+- R8. The implementation must not store prompt bodies, request bodies, tool arguments, authorization headers, cookies, API keys, bearer-like strings, high-entropy tokens, raw IP forwarding headers, or raw trace IDs as attribution metadata.
+- R9. Header-derived project and agent values must keep existing sanitization and length caps unless a compatible tightening is required by tests.
+- R10. Path-derived project inference must persist only a sanitized project slug, not the source path.
+- R10a. Heading-derived project inference must only emit or persist values that pass a strict low-risk project-slug validator; headings containing secret-like strings, URLs, emails, long random tokens, or customer/incident-shaped labels must return no project instead of being stored or emitted.
+
+**Upstream PR shape**
+
+- R11. The first PR must stay small enough for upstream review by focusing on source tags and shared extraction, not the whole attribution platform.
+- R12. If persistence is included, only `project_attribution_source` and `agent_attribution_source` may be added to request storage in this PR.
+- R13. SQLite and PostgreSQL schema paths must stay in sync if any request columns are added.
+
+### Acceptance Examples
+
+- AE1. Given a request with `x-better-ccflare-project: eval-suite`, when better-ccflare records the request, then `project` is `eval-suite` and `project_attribution_source` is `header_project`.
+- AE2. Given a request with only the existing `x-project: eval-suite` header, when better-ccflare records the request, then existing project behavior still works and the source is `header_project`.
+- AE3. Given a request with no project header but a workspace or repo path under a recognized root, when better-ccflare infers the project, then only the sanitized repo slug is stored and the source is `path_project`.
+- AE4. Given a request with no project header or recognized workspace path but a first eligible non-Claude markdown heading that passes the low-risk project-slug validator, when better-ccflare infers the project, then the source is `heading_project`.
+- AE5. Given a request with `x-better-ccflare-agent-id` or `x-anthropic-agent-id`, when the agent interceptor runs, then the agent value comes from the header and the source is `header_agent`.
+- AE6. Given a request with no explicit agent header but a known agent prompt match, when the agent interceptor detects it, then the source is `prompt_agent`.
+- AE7. Given fake `authorization`, `cookie`, `x-api-key`, or bearer-like values in request headers, when attribution metadata is saved or emitted, then none of those values appear in request rows, payload metadata, logs, errors, or analytics responses.
+
+### Scope Boundaries
+
+#### Active in PR 1
+
+- Shared project extraction helper used by both the proxy and usage collector paths.
+- Project source labels for header, path, heading, and none.
+- Agent source labels for explicit header, prompt or registry detection, and none.
+- Backward-compatible namespaced headers as preferred aliases where practical.
+- Runtime propagation through request metadata, worker start messages, usage collector state, summaries, and existing early-failure records.
+- A pre-U5 persistence checkpoint: include only the two source columns in PR 1 if maintainers accept minimal schema expansion and the diff remains small after U2-U4; otherwise skip U5 and ship runtime-only source propagation with persistence as a required follow-up PR.
+
+#### Deferred to Follow-Up Work
+
+- `caller`, `job_id`, `campaign_id`, repo slug, worktree slug, session hash, transcript hash, workflow id, subagent id, or parent-agent lineage fields.
+- Request attempt grouping, failover attempt numbering, and failover waterfall diagnostics.
+- Requested-model versus resolved-model split and transport/provider route classification.
+- Server-side attribution filters, analytics filters, dashboard columns, dashboard widgets, and unattributed spend ratios.
+- Budget enforcement, per-caller limits, per-job ceilings, campaign budgets, and high-context approval policy.
+- pi-evals, pi-lens, private harness, Claude Code wrapper, Codex host, cron, or CI producer instrumentation.
+- Historical backfill from prompt bodies, request payloads, or encrypted payload JSON.
+
+### Sources
+
+- Current brainstorm artifact in `docs/plans/2026-07-08-001-feature-attribution-source-tags-plan.md`.
+- Repo instructions in `CLAUDE.md`, especially migration parity, test-first work, generated-file exclusions, and testing restrictions.
+- Planning research over `packages/proxy/src/proxy.ts`, `packages/proxy/src/usage-collector.ts`, `packages/proxy/src/handlers/agent-interceptor.ts`, `packages/proxy/src/response-handler.ts`, `packages/proxy/src/worker-messages.ts`, `packages/database/src/migrations.ts`, `packages/database/src/migrations-pg.ts`, `packages/database/src/repositories/request.repository.ts`, `packages/database/src/database-operations.ts`, `packages/types/src/request.ts`, and `packages/http-api/src/handlers/requests.ts`.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. Keep PR 1 focused on provenance for existing labels. This makes the change upstreamable and prevents the attribution roadmap from becoming a dashboard, budgeting, or private harness PR.
+- KTD2. Represent source as application-validated string labels rather than raw source details. The labels are enough for diagnostics and avoid storing prompt excerpts, full paths, or header values beyond existing sanitized `project` and `agent_used`.
+- KTD3. Centralize project extraction in a proxy-local helper that returns both value and source. The current duplicate rules in `proxy.ts` and `usage-collector.ts` can drift, and source tagging would make that drift harder to reason about.
+- KTD4. Prefer namespaced better-ccflare headers while preserving existing aliases. `x-better-ccflare-project` and `x-better-ccflare-agent-id` are clearer for upstream docs, while `x-project` and `x-anthropic-agent-id` keep existing clients compatible.
+- KTD5. Treat path and heading extraction as inference. Source labels should say that inference happened, but stored values remain sanitized project slugs and never include the raw path or heading context.
+- KTD6. Persist source columns only after an explicit pre-U5 checkpoint. Proceed into persistence when maintainers accept two nullable columns in PR 1 and the U2-U4 diff remains small; otherwise skip U5, keep PR 1 runtime-only, and treat persistence as the mandatory follow-up needed for historical spend investigations.
+- KTD7. Keep attribution values and source labels atomic on repository conflicts. If an existing `project` or `agent_used` value is preserved, preserve its matching source. If the value is replaced by a more authoritative value, replace the source in the same operation. Allow source upgrades from `none` to non-none, or from inferred to header source, only when the persisted attribution value remains identical or is replaced together with the source.
+
+### High-Level Technical Design
+
+```mermaid
+flowchart TB
+  Client[Client request] --> Proxy[Proxy request metadata]
+  Proxy --> ProjectHelper[Shared project extraction helper]
+  Proxy --> AgentInterceptor[Agent interceptor]
+  ProjectHelper --> RuntimeMeta[project plus project source]
+  AgentInterceptor --> RuntimeMeta[agent plus agent source]
+  RuntimeMeta --> ResponseHandler[Response handler options]
+  ResponseHandler --> StartMessage[Usage collector StartMessage]
+  StartMessage --> CollectorState[Usage collector state]
+  CollectorState --> SaveRequest[Database save path]
+  CollectorState --> Summary[Request summary and stream event]
+  SaveRequest --> Requests[(requests table, optional source columns)]
+```
+
+The data flow has one rule: source labels are created at the extraction boundary and then carried forward, not rediscovered at persistence time.
+Project extraction is created by the shared helper.
+Agent source is created by the interceptor.
+The usage collector treats source fields as a tri-state contract: an explicit source label is authoritative for the matching value, an explicit `none` is authoritative absence, and an absent field means legacy or direct input where fallback extraction may run. Normal proxy flow must not recompute when `StartMessage` carries either a concrete source or authoritative `none`; direct and legacy paths may use the shared helper fallback when enough request context exists.
+
+### Assumptions
+
+- The first upstream PR may include two nullable database columns only after the pre-U5 checkpoint accepts the schema scope; otherwise persistence is split into the mandatory follow-up PR.
+- The existing authenticated request summary API is the right exposure point if source fields are persisted.
+- Dashboard display is not required for PR 1; downstream consumers can ignore new optional response fields.
+- PR 1 should preserve existing path inference behavior while tagging its source. New recognition for `SITES`, worktree directories, or checkout caches belongs in follow-up work unless implementation confirms those roots are already supported today, in which case tests should frame them as compatibility coverage.
+
+### Implementation Constraints
+
+- Do not read or store request body text for attribution beyond the existing parsed context already used by project extraction.
+- Do not touch generated files: `packages/proxy/src/inline-worker.ts`, `packages/database/src/inline-vacuum-worker.ts`, or `packages/database/src/inline-integrity-check-worker.ts`.
+- If `packages/database/src/migrations.ts` changes, mirror the schema and migration in `packages/database/src/migrations-pg.ts`.
+- Use `git add <specific-files>` if committing, not `git add .`.
+- Do not curl the Anthropic endpoint or test through the `claude` account.
+
+---
+
+## Implementation Units
+
+### U1. Lock active PR scope in the plan
+
+- **Goal:** Keep the artifact executable for the first upstream PR rather than the entire attribution roadmap.
+- **Requirements:** R11, R12, R13.
+- **Dependencies:** None.
+- **Files:** `docs/plans/2026-07-08-001-feature-attribution-source-tags-plan.md`.
+- **Approach:** Preserve the original goals and non-goals, but separate active PR 1 work from deferred attribution platform work.
+- **Patterns to follow:** Unified plan sections in this file and repo-relative path rules.
+- **Test scenarios:** Test expectation: none, this is a planning-only unit with no runtime behavior.
+- **Verification:** The plan does not instruct an implementer to build caller/job/campaign fields, dashboard filters, budgets, or producer instrumentation in PR 1.
+
+### U2. Create shared project attribution extraction
+
+- **Goal:** Replace duplicated project extraction logic with one helper that returns a sanitized project and `project_attribution_source`.
+- **Requirements:** R1, R3, R4, R5, R7, R9, R10, AE1, AE2, AE3, AE4.
+- **Dependencies:** U1.
+- **Files:** `packages/proxy/src/proxy.ts`, `packages/proxy/src/usage-collector.ts`, a new or existing helper under `packages/proxy/src`, and a focused helper test file under `packages/proxy/src` or `packages/proxy/src/__tests__`.
+- **Approach:** Move project sanitization and extraction precedence into a proxy-local helper that accepts headers and request context, then returns `project` plus `projectAttributionSource`.
+- **Execution note:** Start with helper tests for header precedence, path inference, heading fallback, and no-match behavior before replacing the duplicated callers.
+- **Helper contract:** Support both the normal proxy path's parsed JSON input and the usage collector's `StartMessage` input. Either expose a decode-and-extract wrapper for base64 `requestBody` or move the base64 decode plus system prompt extraction into the shared module so the collector does not keep divergent fallback rules.
+- **Patterns to follow:** Existing `sanitizeProjectName` behavior, existing header/path/H1 precedence, and usage-collector fallback behavior when `requestBody` is absent.
+- **Test scenarios:**
+  - Given `x-better-ccflare-project` and `x-project`, the namespaced header wins and the source is `header_project`.
+  - Given only `x-project`, the project is still extracted and the source is `header_project`.
+  - Given control characters or an overlong project header, sanitization and length caps match the existing behavior.
+  - Given a recognized `/home` or `/Users` workspace path, the helper infers a sanitized repo slug and the source is `path_project`.
+  - Given an already-supported workspace or repo path, the helper infers only the sanitized repo slug and never stores the full path.
+  - Given a proposed new `SITES`, worktree, or checkout-cache root, the helper treats it as follow-up scope unless implementation proves the root is already supported today.
+  - Given no header or recognized path and a first eligible non-Claude H1 that passes the low-risk project-slug validator, the helper returns that heading with source `heading_project`.
+  - Given no valid header, path, or heading, the helper returns no project and source `none`.
+  - Given a heading containing bearer/API-key-like strings, URLs, emails, long random tokens, or customer/incident-shaped labels, the helper returns no project and does not persist or emit the heading-derived value.
+  - Given only `StartMessage.requestBody` is available in the usage collector fallback path, path and heading extraction still use the shared helper contract and return the same source labels as the proxy path.
+- **Verification:** `proxy.ts` and `usage-collector.ts` both call the shared helper, and their old project extraction rules no longer diverge.
+
+### U3. Add agent source tagging at the interceptor boundary
+
+- **Goal:** Make explicit-header agent attribution distinguishable from prompt or registry-based detection.
+- **Requirements:** R2, R3, R4, R6, R8, R9, AE5, AE6, AE7.
+- **Dependencies:** U1.
+- **Files:** `packages/proxy/src/handlers/agent-interceptor.ts`, `packages/proxy/src/handlers/__tests__/agent-interceptor.header.test.ts`, `packages/proxy/src/handlers/__tests__/agent-interceptor.security.test.ts`.
+- **Approach:** Extend the interceptor result so it carries `agentUsed` plus `agentAttributionSource`, preserving explicit header precedence and existing prompt matching behavior.
+- **Execution note:** Add failing tests for source labels before changing interceptor return plumbing.
+- **Source invariant:** For PR 1, `prompt_agent` covers known-agent prompt and registry-assisted prompt detection. Do not add a separate registry source label unless a later PR explicitly expands the low-cardinality enum.
+- **Patterns to follow:** Current `x-anthropic-agent-id` trim and length cap behavior, existing prompt extraction from system and CLAUDE.md contexts, and model preference substitution behavior.
+- **Test scenarios:**
+  - Given `x-better-ccflare-agent-id`, the interceptor returns the header value and source `header_agent`.
+  - Given only `x-anthropic-agent-id`, existing behavior still works and source is `header_agent`.
+  - Given both preferred and legacy headers, precedence is deterministic and documented by the test.
+  - Given a known prompt or registry-assisted prompt match and no explicit header, the interceptor returns the detected agent and source `prompt_agent`.
+  - Given no header and no prompt or registry-assisted match, the interceptor returns no agent and source `none`.
+  - Given whitespace-padded or overlong header values, sanitization remains compatible with current behavior.
+  - Given fake auth, cookie, API key, bearer-like, or traversal-shaped prompt content, no secret-bearing value is emitted as agent metadata.
+- **Verification:** Existing agent header and security tests still pass, and new tests prove source labels without changing model preference behavior.
+
+### U4. Thread source tags through proxy runtime flow
+
+- **Goal:** Carry project and agent source labels from extraction into worker messages, collector state, summaries, and existing failure paths.
+- **Requirements:** R1, R2, R3, R5, R6, R7, AE1, AE2, AE5, AE6.
+- **Dependencies:** U2, U3.
+- **Files:** `packages/proxy/src/proxy.ts`, `packages/proxy/src/response-handler.ts`, `packages/proxy/src/worker-messages.ts`, `packages/proxy/src/usage-collector.ts`, `packages/proxy/src/handlers/proxy-operations.ts`, `packages/proxy/src/__tests__/response-handler-worker-protocol.test.ts`.
+- **Approach:** Add optional source fields to the existing request metadata, `StartMessage`, and real-time request event paths, then store them on usage collector state and include them in summary objects where `project` and `agentUsed` already flow.
+- **Runtime contract:** Treat source fields as tri-state. A concrete source is authoritative for the matching value, explicit `none` means the value is absent or truly unattributed, and field absence means legacy/direct input where the shared helper fallback may run if request context is available.
+- **Exposure contract:** Source fields may appear only on the same authenticated request-summary surfaces that already expose `project` and `agent_used`. Do not include them on errors, logs, public health/status endpoints, unauthenticated responses, or unrelated analytics payloads.
+- **Patterns to follow:** Current `project` and `agentUsed` propagation through `forwardToClient`, `StartMessage`, request event start payloads, `handleStart`, `_handleEndInternal`, and pool-exhausted synthetic messages.
+- **Test scenarios:**
+  - Given a non-streaming request with project and agent sources, the StartMessage includes both existing values and both source labels.
+  - Given a streaming request with project and agent sources, the StartMessage includes both existing values and both source labels.
+  - Given a request event start payload includes `agentUsed`, it also includes `agentAttributionSource`; if project is emitted through this path later, it carries `projectAttributionSource` as well.
+  - Given a pool-exhausted or early-failure path that already records `project` or `agentUsed`, the matching source labels are preserved; `none` is used only when the corresponding attribution value is absent or truly unattributed.
+  - Given a consumer that ignores unknown StartMessage fields, existing worker protocol behavior remains backward compatible.
+  - Given `requestBody` is absent in the usage collector, `StartMessage.project` and `StartMessage.projectAttributionSource` remain authoritative for normal proxy flow.
+  - Given a legacy or direct usage collector message omits source fields, fallback extraction runs only through the shared helper when enough request context exists; otherwise the source remains explicitly unattributed.
+  - Given error responses, logs, public health/status endpoints, unauthenticated responses, or unrelated analytics payloads are emitted, they do not include raw headers, paths, prompt text, or attribution source fields outside the intended authenticated request-summary surface.
+- **Verification:** Source labels are not recomputed after extraction in normal flow, and request summaries expose them consistently when available.
+
+### U5. Persist source columns if accepted in PR 1
+
+- **Goal:** Save `project_attribution_source` and `agent_attribution_source` beside existing request attribution fields with SQLite and PostgreSQL parity.
+- **Requirements:** R1, R2, R3, R8, R12, R13, AE1, AE2, AE5, AE6, AE7.
+- **Dependencies:** U4.
+- **Pre-U5 checkpoint:** Start U5 only if maintainers accept two nullable source columns in PR 1 and the U2-U4 diff remains small enough for upstream review. If not, skip U5 entirely, leave schema/repository/API response changes for a required follow-up PR, and update the DoD for PR 1 to require runtime-only source propagation.
+- **Files:** `packages/database/src/migrations.ts`, `packages/database/src/migrations-pg.ts`, `packages/database/src/database-operations.ts`, `packages/database/src/repositories/request.repository.ts`, `packages/types/src/request.ts`, `packages/http-api/src/handlers/requests.ts`, `packages/proxy/src/handlers/proxy-operations.ts`, `packages/database/src/migrations.test.ts`, and a request repository test under `packages/database/src/repositories/__tests__` if one exists or is added.
+- **Approach:** Add nullable text columns to fresh schemas and guarded migrations, extend request save types and SQL, map source fields into shared request response types and `/api/requests` summaries, and update direct `dbOps.saveRequest` failure or failover call sites so persisted attribution values keep matching source labels.
+- **Execution note:** Implement schema tests before repository plumbing so SQLite and PostgreSQL parity is not missed.
+- **Patterns to follow:** Existing `project` and `agent_used` columns, existing `RequestData` to `RequestRepository.save` flow, direct `dbOps.saveRequest` calls in `packages/proxy/src/handlers/proxy-operations.ts`, `RequestRow` and `toRequestResponse` mappers, and migration parity rules in `CLAUDE.md`.
+- **Test scenarios:**
+  - Given a fresh SQLite database, the `requests` table includes both source columns.
+  - Given an old SQLite database, migration adds both nullable source columns without disrupting existing rows.
+  - Given PostgreSQL schema creation, both source columns exist in the fresh `requests` schema.
+  - Given PostgreSQL migrations, both source columns are present in the `columnsToAdd` upgrade list.
+  - Given a saved request with source labels, the repository persists and returns both labels.
+  - Given an UPSERT for an existing request, attribution values and source fields follow the atomic conflict policy from KTD7, including mismatched old/new value-source pairs, `none` to non-none upgrades, and inferred to header-source upgrades when allowed.
+  - Given direct failure or failover paths call `dbOps.saveRequest` from `proxy-operations.ts`, `requestMeta` carries `projectAttributionSource` and `agentAttributionSource` and those fields are passed into saved rows with their matching values.
+  - Given `/api/requests` returns summaries, source fields are mapped when present and omitted or null when absent.
+  - Given fake secret-bearing headers, no secret values appear in source columns, payload metadata, logs, errors, or analytics responses.
+  - Given errors, logs, public endpoints, unauthenticated responses, or unrelated analytics payloads are produced, source fields appear only on the intended authenticated request-summary surface.
+- **Verification:** Persistence is optional to the first PR, but if included it is complete across schemas, save path, shared types, and request summary API.
+
+### U6. Keep the broader attribution roadmap deferred
+
+- **Goal:** Preserve roadmap context without making PR 1 too broad for upstream review.
+- **Requirements:** R11, R12.
+- **Dependencies:** U1.
+- **Files:** `docs/plans/2026-07-08-001-feature-attribution-source-tags-plan.md`.
+- **Approach:** Keep caller/job/campaign, diagnostics, filters, dashboard, budget, failover, and producer-instrumentation ideas in Scope Boundaries and Appendix instead of active units.
+- **Test scenarios:** Test expectation: none, this is a planning-only unit with no runtime behavior.
+- **Verification:** The active unit list contains no implementation work for deferred roadmap items.
+
+---
+
+## Verification Contract
+
+| Gate | Applies to | Expected proof |
+|---|---|---|
+| Project helper tests | U2 | Header precedence, sanitization, path inference, heading fallback, and no-match source labels are covered. |
+| Agent interceptor tests | U3 | Header and prompt source labels are covered without regressing model preference substitution or security tests. |
+| Worker protocol tests | U4 | Streaming and non-streaming StartMessage payloads carry optional source labels while existing consumers remain compatible. |
+| Database migration tests | U5, only if persistence is included | SQLite fresh and migrated schemas include both columns, and PostgreSQL schema plus migration list are updated. |
+| Repository/API tests | U5, only if persistence is included | Save, UPSERT, shared type mapping, and `/api/requests` summary mapping preserve source labels. |
+| Full repo tests | All implementation units | `bun test` passes. |
+| Repo checks | All implementation units | `bun run lint && bun run typecheck && bun run format` passes, followed by checking the resulting diff. |
+
+If implementation touches dashboard code through shared types, also run the dashboard package typecheck or build using the package scripts in `packages/dashboard-web/package.json`.
+Do not test with the Anthropic endpoint or the `claude` account.
+
+---
+
+## Definition of Done
+
+- Project extraction is centralized and both existing project extraction callers use it.
+- `project_attribution_source` can distinguish header, path, heading, and none cases.
+- `agent_attribution_source` can distinguish explicit header, prompt or registry-assisted detection, and none cases.
+- Existing `x-project` and `x-anthropic-agent-id` behavior remains backward compatible.
+- Namespaced better-ccflare headers are supported or intentionally deferred with a documented reason.
+- Source labels contain only low-cardinality enum-like values, never prompt bodies, request bodies, raw paths, auth headers, cookies, API keys, or trace IDs.
+- Heading-derived project values pass the low-risk project-slug validator before they are emitted or persisted.
+- Runtime propagation keeps source labels with their matching `project` and `agent_used` values through worker start messages and usage collector state.
+- If persistence passes the pre-U5 checkpoint, SQLite and PostgreSQL schemas, migrations, repository save logic, direct failure/failover save paths, shared types, and `/api/requests` summaries all include the two source columns; otherwise PR 1 explicitly ships runtime-only source propagation and persistence remains a required follow-up.
+- Broader attribution fields, path-root expansion, and dashboards remain deferred follow-up work, not partially implemented in PR 1.
+- Targeted tests, `bun test`, and `bun run lint && bun run typecheck && bun run format` pass or any failures are diagnosed and fixed.
+- The final diff excludes generated inline worker files and contains no abandoned exploratory code.
+
+---
+
+## Appendix
+
+### Deferred attribution roadmap
+
+The broader attribution design remains valuable after PR 1 proves source tagging.
+Future PRs can add sanitized caller lineage fields such as `caller`, `job_id`, `campaign_id`, request attempt groups, requested and resolved model fields, transport classification, server-side filters, dashboard surfaces, budget alerts, and producer-side header emission.
+Those features should be split into separate upstreamable units after the source-tag spine lands.
+
+### Diagnostic queries for later work
+
+These query shapes are not part of PR 1 unless the corresponding fields exist.
+They document why the deferred fields matter.
+
+```sql
+SELECT caller, job_id, campaign_id, model, COUNT(*) AS requests, SUM(total_tokens) AS total_tokens, ROUND(SUM(cost_usd), 2) AS cost_usd
+FROM requests
+WHERE timestamp >= ?
+GROUP BY caller, job_id, campaign_id, model
+ORDER BY cost_usd DESC
+LIMIT 50;
+```
+
+```sql
+SELECT project, project_attribution_source, COUNT(*) AS requests, SUM(total_tokens) AS total_tokens, ROUND(SUM(cost_usd), 2) AS cost_usd
+FROM requests
+WHERE timestamp >= ?
+GROUP BY project, project_attribution_source
+ORDER BY cost_usd DESC;
+```
+
+```sql
+SELECT caller, model, SUM(input_tokens) AS input_tokens, SUM(cache_read_input_tokens) AS cache_read_input_tokens, SUM(cache_creation_input_tokens) AS cache_creation_input_tokens, SUM(output_tokens) AS output_tokens
+FROM requests
+WHERE timestamp >= ?
+GROUP BY caller, model;
+```

--- a/packages/core/src/request-events.ts
+++ b/packages/core/src/request-events.ts
@@ -9,6 +9,9 @@ export type RequestStartEvt = {
 	accountId: string | null;
 	statusCode: number;
 	agentUsed: string | null;
+	agentAttributionSource?:
+		| import("@better-ccflare/types").AgentAttributionSource
+		| null;
 };
 
 export type RequestSummaryEvt = {

--- a/packages/dashboard-web/src/components/RequestDetailsModal.tsx
+++ b/packages/dashboard-web/src/components/RequestDetailsModal.tsx
@@ -7,6 +7,7 @@ import {
 import { Eye } from "lucide-react";
 import { useEffect, useState } from "react";
 import { api, type RequestPayload, type RequestSummary } from "../api";
+import { attributionSourceLabel } from "../lib/attribution";
 import { ConversationView } from "./ConversationView";
 import { CopyButton } from "./CopyButton";
 import { TokenUsageDisplay } from "./TokenUsageDisplay";
@@ -140,9 +141,30 @@ export function RequestDetailsModal({
 							{summary?.model && (
 								<Badge variant="secondary">{summary.model}</Badge>
 							)}
-							{summary?.agentUsed && (
-								<Badge variant="secondary">Agent: {summary.agentUsed}</Badge>
-							)}
+							{summary?.project &&
+								(() => {
+									const srcLabel = attributionSourceLabel(
+										summary.projectAttributionSource,
+									);
+									return (
+										<Badge variant="secondary">
+											Project: {summary.project}
+											{srcLabel ? ` · ${srcLabel}` : ""}
+										</Badge>
+									);
+								})()}
+							{summary?.agentUsed &&
+								(() => {
+									const agentSrcLabel = attributionSourceLabel(
+										summary.agentAttributionSource,
+									);
+									return (
+										<Badge variant="secondary">
+											Agent: {summary.agentUsed}
+											{agentSrcLabel ? ` · ${agentSrcLabel}` : ""}
+										</Badge>
+									);
+								})()}
 							{summary?.totalTokens && (
 								<Badge variant="outline">
 									{formatTokens(summary.totalTokens)} tokens

--- a/packages/dashboard-web/src/components/RequestsTab.tsx
+++ b/packages/dashboard-web/src/components/RequestsTab.tsx
@@ -23,6 +23,7 @@ import { api, type RequestPayload, type RequestSummary } from "../api";
 import { API_LIMITS } from "../constants";
 import { useAccounts, useApiKeys, useRequests } from "../hooks/queries";
 import { useRequestStream } from "../hooks/useRequestStream";
+import { attributionSourceLabel } from "../lib/attribution";
 import { isAnthropicPeakHour, isZaiPeakHour } from "../utils/provider-utils";
 import { CopyButton } from "./CopyButton";
 import { RequestDetailsModal } from "./RequestDetailsModal";
@@ -719,6 +720,13 @@ export function RequestsTab() {
 									? `${request.meta.accountId.slice(0, 8)}...`
 									: null);
 							const agent = summary?.agentUsed || request.meta.agentUsed;
+							const agentSrcLabel = attributionSourceLabel(
+								summary?.agentAttributionSource ||
+									request.meta.agentAttributionSource,
+							);
+							const projectSrcLabel = attributionSourceLabel(
+								summary?.projectAttributionSource,
+							);
 							const isZaiPeak =
 								zaiAccountNames.has(request.meta.accountName ?? "") &&
 								isZaiPeakHour(request.meta.timestamp);
@@ -841,6 +849,7 @@ export function RequestsTab() {
 
 									{/* Badges row: wraps freely, holds all the non-essential context */}
 									{(summary?.model ||
+										summary?.project ||
 										agent ||
 										summary?.comboName ||
 										summary?.apiKeyName ||
@@ -858,10 +867,25 @@ export function RequestsTab() {
 													{summary.model}
 												</Badge>
 											)}
+											{summary?.project && (
+												<Badge variant="secondary" className="text-xs">
+													Project: {summary.project}
+													{projectSrcLabel && (
+														<span className="text-muted-foreground/70 ml-1">
+															· {projectSrcLabel}
+														</span>
+													)}
+												</Badge>
+											)}
 											{agent && (
 												<Badge variant="secondary" className="text-xs">
 													<Bot className="h-3 w-3 mr-1" />
 													{agent}
+													{agentSrcLabel && (
+														<span className="text-muted-foreground/70 ml-1">
+															· {agentSrcLabel}
+														</span>
+													)}
 												</Badge>
 											)}
 											{summary?.comboName && (

--- a/packages/dashboard-web/src/hooks/useRequestStream.ts
+++ b/packages/dashboard-web/src/hooks/useRequestStream.ts
@@ -1,3 +1,4 @@
+import type { AgentAttributionSource } from "@better-ccflare/types";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef } from "react";
 import type { Account, RequestPayload, RequestResponse } from "../api";
@@ -93,6 +94,7 @@ export function useRequestStream(limit = 200) {
 							accountId: string | null;
 							statusCode: number;
 							agentUsed: string | null;
+							agentAttributionSource?: AgentAttributionSource | null;
 					  }
 					| { type: "summary"; payload: RequestResponse };
 
@@ -158,6 +160,8 @@ export function useRequestStream(limit = 200) {
 									success: false,
 									pending: true,
 									agentUsed: evt.agentUsed || undefined,
+									agentAttributionSource:
+										evt.agentAttributionSource || undefined,
 									rateLimited: evt.statusCode === 429,
 									bodiesOmitted: true,
 								},

--- a/packages/dashboard-web/src/lib/__tests__/attribution.test.ts
+++ b/packages/dashboard-web/src/lib/__tests__/attribution.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+import { attributionSourceLabel } from "../attribution";
+
+describe("attributionSourceLabel", () => {
+	it("maps header_project to 'header'", () => {
+		expect(attributionSourceLabel("header_project")).toBe("header");
+	});
+
+	it("maps header_agent to 'header'", () => {
+		expect(attributionSourceLabel("header_agent")).toBe("header");
+	});
+
+	it("maps path_project to 'path'", () => {
+		expect(attributionSourceLabel("path_project")).toBe("path");
+	});
+
+	it("maps heading_project to 'heading'", () => {
+		expect(attributionSourceLabel("heading_project")).toBe("heading");
+	});
+
+	it("maps prompt_agent to 'prompt'", () => {
+		expect(attributionSourceLabel("prompt_agent")).toBe("prompt");
+	});
+
+	it("maps 'none' to null", () => {
+		expect(attributionSourceLabel("none")).toBeNull();
+	});
+
+	it("maps undefined to null", () => {
+		expect(attributionSourceLabel(undefined)).toBeNull();
+	});
+});

--- a/packages/dashboard-web/src/lib/attribution.ts
+++ b/packages/dashboard-web/src/lib/attribution.ts
@@ -1,0 +1,27 @@
+import type {
+	AgentAttributionSource,
+	ProjectAttributionSource,
+} from "@better-ccflare/types";
+
+/**
+ * Maps a raw attribution source enum value to a short human label.
+ * Returns null for "none"/undefined so callers can render nothing when
+ * there's no meaningful provenance to show.
+ */
+export function attributionSourceLabel(
+	source?: ProjectAttributionSource | AgentAttributionSource | null,
+): string | null {
+	switch (source) {
+		case "header_project":
+		case "header_agent":
+			return "header";
+		case "path_project":
+			return "path";
+		case "heading_project":
+			return "heading";
+		case "prompt_agent":
+			return "prompt";
+		default:
+			return null; // "none" / undefined -> no badge
+	}
+}

--- a/packages/database/src/database-operations.ts
+++ b/packages/database/src/database-operations.ts
@@ -7,12 +7,14 @@ import type { Disposable } from "@better-ccflare/core";
 import { TIME_CONSTANTS } from "@better-ccflare/core";
 import type {
 	Account,
+	AgentAttributionSource,
 	Combo,
 	ComboFamily,
 	ComboFamilyAssignment,
 	ComboSlot,
 	ComboWithSlots,
 	IntegrityStatus,
+	ProjectAttributionSource,
 	RateLimitReason,
 	StrategyStore,
 } from "@better-ccflare/types";
@@ -946,6 +948,8 @@ OAuth tokens will need to be re-authenticated.
 		comboName?: string | null,
 		originalModel?: string | null,
 		appliedModel?: string | null,
+		projectAttributionSource?: ProjectAttributionSource | null,
+		agentAttributionSource?: AgentAttributionSource | null,
 	): Promise<void> {
 		await withDatabaseRetry(
 			() =>
@@ -968,6 +972,8 @@ OAuth tokens will need to be re-authenticated.
 					comboName,
 					originalModel,
 					appliedModel,
+					projectAttributionSource,
+					agentAttributionSource,
 				}),
 			this.retryConfig,
 			"saveRequest",

--- a/packages/database/src/migrations-pg.ts
+++ b/packages/database/src/migrations-pg.ts
@@ -4,6 +4,14 @@ import type { BunSqlAdapter } from "./adapters/bun-sql-adapter";
 const log = new Logger("DatabaseMigrations-PG");
 
 /**
+ * PostgreSQL SQLSTATE for duplicate_column. Bun's `Bun.SQL` PostgresError
+ * surfaces the raw Postgres SQLSTATE code on `.code` (there is no separate
+ * `sqlState` field, unlike the MySQL error class), so this is safe to match
+ * directly rather than sniffing the error message.
+ */
+const PG_DUPLICATE_COLUMN = "42701";
+
+/**
  * Check if a column exists in a PostgreSQL table using information_schema
  */
 async function columnExists(
@@ -109,7 +117,9 @@ export async function ensureSchemaPg(adapter: BunSqlAdapter): Promise<void> {
 			billing_type TEXT DEFAULT 'api',
 			combo_name TEXT,
 			original_model TEXT,
-			applied_model TEXT
+			applied_model TEXT,
+			project_attribution_source TEXT,
+			agent_attribution_source TEXT
 		)
 	`);
 
@@ -430,6 +440,18 @@ export async function runMigrationsPg(adapter: BunSqlAdapter): Promise<void> {
 			definition: "ALTER TABLE requests ADD COLUMN applied_model TEXT",
 		},
 		{
+			table: "requests",
+			column: "project_attribution_source",
+			definition:
+				"ALTER TABLE requests ADD COLUMN project_attribution_source TEXT",
+		},
+		{
+			table: "requests",
+			column: "agent_attribution_source",
+			definition:
+				"ALTER TABLE requests ADD COLUMN agent_attribution_source TEXT",
+		},
+		{
 			table: "request_payloads",
 			column: "timestamp",
 			definition: "ALTER TABLE request_payloads ADD COLUMN timestamp BIGINT",
@@ -454,8 +476,22 @@ export async function runMigrationsPg(adapter: BunSqlAdapter): Promise<void> {
 				await adapter.unsafe(col.definition);
 				log.info(`Added column ${col.table}.${col.column}`);
 			} catch (error) {
-				log.warn(
-					`Could not add column ${col.table}.${col.column}: ${(error as Error).message}`,
+				const code = (error as { code?: string } | undefined)?.code;
+				if (code !== PG_DUPLICATE_COLUMN) {
+					// Not the known duplicate-column race: a genuine failure
+					// (permissions, lock timeout, etc). Don't swallow it, a
+					// missing column here means unconditional inserts against
+					// it (e.g. RequestRepository) will fail on every write.
+					throw error;
+				}
+				// Another instance won the race to add this column concurrently.
+				// Re-verify it actually landed before treating this as a no-op.
+				const nowExists = await columnExists(adapter, col.table, col.column);
+				if (!nowExists) {
+					throw error;
+				}
+				log.info(
+					`Column ${col.table}.${col.column} already added by a concurrent migration`,
 				);
 			}
 		}

--- a/packages/database/src/migrations.test.ts
+++ b/packages/database/src/migrations.test.ts
@@ -1171,3 +1171,207 @@ describe("Database Backup Behavior", () => {
 		expect(cols).toContain("paused");
 	});
 });
+
+describe("Attribution source columns (project_attribution_source / agent_attribution_source)", () => {
+	let db: Database;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("fresh SQLite DB has both attribution source columns after schema init + migrations", () => {
+		ensureSchema(db);
+		runMigrations(db);
+
+		const columns = db.prepare("PRAGMA table_info(requests)").all() as Array<{
+			name: string;
+			type: string;
+			notnull: number;
+		}>;
+		const columnNames = columns.map((c) => c.name);
+
+		expect(columnNames).toContain("project_attribution_source");
+		expect(columnNames).toContain("agent_attribution_source");
+
+		const projectSourceCol = columns.find(
+			(c) => c.name === "project_attribution_source",
+		);
+		const agentSourceCol = columns.find(
+			(c) => c.name === "agent_attribution_source",
+		);
+		expect(projectSourceCol?.notnull).toBe(0);
+		expect(agentSourceCol?.notnull).toBe(0);
+	});
+
+	it("old SQLite DB without the columns gets them added by runMigrations, nullable, with existing rows intact", () => {
+		// Simulate a pre-U5 requests table (no project_attribution_source /
+		// agent_attribution_source columns), mirroring the shape ensureSchema()
+		// produced before this migration was added.
+		db.exec(`
+			CREATE TABLE requests (
+				id TEXT PRIMARY KEY,
+				timestamp INTEGER NOT NULL,
+				method TEXT NOT NULL,
+				path TEXT NOT NULL,
+				account_used TEXT,
+				status_code INTEGER,
+				success BOOLEAN,
+				error_message TEXT,
+				response_time_ms INTEGER,
+				failover_attempts INTEGER DEFAULT 0,
+				model TEXT,
+				prompt_tokens INTEGER DEFAULT 0,
+				completion_tokens INTEGER DEFAULT 0,
+				total_tokens INTEGER DEFAULT 0,
+				cost_usd REAL DEFAULT 0,
+				output_tokens_per_second REAL,
+				input_tokens INTEGER DEFAULT 0,
+				cache_read_input_tokens INTEGER DEFAULT 0,
+				cache_creation_input_tokens INTEGER DEFAULT 0,
+				output_tokens INTEGER DEFAULT 0,
+				agent_used TEXT,
+				project TEXT,
+				billing_type TEXT DEFAULT 'api',
+				combo_name TEXT
+			)
+		`);
+		db.exec(`
+			CREATE TABLE accounts (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				provider TEXT DEFAULT 'anthropic',
+				api_key TEXT,
+				refresh_token TEXT,
+				access_token TEXT,
+				expires_at INTEGER,
+				created_at INTEGER NOT NULL,
+				last_used INTEGER,
+				request_count INTEGER DEFAULT 0,
+				total_requests INTEGER DEFAULT 0,
+				priority INTEGER DEFAULT 0
+			)
+		`);
+		db.exec(`
+			CREATE TABLE request_payloads (
+				id TEXT PRIMARY KEY,
+				json TEXT NOT NULL
+			)
+		`);
+		db.exec(`
+			CREATE TABLE oauth_sessions (
+				id TEXT PRIMARY KEY,
+				account_name TEXT NOT NULL,
+				verifier TEXT NOT NULL,
+				mode TEXT NOT NULL,
+				created_at INTEGER NOT NULL,
+				expires_at INTEGER NOT NULL
+			)
+		`);
+		db.exec(`
+			CREATE TABLE api_keys (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL UNIQUE,
+				hashed_key TEXT NOT NULL UNIQUE,
+				prefix_last_8 TEXT NOT NULL,
+				created_at INTEGER NOT NULL,
+				last_used INTEGER,
+				usage_count INTEGER DEFAULT 0,
+				is_active INTEGER DEFAULT 1
+			)
+		`);
+
+		db.prepare(
+			`INSERT INTO requests (id, timestamp, method, path, status_code, success, response_time_ms, failover_attempts, project, combo_name)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			"pre-existing-req",
+			1_700_000_000_000,
+			"POST",
+			"/v1/messages",
+			200,
+			1,
+			123,
+			0,
+			"legacy-project",
+			"legacy-combo",
+		);
+
+		runMigrations(db);
+
+		const columns = db.prepare("PRAGMA table_info(requests)").all() as Array<{
+			name: string;
+			notnull: number;
+		}>;
+		const columnNames = columns.map((c) => c.name);
+		expect(columnNames).toContain("project_attribution_source");
+		expect(columnNames).toContain("agent_attribution_source");
+		expect(
+			columns.find((c) => c.name === "project_attribution_source")?.notnull,
+		).toBe(0);
+		expect(
+			columns.find((c) => c.name === "agent_attribution_source")?.notnull,
+		).toBe(0);
+
+		// Pre-existing row must survive the migration untouched, with the new
+		// columns defaulting to NULL (no DEFAULT clause specified).
+		const row = db
+			.prepare(
+				"SELECT id, project, combo_name, project_attribution_source, agent_attribution_source FROM requests WHERE id = ?",
+			)
+			.get("pre-existing-req") as {
+			id: string;
+			project: string | null;
+			combo_name: string | null;
+			project_attribution_source: string | null;
+			agent_attribution_source: string | null;
+		};
+		expect(row.id).toBe("pre-existing-req");
+		expect(row.project).toBe("legacy-project");
+		expect(row.combo_name).toBe("legacy-combo");
+		expect(row.project_attribution_source).toBeNull();
+		expect(row.agent_attribution_source).toBeNull();
+	});
+});
+
+describe("PostgreSQL migration parity — attribution source columns", () => {
+	// A live PostgreSQL server is not available in this environment, so this
+	// is a static-parity check: read migrations-pg.ts as text and assert both
+	// new columns are wired into ensureSchemaPg's CREATE TABLE and into the
+	// columnsToAdd list consumed by runMigrationsPg, mirroring the SQLite
+	// migration added above. See repo CLAUDE.md "Database Migrations — Port
+	// to PostgreSQL" checklist.
+	it("ensureSchemaPg's requests CREATE TABLE includes both attribution source columns", () => {
+		const source = fs.readFileSync(
+			path.join(__dirname, "../src/migrations-pg.ts"),
+			"utf8",
+		);
+		const ensureSchemaPgMatch = source.match(
+			/export async function ensureSchemaPg[\s\S]*?\n}\n/,
+		);
+		expect(ensureSchemaPgMatch).not.toBeNull();
+		const ensureSchemaPgBody = ensureSchemaPgMatch?.[0] ?? "";
+		expect(ensureSchemaPgBody).toContain("project_attribution_source TEXT");
+		expect(ensureSchemaPgBody).toContain("agent_attribution_source TEXT");
+	});
+
+	it("runMigrationsPg's columnsToAdd includes both attribution source columns for the requests table", () => {
+		const source = fs.readFileSync(
+			path.join(__dirname, "../src/migrations-pg.ts"),
+			"utf8",
+		);
+		const columnsToAddMatch = source.match(/const columnsToAdd[\s\S]*?\n\t\];/);
+		expect(columnsToAddMatch).not.toBeNull();
+		const columnsToAddBody = columnsToAddMatch?.[0] ?? "";
+
+		expect(columnsToAddBody).toContain(
+			'"ALTER TABLE requests ADD COLUMN project_attribution_source TEXT"',
+		);
+		expect(columnsToAddBody).toContain(
+			'"ALTER TABLE requests ADD COLUMN agent_attribution_source TEXT"',
+		);
+	});
+});

--- a/packages/database/src/migrations.ts
+++ b/packages/database/src/migrations.ts
@@ -153,7 +153,9 @@ export function ensureSchema(db: Database): void {
 			project TEXT,
 			billing_type TEXT DEFAULT 'api',
 			original_model TEXT,
-			applied_model TEXT
+			applied_model TEXT,
+			project_attribution_source TEXT,
+			agent_attribution_source TEXT
 		)
 	`);
 
@@ -945,6 +947,22 @@ export function runMigrations(db: Database, dbPath?: string): void {
 		if (!requestsColumnNames.includes("applied_model")) {
 			db.prepare("ALTER TABLE requests ADD COLUMN applied_model TEXT").run();
 			log.info("Added applied_model column to requests table");
+		}
+
+		// Add project_attribution_source column if it doesn't exist
+		if (!requestsColumnNames.includes("project_attribution_source")) {
+			db.prepare(
+				"ALTER TABLE requests ADD COLUMN project_attribution_source TEXT",
+			).run();
+			log.info("Added project_attribution_source column to requests table");
+		}
+
+		// Add agent_attribution_source column if it doesn't exist
+		if (!requestsColumnNames.includes("agent_attribution_source")) {
+			db.prepare(
+				"ALTER TABLE requests ADD COLUMN agent_attribution_source TEXT",
+			).run();
+			log.info("Added agent_attribution_source column to requests table");
 		}
 
 		// Add timestamp column to request_payloads if it doesn't exist

--- a/packages/database/src/repositories/__tests__/request-attribution-source.test.ts
+++ b/packages/database/src/repositories/__tests__/request-attribution-source.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Tests for RequestRepository persistence of project_attribution_source and
+ * agent_attribution_source (Unit U5 of the attribution-source plan).
+ *
+ * Covers:
+ *  - save() persists both source labels and they read back correctly.
+ *  - UPSERT conflict resolution is SOURCE-RANKED (round-2 P1 fix): for both
+ *    (project, project_attribution_source) and (agent_used,
+ *    agent_attribution_source), the incoming pair replaces the existing pair
+ *    IN LOCKSTEP only when it has a non-null value AND a source rank >= the
+ *    existing source rank (header > path > heading for project; header >
+ *    prompt for agent; null/"none" rank lowest). A strictly lower-authority
+ *    (or omitted/none) incoming source can never erase or downgrade a
+ *    higher-authority attribution recorded earlier for the same request id.
+ *  - UPSERT upgrade: a later save() with a same-value but higher-authority
+ *    source updates project_attribution_source to the new source.
+ *  - Secret-safety: only the known enum labels are ever persisted in the
+ *    source columns.
+ */
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { BunSqlAdapter } from "../../adapters/bun-sql-adapter";
+import { ensureSchema, runMigrations } from "../../migrations";
+import { RequestRepository } from "../request.repository";
+
+const KNOWN_PROJECT_SOURCES = new Set([
+	"header_project",
+	"path_project",
+	"heading_project",
+	"none",
+]);
+const KNOWN_AGENT_SOURCES = new Set(["header_agent", "prompt_agent", "none"]);
+
+function makeDb(): Database {
+	const db = new Database(":memory:");
+	ensureSchema(db);
+	runMigrations(db);
+	return db;
+}
+
+function baseRequestData(id: string, overrides: Record<string, unknown> = {}) {
+	return {
+		id,
+		method: "POST",
+		path: "/v1/messages",
+		accountUsed: null,
+		statusCode: 200,
+		success: true,
+		errorMessage: null,
+		responseTime: 100,
+		failoverAttempts: 0,
+		...overrides,
+	};
+}
+
+describe("RequestRepository — attribution source persistence", () => {
+	let db: Database;
+	let repo: RequestRepository;
+
+	beforeEach(() => {
+		db = makeDb();
+		repo = new RequestRepository(new BunSqlAdapter(db));
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("saves and reads back project_attribution_source and agent_attribution_source", async () => {
+		await repo.save(
+			baseRequestData("req-1", {
+				project: "my-project",
+				projectAttributionSource: "header_project",
+				agentUsed: "my-agent",
+				agentAttributionSource: "prompt_agent",
+			}),
+		);
+
+		const row = db
+			.prepare(
+				"SELECT project, project_attribution_source, agent_used, agent_attribution_source FROM requests WHERE id = ?",
+			)
+			.get("req-1") as {
+			project: string | null;
+			project_attribution_source: string | null;
+			agent_used: string | null;
+			agent_attribution_source: string | null;
+		};
+
+		expect(row.project).toBe("my-project");
+		expect(row.project_attribution_source).toBe("header_project");
+		expect(row.agent_used).toBe("my-agent");
+		expect(row.agent_attribution_source).toBe("prompt_agent");
+	});
+
+	it("UPSERT atomicity: project/project_attribution_source are preserved together when the new project is null; agent_used/agent_attribution_source are preserved together when the incoming source is lower authority", async () => {
+		await repo.save(
+			baseRequestData("req-2", {
+				project: "foo",
+				projectAttributionSource: "heading_project",
+				agentUsed: "agent-a",
+				agentAttributionSource: "header_agent",
+			}),
+		);
+
+		// Conflict: project omitted (undefined -> null binding); agent value
+		// changes but arrives via a lower-authority source (prompt < header).
+		await repo.save(
+			baseRequestData("req-2", {
+				project: null,
+				projectAttributionSource: null,
+				agentUsed: "agent-b",
+				agentAttributionSource: "prompt_agent",
+			}),
+		);
+
+		const row = db
+			.prepare(
+				"SELECT project, project_attribution_source, agent_used, agent_attribution_source FROM requests WHERE id = ?",
+			)
+			.get("req-2") as {
+			project: string | null;
+			project_attribution_source: string | null;
+			agent_used: string | null;
+			agent_attribution_source: string | null;
+		};
+
+		// project preserved (null incoming value) AND its source preserved in lockstep.
+		expect(row.project).toBe("foo");
+		expect(row.project_attribution_source).toBe("heading_project");
+
+		// agent_used preserved (lower-authority incoming source) AND its source
+		// preserved in lockstep — a prompt_agent re-derivation must not erase a
+		// prior header_agent attribution.
+		expect(row.agent_used).toBe("agent-a");
+		expect(row.agent_attribution_source).toBe("header_agent");
+	});
+
+	it("UPSERT: a same-or-higher-authority incoming source still overwrites agent_used/agent_attribution_source together", async () => {
+		await repo.save(
+			baseRequestData("req-2b", {
+				agentUsed: "agent-a",
+				agentAttributionSource: "prompt_agent",
+			}),
+		);
+
+		await repo.save(
+			baseRequestData("req-2b", {
+				agentUsed: "agent-b",
+				agentAttributionSource: "header_agent",
+			}),
+		);
+
+		const row = db
+			.prepare(
+				"SELECT agent_used, agent_attribution_source FROM requests WHERE id = ?",
+			)
+			.get("req-2b") as {
+			agent_used: string | null;
+			agent_attribution_source: string | null;
+		};
+
+		expect(row.agent_used).toBe("agent-b");
+		expect(row.agent_attribution_source).toBe("header_agent");
+	});
+
+	it("UPSERT upgrade: a later save() with a same-value but higher-authority source updates project_attribution_source to the new source", async () => {
+		await repo.save(
+			baseRequestData("req-3", {
+				project: "foo",
+				projectAttributionSource: "heading_project",
+			}),
+		);
+
+		await repo.save(
+			baseRequestData("req-3", {
+				project: "foo",
+				projectAttributionSource: "header_project",
+			}),
+		);
+
+		const row = db
+			.prepare(
+				"SELECT project, project_attribution_source FROM requests WHERE id = ?",
+			)
+			.get("req-3") as {
+			project: string | null;
+			project_attribution_source: string | null;
+		};
+
+		expect(row.project).toBe("foo");
+		expect(row.project_attribution_source).toBe("header_project");
+	});
+
+	it("UPSERT: an omitted/none incoming source does not erase an existing header attribution", async () => {
+		await repo.save(
+			baseRequestData("req-6", {
+				project: "secure-project",
+				projectAttributionSource: "header_project",
+			}),
+		);
+
+		// Re-save with no attribution at all (legacy caller / omitted fields).
+		await repo.save(baseRequestData("req-6"));
+
+		const row = db
+			.prepare(
+				"SELECT project, project_attribution_source FROM requests WHERE id = ?",
+			)
+			.get("req-6") as {
+			project: string | null;
+			project_attribution_source: string | null;
+		};
+
+		expect(row.project).toBe("secure-project");
+		expect(row.project_attribution_source).toBe("header_project");
+	});
+
+	it("UPSERT: a lower-authority inferred source does not overwrite a header-attributed pair", async () => {
+		await repo.save(
+			baseRequestData("req-7", {
+				project: "secure-project",
+				projectAttributionSource: "header_project",
+			}),
+		);
+
+		// A later request infers a different project from a heading — must not
+		// downgrade the earlier header attribution.
+		await repo.save(
+			baseRequestData("req-7", {
+				project: "inferred-from-heading",
+				projectAttributionSource: "heading_project",
+			}),
+		);
+
+		const row = db
+			.prepare(
+				"SELECT project, project_attribution_source FROM requests WHERE id = ?",
+			)
+			.get("req-7") as {
+			project: string | null;
+			project_attribution_source: string | null;
+		};
+
+		expect(row.project).toBe("secure-project");
+		expect(row.project_attribution_source).toBe("header_project");
+	});
+
+	it("secret-safety: persisted source columns contain only known enum labels, never raw header/secret values", async () => {
+		await repo.save(
+			baseRequestData("req-4", {
+				project: "some-project",
+				projectAttributionSource: "path_project",
+				agentUsed: "some-agent",
+				agentAttributionSource: "header_agent",
+			}),
+		);
+
+		const row = db
+			.prepare(
+				"SELECT project_attribution_source, agent_attribution_source FROM requests WHERE id = ?",
+			)
+			.get("req-4") as {
+			project_attribution_source: string | null;
+			agent_attribution_source: string | null;
+		};
+
+		expect(row.project_attribution_source).not.toBeNull();
+		expect(row.agent_attribution_source).not.toBeNull();
+		expect(
+			KNOWN_PROJECT_SOURCES.has(row.project_attribution_source as string),
+		).toBe(true);
+		expect(
+			KNOWN_AGENT_SOURCES.has(row.agent_attribution_source as string),
+		).toBe(true);
+	});
+
+	it("saving without attribution source fields leaves the columns null", async () => {
+		await repo.save(baseRequestData("req-5"));
+
+		const row = db
+			.prepare(
+				"SELECT project_attribution_source, agent_attribution_source FROM requests WHERE id = ?",
+			)
+			.get("req-5") as {
+			project_attribution_source: string | null;
+			agent_attribution_source: string | null;
+		};
+
+		expect(row.project_attribution_source).toBeNull();
+		expect(row.agent_attribution_source).toBeNull();
+	});
+});

--- a/packages/database/src/repositories/request.repository.ts
+++ b/packages/database/src/repositories/request.repository.ts
@@ -1,8 +1,39 @@
 import { Logger } from "@better-ccflare/logger";
+import type {
+	AgentAttributionSource,
+	ProjectAttributionSource,
+} from "@better-ccflare/types";
 import { decryptPayload, encryptPayload } from "../payload-encryption";
 import { BaseRepository } from "./base.repository";
 
 const log = new Logger("RequestRepository");
+
+// Source-authority ranks for the UPSERT conflict resolution below. Higher
+// number = higher authority. NULL and "none" both fall through to the ELSE
+// branch (rank 0) since neither is an explicit attribution.
+//
+// Project: header (explicit client header) > path (workspace path in the
+// system prompt) > heading (inferred from an H1 heading) > none.
+const PROJECT_SOURCE_RANK_SQL = `CASE %COL%
+	WHEN 'header_project' THEN 3
+	WHEN 'path_project' THEN 2
+	WHEN 'heading_project' THEN 1
+	ELSE 0
+END`;
+// Agent: header (explicit client header) > prompt (inferred from the prompt) > none.
+const AGENT_SOURCE_RANK_SQL = `CASE %COL%
+	WHEN 'header_agent' THEN 2
+	WHEN 'prompt_agent' THEN 1
+	ELSE 0
+END`;
+
+function projectRank(col: string): string {
+	return PROJECT_SOURCE_RANK_SQL.replace("%COL%", col);
+}
+
+function agentRank(col: string): string {
+	return AGENT_SOURCE_RANK_SQL.replace("%COL%", col);
+}
 
 /**
  * Decrypt a stored payload for a list endpoint, swallowing per-row errors
@@ -52,6 +83,8 @@ export interface RequestData {
 	 */
 	originalModel?: string | null;
 	appliedModel?: string | null;
+	projectAttributionSource?: ProjectAttributionSource | null;
+	agentAttributionSource?: AgentAttributionSource | null;
 	usage?: {
 		model?: string;
 		promptTokens?: number;
@@ -69,6 +102,23 @@ export interface RequestData {
 export class RequestRepository extends BaseRepository<RequestData> {
 	async save(data: RequestData): Promise<void> {
 		const { usage } = data;
+		const projectRankIncoming = projectRank(
+			"EXCLUDED.project_attribution_source",
+		);
+		const projectRankExisting = projectRank(
+			"requests.project_attribution_source",
+		);
+		const agentRankIncoming = agentRank("EXCLUDED.agent_attribution_source");
+		const agentRankExisting = agentRank("requests.agent_attribution_source");
+		// An incoming project/agent pair wins the conflict only when it carries a
+		// non-null value AND its source is at least as authoritative as the
+		// existing one. Equal rank still wins (keeps legacy no-source callers,
+		// where both sides rank 0, overwriting as before; and lets a fresh
+		// same-authority re-derivation replace a stale one). Strictly lower rank
+		// never wins, so an omitted/`none`/lower-authority source can no longer
+		// erase or downgrade a higher-authority attribution (e.g. header_*).
+		const projectWinsIncoming = `EXCLUDED.project IS NOT NULL AND ${projectRankIncoming} >= ${projectRankExisting}`;
+		const agentWinsIncoming = `EXCLUDED.agent_used IS NOT NULL AND ${agentRankIncoming} >= ${agentRankExisting}`;
 		await this.run(
 			`
 			INSERT INTO requests (
@@ -77,9 +127,10 @@ export class RequestRepository extends BaseRepository<RequestData> {
 				model, prompt_tokens, completion_tokens, total_tokens, cost_usd,
 				input_tokens, cache_read_input_tokens, cache_creation_input_tokens, output_tokens,
 				agent_used, output_tokens_per_second, api_key_id, api_key_name, project,
-				billing_type, combo_name, original_model, applied_model
+				billing_type, combo_name, original_model, applied_model,
+				project_attribution_source, agent_attribution_source
 			)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			ON CONFLICT (id) DO UPDATE SET
 				timestamp = EXCLUDED.timestamp,
 				method = EXCLUDED.method,
@@ -99,15 +150,25 @@ export class RequestRepository extends BaseRepository<RequestData> {
 				cache_read_input_tokens = EXCLUDED.cache_read_input_tokens,
 				cache_creation_input_tokens = EXCLUDED.cache_creation_input_tokens,
 				output_tokens = EXCLUDED.output_tokens,
-				agent_used = EXCLUDED.agent_used,
 				output_tokens_per_second = EXCLUDED.output_tokens_per_second,
 				api_key_id = EXCLUDED.api_key_id,
 				api_key_name = EXCLUDED.api_key_name,
-				project = COALESCE(EXCLUDED.project, requests.project),
 				billing_type = COALESCE(EXCLUDED.billing_type, requests.billing_type),
 				combo_name = COALESCE(EXCLUDED.combo_name, requests.combo_name),
 				original_model = COALESCE(EXCLUDED.original_model, requests.original_model),
-				applied_model = COALESCE(EXCLUDED.applied_model, requests.applied_model)
+				applied_model = COALESCE(EXCLUDED.applied_model, requests.applied_model),
+				-- (project, project_attribution_source) and (agent_used, agent_attribution_source)
+				-- move in LOCKSTEP and are resolved by SOURCE AUTHORITY, not preserve-first or
+				-- unconditional-overwrite (see projectRank/agentRank above). The incoming pair
+				-- replaces the existing pair only when it has a non-null value AND a source rank
+				-- >= the existing source rank; otherwise the existing pair is kept verbatim. This
+				-- stops a re-save with an omitted/none/lower-authority source (e.g. a heading
+				-- re-derived on a later request) from erasing or downgrading a higher-authority
+				-- attribution (e.g. header_project) recorded earlier for the same request id.
+				project = CASE WHEN ${projectWinsIncoming} THEN EXCLUDED.project ELSE requests.project END,
+				project_attribution_source = CASE WHEN ${projectWinsIncoming} THEN EXCLUDED.project_attribution_source ELSE requests.project_attribution_source END,
+				agent_used = CASE WHEN ${agentWinsIncoming} THEN EXCLUDED.agent_used ELSE requests.agent_used END,
+				agent_attribution_source = CASE WHEN ${agentWinsIncoming} THEN EXCLUDED.agent_attribution_source ELSE requests.agent_attribution_source END
 		`,
 			[
 				data.id,
@@ -138,6 +199,8 @@ export class RequestRepository extends BaseRepository<RequestData> {
 				data.comboName || null,
 				data.originalModel || null,
 				data.appliedModel || null,
+				data.projectAttributionSource || null,
+				data.agentAttributionSource || null,
 			],
 		);
 	}

--- a/packages/http-api/src/handlers/__tests__/requests.test.ts
+++ b/packages/http-api/src/handlers/__tests__/requests.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for createRequestsSummaryHandler's attribution-source mapping (P2).
+ *
+ * Covers that project_attribution_source / agent_attribution_source columns
+ * persisted via DatabaseOperations.saveRequest are read back and mapped onto
+ * the RequestResponse fields the dashboard reads: projectAttributionSource
+ * and agentAttributionSource (via the `as ProjectAttributionSource` /
+ * `as AgentAttributionSource` casts in packages/http-api/src/handlers/requests.ts).
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { existsSync, unlinkSync } from "node:fs";
+import type { DatabaseOperations } from "@better-ccflare/database";
+import { DatabaseFactory } from "@better-ccflare/database";
+import type { RequestResponse } from "@better-ccflare/types";
+import { createRequestsSummaryHandler } from "../requests";
+
+const TEST_DB_PATH = "/tmp/test-requests-summary-handler.db";
+
+describe("createRequestsSummaryHandler — attribution source mapping", () => {
+	let dbOps: DatabaseOperations;
+	let handler: (limit?: number) => Promise<Response>;
+
+	beforeAll(async () => {
+		try {
+			if (existsSync(TEST_DB_PATH)) {
+				unlinkSync(TEST_DB_PATH);
+			}
+		} catch (error) {
+			console.warn("Failed to clean up existing test database:", error);
+		}
+
+		DatabaseFactory.initialize(TEST_DB_PATH);
+		dbOps = DatabaseFactory.getInstance();
+
+		handler = createRequestsSummaryHandler(dbOps.getAdapter());
+
+		await dbOps.saveRequest(
+			"req-attribution-1",
+			"POST",
+			"/v1/messages",
+			null, // accountUsed
+			200, // statusCode
+			true, // success
+			null, // errorMessage
+			100, // responseTime
+			0, // failoverAttempts
+			undefined, // usage
+			"bot", // agentUsed
+			undefined, // apiKeyId
+			undefined, // apiKeyName
+			"acme", // project
+			undefined, // billingType
+			undefined, // comboName
+			undefined, // originalModel
+			undefined, // appliedModel
+			"path_project", // projectAttributionSource
+			"prompt_agent", // agentAttributionSource
+		);
+	});
+
+	afterAll(() => {
+		try {
+			if (existsSync(TEST_DB_PATH)) {
+				unlinkSync(TEST_DB_PATH);
+			}
+		} catch (error) {
+			console.warn("Failed to clean up test database:", error);
+		}
+		DatabaseFactory.reset();
+	});
+
+	it("maps project_attribution_source and agent_attribution_source onto the response", async () => {
+		const response = await handler(50);
+		expect(response.status).toBe(200);
+
+		const body = (await response.json()) as RequestResponse[];
+		const row = body.find((r) => r.id === "req-attribution-1");
+
+		expect(row).toBeDefined();
+		expect(row?.project).toBe("acme");
+		expect(row?.projectAttributionSource).toBe("path_project");
+		expect(row?.agentUsed).toBe("bot");
+		expect(row?.agentAttributionSource).toBe("prompt_agent");
+	});
+});

--- a/packages/http-api/src/handlers/requests.ts
+++ b/packages/http-api/src/handlers/requests.ts
@@ -3,6 +3,10 @@ import type {
 	DatabaseOperations,
 } from "@better-ccflare/database";
 import { jsonResponse } from "@better-ccflare/http-common";
+import type {
+	AgentAttributionSource,
+	ProjectAttributionSource,
+} from "@better-ccflare/types";
 import type { RequestResponse } from "../types";
 
 const MAX_BODY_PREVIEW_BYTES = 256 * 1024; // 256KB - match response body cap to preserve full conversation history
@@ -64,6 +68,9 @@ export function createRequestsSummaryHandler(db: BunSqlAdapter) {
 			combo_name: string | null;
 			original_model: string | null;
 			applied_model: string | null;
+			project: string | null;
+			project_attribution_source: string | null;
+			agent_attribution_source: string | null;
 		}>(
 			`
 			SELECT r.*, a.name as account_name
@@ -104,6 +111,13 @@ export function createRequestsSummaryHandler(db: BunSqlAdapter) {
 			comboName: request.combo_name || undefined,
 			originalModel: request.original_model || undefined,
 			appliedModel: request.applied_model || undefined,
+			project: request.project || undefined,
+			projectAttributionSource:
+				(request.project_attribution_source as ProjectAttributionSource) ||
+				undefined,
+			agentAttributionSource:
+				(request.agent_attribution_source as AgentAttributionSource) ||
+				undefined,
 			rateLimited: request.status_code === 429,
 		}));
 

--- a/packages/proxy/src/__tests__/project-attribution.test.ts
+++ b/packages/proxy/src/__tests__/project-attribution.test.ts
@@ -1,0 +1,455 @@
+/**
+ * Tests for the shared project attribution extraction helper (U2).
+ *
+ * These tests are written BEFORE `../project-attribution` exists (or before
+ * its exports are implemented) so the initial run is expected to fail (red),
+ * per the plan's test-first execution note for U2. Once
+ * `packages/proxy/src/project-attribution.ts` is implemented, these should
+ * pass (green) without modification.
+ *
+ * Covers the plan's U2 scenarios (docs/plans/2026-07-08-001-feature-attribution-source-tags-plan.md):
+ *  - namespaced header precedence over legacy header
+ *  - legacy `x-project` header still works
+ *  - control-char stripping + length cap (64) preserved
+ *  - workspace path inference (/home, /Users) -> path_project
+ *  - H1 heading inference -> heading_project
+ *  - "claude"-prefixed heading rejected
+ *  - secret-like headings rejected via isLowRiskProjectSlug -> none
+ *  - no header/path/heading -> none
+ *  - usage-collector base64 fallback path (extractProjectAttributionFromParts)
+ *    returns the same source labels as the parsed-body path
+ */
+import { describe, expect, it } from "bun:test";
+import {
+	extractProjectAttributionFromParts,
+	extractProjectAttributionFromRequest,
+	extractSystemPromptFromBase64,
+	isLowRiskProjectSlug,
+} from "../project-attribution";
+
+describe("extractProjectAttributionFromRequest", () => {
+	it("prefers x-better-ccflare-project over x-project when both are present", () => {
+		const headers = new Headers({
+			"x-better-ccflare-project": "ns-project",
+			"x-project": "legacy-project",
+		});
+		const result = extractProjectAttributionFromRequest(headers, null);
+		expect(result.project).toBe("ns-project");
+		expect(result.projectAttributionSource).toBe("header_project");
+	});
+
+	it("falls back to x-project when the namespaced header is absent", () => {
+		const headers = new Headers({ "x-project": "legacy-only" });
+		const result = extractProjectAttributionFromRequest(headers, null);
+		expect(result.project).toBe("legacy-only");
+		expect(result.projectAttributionSource).toBe("header_project");
+	});
+
+	it("strips control characters and caps header-derived project length at 64", () => {
+		const raw = `\x01\x02${"x".repeat(80)}\n`;
+		const headers = new Headers({ "x-project": raw });
+		const result = extractProjectAttributionFromRequest(headers, null);
+		expect(result.project).not.toBeNull();
+		expect(result.project?.length).toBeLessThanOrEqual(64);
+		// biome-ignore lint/suspicious/noControlCharactersInRegex: asserting control chars are gone
+		expect(result.project ?? "").not.toMatch(/[\x00-\x1F\x7F]/);
+		expect(result.projectAttributionSource).toBe("header_project");
+	});
+
+	it("infers a sanitized repo slug from a /home workspace path in the system prompt", () => {
+		const headers = new Headers();
+		const body = {
+			system: "context at /home/will/projects/better-ccflare/foo.ts done",
+		};
+		const result = extractProjectAttributionFromRequest(headers, body);
+		expect(result.project).toBe("better-ccflare");
+		expect(result.projectAttributionSource).toBe("path_project");
+	});
+
+	it("infers a sanitized repo slug from a /Users workspace path in the system prompt", () => {
+		const headers = new Headers();
+		const body = {
+			system: "working at /Users/will/Desktop/MyProj/file.txt now",
+		};
+		const result = extractProjectAttributionFromRequest(headers, body);
+		expect(result.project).toBe("MyProj");
+		expect(result.projectAttributionSource).toBe("path_project");
+	});
+
+	it("uses the first eligible non-Claude H1 heading as the project when no header/path match", () => {
+		const headers = new Headers();
+		const body = { system: "# Harness\nWelcome to the project." };
+		const result = extractProjectAttributionFromRequest(headers, body);
+		expect(result.project).toBe("Harness");
+		expect(result.projectAttributionSource).toBe("heading_project");
+	});
+
+	it("rejects an H1 heading that starts with 'claude' (case-insensitive)", () => {
+		const headers = new Headers();
+		const body = { system: "# Claude Code Instructions\nSome content." };
+		const result = extractProjectAttributionFromRequest(headers, body);
+		expect(result.project).toBeNull();
+		expect(result.projectAttributionSource).toBe("none");
+	});
+
+	it("falls through a leading Claude heading to the next eligible H1 heading", () => {
+		// Regression: extraction used to stop at the FIRST H1 heading rather
+		// than the first ELIGIBLE one, losing valid attribution whenever a
+		// Claude-prefixed heading appeared before the real project heading.
+		const headers = new Headers();
+		const body = {
+			system: "# Claude Code Instructions\nSome content.\n# Harness\nMore.",
+		};
+		const result = extractProjectAttributionFromRequest(headers, body);
+		expect(result.project).toBe("Harness");
+		expect(result.projectAttributionSource).toBe("heading_project");
+	});
+
+	it("returns none when there is no header, path, or heading", () => {
+		const headers = new Headers();
+		const body = { system: "Just a plain system prompt with no markers." };
+		const result = extractProjectAttributionFromRequest(headers, body);
+		expect(result.project).toBeNull();
+		expect(result.projectAttributionSource).toBe("none");
+	});
+
+	it("returns none for a completely empty request (no headers, no body)", () => {
+		const headers = new Headers();
+		const result = extractProjectAttributionFromRequest(headers, null);
+		expect(result.project).toBeNull();
+		expect(result.projectAttributionSource).toBe("none");
+	});
+
+	describe("secret-like headings are rejected (isLowRiskProjectSlug -> false)", () => {
+		const cases: Array<[string, string]> = [
+			["bearer-ish token", "# Authorization: Bearer sk_live_abc123456789"],
+			["URL", "# https://example.com/secret-path"],
+			["email address", "# Contact will@example.com for help"],
+			["sk- style API key", "# sk-ABCDEFGHIJ1234567890"],
+			["AKIA-style AWS key", "# AKIAIOSFODNN7EXAMPLE"],
+			[
+				"long random base64-ish token",
+				"# aGVsbG8gd29ybGQgdGhpcyBpcyBhIHRlc3Q123456",
+			],
+			[
+				"sentence/incident-shaped (>6 words)",
+				"# This is a very long sentence about an incident that happened today",
+			],
+			[
+				"24-char unbroken hex token (hardened LONG_TOKEN_RE)",
+				"# a1b2c3d4e5f6a1b2c3d4e5f6",
+			],
+			["bare IPv4 address (hardened IPV4_RE)", "# 10.0.0.5"],
+			[
+				"20+ char unbroken alphanumeric session id (hardened LONG_TOKEN_RE)",
+				"# sess1234567890qwerty",
+			],
+			[
+				"multi-segment secret token (second separator defeats SECRET_TOKEN_RE)",
+				"# sk_live_abc123456789",
+			],
+			[
+				"short incident/customer label (dodges the six-word sentence heuristic)",
+				"# Incident INC-123 Acme",
+			],
+		];
+
+		for (const [label, system] of cases) {
+			it(`rejects: ${label}`, () => {
+				const headers = new Headers();
+				const result = extractProjectAttributionFromRequest(headers, {
+					system,
+				});
+				expect(result.project).toBeNull();
+				expect(result.projectAttributionSource).toBe("none");
+			});
+		}
+	});
+
+	describe("round-2 P1 hardening: still-leaking heading shapes are rejected end-to-end (H1)", () => {
+		const cases: Array<[string, string]> = [
+			[
+				"multi-segment credential label with a letters-only opaque tail",
+				"# api-key-abcdefghijkl",
+			],
+			["16-char opaque hex/base32 token", "# deadbeefcafebabe"],
+			["dotted hostname-shaped label", "# customer.example.com"],
+			["round-1: sk_live-style secret", "# sk_live_abc123456789"],
+			["round-1: incident/customer label", "# Incident INC-123 Acme"],
+		];
+
+		for (const [label, system] of cases) {
+			it(`rejects: ${label}`, () => {
+				const headers = new Headers();
+				const result = extractProjectAttributionFromRequest(headers, {
+					system,
+				});
+				expect(result.project).toBeNull();
+				expect(result.projectAttributionSource).toBe("none");
+			});
+		}
+
+		const legit: Array<[string, string, string]> = [
+			["Harness", "# Harness\nWelcome.", "Harness"],
+			[
+				"attribution-source-tags",
+				"# attribution-source-tags\nDetails.",
+				"attribution-source-tags",
+			],
+			["My Cool Project", "# My Cool Project\nDetails.", "My Cool Project"],
+		];
+
+		for (const [label, system, expected] of legit) {
+			it(`still extracts legit slug: ${label}`, () => {
+				const headers = new Headers();
+				const result = extractProjectAttributionFromRequest(headers, {
+					system,
+				});
+				expect(result.project).toBe(expected);
+				expect(result.projectAttributionSource).toBe("heading_project");
+			});
+		}
+	});
+
+	it("rejects an H1 heading whose secret sits past the 64-char truncation boundary end-to-end", () => {
+		// Full end-to-end path (not just isLowRiskProjectSlug directly): a
+		// heading that is unambiguously rejected (UUID + >6 words) must still
+		// come back as no attribution, proving the full un-truncated heading
+		// is what gets validated.
+		const headers = new Headers();
+		const body = {
+			system:
+				"# <a heading carrying a UUID like 550e8400-e29b-41d4-a716-446655440000>",
+		};
+		const result = extractProjectAttributionFromRequest(headers, body);
+		expect(result.project).toBeNull();
+		expect(result.projectAttributionSource).toBe("none");
+	});
+});
+
+describe("isLowRiskProjectSlug", () => {
+	it("accepts ordinary repo-name-shaped labels", () => {
+		expect(isLowRiskProjectSlug("better-ccflare")).toBe(true);
+		expect(isLowRiskProjectSlug("Harness")).toBe(true);
+		expect(isLowRiskProjectSlug("eval-suite")).toBe(true);
+		expect(isLowRiskProjectSlug("My Project")).toBe(true);
+	});
+
+	it("rejects URL-shaped, email-shaped, and secret-shaped values", () => {
+		expect(isLowRiskProjectSlug("https://example.com")).toBe(false);
+		expect(isLowRiskProjectSlug("www.example.com")).toBe(false);
+		expect(isLowRiskProjectSlug("me@example.com")).toBe(false);
+		expect(isLowRiskProjectSlug("Bearer sk_live_abc123456789")).toBe(false);
+	});
+
+	describe("hardened LONG_TOKEN_RE / IPV4_RE (unbroken 20+ alphanumeric run, bare IPv4)", () => {
+		it("rejects a 24-char unbroken hex token", () => {
+			expect(isLowRiskProjectSlug("a1b2c3d4e5f6a1b2c3d4e5f6")).toBe(false);
+		});
+
+		it("rejects a bare IPv4 address", () => {
+			expect(isLowRiskProjectSlug("10.0.0.5")).toBe(false);
+		});
+
+		it("rejects a 20+ char unbroken alphanumeric session id", () => {
+			expect(isLowRiskProjectSlug("sess1234567890qwerty")).toBe(false);
+		});
+
+		it("still accepts hyphen-broken slugs over 20 chars total (no over-rejection regression)", () => {
+			// Total length > 20 chars, but every hyphen-delimited segment is well
+			// under the 20-char unbroken-run threshold — must NOT be rejected.
+			expect(isLowRiskProjectSlug("attribution-source-tags")).toBe(true);
+			expect(isLowRiskProjectSlug("my-really-long-project-name")).toBe(true);
+		});
+	});
+
+	describe("rejects multi-segment secret shapes and customer/incident labels (P1 privacy)", () => {
+		it("rejects a multi-segment secret token where a second separator defeats SECRET_TOKEN_RE", () => {
+			// "sk_live_" + a digit-bearing tail: each underscore-delimited segment
+			// stays under LONG_TOKEN_RE's 20-char threshold, and the second
+			// separator ("_live_") means the single-separator SECRET_TOKEN_RE
+			// never matches either. Must still be rejected as a secret shape.
+			expect(isLowRiskProjectSlug("sk_live_abc123456789")).toBe(false);
+		});
+
+		it("rejects other known secret-token prefixes with a second separator", () => {
+			expect(isLowRiskProjectSlug("ghp_9f8e7d6c5b4a3210")).toBe(false);
+			expect(isLowRiskProjectSlug("xoxb-1234-5678-abcdefgh")).toBe(false);
+			expect(isLowRiskProjectSlug("api-key-9f8e7d6c5b4a")).toBe(false);
+		});
+
+		it("rejects a short incident/customer label that dodges the six-word sentence heuristic", () => {
+			expect(isLowRiskProjectSlug("Incident INC-123 Acme")).toBe(false);
+		});
+
+		it("rejects other customer/ticket-shaped labels", () => {
+			expect(isLowRiskProjectSlug("Ticket CASE-42")).toBe(false);
+			expect(isLowRiskProjectSlug("Customer Acme Corp")).toBe(false);
+			expect(isLowRiskProjectSlug("PROJ-4821")).toBe(false);
+			expect(isLowRiskProjectSlug("acct-88213")).toBe(false);
+		});
+
+		it("does not over-reject ordinary hyphenated slugs with word-only tails", () => {
+			expect(isLowRiskProjectSlug("attribution-source-tags")).toBe(true);
+			expect(isLowRiskProjectSlug("my-really-long-project-name")).toBe(true);
+			expect(isLowRiskProjectSlug("better-ccflare")).toBe(true);
+		});
+	});
+
+	describe("rejects trace-id, URL, and path shapes (hardened heading validator)", () => {
+		const rejectedCases: Array<[string, string]> = [
+			["UUID / raw trace id", "550e8400-e29b-41d4-a716-446655440000"],
+			["uppercase host (case-insensitive)", "WWW.EXAMPLE.COM"],
+			["URI scheme", "file:/etc/passwd"],
+			["Windows drive path", "C:/Users/alice/acme"],
+			["traversal path", "../../etc/passwd"],
+			["absolute path", "/etc/passwd"],
+			[
+				"host:port/path (slash+colon excluded from slug grammar)",
+				"host:8080/path",
+			],
+		];
+
+		for (const [label, value] of rejectedCases) {
+			it(`rejects: ${label}`, () => {
+				expect(isLowRiskProjectSlug(value)).toBe(false);
+			});
+		}
+
+		it("still accepts ordinary slug-shaped labels (no over-rejection regression)", () => {
+			expect(isLowRiskProjectSlug("better-ccflare")).toBe(true);
+			expect(isLowRiskProjectSlug("Harness")).toBe(true);
+			expect(isLowRiskProjectSlug("eval-suite")).toBe(true);
+			expect(isLowRiskProjectSlug("My Project")).toBe(true);
+			expect(isLowRiskProjectSlug("attribution-source-tags")).toBe(true);
+			expect(isLowRiskProjectSlug("my-really-long-project-name")).toBe(true);
+		});
+	});
+
+	describe("round-2 P1 hardening: dotted hostnames, opaque tokens, credential labels", () => {
+		it("rejects dotted hostname-shaped labels", () => {
+			expect(isLowRiskProjectSlug("customer.example.com")).toBe(false);
+			expect(isLowRiskProjectSlug("*.example.com")).toBe(false);
+			expect(isLowRiskProjectSlug("foo.bar")).toBe(false);
+		});
+
+		it("rejects a 16-char opaque hex/base32-shaped token below the 20-char LONG_TOKEN_RE floor", () => {
+			expect(isLowRiskProjectSlug("deadbeefcafebabe")).toBe(false);
+		});
+
+		it("rejects a 16+ char opaque alnum token that mixes letters and digits", () => {
+			expect(isLowRiskProjectSlug("aB3dE7gH9jK1mN5p")).toBe(false);
+		});
+
+		it("rejects a credential-labeled value with a letters-only opaque tail", () => {
+			expect(isLowRiskProjectSlug("api-key-abcdefghijkl")).toBe(false);
+			expect(isLowRiskProjectSlug("apikey-abcdefghijkl")).toBe(false);
+			expect(isLowRiskProjectSlug("access-key-abcdefghijkl")).toBe(false);
+			expect(isLowRiskProjectSlug("password-abcdefghijkl")).toBe(false);
+		});
+
+		it("does not over-reject legit slugs (no embedded dots, no 16+ char single segment)", () => {
+			expect(isLowRiskProjectSlug("Harness")).toBe(true);
+			expect(isLowRiskProjectSlug("attribution-source-tags")).toBe(true);
+			expect(isLowRiskProjectSlug("My Cool Project")).toBe(true);
+			expect(isLowRiskProjectSlug("better-ccflare")).toBe(true);
+		});
+	});
+
+	describe("validates the FULL value, not a 64-char-truncated prefix (R10a)", () => {
+		// Pre-boundary prefix: exactly 64 chars, slug-clean (dash-delimited
+		// 15-char runs, so no unbroken alnum run reaches the 20-char
+		// LONG_TOKEN_RE threshold) and ending in a dash so nothing can merge
+		// across the boundary with whatever follows.
+		const CLEAN_64_PREFIX = `${"x".repeat(15)}-`.repeat(4);
+
+		it("sanity: the clean 64-char prefix alone is accepted", () => {
+			expect(CLEAN_64_PREFIX.length).toBe(64);
+			expect(isLowRiskProjectSlug(CLEAN_64_PREFIX)).toBe(true);
+		});
+
+		it("rejects wholesale once a 25-char high-entropy token sits entirely past char 64", () => {
+			// A pre-truncation validator (64-char cap applied BEFORE validation,
+			// the bug this hardening fixes) would have sliced this value down to
+			// CLEAN_64_PREFIX and returned true, because the secret only exists
+			// past the truncation boundary. The hardened validator sees the
+			// full, untruncated value and rejects it — both via LONG_TOKEN_RE
+			// matching the trailing run and via the slug grammar's length bound.
+			const boundaryStraddlingSecret = `${CLEAN_64_PREFIX}${"Z".repeat(25)}`;
+			expect(isLowRiskProjectSlug(boundaryStraddlingSecret)).toBe(false);
+		});
+	});
+});
+
+describe("extractSystemPromptFromBase64", () => {
+	it("tolerates a null element in a system array without throwing (parity with the parsed-body path)", () => {
+		const requestBodyBase64 = Buffer.from(
+			JSON.stringify({
+				system: [
+					null,
+					{ type: "text", text: "context /home/u/projects/acme/x.ts" },
+				],
+			}),
+		).toString("base64");
+
+		let result: string | null = null;
+		expect(() => {
+			result = extractSystemPromptFromBase64(requestBodyBase64);
+		}).not.toThrow();
+		expect(result).toContain("/home/u/projects/acme/x.ts");
+	});
+});
+
+describe("extractProjectAttributionFromParts (usage-collector base64 fallback)", () => {
+	it("returns header_project from a lowercased Record<string,string> header map", () => {
+		const result = extractProjectAttributionFromParts(
+			{ "X-Better-Ccflare-Project": "MyProj" },
+			null,
+		);
+		expect(result.project).toBe("MyProj");
+		expect(result.projectAttributionSource).toBe("header_project");
+	});
+
+	it("returns path_project from a base64-encoded body, matching the parsed-body path", () => {
+		const body = {
+			system: "context at /home/will/repos/eval-suite/index.ts done",
+		};
+		const requestBodyBase64 = Buffer.from(JSON.stringify(body)).toString(
+			"base64",
+		);
+		const result = extractProjectAttributionFromParts({}, requestBodyBase64);
+		expect(result.project).toBe("eval-suite");
+		expect(result.projectAttributionSource).toBe("path_project");
+	});
+
+	it("returns heading_project from a base64-encoded body, matching the parsed-body path", () => {
+		const body = { system: "# eval-suite\nDetails here." };
+		const requestBodyBase64 = Buffer.from(JSON.stringify(body)).toString(
+			"base64",
+		);
+		const result = extractProjectAttributionFromParts({}, requestBodyBase64);
+		expect(result.project).toBe("eval-suite");
+		expect(result.projectAttributionSource).toBe("heading_project");
+	});
+
+	it("returns none when headers are null/undefined and body is null", () => {
+		const result = extractProjectAttributionFromParts(null, null);
+		expect(result.project).toBeNull();
+		expect(result.projectAttributionSource).toBe("none");
+	});
+
+	it("resolves path_project from a base64 body whose system array contains a null element (parity with the parsed-body path)", () => {
+		const requestBodyBase64 = Buffer.from(
+			JSON.stringify({
+				system: [
+					null,
+					{ type: "text", text: "context /home/u/projects/acme/x.ts" },
+				],
+			}),
+		).toString("base64");
+
+		const result = extractProjectAttributionFromParts({}, requestBodyBase64);
+		expect(result.project).toBe("acme");
+		expect(result.projectAttributionSource).toBe("path_project");
+	});
+});

--- a/packages/proxy/src/__tests__/response-handler-worker-protocol.test.ts
+++ b/packages/proxy/src/__tests__/response-handler-worker-protocol.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock, spyOn } from "bun:test";
+import { requestEvents } from "@better-ccflare/core";
 import type { Account } from "@better-ccflare/types";
 import * as modelCatalogModule from "../model-catalog";
 import { forwardToClient } from "../response-handler";
@@ -282,6 +283,182 @@ describe("forwardToClient usage-collector protocol", () => {
 		} finally {
 			Response.prototype.clone = originalClone;
 		}
+	});
+
+	it("non-streaming request with project+agent sources set in options produces a StartMessage carrying both source labels", async () => {
+		const { starts } = createMockCollector();
+		const ctx = createCtx();
+
+		await forwardToClient(
+			{
+				requestId: "req-sources-non-stream",
+				method: "POST",
+				path: "/v1/messages",
+				account: null,
+				requestHeaders: new Headers({ "content-type": "application/json" }),
+				requestBody: new TextEncoder().encode("{}"),
+				project: "acme-project",
+				projectAttributionSource: "header_project",
+				response: new Response(JSON.stringify({ ok: true }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				}),
+				timestamp: Date.now(),
+				retryAttempt: 0,
+				failoverAttempts: 0,
+				agentUsed: "code-reviewer",
+				agentAttributionSource: "prompt_agent",
+			},
+			ctx,
+		);
+
+		expect(starts[0].projectAttributionSource).toBe("header_project");
+		expect(starts[0].agentAttributionSource).toBe("prompt_agent");
+	});
+
+	it("streaming request with project+agent sources set in options produces a StartMessage carrying both source labels", async () => {
+		const { starts, ends } = createMockCollector();
+		const ctx = createCtx();
+		ctx.provider.isStreamingResponse = () => true;
+
+		const body = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(new TextEncoder().encode("data: one\n\n"));
+				controller.close();
+			},
+		});
+
+		const response = await forwardToClient(
+			{
+				requestId: "req-sources-stream",
+				method: "POST",
+				path: "/v1/messages",
+				account: null,
+				requestHeaders: new Headers({ "content-type": "application/json" }),
+				requestBody: new TextEncoder().encode("{}"),
+				project: "acme-project",
+				projectAttributionSource: "path_project",
+				response: new Response(body, {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				}),
+				timestamp: Date.now(),
+				retryAttempt: 0,
+				failoverAttempts: 0,
+				agentUsed: "code-reviewer",
+				agentAttributionSource: "header_agent",
+			},
+			ctx,
+		);
+
+		await response.text();
+		await waitFor(() => ends.length > 0);
+
+		expect(starts[0].projectAttributionSource).toBe("path_project");
+		expect(starts[0].agentAttributionSource).toBe("header_agent");
+	});
+
+	it("defaults source labels to 'none' when options omit them", async () => {
+		const { starts } = createMockCollector();
+		const ctx = createCtx();
+
+		await forwardToClient(
+			{
+				requestId: "req-sources-default",
+				method: "POST",
+				path: "/v1/messages",
+				account: null,
+				requestHeaders: new Headers({ "content-type": "application/json" }),
+				requestBody: new TextEncoder().encode("{}"),
+				response: new Response(JSON.stringify({ ok: true }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				}),
+				timestamp: Date.now(),
+				retryAttempt: 0,
+				failoverAttempts: 0,
+			},
+			ctx,
+		);
+
+		expect(starts[0].projectAttributionSource).toBe("none");
+		expect(starts[0].agentAttributionSource).toBe("none");
+	});
+
+	it("SSE start event includes agentAttributionSource", async () => {
+		const { collector: _collector } = createMockCollector();
+		const ctx = createCtx();
+
+		const events: Array<Record<string, unknown>> = [];
+		const listener = (evt: Record<string, unknown>) => {
+			if (evt.type === "start") events.push(evt);
+		};
+		requestEvents.on("event", listener);
+
+		try {
+			await forwardToClient(
+				{
+					requestId: "req-sse-source",
+					method: "POST",
+					path: "/v1/messages",
+					account: null,
+					requestHeaders: new Headers({ "content-type": "application/json" }),
+					requestBody: new TextEncoder().encode("{}"),
+					response: new Response(JSON.stringify({ ok: true }), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+					timestamp: Date.now(),
+					retryAttempt: 0,
+					failoverAttempts: 0,
+					agentUsed: "code-reviewer",
+					agentAttributionSource: "header_agent",
+				},
+				ctx,
+			);
+
+			expect(events.length).toBeGreaterThan(0);
+			expect(events[0].agentAttributionSource).toBe("header_agent");
+		} finally {
+			requestEvents.off("event", listener);
+		}
+	});
+
+	it("accepts a legacy StartMessage without source fields without throwing, leaving them undefined", () => {
+		const { collector, starts } = createMockCollector();
+
+		// Simulates a message built by an older worker/producer that predates
+		// the projectAttributionSource/agentAttributionSource fields. Both are
+		// optional on StartMessage precisely so this legacy shape still type-checks.
+		const legacyStartMessage: import("../worker-messages").StartMessage = {
+			type: "start",
+			messageId: "legacy-msg-1",
+			requestId: "req-legacy",
+			accountId: null,
+			method: "POST",
+			path: "/v1/messages",
+			timestamp: Date.now(),
+			requestHeaders: {},
+			requestBody: null,
+			project: null,
+			responseStatus: 200,
+			responseHeaders: {},
+			isStream: false,
+			providerName: "anthropic",
+			accountBillingType: null,
+			accountAutoPauseOnOverageEnabled: null,
+			accountName: null,
+			agentUsed: null,
+			comboName: null,
+			apiKeyId: null,
+			apiKeyName: null,
+			retryAttempt: 0,
+			failoverAttempts: 0,
+		};
+
+		expect(() => collector.handleStart(legacyStartMessage)).not.toThrow();
+		expect(starts[0].projectAttributionSource).toBeUndefined();
+		expect(starts[0].agentAttributionSource).toBeUndefined();
 	});
 });
 

--- a/packages/proxy/src/__tests__/usage-collector-attribution-tristate.test.ts
+++ b/packages/proxy/src/__tests__/usage-collector-attribution-tristate.test.ts
@@ -1,0 +1,240 @@
+/**
+ * End-to-end tests for the tri-state project/agent attribution-source
+ * contract implemented in `UsageCollector.handleStart`
+ * (packages/proxy/src/usage-collector.ts).
+ *
+ * The only prior coverage of this branching (in
+ * response-handler-worker-protocol.test.ts) exercised a MOCK collector whose
+ * handleStart just pushed the raw input message onto an array — it asserted
+ * on the input, never on real branching logic. These tests instantiate the
+ * real `UsageCollector` against a temp SQLite DB and assert on the
+ * `RequestResponse` summary emitted via `onSummary`, which is populated from
+ * the collector's internal `RequestState` after `handleStart` has run its
+ * branching logic.
+ *
+ * Tri-state contract (usage-collector.ts handleStart, ~lines 377-394):
+ *  (A) msg.projectAttributionSource != null -> authoritative, used as-is,
+ *      no recomputation (covers both a concrete value and "none").
+ *  (B) msg.project set but no source -> legacy, tagged "none".
+ *  (C) neither project nor source -> fully legacy/direct, recomputed via
+ *      extractProjectAttributionFromParts.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync, unlinkSync } from "node:fs";
+
+import {
+	AsyncDbWriter,
+	DatabaseFactory,
+	type DatabaseOperations,
+} from "@better-ccflare/database";
+import type { RequestResponse } from "@better-ccflare/types";
+import { UsageCollector } from "../usage-collector";
+import type { EndMessage, StartMessage } from "../worker-messages";
+
+const TEST_DB_PATH = "/tmp/test-usage-collector-attribution-tristate.db";
+
+describe("UsageCollector - attribution tri-state (real collector, end-to-end)", () => {
+	let dbOps: DatabaseOperations;
+	let asyncWriter: AsyncDbWriter;
+	let collector: UsageCollector;
+	let summaries: Map<string, RequestResponse>;
+
+	beforeAll(() => {
+		try {
+			if (existsSync(TEST_DB_PATH)) unlinkSync(TEST_DB_PATH);
+		} catch (error) {
+			console.warn("Failed to clean up existing test database:", error);
+		}
+		DatabaseFactory.initialize(TEST_DB_PATH);
+		dbOps = DatabaseFactory.getInstance();
+		asyncWriter = new AsyncDbWriter();
+		summaries = new Map();
+		collector = new UsageCollector(
+			dbOps,
+			asyncWriter,
+			() => false,
+			(summary) => {
+				summaries.set(summary.id, summary);
+			},
+		);
+	});
+
+	afterAll(async () => {
+		collector.dispose();
+		await collector.drain();
+		DatabaseFactory.reset();
+		try {
+			if (existsSync(TEST_DB_PATH)) unlinkSync(TEST_DB_PATH);
+		} catch (error) {
+			console.warn("Failed to clean up test database:", error);
+		}
+	});
+
+	function makeStart(
+		overrides: Partial<StartMessage> & { requestId: string },
+	): StartMessage {
+		return {
+			type: "start",
+			messageId: `msg-${overrides.requestId}`,
+			accountId: null,
+			method: "POST",
+			path: "/v1/messages",
+			timestamp: Date.now(),
+			requestHeaders: {},
+			requestBody: null,
+			project: null,
+			responseStatus: 200,
+			responseHeaders: {},
+			isStream: false,
+			providerName: "anthropic",
+			accountBillingType: null,
+			accountAutoPauseOnOverageEnabled: null,
+			accountName: null,
+			agentUsed: null,
+			comboName: null,
+			apiKeyId: null,
+			apiKeyName: null,
+			retryAttempt: 0,
+			failoverAttempts: 0,
+			...overrides,
+		};
+	}
+
+	function base64Body(body: unknown): string {
+		return Buffer.from(JSON.stringify(body)).toString("base64");
+	}
+
+	/**
+	 * Drives a full start->end cycle through the REAL collector and returns
+	 * the captured summary. Awaiting the Promise returned by handleEnd is
+	 * sufficient: _handleEndInternal builds and emits the summary
+	 * synchronously (no model usage was recorded in these fixtures, so the
+	 * `await estimateCostUSD(...)` branch never executes) before that
+	 * promise settles — there is no async gap between "end processed" and
+	 * "onSummary fired" to race. Fails loudly if onSummary never fired, so a
+	 * silently-skipped request (e.g. shouldLogRequest returning false)
+	 * cannot produce a false pass.
+	 */
+	async function runRequestAndGetSummary(
+		start: StartMessage,
+	): Promise<RequestResponse> {
+		collector.handleStart(start);
+		const endMsg: EndMessage = {
+			type: "end",
+			requestId: start.requestId,
+			success: true,
+		};
+		await collector.handleEnd(endMsg);
+		const summary = summaries.get(start.requestId);
+		if (!summary) {
+			throw new Error(
+				`onSummary was not invoked for requestId=${start.requestId} — request may have been silently skipped`,
+			);
+		}
+		return summary;
+	}
+
+	test("branch A: authoritative project + source are used as-is, without recomputation", async () => {
+		const start = makeStart({
+			requestId: "tristate-1-authoritative-value",
+			project: "foo",
+			projectAttributionSource: "path_project",
+			agentUsed: "agent-x",
+			agentAttributionSource: "header_agent",
+			// System prompt contains a DIFFERENT workspace path. If the
+			// collector recomputed instead of honoring the authoritative
+			// source, project would become "otherrepo" / path_project would
+			// be recomputed (still path_project, but for the wrong project).
+			requestBody: base64Body({
+				system: "context at /home/u/projects/otherrepo/x.ts done",
+			}),
+		});
+
+		const summary = await runRequestAndGetSummary(start);
+
+		expect(summary.project).toBe("foo");
+		expect(summary.projectAttributionSource).toBe("path_project");
+		expect(summary.agentAttributionSource).toBe("header_agent");
+	});
+
+	test('branch A: authoritative "none" suppresses recomputation even with a matching path in the body', async () => {
+		const start = makeStart({
+			requestId: "tristate-2-authoritative-none",
+			project: null,
+			projectAttributionSource: "none",
+			agentUsed: null,
+			agentAttributionSource: "none",
+			// Recognizable workspace path present — must NOT be picked up,
+			// because the authoritative source is "none".
+			requestBody: base64Body({
+				system: "context at /home/u/projects/shouldnotmatch/x.ts done",
+			}),
+		});
+
+		const summary = await runRequestAndGetSummary(start);
+
+		expect(summary.projectAttributionSource).toBe("none");
+		expect(summary.project == null).toBe(true);
+	});
+
+	test('branch B: legacy project without a source is tagged "none"', async () => {
+		const start = makeStart({
+			requestId: "tristate-3-legacy-project",
+			project: "bar",
+			// projectAttributionSource and agentAttributionSource intentionally omitted.
+		});
+
+		const summary = await runRequestAndGetSummary(start);
+
+		expect(summary.project).toBe("bar");
+		expect(summary.projectAttributionSource).toBe("none");
+	});
+
+	test("branch C: fully legacy/direct request recomputes via the shared helper", async () => {
+		const start = makeStart({
+			requestId: "tristate-4-fully-legacy-recompute",
+			project: null,
+			// projectAttributionSource and agentAttributionSource intentionally omitted.
+			requestBody: base64Body({
+				system: "some text /home/u/projects/myrepo/main.ts more text",
+			}),
+		});
+
+		const summary = await runRequestAndGetSummary(start);
+
+		expect(summary.project).toBe("myrepo");
+		expect(summary.projectAttributionSource).toBe("path_project");
+		expect(summary.agentAttributionSource).toBe("none");
+	});
+
+	test("branch A: authoritative project value is sanitized (control chars stripped) while the authoritative source is still honored", async () => {
+		const rawProject = "ac\x1b[31m me\x07";
+		const start = makeStart({
+			requestId: "tristate-5-authoritative-value-sanitized",
+			project: rawProject,
+			projectAttributionSource: "header_project",
+		});
+
+		const summary = await runRequestAndGetSummary(start);
+
+		// biome-ignore lint/suspicious/noControlCharactersInRegex: computing the expected sanitized value the same way sanitizeProjectName does
+		const expected = rawProject.replace(/[\x00-\x1F\x7F]/g, "").trim();
+		expect(summary.project).toBe(expected);
+		// biome-ignore lint/suspicious/noControlCharactersInRegex: asserting control chars are gone
+		expect(summary.project ?? "").not.toMatch(/[\x00-\x1F\x7F]/);
+		expect(summary.projectAttributionSource).toBe("header_project");
+	});
+
+	test('branch A: an authoritative project value that sanitizes to empty falls back to "none"', async () => {
+		const start = makeStart({
+			requestId: "tristate-6-authoritative-value-empties",
+			project: " ",
+			projectAttributionSource: "header_project",
+		});
+
+		const summary = await runRequestAndGetSummary(start);
+
+		expect(summary.project == null).toBe(true);
+		expect(summary.projectAttributionSource).toBe("none");
+	});
+});

--- a/packages/proxy/src/__tests__/usage-collector-payload-meta.test.ts
+++ b/packages/proxy/src/__tests__/usage-collector-payload-meta.test.ts
@@ -1,0 +1,138 @@
+/**
+ * P2 regression test: RequestPayload.meta must carry projectAttributionSource
+ * alongside meta.project (packages/types/src/request.ts), and the
+ * UsageCollector must actually serialize it (packages/proxy/src/usage-collector.ts).
+ *
+ * Before this fix, `meta.project` was persisted but its provenance source was
+ * dropped, so `/api/requests/payload/:id` and the dashboard's Copy-as-JSON
+ * exposed a project name with no way to tell whether it came from a header,
+ * a workspace path, or a heading.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync, unlinkSync } from "node:fs";
+
+import {
+	AsyncDbWriter,
+	DatabaseFactory,
+	type DatabaseOperations,
+} from "@better-ccflare/database";
+import type { RequestResponse } from "@better-ccflare/types";
+import { UsageCollector } from "../usage-collector";
+import type { EndMessage, StartMessage } from "../worker-messages";
+
+const TEST_DB_PATH = "/tmp/test-usage-collector-payload-meta.db";
+
+describe("UsageCollector - RequestPayload.meta includes projectAttributionSource (P2)", () => {
+	let dbOps: DatabaseOperations;
+	let asyncWriter: AsyncDbWriter;
+	let collector: UsageCollector;
+	let summaries: Map<string, RequestResponse>;
+
+	beforeAll(() => {
+		try {
+			if (existsSync(TEST_DB_PATH)) unlinkSync(TEST_DB_PATH);
+		} catch (error) {
+			console.warn("Failed to clean up existing test database:", error);
+		}
+		DatabaseFactory.initialize(TEST_DB_PATH);
+		dbOps = DatabaseFactory.getInstance();
+		asyncWriter = new AsyncDbWriter();
+		summaries = new Map();
+		collector = new UsageCollector(
+			dbOps,
+			asyncWriter,
+			() => true, // store payloads — required for meta persistence
+			(summary) => {
+				summaries.set(summary.id, summary);
+			},
+		);
+	});
+
+	afterAll(async () => {
+		collector.dispose();
+		try {
+			if (existsSync(TEST_DB_PATH)) unlinkSync(TEST_DB_PATH);
+		} catch (error) {
+			console.warn("Failed to clean up test database:", error);
+		}
+	});
+
+	function makeStart(
+		overrides: Partial<StartMessage> & { requestId: string },
+	): StartMessage {
+		return {
+			type: "start",
+			messageId: `msg-${overrides.requestId}`,
+			accountId: null,
+			method: "POST",
+			path: "/v1/messages",
+			timestamp: Date.now(),
+			requestHeaders: {},
+			requestBody: null,
+			project: null,
+			responseStatus: 200,
+			responseHeaders: {},
+			isStream: false,
+			providerName: "anthropic",
+			accountBillingType: null,
+			accountAutoPauseOnOverageEnabled: null,
+			accountName: null,
+			agentUsed: null,
+			comboName: null,
+			apiKeyId: null,
+			apiKeyName: null,
+			retryAttempt: 0,
+			failoverAttempts: 0,
+			...overrides,
+		};
+	}
+
+	test("persists meta.project and meta.projectAttributionSource together in the stored payload", async () => {
+		const requestId = "payload-meta-1-authoritative-value";
+		const start = makeStart({
+			requestId,
+			project: "foo",
+			projectAttributionSource: "path_project",
+		});
+
+		collector.handleStart(start);
+		const endMsg: EndMessage = { type: "end", requestId, success: true };
+		await collector.handleEnd(endMsg);
+		await collector.drain();
+
+		const summary = summaries.get(requestId);
+		if (!summary) {
+			throw new Error(`onSummary was not invoked for requestId=${requestId}`);
+		}
+		expect(summary.project).toBe("foo");
+		expect(summary.projectAttributionSource).toBe("path_project");
+
+		const payload = (await dbOps.getRequestPayload(requestId)) as {
+			meta?: { project?: string; projectAttributionSource?: string };
+		} | null;
+		expect(payload).not.toBeNull();
+		expect(payload?.meta?.project).toBe("foo");
+		expect(payload?.meta?.projectAttributionSource).toBe("path_project");
+	});
+
+	test('persists meta.projectAttributionSource "none" when there is no project', async () => {
+		const requestId = "payload-meta-2-none";
+		const start = makeStart({
+			requestId,
+			project: null,
+			projectAttributionSource: "none",
+		});
+
+		collector.handleStart(start);
+		const endMsg: EndMessage = { type: "end", requestId, success: true };
+		await collector.handleEnd(endMsg);
+		await collector.drain();
+
+		const payload = (await dbOps.getRequestPayload(requestId)) as {
+			meta?: { project?: string; projectAttributionSource?: string };
+		} | null;
+		expect(payload).not.toBeNull();
+		expect(payload?.meta?.project).toBeUndefined();
+		expect(payload?.meta?.projectAttributionSource).toBe("none");
+	});
+});

--- a/packages/proxy/src/handlers/__tests__/agent-interceptor.header.test.ts
+++ b/packages/proxy/src/handlers/__tests__/agent-interceptor.header.test.ts
@@ -1,10 +1,12 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { existsSync, unlinkSync } from "node:fs";
 
+import { agentRegistry } from "@better-ccflare/agents";
 import {
 	DatabaseFactory,
 	type DatabaseOperations,
 } from "@better-ccflare/database";
+import type { Agent } from "@better-ccflare/types";
 import type { ModelCatalog } from "../../model-catalog";
 import { interceptAndModifyRequest } from "../agent-interceptor";
 
@@ -82,6 +84,7 @@ describe("Agent Interceptor - X-Anthropic-Agent-Id Header", () => {
 				headers({ "x-anthropic-agent-id": "my-router-agent" }),
 			);
 			expect(result.agentUsed).toBe("my-router-agent");
+			expect(result.agentAttributionSource).toBe("header_agent");
 		});
 
 		test("header is case-insensitive", async () => {
@@ -93,6 +96,7 @@ describe("Agent Interceptor - X-Anthropic-Agent-Id Header", () => {
 				headers({ "X-Anthropic-Agent-Id": "case-insensitive-agent" }),
 			);
 			expect(result.agentUsed).toBe("case-insensitive-agent");
+			expect(result.agentAttributionSource).toBe("header_agent");
 		});
 
 		test("absent header falls through to system-prompt path (unchanged)", async () => {
@@ -101,6 +105,94 @@ describe("Agent Interceptor - X-Anthropic-Agent-Id Header", () => {
 			// No explicit header and a benign prompt => no agent detected
 			expect(result.agentUsed).toBeNull();
 			expect(result.modifiedBody).toBe(buffer);
+			expect(result.agentAttributionSource).toBe("none");
+		});
+	});
+
+	describe("x-better-ccflare-agent-id namespaced header alias", () => {
+		test("namespaced header present -> agentUsed is header value, source is header_agent", async () => {
+			const buffer = toArrayBuffer(createMockRequestBody());
+			const result = await interceptAndModifyRequest(
+				buffer,
+				dbOps,
+				headers({ "x-better-ccflare-agent-id": "namespaced-agent" }),
+			);
+			expect(result.agentUsed).toBe("namespaced-agent");
+			expect(result.agentAttributionSource).toBe("header_agent");
+		});
+
+		test("both namespaced and legacy headers present -> namespaced header wins deterministically", async () => {
+			const buffer = toArrayBuffer(createMockRequestBody());
+			const result = await interceptAndModifyRequest(
+				buffer,
+				dbOps,
+				headers({
+					"x-better-ccflare-agent-id": "namespaced-agent",
+					"x-anthropic-agent-id": "legacy-agent",
+				}),
+			);
+			expect(result.agentUsed).toBe("namespaced-agent");
+			expect(result.agentAttributionSource).toBe("header_agent");
+		});
+
+		test("trims surrounding whitespace before use", async () => {
+			const buffer = toArrayBuffer(createMockRequestBody());
+			const result = await interceptAndModifyRequest(
+				buffer,
+				dbOps,
+				headers({
+					"x-better-ccflare-agent-id": "  trimmed-namespaced-agent  ",
+				}),
+			);
+			expect(result.agentUsed).toBe("trimmed-namespaced-agent");
+			expect(result.agentAttributionSource).toBe("header_agent");
+		});
+
+		test("caps value at 256 characters", async () => {
+			const longId = "b".repeat(500);
+			const buffer = toArrayBuffer(createMockRequestBody());
+			const result = await interceptAndModifyRequest(
+				buffer,
+				dbOps,
+				headers({ "x-better-ccflare-agent-id": longId }),
+			);
+			expect(result.agentUsed).toHaveLength(256);
+			expect(result.agentUsed).toBe("b".repeat(256));
+			expect(result.agentAttributionSource).toBe("header_agent");
+		});
+	});
+
+	describe("Attribution source for prompt/registry-based detection", () => {
+		test("detected agent via system-prompt match -> source is prompt_agent", async () => {
+			const fakeAgent: Agent = {
+				id: "fixture-prompt-agent",
+				name: "Fixture Prompt Agent",
+				description: "Test fixture agent for prompt-match source labeling",
+				color: "gray",
+				model: "claude-3-5-sonnet-20241022",
+				systemPrompt: "You are the fixture-prompt-agent-83f2 test agent.",
+				source: "global",
+				filePath: "/tmp/fixture-prompt-agent.md",
+			};
+
+			// The agent-interceptor imports the agentRegistry singleton directly,
+			// so we stub its getAgents() for the duration of this test rather than
+			// writing real workspace/global agent files to disk.
+			const originalGetAgents = agentRegistry.getAgents.bind(agentRegistry);
+			agentRegistry.getAgents = async () => [fakeAgent];
+
+			try {
+				const buffer = toArrayBuffer(
+					createMockRequestBody({
+						system: `Some preamble.\n${fakeAgent.systemPrompt}\nSome epilogue.`,
+					}),
+				);
+				const result = await interceptAndModifyRequest(buffer, dbOps);
+				expect(result.agentUsed).toBe("fixture-prompt-agent");
+				expect(result.agentAttributionSource).toBe("prompt_agent");
+			} finally {
+				agentRegistry.getAgents = originalGetAgents;
+			}
 		});
 	});
 
@@ -117,6 +209,7 @@ describe("Agent Interceptor - X-Anthropic-Agent-Id Header", () => {
 				{ getModelCatalog: async () => nonVetoingCatalog() },
 			);
 			expect(result.agentUsed).toBe("preferred-agent");
+			expect(result.agentAttributionSource).toBe("header_agent");
 			expect(result.originalModel).toBe("claude-3-5-sonnet-20241022");
 			expect(result.appliedModel).toBe("claude-opus-model");
 			expect(result.modifiedBody).not.toBe(buffer);
@@ -136,6 +229,7 @@ describe("Agent Interceptor - X-Anthropic-Agent-Id Header", () => {
 				headers({ "x-anthropic-agent-id": "no-pref-agent" }),
 			);
 			expect(result.agentUsed).toBe("no-pref-agent");
+			expect(result.agentAttributionSource).toBe("header_agent");
 			expect(result.originalModel).toBe("claude-3-5-sonnet-20241022");
 			expect(result.appliedModel).toBe("claude-3-5-sonnet-20241022");
 			// No substitution => body passed through unchanged
@@ -169,6 +263,7 @@ describe("Agent Interceptor - X-Anthropic-Agent-Id Header", () => {
 				headers({ "x-anthropic-agent-id": "  trimmed-agent  " }),
 			);
 			expect(result.agentUsed).toBe("trimmed-agent");
+			expect(result.agentAttributionSource).toBe("header_agent");
 		});
 
 		test("caps value at 256 characters", async () => {
@@ -181,6 +276,7 @@ describe("Agent Interceptor - X-Anthropic-Agent-Id Header", () => {
 			);
 			expect(result.agentUsed).toHaveLength(256);
 			expect(result.agentUsed).toBe("a".repeat(256));
+			expect(result.agentAttributionSource).toBe("header_agent");
 		});
 
 		test("empty/whitespace-only header is treated as absent", async () => {
@@ -192,6 +288,7 @@ describe("Agent Interceptor - X-Anthropic-Agent-Id Header", () => {
 			);
 			// Falls through to system-prompt path => no agent from a benign prompt
 			expect(result.agentUsed).toBeNull();
+			expect(result.agentAttributionSource).toBe("none");
 		});
 	});
 });

--- a/packages/proxy/src/handlers/__tests__/agent-interceptor.security.test.ts
+++ b/packages/proxy/src/handlers/__tests__/agent-interceptor.security.test.ts
@@ -81,6 +81,9 @@ describe("Agent Interceptor - Directory Traversal Security", () => {
 			expect(result).toBeDefined();
 			// Verify no agent was detected from the malicious path
 			expect(result.agentUsed).toBeNull();
+			// No agent was attributed from the malicious/traversal content, so the
+			// source label must be "none" -- never a secret-derived value.
+			expect(result.agentAttributionSource).toBe("none");
 			// The original request should be returned unmodified
 			expect(result.modifiedBody).toBe(buffer);
 		});

--- a/packages/proxy/src/handlers/__tests__/proxy-operations-extra-usage-exhausted.test.ts
+++ b/packages/proxy/src/handlers/__tests__/proxy-operations-extra-usage-exhausted.test.ts
@@ -201,4 +201,85 @@ describe("proxyWithAccount — extra_usage_exhausted (issue #293)", () => {
 		// 10th positional arg is the `usage` parameter.
 		expect(args[9]).toEqual({ model: "claude-sonnet-4-5" });
 	});
+
+	it("passes requestMeta attribution sources and rewritten models through to saveRequest", async () => {
+		globalThis.fetch = mock(async () => extraUsageExhaustedResponse());
+
+		const ctx = makeProxyContextWithAsyncExec();
+		const account = makeAccount();
+		const bodyBuffer = makeRequestBody("claude-sonnet-4-5");
+		const req = makeRequest(bodyBuffer);
+
+		await proxyWithAccount(
+			req,
+			new URL("https://proxy.local/v1/messages"),
+			account,
+			{
+				...makeRequestMeta(),
+				project: "Harness",
+				agentUsed: "reviewer",
+				projectAttributionSource: "header_project",
+				agentAttributionSource: "header_agent",
+				originalModel: "claude-sonnet-4-5",
+				appliedModel: "claude-opus-4-6",
+			},
+			bodyBuffer,
+			() => undefined,
+			0,
+			ctx,
+		);
+
+		const saveMock = ctx.dbOps.saveRequest as ReturnType<typeof mock>;
+		expect(saveMock.mock.calls.length).toBe(1);
+		const args = saveMock.mock.calls[0] as unknown[];
+		// Full positional order (0-indexed): id, method, path, accountUsed,
+		// statusCode, success, errorMessage, responseTime, failoverAttempts,
+		// usage, agentUsed, apiKeyId, apiKeyName, project, billingType,
+		// comboName, originalModel, appliedModel, projectAttributionSource,
+		// agentAttributionSource.
+		expect(args[6]).toBe("extra_usage_exhausted");
+		expect(args[10]).toBe("reviewer");
+		expect(args[13]).toBe("Harness");
+		expect(args[16]).toBe("claude-sonnet-4-5");
+		expect(args[17]).toBe("claude-opus-4-6");
+		expect(args[18]).toBe("header_project");
+		expect(args[19]).toBe("header_agent");
+	});
+
+	it("persists null/null originalModel/appliedModel when requestMeta carries an unmodified pair", async () => {
+		globalThis.fetch = mock(async () => extraUsageExhaustedResponse());
+
+		const ctx = makeProxyContextWithAsyncExec();
+		const account = makeAccount();
+		const bodyBuffer = makeRequestBody("claude-sonnet-4-5");
+		const req = makeRequest(bodyBuffer);
+
+		await proxyWithAccount(
+			req,
+			new URL("https://proxy.local/v1/messages"),
+			account,
+			{
+				...makeRequestMeta(),
+				// Agent-detected but NOT rewritten: original === applied. The
+				// direct extra_usage_exhausted save path must match the other
+				// direct persistence sites and gate through isModelRewrite.
+				originalModel: "claude-sonnet-4-5",
+				appliedModel: "claude-sonnet-4-5",
+				projectAttributionSource: "path_project",
+				agentAttributionSource: "prompt_agent",
+			},
+			bodyBuffer,
+			() => undefined,
+			0,
+			ctx,
+		);
+
+		const saveMock = ctx.dbOps.saveRequest as ReturnType<typeof mock>;
+		expect(saveMock.mock.calls.length).toBe(1);
+		const args = saveMock.mock.calls[0] as unknown[];
+		expect(args[16]).toBeNull();
+		expect(args[17]).toBeNull();
+		expect(args[18]).toBe("path_project");
+		expect(args[19]).toBe("prompt_agent");
+	});
 });

--- a/packages/proxy/src/handlers/__tests__/proxy-operations-failover.test.ts
+++ b/packages/proxy/src/handlers/__tests__/proxy-operations-failover.test.ts
@@ -43,13 +43,14 @@ function makeAccount(overrides: Partial<Account> = {}): Account {
 	};
 }
 
-function makeRequestMeta(): RequestMeta {
+function makeRequestMeta(overrides: Partial<RequestMeta> = {}): RequestMeta {
 	return {
 		id: "req-1",
 		method: "POST",
 		path: "/v1/messages",
 		timestamp: Date.now(),
 		headers: new Headers(),
+		...overrides,
 	};
 }
 
@@ -477,6 +478,210 @@ describe("proxyWithAccount — rate limit audit trail (issue #178)", () => {
 			(args: unknown[]) => args[2] as string,
 		);
 		expect(reasons).toContain("all_models_exhausted_429");
+	});
+});
+
+describe("proxyWithAccount — attribution source pass-through to saveRequest (P2)", () => {
+	let originalFetch: typeof globalThis.fetch;
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("passes requestMeta.projectAttributionSource/agentAttributionSource through to saveRequest at positions 18/19 on the model_fallback_429 failover path", async () => {
+		globalThis.fetch = mock(async () =>
+			jsonResponse(
+				{
+					error: {
+						type: "api_error",
+						message:
+							"Rate limit exceeded: limit_rpm/qwen/qwen3.6-plus:free/abc",
+					},
+				},
+				429,
+			),
+		);
+
+		const ctx = makeProxyContextWithAsyncExec();
+		const bodyBuffer = makeRequestBody();
+		const req = makeRequest(bodyBuffer);
+
+		await proxyWithAccount(
+			req,
+			new URL("https://proxy.local/v1/messages"),
+			makeAccount(), // no model_fallbacks -> model_fallback_429 path
+			makeRequestMeta({
+				projectAttributionSource: "header_project",
+				agentAttributionSource: "header_agent",
+			}),
+			bodyBuffer,
+			() => undefined,
+			0,
+			ctx,
+		);
+
+		const saveRequestMock = ctx.dbOps.saveRequest as ReturnType<typeof mock>;
+		expect(saveRequestMock.mock.calls.length).toBeGreaterThan(0);
+		const args = saveRequestMock.mock.calls[0] as unknown[];
+		// Full positional order (0-indexed): id, method, path, accountUsed,
+		// statusCode, success, errorMessage, responseTime, failoverAttempts,
+		// usage, agentUsed, apiKeyId, apiKeyName, project, billingType,
+		// comboName, originalModel, appliedModel, projectAttributionSource,
+		// agentAttributionSource.
+		expect(args[18]).toBe("header_project");
+		expect(args[19]).toBe("header_agent");
+	});
+
+	it("passes null attribution sources through to saveRequest when requestMeta omits them", async () => {
+		globalThis.fetch = mock(async () =>
+			jsonResponse(
+				{
+					error: {
+						type: "api_error",
+						message: "Rate limit exceeded: limit_rpm/model/abc",
+					},
+				},
+				429,
+			),
+		);
+
+		const ctx = makeProxyContextWithAsyncExec();
+		const bodyBuffer = makeRequestBody();
+		const req = makeRequest(bodyBuffer);
+
+		await proxyWithAccount(
+			req,
+			new URL("https://proxy.local/v1/messages"),
+			makeAccount({
+				model_mappings: JSON.stringify({
+					sonnet: [
+						"qwen/qwen3.6-plus:free",
+						"bytedance-seed/dola-seed-2.0-pro:free",
+					],
+				}),
+			}),
+			makeRequestMeta(), // no attribution source overrides
+			bodyBuffer,
+			() => undefined,
+			0,
+			ctx,
+		);
+
+		const saveRequestMock = ctx.dbOps.saveRequest as ReturnType<typeof mock>;
+		const reasons = saveRequestMock.mock.calls.map(
+			(args: unknown[]) => args[6] as string,
+		);
+		expect(reasons).toContain("all_models_exhausted_429");
+		const call = saveRequestMock.mock.calls.find(
+			(args: unknown[]) => args[6] === "all_models_exhausted_429",
+		) as unknown[];
+		expect(call[18]).toBeNull();
+		expect(call[19]).toBeNull();
+	});
+});
+
+describe("proxyWithAccount — originalModel/appliedModel gated by isModelRewrite on direct 429 saveRequest paths (P2)", () => {
+	let originalFetch: typeof globalThis.fetch;
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("persists null/null (not the equal pair) on the model_fallback_429 path when requestMeta carries an unmodified originalModel/appliedModel pair", async () => {
+		globalThis.fetch = mock(async () =>
+			jsonResponse(
+				{
+					error: {
+						type: "api_error",
+						message:
+							"Rate limit exceeded: limit_rpm/qwen/qwen3.6-plus:free/abc",
+					},
+				},
+				429,
+			),
+		);
+
+		const ctx = makeProxyContextWithAsyncExec();
+		const bodyBuffer = makeRequestBody();
+		const req = makeRequest(bodyBuffer);
+
+		await proxyWithAccount(
+			req,
+			new URL("https://proxy.local/v1/messages"),
+			makeAccount(), // no model_fallbacks -> model_fallback_429 path
+			makeRequestMeta({
+				// Agent-detected but NOT rewritten: original === applied. Before the
+				// fix this bypassed isModelRewrite and persisted the equal pair,
+				// making an untouched request look like a real rewrite.
+				originalModel: "claude-sonnet-4-5",
+				appliedModel: "claude-sonnet-4-5",
+			}),
+			bodyBuffer,
+			() => undefined,
+			0,
+			ctx,
+		);
+
+		const saveRequestMock = ctx.dbOps.saveRequest as ReturnType<typeof mock>;
+		expect(saveRequestMock.mock.calls.length).toBeGreaterThan(0);
+		const args = saveRequestMock.mock.calls[0] as unknown[];
+		expect(args[16]).toBeNull();
+		expect(args[17]).toBeNull();
+	});
+
+	it("still persists a genuine originalModel/appliedModel rewrite pair on the all_models_exhausted_429 path", async () => {
+		globalThis.fetch = mock(async () =>
+			jsonResponse(
+				{
+					error: {
+						type: "api_error",
+						message: "Rate limit exceeded: limit_rpm/model/abc",
+					},
+				},
+				429,
+			),
+		);
+
+		const ctx = makeProxyContextWithAsyncExec();
+		const bodyBuffer = makeRequestBody();
+		const req = makeRequest(bodyBuffer);
+
+		await proxyWithAccount(
+			req,
+			new URL("https://proxy.local/v1/messages"),
+			makeAccount({
+				model_mappings: JSON.stringify({
+					sonnet: [
+						"qwen/qwen3.6-plus:free",
+						"bytedance-seed/dola-seed-2.0-pro:free",
+					],
+				}),
+			}),
+			makeRequestMeta({
+				originalModel: "claude-sonnet-4-5",
+				appliedModel: "qwen/qwen3.6-plus:free",
+			}),
+			bodyBuffer,
+			() => undefined,
+			0,
+			ctx,
+		);
+
+		const saveRequestMock = ctx.dbOps.saveRequest as ReturnType<typeof mock>;
+		const call = saveRequestMock.mock.calls.find(
+			(args: unknown[]) => args[6] === "all_models_exhausted_429",
+		) as unknown[];
+		expect(call).toBeDefined();
+		expect(call[16]).toBe("claude-sonnet-4-5");
+		expect(call[17]).toBe("qwen/qwen3.6-plus:free");
 	});
 });
 

--- a/packages/proxy/src/handlers/__tests__/proxy-operations-out-of-credits.test.ts
+++ b/packages/proxy/src/handlers/__tests__/proxy-operations-out-of-credits.test.ts
@@ -221,4 +221,39 @@ describe("proxyWithAccount — out_of_credits (issue #261)", () => {
 		const saveMock = ctx.dbOps.saveRequest as ReturnType<typeof mock>;
 		expect(saveMock.mock.calls.length).toBe(0);
 	});
+
+	it("persists null/null originalModel/appliedModel (not the equal pair) when requestMeta carries an unmodified pair (P2: isModelRewrite guard)", async () => {
+		globalThis.fetch = mock(async () => outOfCreditsResponse());
+
+		const ctx = makeProxyContextWithAsyncExec();
+		const account = makeAccount();
+		const bodyBuffer = makeRequestBody("claude-sonnet-4-5");
+		const req = makeRequest(bodyBuffer);
+
+		await proxyWithAccount(
+			req,
+			new URL("https://proxy.local/v1/messages"),
+			account,
+			{
+				...makeRequestMeta(),
+				// Agent-detected but NOT rewritten: original === applied. Before the
+				// fix, the three direct 429 saveRequest call sites persisted this
+				// equal pair unconditionally, bypassing isModelRewrite and
+				// corrupting observability.
+				originalModel: "claude-sonnet-4-5",
+				appliedModel: "claude-sonnet-4-5",
+			},
+			bodyBuffer,
+			() => undefined,
+			0,
+			ctx,
+		);
+
+		const saveMock = ctx.dbOps.saveRequest as ReturnType<typeof mock>;
+		expect(saveMock.mock.calls.length).toBe(1);
+		const args = saveMock.mock.calls[0] as unknown[];
+		// 17th/18th positional args are originalModel/appliedModel.
+		expect(args[16]).toBeNull();
+		expect(args[17]).toBeNull();
+	});
 });

--- a/packages/proxy/src/handlers/agent-interceptor.ts
+++ b/packages/proxy/src/handlers/agent-interceptor.ts
@@ -5,6 +5,7 @@ import { agentRegistry } from "@better-ccflare/agents";
 import type { DatabaseOperations } from "@better-ccflare/database";
 import { Logger } from "@better-ccflare/logger";
 import { validatePath } from "@better-ccflare/security";
+import type { AgentAttributionSource } from "@better-ccflare/types";
 import { getModelCatalog, type ModelCatalog } from "../model-catalog";
 import { RequestBodyContext } from "../request-body-context";
 
@@ -15,6 +16,7 @@ export interface AgentInterceptResult {
 	agentUsed: string | null;
 	originalModel: string | null;
 	appliedModel: string | null;
+	agentAttributionSource: AgentAttributionSource;
 }
 
 /**
@@ -72,6 +74,7 @@ export async function interceptAndModifyRequest(
 			agentUsed: null,
 			originalModel: null,
 			appliedModel: null,
+			agentAttributionSource: "none",
 		};
 	}
 
@@ -93,14 +96,14 @@ export async function interceptAndModifyRequest(
 		// a multi-agent orchestrator, a router, an SDK wrapper — declare which agent
 		// issued the request, so downstream observability tools can attribute usage
 		// per agent. Takes precedence over system-prompt matching; absent = unchanged.
-		const explicitAgentId = requestHeaders
-			?.get("x-anthropic-agent-id")
-			?.trim()
-			?.slice(0, 256);
+		// The namespaced `x-better-ccflare-agent-id` header is preferred; the legacy
+		// `x-anthropic-agent-id` header is honored for backward compatibility when
+		// the namespaced header is absent.
+		const explicitAgentId =
+			requestHeaders?.get("x-better-ccflare-agent-id")?.trim()?.slice(0, 256) ||
+			requestHeaders?.get("x-anthropic-agent-id")?.trim()?.slice(0, 256);
 		if (explicitAgentId) {
-			log.debug(
-				`Agent attributed via x-anthropic-agent-id: ${explicitAgentId}`,
-			);
+			log.debug(`Agent attributed via explicit header: ${explicitAgentId}`);
 			// Both the header path and the system-prompt path below rewrite the
 			// model only on an explicit DB preference set via the dashboard/CLI;
 			// an agent's frontmatter `model` is never consulted here, since a
@@ -119,6 +122,7 @@ export async function interceptAndModifyRequest(
 						agentUsed: explicitAgentId,
 						originalModel,
 						appliedModel: preferredModel,
+						agentAttributionSource: "header_agent",
 					};
 				}
 				log.warn(
@@ -130,6 +134,7 @@ export async function interceptAndModifyRequest(
 				agentUsed: explicitAgentId,
 				originalModel,
 				appliedModel: originalModel,
+				agentAttributionSource: "header_agent",
 			};
 		}
 
@@ -143,6 +148,7 @@ export async function interceptAndModifyRequest(
 				agentUsed: null,
 				originalModel,
 				appliedModel: originalModel,
+				agentAttributionSource: "none",
 			};
 		}
 
@@ -204,6 +210,7 @@ export async function interceptAndModifyRequest(
 				agentUsed: null,
 				originalModel,
 				appliedModel: originalModel,
+				agentAttributionSource: "none",
 			};
 		}
 
@@ -232,6 +239,7 @@ export async function interceptAndModifyRequest(
 				agentUsed: detectedAgent.id,
 				originalModel,
 				appliedModel: originalModel,
+				agentAttributionSource: "prompt_agent",
 			};
 		}
 
@@ -245,6 +253,7 @@ export async function interceptAndModifyRequest(
 				agentUsed: detectedAgent.id,
 				originalModel,
 				appliedModel: originalModel,
+				agentAttributionSource: "prompt_agent",
 			};
 		}
 
@@ -257,6 +266,7 @@ export async function interceptAndModifyRequest(
 			agentUsed: detectedAgent.id,
 			originalModel,
 			appliedModel: preferredModel,
+			agentAttributionSource: "prompt_agent",
 		};
 	} catch (error) {
 		log.error("Failed to intercept/modify request:", error);
@@ -268,6 +278,7 @@ export async function interceptAndModifyRequest(
 			agentUsed: null,
 			originalModel,
 			appliedModel: originalModel,
+			agentAttributionSource: "none",
 		};
 	}
 }

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -22,6 +22,7 @@ import type {
 import { cacheBodyStore } from "../cache-body-store";
 import { RequestBodyContext } from "../request-body-context";
 import { forwardToClient } from "../response-handler";
+import { isModelRewrite } from "../worker-messages";
 import { ERROR_MESSAGES, type ProxyContext } from "./proxy-types";
 import { applyRateLimitCooldown } from "./rate-limit-cooldown";
 import { makeProxyRequest, validateProviderPath } from "./request-handler";
@@ -461,6 +462,7 @@ export async function proxyUnauthenticated(
 				requestBody: requestBodyBuffer,
 				project: requestMeta.project,
 				query: url.search || null,
+				projectAttributionSource: requestMeta.projectAttributionSource ?? null,
 				response,
 				timestamp: requestMeta.timestamp,
 				retryAttempt: 0,
@@ -468,6 +470,7 @@ export async function proxyUnauthenticated(
 				agentUsed: requestMeta.agentUsed,
 				originalModel: requestMeta.originalModel,
 				appliedModel: requestMeta.appliedModel,
+				agentAttributionSource: requestMeta.agentAttributionSource ?? null,
 				comboName: requestMeta.comboName,
 				apiKeyId,
 				apiKeyName,
@@ -854,6 +857,14 @@ export async function proxyWithAccount(
 						requestMeta.project ?? null,
 						undefined,
 						requestMeta.comboName ?? null,
+						isModelRewrite(requestMeta.originalModel, requestMeta.appliedModel)
+							? (requestMeta.originalModel ?? null)
+							: null,
+						isModelRewrite(requestMeta.originalModel, requestMeta.appliedModel)
+							? (requestMeta.appliedModel ?? null)
+							: null,
+						requestMeta.projectAttributionSource ?? null,
+						requestMeta.agentAttributionSource ?? null,
 					),
 				);
 				return null;
@@ -916,6 +927,20 @@ export async function proxyWithAccount(
 								requestMeta.project ?? null,
 								undefined,
 								requestMeta.comboName ?? null,
+								isModelRewrite(
+									requestMeta.originalModel,
+									requestMeta.appliedModel,
+								)
+									? (requestMeta.originalModel ?? null)
+									: null,
+								isModelRewrite(
+									requestMeta.originalModel,
+									requestMeta.appliedModel,
+								)
+									? (requestMeta.appliedModel ?? null)
+									: null,
+								requestMeta.projectAttributionSource ?? null,
+								requestMeta.agentAttributionSource ?? null,
 							),
 						);
 						return null;
@@ -1052,6 +1077,20 @@ export async function proxyWithAccount(
 								requestMeta.project ?? null,
 								undefined,
 								requestMeta.comboName ?? null,
+								isModelRewrite(
+									requestMeta.originalModel,
+									requestMeta.appliedModel,
+								)
+									? (requestMeta.originalModel ?? null)
+									: null,
+								isModelRewrite(
+									requestMeta.originalModel,
+									requestMeta.appliedModel,
+								)
+									? (requestMeta.appliedModel ?? null)
+									: null,
+								requestMeta.projectAttributionSource ?? null,
+								requestMeta.agentAttributionSource ?? null,
 							),
 						);
 					}
@@ -1209,6 +1248,8 @@ export async function proxyWithAccount(
 						requestBody: effectiveBodyBuffer,
 						project: requestMeta.project,
 						query: url.search || null,
+						projectAttributionSource:
+							requestMeta.projectAttributionSource ?? null,
 						response,
 						timestamp: requestMeta.timestamp,
 						retryAttempt: 0,
@@ -1216,6 +1257,7 @@ export async function proxyWithAccount(
 						agentUsed: requestMeta.agentUsed,
 						originalModel: requestMeta.originalModel,
 						appliedModel: requestMeta.appliedModel,
+						agentAttributionSource: requestMeta.agentAttributionSource ?? null,
 						comboName: requestMeta.comboName,
 						apiKeyId,
 						apiKeyName,
@@ -1237,6 +1279,7 @@ export async function proxyWithAccount(
 				requestBody: effectiveBodyBuffer,
 				project: requestMeta.project,
 				query: url.search || null,
+				projectAttributionSource: requestMeta.projectAttributionSource ?? null,
 				response,
 				timestamp: requestMeta.timestamp,
 				retryAttempt: 0,
@@ -1244,6 +1287,7 @@ export async function proxyWithAccount(
 				agentUsed: requestMeta.agentUsed,
 				originalModel: requestMeta.originalModel,
 				appliedModel: requestMeta.appliedModel,
+				agentAttributionSource: requestMeta.agentAttributionSource ?? null,
 				comboName: requestMeta.comboName,
 				apiKeyId,
 				apiKeyName,

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -786,6 +786,14 @@ export async function proxyWithAccount(
 					requestMeta.project ?? null,
 					undefined,
 					requestMeta.comboName ?? null,
+					isModelRewrite(requestMeta.originalModel, requestMeta.appliedModel)
+						? (requestMeta.originalModel ?? null)
+						: null,
+					isModelRewrite(requestMeta.originalModel, requestMeta.appliedModel)
+						? (requestMeta.appliedModel ?? null)
+						: null,
+					requestMeta.projectAttributionSource ?? null,
+					requestMeta.agentAttributionSource ?? null,
 				),
 			);
 			// Do not bench the account or fail over — pass Anthropic's real error

--- a/packages/proxy/src/project-attribution.ts
+++ b/packages/proxy/src/project-attribution.ts
@@ -1,0 +1,336 @@
+import { Logger } from "@better-ccflare/logger";
+import type { ProjectAttributionSource } from "@better-ccflare/types";
+import type { RequestJsonBody } from "./request-body-context";
+
+const log = new Logger("ProjectAttribution");
+
+export interface ProjectExtractionResult {
+	project: string | null;
+	projectAttributionSource: ProjectAttributionSource;
+}
+
+// Project names are persisted to a single TEXT column and surfaced in the UI.
+// Cap length and strip control chars so a hostile system prompt can't smuggle
+// newlines, ANSI escapes, or megabyte-long blobs into the database.
+export const PROJECT_NAME_MAX_LEN = 64;
+
+export function sanitizeProjectName(
+	raw: string | undefined | null,
+): string | null {
+	if (!raw) return null;
+	// Strip ASCII control chars (incl. newlines/tabs) — keep Unicode letters,
+	// dashes, dots, and spaces that real project directories use.
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping them is the point
+	const cleaned = raw.replace(/[\x00-\x1F\x7F]/g, "").trim();
+	if (!cleaned) return null;
+	return cleaned.length > PROJECT_NAME_MAX_LEN
+		? cleaned.slice(0, PROJECT_NAME_MAX_LEN)
+		: cleaned;
+}
+
+export function extractSystemPromptFromJson(
+	body: RequestJsonBody | null,
+): string | null {
+	if (!body) return null;
+	const system = body.system;
+
+	if (typeof system === "string") {
+		return system;
+	}
+
+	if (Array.isArray(system)) {
+		return system
+			.filter(
+				(item): item is { type?: string; text: string } =>
+					typeof item === "object" &&
+					item !== null &&
+					(item as { type?: string }).type === "text" &&
+					typeof (item as { text?: unknown }).text === "string",
+			)
+			.map((item) => item.text)
+			.join("\n");
+	}
+
+	return null;
+}
+
+export function extractSystemPromptFromBase64(
+	requestBody: string | null,
+): string | null {
+	if (!requestBody) return null;
+
+	try {
+		// Decode base64 request body, then reuse the SAME extraction as the
+		// parsed-body path so the legacy/direct fallback never diverges (R7) —
+		// e.g. `system: [null, {type:"text", text:"..."}]` is tolerated here
+		// exactly as extractSystemPromptFromJson tolerates it, not thrown on.
+		const decodedBody = Buffer.from(requestBody, "base64").toString("utf-8");
+		const parsed = JSON.parse(decodedBody) as RequestJsonBody;
+		return extractSystemPromptFromJson(parsed);
+	} catch (error) {
+		// Malformed/undecodable body — treat as no system prompt, but keep it
+		// diagnosable on the legacy usage-collector recompute path.
+		log.debug("Failed to extract system prompt from request body:", error);
+	}
+
+	return null;
+}
+
+// Matches bearer/API-key-ish tokens such as sk-..., pk_..., rk-..., ak_...
+const SECRET_TOKEN_RE = /\b(?:sk|pk|rk|ak)[-_][A-Za-z0-9]{8,}/i;
+// Known branded secret-token prefixes SECRET_TOKEN_RE doesn't cover: GitHub
+// PATs (ghp_/gho_/ghu_/ghs_/ghr_) and Slack tokens (xoxb-/xoxp-/xoxa-/xoxr-/xoxs-).
+const KNOWN_SECRET_PREFIX_RE =
+	/\bgh[opsur]_[A-Za-z0-9]{6,}\b|\bxox[baprs]-[A-Za-z0-9-]{6,}\b/i;
+// "sk_live_...", "api-key-9f8e7d6c...": 2+ short segments delimited by `_`/`-`
+// followed by a long tail that mixes letters AND digits. A second separator
+// defeats SECRET_TOKEN_RE (which only tolerates one), and each individual
+// segment can stay under LONG_TOKEN_RE's 20-char unbroken-run threshold — this
+// catches the shape as a whole instead. The digit+letter requirement on the
+// tail is what keeps ordinary hyphenated slugs safe: "attribution-source-tags"
+// and "my-really-long-project-name" have word-only (no-digit) tails, so they
+// are unaffected; only token-shaped tails ("abc123456789") match.
+const MULTI_SEGMENT_TOKEN_RE =
+	/\b(?:[A-Za-z0-9]+[_-]){2,}(?=[A-Za-z0-9]*[0-9])(?=[A-Za-z0-9]*[A-Za-z])[A-Za-z0-9]{8,}\b/;
+// AWS access-key-id shape.
+const AWS_KEY_RE = /AKIA[0-9A-Z]{12,}/;
+// An unbroken run of 20+ alphanumeric chars — the shape of a raw secret, hash,
+// or high-entropy token. Excludes separators (-, _, /) on purpose so ordinary
+// hyphenated slugs like "attribution-source-tags" are NOT rejected, while still
+// catching bare tokens the old 32-char base64-class pattern missed (16-31 char
+// hex/base32 secrets, session ids, etc.).
+const LONG_TOKEN_RE = /[A-Za-z0-9]{20,}/;
+// Bare IPv4 address — an internal host, never a real project name.
+const IPV4_RE = /\b\d{1,3}(?:\.\d{1,3}){3}\b/;
+// UUID / raw trace-id shape (explicitly prohibited as attribution metadata).
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+// A leading URI scheme or Windows drive letter (file:, http:, mailto:, C:, ...).
+// Matches "scheme:" anchored at the start; ordinary slugs have no leading scheme.
+const URI_SCHEME_RE = /^[A-Za-z][A-Za-z0-9+.-]*:/;
+// Customer / incident / ticket labels — operational metadata (who reported,
+// what ticket) that must never be surfaced as a project name, even when short
+// enough to dodge the six-word sentence heuristic (e.g. "Incident INC-123 Acme").
+const INCIDENT_LABEL_RE =
+	/\b(?:incident|inc|ticket|case|customer|acct|account)\b[-\s]?[A-Za-z0-9-]+/i;
+// Jira-style ticket keys (PROJ-123) and explicit INC-### shapes.
+const JIRA_TICKET_RE = /\b[A-Z]{2,}-\d+\b/;
+// Dotted hostname-shaped label: an alphanumeric on both sides of a `.`, e.g.
+// "customer.example.com" or "*.example.com" (via the "example.com" tail) or
+// even a bare "foo.bar". Real project slugs don't need embedded dots between
+// alnum runs, and this shape is exactly how hostnames/domains look, so it's
+// rejected wholesale rather than only when a known TLD/scheme is present.
+const DOTTED_HOSTNAME_LABEL_RE = /[A-Za-z0-9]\.[A-Za-z0-9]/;
+// Opaque hex-shaped token: 16+ chars drawn only from [0-9a-f] (case-insensitive)
+// with no separators — the shape of a hex-encoded id/hash/secret (e.g.
+// "deadbeefcafebabe"). Below LONG_TOKEN_RE's 20-char general threshold, so it
+// needs its own narrower rule restricted to the hex alphabet.
+const HEX_OPAQUE_TOKEN_RE = /\b[0-9a-fA-F]{16,}\b/;
+// Opaque base32/base64-ish token: 16+ unbroken alnum chars that mix letters
+// AND digits — the shape of a random/opaque id (session id, API key body,
+// etc.) rather than an ordinary English word. Requiring a digit keeps this
+// from flagging long single-word slugs ("documentation-site" segments stay
+// short anyway; a hypothetical all-letter 16+ char word is still let through).
+const OPAQUE_MIXED_TOKEN_RE =
+	/\b(?=[A-Za-z0-9]*[0-9])(?=[A-Za-z0-9]*[A-Za-z])[A-Za-z0-9]{16,}\b/;
+// Credential-label prefix ("api-key-", "apikey", "access-key", "secret-key",
+// "auth-token", "password", "credential(s)") followed by an opaque-looking
+// tail. Catches shapes like "api-key-abcdefghijkl" that dodge
+// MULTI_SEGMENT_TOKEN_RE because the tail is letters-only (no digit), by
+// keying off the credential-shaped label itself rather than the tail's
+// character class.
+const CREDENTIAL_LABEL_RE =
+	/\b(?:api[-_ ]?key|apikey|access[-_ ]?key|secret[-_ ]?key|auth[-_ ]?token|api[-_ ]?token|password|credentials?)\b[-_\s]?[A-Za-z0-9]{6,}/i;
+// Allowed low-risk project-slug shape: starts with a word char or dot, then
+// word chars, dots, spaces, or dashes, capped at 64 chars. Slashes and colons
+// are intentionally excluded — they enable path, URI, host:port, and drive-letter
+// shapes that must never be surfaced as a project label.
+const SLUG_SHAPE_RE = /^[\w.][\w .-]{0,63}$/;
+
+/**
+ * Conservative validator for heading-derived project labels (R10a, hardened
+ * round-2 per P1 review: reject-when-in-doubt rather than denylist
+ * whack-a-mole).
+ *
+ * Validates the FULL cleaned heading (control-stripped, trimmed, but NEVER
+ * length-capped) so a secret positioned near the 64-char truncation boundary
+ * cannot be shortened below a detector threshold and slip through. Rejects
+ * values that look like they could carry a secret, a raw trace/UUID id, a URL
+ * or URI scheme, a dotted hostname-shaped label, an absolute/drive/traversal
+ * path, an email address, a multi-segment API-key/token shape, an opaque
+ * hex/base32/base64-ish token (16+ chars), a credential-labeled value
+ * ("api-key-..."), a customer/incident/ticket label, or free-form
+ * sentence/incident text. Accepts ordinary repo-name-shaped labels
+ * (e.g. "better-ccflare", "Harness", "eval-suite", "My Project").
+ */
+export function isLowRiskProjectSlug(value: string): boolean {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping them is the point
+	const cleaned = value.replace(/[\x00-\x1F\x7F]/g, "").trim();
+	if (!cleaned) return false;
+	const lower = cleaned.toLowerCase();
+
+	// URLs / URI schemes / hosts (case-insensitive — WWW.EXAMPLE.COM must fail too).
+	if (
+		lower.includes("://") ||
+		lower.includes("www.") ||
+		URI_SCHEME_RE.test(cleaned)
+	) {
+		return false;
+	}
+
+	// Absolute, Windows-drive, UNC, or traversal paths.
+	if (
+		cleaned.startsWith("/") ||
+		cleaned.startsWith("\\") ||
+		cleaned.includes("..")
+	) {
+		return false;
+	}
+
+	// Email address.
+	const atIndex = cleaned.indexOf("@");
+	if (atIndex !== -1 && cleaned.indexOf(".", atIndex) !== -1) return false;
+
+	// Raw trace / UUID identifiers.
+	if (UUID_RE.test(cleaned)) return false;
+
+	// Dotted hostname-shaped labels (customer.example.com, foo.bar, ...) —
+	// reject before the slug check even though dots are otherwise slug-legal,
+	// since this exact shape is how a hostname/domain reads.
+	if (DOTTED_HOSTNAME_LABEL_RE.test(cleaned)) return false;
+
+	// Secrets, keys, IPs, and high-entropy tokens.
+	if (
+		SECRET_TOKEN_RE.test(cleaned) ||
+		KNOWN_SECRET_PREFIX_RE.test(cleaned) ||
+		MULTI_SEGMENT_TOKEN_RE.test(cleaned) ||
+		CREDENTIAL_LABEL_RE.test(cleaned) ||
+		lower.includes("bearer ") ||
+		AWS_KEY_RE.test(cleaned) ||
+		IPV4_RE.test(cleaned) ||
+		LONG_TOKEN_RE.test(cleaned) ||
+		HEX_OPAQUE_TOKEN_RE.test(cleaned) ||
+		OPAQUE_MIXED_TOKEN_RE.test(cleaned)
+	) {
+		return false;
+	}
+
+	// Customer / incident / ticket-shaped labels — operational metadata, not a
+	// project name, even when short enough to dodge the sentence heuristic below.
+	if (INCIDENT_LABEL_RE.test(cleaned) || JIRA_TICKET_RE.test(cleaned)) {
+		return false;
+	}
+
+	// Sentence / incident-shaped free text.
+	if (cleaned.split(/\s+/).filter(Boolean).length > 6) return false;
+
+	// Strict slug grammar on the FULL value (no slashes/colons; a >64-char value
+	// fails the {0,63} bound and is rejected wholesale rather than truncated).
+	return SLUG_SHAPE_RE.test(cleaned);
+}
+
+const WORKSPACE_PATH_RE =
+	/\/(?:Users|home)\/[^/]+\/(?:Desktop|projects|repos|src)\/([^/]+)\//;
+// Global so extractProjectAttribution can walk every H1 heading in the system
+// prompt (not just the first) and pick the first one that is eligible.
+const HEADING_RE = /^#\s+([^\n\r]{1,100})/gm;
+
+/**
+ * Core project attribution extraction. Accepts a header accessor so it works
+ * uniformly for both the proxy's `Headers` object and the usage collector's
+ * `Record<string, string>` header map.
+ *
+ * Precedence:
+ *  1. `x-better-ccflare-project` header, then legacy `x-project` header.
+ *  2. Workspace path embedded in the system prompt.
+ *  3. First eligible non-Claude, low-risk-slug H1 heading in the system prompt.
+ *  4. No project.
+ */
+export function extractProjectAttribution(
+	getHeader: (name: string) => string | null | undefined,
+	systemPrompt: string | null,
+): ProjectExtractionResult {
+	const namespacedHeader = sanitizeProjectName(
+		getHeader("x-better-ccflare-project"),
+	);
+	if (namespacedHeader) {
+		return {
+			project: namespacedHeader,
+			projectAttributionSource: "header_project",
+		};
+	}
+
+	const legacyHeader = sanitizeProjectName(getHeader("x-project"));
+	if (legacyHeader) {
+		return {
+			project: legacyHeader,
+			projectAttributionSource: "header_project",
+		};
+	}
+
+	if (systemPrompt) {
+		const pathMatch = systemPrompt.match(WORKSPACE_PATH_RE);
+		const sanitizedPath = sanitizeProjectName(pathMatch?.[1]);
+		if (sanitizedPath) {
+			return {
+				project: sanitizedPath,
+				projectAttributionSource: "path_project",
+			};
+		}
+
+		// Walk EVERY H1 heading (not just the first) and use the first one that
+		// is both non-Claude and passes the low-risk slug validator. A doc that
+		// opens with "# Claude Code Instructions" before a real "# Harness"
+		// heading must not lose attribution just because the first heading was
+		// ineligible.
+		for (const headingMatch of systemPrompt.matchAll(HEADING_RE)) {
+			// Validate the FULL captured heading, then length-cap only after it
+			// passes — truncating first could shorten a boundary-straddling secret
+			// below a detector threshold and let a partial secret through.
+			const rawHeading = headingMatch[1];
+			if (rawHeading.trim().toLowerCase().startsWith("claude")) continue;
+			if (!isLowRiskProjectSlug(rawHeading)) continue;
+			const heading = sanitizeProjectName(rawHeading);
+			if (heading) {
+				return {
+					project: heading,
+					projectAttributionSource: "heading_project",
+				};
+			}
+		}
+	}
+
+	return { project: null, projectAttributionSource: "none" };
+}
+
+/**
+ * Convenience wrapper for the proxy's parsed-JSON-body request path.
+ */
+export function extractProjectAttributionFromRequest(
+	headers: Headers,
+	body: RequestJsonBody | null,
+): ProjectExtractionResult {
+	const systemPrompt = extractSystemPromptFromJson(body);
+	return extractProjectAttribution((n) => headers.get(n), systemPrompt);
+}
+
+/**
+ * Convenience wrapper for the usage collector's `StartMessage`-shaped input,
+ * where headers arrive as a plain `Record<string, string>` and the body is a
+ * base64-encoded JSON string.
+ */
+export function extractProjectAttributionFromParts(
+	requestHeaders: Record<string, string> | null | undefined,
+	requestBodyBase64: string | null,
+): ProjectExtractionResult {
+	const headerMap: Record<string, string> = {};
+	if (requestHeaders) {
+		for (const [key, value] of Object.entries(requestHeaders)) {
+			headerMap[key.toLowerCase()] = value;
+		}
+	}
+	const systemPrompt = extractSystemPromptFromBase64(requestBodyBase64);
+	return extractProjectAttribution(
+		(n) => headerMap[n.toLowerCase()],
+		systemPrompt,
+	);
+}

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -27,6 +27,7 @@ import {
 	selectAccountsForRequest,
 	validateProviderPath,
 } from "./handlers";
+import { extractProjectAttributionFromRequest } from "./project-attribution";
 import {
 	buildSessionRejectResponse,
 	recordSessionRequest,
@@ -41,70 +42,6 @@ import {
 export type { ProxyContext } from "./handlers";
 
 const log = new Logger("Proxy");
-
-const PROJECT_NAME_MAX_LEN = 64;
-
-function sanitizeProjectName(raw: string | undefined | null): string | null {
-	if (!raw) return null;
-	// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping them is the point
-	const cleaned = raw.replace(/[\x00-\x1F\x7F]/g, "").trim();
-	if (!cleaned) return null;
-	return cleaned.length > PROJECT_NAME_MAX_LEN
-		? cleaned.slice(0, PROJECT_NAME_MAX_LEN)
-		: cleaned;
-}
-
-function extractSystemPrompt(body: RequestJsonBody | null): string | null {
-	if (!body) return null;
-	const system = body.system;
-
-	if (typeof system === "string") {
-		return system;
-	}
-
-	if (Array.isArray(system)) {
-		return system
-			.filter(
-				(item): item is { type?: string; text: string } =>
-					typeof item === "object" &&
-					item !== null &&
-					(item as { type?: string }).type === "text" &&
-					typeof (item as { text?: unknown }).text === "string",
-			)
-			.map((item) => item.text)
-			.join("\n");
-	}
-
-	return null;
-}
-
-function extractProjectFromRequest(
-	headers: Headers,
-	body: RequestJsonBody | null,
-): string | null {
-	const headerProject = headers.get("x-project");
-	const sanitizedHeader = sanitizeProjectName(headerProject);
-	if (sanitizedHeader) return sanitizedHeader;
-
-	const systemPrompt = extractSystemPrompt(body);
-	if (!systemPrompt) return null;
-
-	const pathMatch = systemPrompt.match(
-		/\/(?:Users|home)\/[^/]+\/(?:Desktop|projects|repos|src)\/([^/]+)\//,
-	);
-	const sanitizedPath = sanitizeProjectName(pathMatch?.[1]);
-	if (sanitizedPath) return sanitizedPath;
-
-	const headingMatch = systemPrompt.match(/^#\s+([^\n\r]{1,100})/m);
-	if (headingMatch) {
-		const heading = sanitizeProjectName(headingMatch[1]);
-		if (heading && !heading.toLowerCase().startsWith("claude")) {
-			return heading;
-		}
-	}
-
-	return null;
-}
 
 // ===== USAGE COLLECTOR MANAGEMENT =====
 
@@ -188,7 +125,8 @@ export async function handleProxy(
 	// and reuse parsed body for /v1/messages validation (consolidate parses)
 	const parsedBody = requestBodyContext.getParsedJson();
 	const requestModel = requestBodyContext.getModel();
-	const project = extractProjectFromRequest(req.headers, parsedBody);
+	const { project, projectAttributionSource } =
+		extractProjectAttributionFromRequest(req.headers, parsedBody);
 
 	// 3a. Validate request body for /v1/messages endpoint
 	if (url.pathname === "/v1/messages" && requestBodyBuffer) {
@@ -226,15 +164,20 @@ export async function handleProxy(
 	}
 
 	// 4. Intercept and modify request for agent model preferences
-	const { modifiedBody, agentUsed, originalModel, appliedModel } =
-		await interceptAndModifyRequest(
-			requestBodyContext,
-			ctx.dbOps,
-			req.headers,
-			{
-				frontmatterModelFallback: ctx.config.getAgentFrontmatterModelFallback(),
-			},
-		);
+	const {
+		modifiedBody,
+		agentUsed,
+		originalModel,
+		appliedModel,
+		agentAttributionSource,
+	} = await interceptAndModifyRequest(
+		requestBodyContext,
+		ctx.dbOps,
+		req.headers,
+		{
+			frontmatterModelFallback: ctx.config.getAgentFrontmatterModelFallback(),
+		},
+	);
 
 	// Use modified body if available
 	const finalBodyBuffer = modifiedBody || requestBodyContext.getBuffer();
@@ -252,7 +195,9 @@ export async function handleProxy(
 	// 5. Create request metadata with agent info
 	const requestMeta = createRequestMetadata(req, url);
 	requestMeta.agentUsed = agentUsed;
+	requestMeta.agentAttributionSource = agentAttributionSource;
 	requestMeta.project = project;
+	requestMeta.projectAttributionSource = projectAttributionSource;
 	requestMeta.clientSessionId = requestBodyContext.getClientId();
 	requestMeta.originalModel = originalModel;
 	requestMeta.appliedModel = appliedModel;
@@ -392,6 +337,8 @@ export async function handleProxy(
 				requestHeaders: Object.fromEntries(req.headers.entries()),
 				requestBody: null,
 				project: project ?? null,
+				projectAttributionSource: projectAttributionSource ?? "none",
+				agentAttributionSource: agentAttributionSource ?? "none",
 				responseStatus: 503,
 				responseHeaders: Object.fromEntries(
 					poolExhaustedResponse.headers.entries(),

--- a/packages/proxy/src/response-handler.ts
+++ b/packages/proxy/src/response-handler.ts
@@ -4,7 +4,12 @@ import {
 	withSanitizedProxyHeaders,
 } from "@better-ccflare/http-common";
 import { Logger } from "@better-ccflare/logger";
-import type { Account, RateLimitReason } from "@better-ccflare/types";
+import type {
+	Account,
+	AgentAttributionSource,
+	ProjectAttributionSource,
+	RateLimitReason,
+} from "@better-ccflare/types";
 import type { ProxyContext } from "./handlers";
 import { applyRateLimitCooldown } from "./handlers/rate-limit-cooldown";
 import { createSseRateLimitSniffer } from "./handlers/sse-rate-limit-sniffer";
@@ -91,11 +96,13 @@ export interface ResponseHandlerOptions {
 	project?: string | null;
 	/** Raw URL query string (e.g. `?after_id=...`), used for passive model-catalog capture. */
 	query?: string | null;
+	projectAttributionSource?: ProjectAttributionSource | null;
 	response: Response;
 	timestamp: number;
 	retryAttempt: number;
 	failoverAttempts: number;
 	agentUsed?: string | null;
+	agentAttributionSource?: AgentAttributionSource | null;
 	apiKeyId?: string | null;
 	apiKeyName?: string | null;
 	comboName?: string | null;
@@ -121,11 +128,13 @@ export async function forwardToClient(
 		requestBody,
 		project,
 		query,
+		projectAttributionSource,
 		response: responseRaw,
 		timestamp,
 		retryAttempt, // Always 0 in new flow, but kept for message compatibility
 		failoverAttempts,
 		agentUsed,
+		agentAttributionSource,
 		apiKeyId,
 		apiKeyName,
 		comboName,
@@ -181,6 +190,8 @@ export async function forwardToClient(
 						).toString("base64")
 					: null,
 			project: project ?? null,
+			projectAttributionSource: projectAttributionSource ?? "none",
+			agentAttributionSource: agentAttributionSource ?? "none",
 			responseStatus: response.status,
 			responseHeaders: responseHeadersObj,
 			isStream,
@@ -220,6 +231,7 @@ export async function forwardToClient(
 			accountId: account?.id || null,
 			statusCode: response.status,
 			agentUsed: agentUsed || null,
+			agentAttributionSource: agentAttributionSource ?? "none",
 		});
 	}
 

--- a/packages/proxy/src/usage-collector.ts
+++ b/packages/proxy/src/usage-collector.ts
@@ -5,9 +5,18 @@ import {
 } from "@better-ccflare/core";
 import { AsyncDbWriter, DatabaseOperations } from "@better-ccflare/database";
 import { Logger } from "@better-ccflare/logger";
-import { NO_ACCOUNT_ID, type RequestResponse } from "@better-ccflare/types";
+import {
+	type AgentAttributionSource,
+	NO_ACCOUNT_ID,
+	type ProjectAttributionSource,
+	type RequestResponse,
+} from "@better-ccflare/types";
 import { formatCost } from "@better-ccflare/ui-common";
 import { cacheBodyStore } from "./cache-body-store";
+import {
+	extractProjectAttributionFromParts,
+	sanitizeProjectName,
+} from "./project-attribution";
 import { combineChunks } from "./stream-tee";
 import {
 	type EndMessage,
@@ -36,7 +45,9 @@ interface RequestState {
 	lastActivity: number;
 	createdAt: number; // TTL tracking
 	agentUsed?: string;
+	agentAttributionSource?: AgentAttributionSource | null;
 	project?: string | null;
+	projectAttributionSource?: ProjectAttributionSource | null;
 	billingType?: string;
 	firstTokenTimestamp?: number;
 	lastTokenTimestamp?: number;
@@ -60,102 +71,6 @@ function shouldLogRequest(path: string, status: number): boolean {
 		return false;
 	}
 	return true;
-}
-
-// Project names are persisted to a single TEXT column and surfaced in the UI.
-// Cap length and strip control chars so a hostile system prompt can't smuggle
-// newlines, ANSI escapes, or megabyte-long blobs into the database.
-const PROJECT_NAME_MAX_LEN = 64;
-
-function sanitizeProjectName(raw: string | undefined | null): string | null {
-	if (!raw) return null;
-	// Strip ASCII control chars (incl. newlines/tabs) — keep Unicode letters,
-	// dashes, dots, and spaces that real project directories use.
-	// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping them is the point
-	const cleaned = raw.replace(/[\x00-\x1F\x7F]/g, "").trim();
-	if (!cleaned) return null;
-	return cleaned.length > PROJECT_NAME_MAX_LEN
-		? cleaned.slice(0, PROJECT_NAME_MAX_LEN)
-		: cleaned;
-}
-
-/**
- * Extract a project name from a Claude API request.
- *
- * Resolution order:
- *  1. Case-insensitive `x-project` request header
- *  2. Workspace path embedded in the system prompt
- *     (e.g. /Users/me/Desktop/MyProj/...)
- *  3. First Markdown H1 heading in the system prompt (if reasonable)
- *
- * All return values are sanitized (control chars stripped, length-capped).
- * Returns null when no project can be inferred.
- */
-function extractProjectFromRequest(startMessage: StartMessage): string | null {
-	const messageProject = sanitizeProjectName(startMessage.project);
-	if (messageProject) return messageProject;
-
-	if (startMessage.requestHeaders) {
-		// The Web Headers API normalizes keys to lowercase, but defensively
-		// match case-insensitively in case the collector receives a plain object.
-		const headerProject = Object.entries(startMessage.requestHeaders).find(
-			([k]) => k.toLowerCase() === "x-project",
-		)?.[1];
-		const sanitizedHeader = sanitizeProjectName(headerProject);
-		if (sanitizedHeader) return sanitizedHeader;
-	}
-
-	const systemPrompt = _extractSystemPrompt(startMessage.requestBody);
-	if (!systemPrompt) return null;
-
-	const pathMatch = systemPrompt.match(
-		/\/(?:Users|home)\/[^/]+\/(?:Desktop|projects|repos|src)\/([^/]+)\//,
-	);
-	const sanitizedPath = sanitizeProjectName(pathMatch?.[1]);
-	if (sanitizedPath) return sanitizedPath;
-
-	// Mirror of the regex in proxy.ts (both cap output via sanitizeProjectName)
-	const headingMatch = systemPrompt.match(/^#\s+([^\n\r]{1,100})/m);
-	if (headingMatch) {
-		const heading = sanitizeProjectName(headingMatch[1]);
-		if (heading && !heading.toLowerCase().startsWith("claude")) {
-			return heading;
-		}
-	}
-
-	return null;
-}
-
-// Extract system prompt from request body
-function _extractSystemPrompt(requestBody: string | null): string | null {
-	if (!requestBody) return null;
-
-	try {
-		// Decode base64 request body
-		const decodedBody = Buffer.from(requestBody, "base64").toString("utf-8");
-		const parsed = JSON.parse(decodedBody);
-
-		// Check if there's a system property in the request
-		if (parsed.system) {
-			// Handle both string and array formats
-			if (typeof parsed.system === "string") {
-				return parsed.system;
-			} else if (Array.isArray(parsed.system)) {
-				// Concatenate all text from system messages
-				return parsed.system
-					.filter(
-						(item: { type?: string; text?: string }) =>
-							item.type === "text" && item.text,
-					)
-					.map((item: { type?: string; text?: string }) => item.text)
-					.join("\n");
-			}
-		}
-	} catch (error) {
-		log.debug("Failed to extract system prompt:", error);
-	}
-
-	return null;
 }
 
 // Parse SSE lines to extract usage (reuse existing logic)
@@ -464,9 +379,33 @@ export class UsageCollector {
 			state.agentUsed = msg.agentUsed;
 			log.debug(`Agent '${msg.agentUsed}' used for request ${msg.requestId}`);
 		}
+		state.agentAttributionSource = msg.agentAttributionSource ?? "none";
 
-		// Extract project name (header or system prompt)
-		state.project = extractProjectFromRequest(msg);
+		// Tri-state source contract: an authoritative source label on the StartMessage
+		// (a concrete value or "none") is honored without recomputation; a legacy
+		// message that carries a project but no source is tagged "none"; a fully
+		// legacy/direct message with neither is recomputed via the shared helper.
+		if (msg.projectAttributionSource != null) {
+			// Authoritative source, but still sanitize the value — a legacy/direct
+			// producer could pair a real source label with an unsanitized project
+			// (control chars, ANSI, overlong). Drop to "none" if nothing survives.
+			const sanitized = sanitizeProjectName(msg.project);
+			state.project = sanitized;
+			state.projectAttributionSource = sanitized
+				? msg.projectAttributionSource
+				: "none";
+		} else if (msg.project) {
+			// Legacy message: project set, no source. Sanitize and tag "none".
+			state.project = sanitizeProjectName(msg.project);
+			state.projectAttributionSource = "none";
+		} else {
+			const extracted = extractProjectAttributionFromParts(
+				msg.requestHeaders,
+				msg.requestBody,
+			);
+			state.project = extracted.project;
+			state.projectAttributionSource = extracted.projectAttributionSource;
+		}
 		if (state.project) {
 			log.debug(
 				`Project '${state.project}' extracted for request ${msg.requestId}`,
@@ -793,6 +732,8 @@ export class UsageCollector {
 					// instead of duplicating the `model` column's value.
 					modelRewritten ? startMessage.originalModel : null,
 					modelRewritten ? startMessage.appliedModel : null,
+					state.projectAttributionSource ?? null,
+					state.agentAttributionSource ?? null,
 				);
 			} catch (error) {
 				log.error(
@@ -862,6 +803,8 @@ export class UsageCollector {
 						isStream: startMessage.isStream,
 						retry: startMessage.retryAttempt,
 						project: state.project ?? undefined,
+						projectAttributionSource:
+							state.projectAttributionSource ?? undefined,
 					},
 				});
 
@@ -933,6 +876,8 @@ export class UsageCollector {
 			originalModel: startMessage.originalModel || undefined,
 			appliedModel: startMessage.appliedModel || undefined,
 			comboName: startMessage.comboName || undefined,
+			projectAttributionSource: state.projectAttributionSource ?? undefined,
+			agentAttributionSource: state.agentAttributionSource ?? undefined,
 		};
 
 		// Notify cacheBodyStore and emit summary for real-time updates

--- a/packages/proxy/src/worker-messages.ts
+++ b/packages/proxy/src/worker-messages.ts
@@ -3,6 +3,11 @@
  * Handles both streaming and non-streaming responses
  */
 
+import type {
+	AgentAttributionSource,
+	ProjectAttributionSource,
+} from "@better-ccflare/types";
+
 // ===== MAIN THREAD → WORKER =====
 
 export interface StartMessage {
@@ -38,6 +43,8 @@ export interface StartMessage {
 
 	// Agent info
 	agentUsed: string | null;
+	projectAttributionSource?: ProjectAttributionSource | null;
+	agentAttributionSource?: AgentAttributionSource | null;
 
 	// Model rewrite observability: the model the client originally requested
 	// and the model actually forwarded upstream. Both null unless an

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1,4 +1,8 @@
 import type { AllowedModel } from "./agent";
+import type {
+	AgentAttributionSource,
+	ProjectAttributionSource,
+} from "./request";
 
 /** Combo slot routing info — maps each returned account to its slot's model override */
 export interface ComboSlotInfo {
@@ -15,6 +19,8 @@ export interface RequestMeta {
 	timestamp: number;
 	agentUsed?: string | null;
 	project?: string | null;
+	projectAttributionSource?: ProjectAttributionSource | null;
+	agentAttributionSource?: AgentAttributionSource | null;
 	headers?: Headers;
 	/** Active combo name (set when combo routing is used) */
 	comboName?: string | null;

--- a/packages/types/src/request.ts
+++ b/packages/types/src/request.ts
@@ -1,3 +1,11 @@
+export type ProjectAttributionSource =
+	| "header_project"
+	| "path_project"
+	| "heading_project"
+	| "none";
+
+export type AgentAttributionSource = "header_agent" | "prompt_agent" | "none";
+
 // Database row type
 export interface RequestRow {
 	id: string;
@@ -28,6 +36,8 @@ export interface RequestRow {
 	combo_name: string | null;
 	original_model: string | null;
 	applied_model: string | null;
+	project_attribution_source: string | null;
+	agent_attribution_source: string | null;
 }
 
 // Domain model
@@ -60,6 +70,8 @@ export interface Request {
 	comboName?: string;
 	originalModel?: string;
 	appliedModel?: string;
+	projectAttributionSource?: ProjectAttributionSource;
+	agentAttributionSource?: AgentAttributionSource;
 }
 
 // API response type
@@ -95,6 +107,8 @@ export interface RequestResponse {
 	// Derived from statusCode === 429 server-side so the list view can render
 	// the "Rate Limited" badge without lazy-loading the full payload.
 	rateLimited?: boolean;
+	projectAttributionSource?: ProjectAttributionSource;
+	agentAttributionSource?: AgentAttributionSource;
 }
 
 // Detailed request with payload
@@ -123,6 +137,9 @@ export interface RequestPayload {
 		path?: string;
 		method?: string;
 		agentUsed?: string;
+		agentAttributionSource?: AgentAttributionSource;
+		project?: string;
+		projectAttributionSource?: ProjectAttributionSource;
 		requestBodyTruncated?: boolean;
 		responseBodyTruncated?: boolean;
 		limitApplied?: number;
@@ -183,6 +200,10 @@ export function toRequest(row: RequestRow): Request {
 		comboName: row.combo_name || undefined,
 		originalModel: row.original_model || undefined,
 		appliedModel: row.applied_model || undefined,
+		projectAttributionSource:
+			(row.project_attribution_source as ProjectAttributionSource) || undefined,
+		agentAttributionSource:
+			(row.agent_attribution_source as AgentAttributionSource) || undefined,
 	};
 }
 
@@ -217,6 +238,8 @@ export function toRequestResponse(request: Request): RequestResponse {
 		originalModel: request.originalModel,
 		appliedModel: request.appliedModel,
 		rateLimited: request.statusCode === 429,
+		projectAttributionSource: request.projectAttributionSource,
+		agentAttributionSource: request.agentAttributionSource,
 	};
 }
 


### PR DESCRIPTION
## Summary

Adds low-cardinality provenance labels for the existing `project` and `agent_used` fields so request history shows whether attribution came from an explicit header, workspace path, prompt heading, or agent detection.

This is the current-main replacement for draft #298. It preserves the original source commit and adds compatibility with the newer `extra_usage_exhausted` direct persistence path that landed after #298 branched. Draft #298 should remain open until this replacement is merged or otherwise accepted.

## Attribution labels

- `project_attribution_source`: `header_project`, `path_project`, `heading_project`, or `none`
- `agent_attribution_source`: `header_agent`, `prompt_agent`, or `none`

Only fixed enum labels are persisted. Raw headers, paths, prompt text, request bodies, and secrets are not stored as attribution sources.

## Implementation

- Centralizes project extraction and source classification.
- Adds preferred namespaced project and agent headers while retaining legacy header support.
- Propagates source labels through worker messages, request events, usage collection, direct persistence paths, authenticated API summaries, and dashboard views.
- Adds SQLite and PostgreSQL schema and migration parity.
- Keeps value/source updates atomic according to source authority.
- Applies original/applied model gating and source propagation to the newer `extra_usage_exhausted` save path.

## Provenance

- Original source commit: `91df339f544e0039283ff36771345a36dfc52633`
- Preserved via cherry-pick with `-x` as `b5099129`
- Current-main compatibility commit: `a584070a`

## Validation

- Focused attribution, migration, HTTP API, dashboard, failover, and exhaustion suites: 161 passed
- `bun run build`: passed
- `bun run lint`: passed with 211 existing warnings
- `bun run typecheck`: passed
- `bun run format`: passed
- `git diff --check`: passed

No real provider endpoints were called.