### PR TITLE
fix(core): bound and single-flight models.dev pricing fetches

### DIFF
--- a/packages/core/src/pricing.test.ts
+++ b/packages/core/src/pricing.test.ts
@@ -24,6 +24,107 @@ const mockAccountRepository = {
 	hasAccountsForProvider: vi.fn(),
 };
 
+describe("models.dev pricing", () => {
+	let originalFetch: typeof global.fetch;
+	let originalOffline: string | undefined;
+
+	beforeEach(() => {
+		originalFetch = global.fetch;
+		originalOffline = process.env.CF_PRICING_OFFLINE;
+		delete process.env.CF_PRICING_OFFLINE;
+		resetNanoGPTPricingCacheForTest();
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		global.fetch = originalFetch;
+		if (originalOffline === undefined) {
+			delete process.env.CF_PRICING_OFFLINE;
+		} else {
+			process.env.CF_PRICING_OFFLINE = originalOffline;
+		}
+		resetNanoGPTPricingCacheForTest();
+		vi.restoreAllMocks();
+	});
+
+	it("shares one cold models.dev fetch across concurrent estimates", async () => {
+		let resolveModelsDev!: (response: Response) => void;
+		const modelsDevResponse = new Promise<Response>((resolve) => {
+			resolveModelsDev = resolve;
+		});
+		const fetchMock = vi.fn((input: string | URL | Request) => {
+			if (String(input) === "https://models.dev/api.json") {
+				return modelsDevResponse;
+			}
+			return Promise.resolve({
+				ok: true,
+				json: async () => ({ object: "list", data: [] }),
+			} as Response);
+		});
+		global.fetch = fetchMock as typeof global.fetch;
+
+		const estimates = [
+			estimateCostUSD("claude-sonnet-4-20250514", { outputTokens: 1 }),
+			estimateCostUSD("claude-sonnet-4-20250514", { outputTokens: 2 }),
+		];
+		await Promise.resolve();
+		await Promise.resolve();
+
+		const modelsDevCalls = fetchMock.mock.calls.filter(
+			([input]) => String(input) === "https://models.dev/api.json",
+		).length;
+		resolveModelsDev({
+			ok: true,
+			json: async () => ({}),
+		} as Response);
+		await Promise.all(estimates);
+
+		expect(modelsDevCalls).toBe(1);
+	});
+
+	it("aborts a stalled models.dev fetch and falls back to bundled pricing", async () => {
+		vi.useFakeTimers();
+		let modelsDevSignal: AbortSignal | undefined;
+		const fetchMock = vi.fn(
+			(input: string | URL | Request, init?: RequestInit) => {
+				if (String(input) !== "https://models.dev/api.json") {
+					return Promise.resolve({
+						ok: true,
+						json: async () => ({ object: "list", data: [] }),
+					} as Response);
+				}
+
+				modelsDevSignal = init?.signal ?? undefined;
+				return new Promise<Response>((_resolve, reject) => {
+					modelsDevSignal?.addEventListener(
+						"abort",
+						() => reject(new DOMException("aborted", "AbortError")),
+						{ once: true },
+					);
+					// Test-only escape hatch: the pre-fix fetch has no signal, so make
+					// the failing test settle instead of leaving a permanent promise.
+					setTimeout(
+						() => reject(new Error("test fetch guard expired")),
+						10_001,
+					);
+				});
+			},
+		);
+		global.fetch = fetchMock as typeof global.fetch;
+
+		const estimate = estimateCostUSD("claude-sonnet-4-20250514", {
+			outputTokens: 1_000_000,
+		});
+		vi.advanceTimersByTime(10_001);
+		const cost = await estimate;
+
+		expect(modelsDevSignal).toBeInstanceOf(AbortSignal);
+		expect(modelsDevSignal?.aborted).toBe(true);
+		expect(cost).toBe(15);
+	});
+});
+
 describe("NanoGPT Pricing", () => {
 	beforeEach(() => {
 		// Clear any existing intervals

--- a/packages/core/src/pricing.ts
+++ b/packages/core/src/pricing.ts
@@ -245,6 +245,8 @@ interface NanoGPTApiResponse {
 	data: NanoGPTModel[];
 }
 
+const MODELS_DEV_FETCH_TIMEOUT_MS = 10_000;
+
 // Cache constants for NanoGPT pricing
 export const NANOGPT_CACHE_DURATION_MS = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
 
@@ -258,6 +260,7 @@ class PriceCatalogue {
 	private static instance: PriceCatalogue;
 	private priceData: ApiResponse | null = null;
 	private lastFetch = 0;
+	private remoteFetchPromise: Promise<ApiResponse | null> | null = null;
 	private warnedModels = new Set<string>();
 	private warnedRatesUnknownModels = new Set<string>();
 	private logger: Logger | null = null;
@@ -483,8 +486,30 @@ class PriceCatalogue {
 			return null;
 		}
 
+		if (this.remoteFetchPromise) return this.remoteFetchPromise;
+
+		const fetchPromise = this.fetchRemoteOnce();
+		this.remoteFetchPromise = fetchPromise;
 		try {
-			const response = await fetch("https://models.dev/api.json");
+			return await fetchPromise;
+		} finally {
+			if (this.remoteFetchPromise === fetchPromise) {
+				this.remoteFetchPromise = null;
+			}
+		}
+	}
+
+	private async fetchRemoteOnce(): Promise<ApiResponse | null> {
+		const controller = new AbortController();
+		const timeoutId = setTimeout(
+			() => controller.abort(),
+			MODELS_DEV_FETCH_TIMEOUT_MS,
+		);
+
+		try {
+			const response = await fetch("https://models.dev/api.json", {
+				signal: controller.signal,
+			});
 			if (!response.ok) {
 				throw new Error(`HTTP ${response.status}: ${response.statusText}`);
 			}
@@ -494,6 +519,8 @@ class PriceCatalogue {
 		} catch (error) {
 			this.logger?.warn("Failed to fetch pricing data: %s", error);
 			return null;
+		} finally {
+			clearTimeout(timeoutId);
 		}
 	}
 


### PR DESCRIPTION
## Summary

Makes remote models.dev pricing catalogue fetches single-flight and time-bounded so concurrent cost estimates share one request and a stalled catalogue cannot hang request finalization.

This is a focused unit extracted from draft #308. It intentionally does not include UsageCollector lifecycle retention or server shutdown sequencing; those remain as separate follow-ups from #308.

## Behavior

- Concurrent cold `estimateCostUSD` calls share one models.dev fetch.
- models.dev fetches abort after 10 seconds and fall back to bundled pricing.
- Existing NanoGPT pricing behavior is unchanged.

## Provenance

- Source commit: `f32f430ca4496d7160e55c89a730b128323b4ee6`
- Preserved via cherry-pick with `-x`

## Validation

- `bun test packages/core/src/pricing.test.ts`: 15 passed
- `bun run build`: passed
- `bun run lint`: passed with 211 existing warnings
- `bun run typecheck`: passed
- `bun run format`: passed
- `git diff --check`: passed

No real provider endpoints were called.