### PR TITLE
fix(proxy): retain active stream usage state and harden finalization

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,6 +121,7 @@ These environment variables are not stored in the configuration file and must be
 | `DATABASE_URL` | Use PostgreSQL instead of SQLite. Set to a `postgresql://` or `postgres://` connection string. When set, `better-ccflare_DB_PATH` is ignored. | - | `DATABASE_URL=postgresql://user:pass@localhost:5432/ccflare` |
 | `CF_PRICING_REFRESH_HOURS` | Hours between pricing data refreshes | `24` | `CF_PRICING_REFRESH_HOURS=12` |
 | `CF_PRICING_OFFLINE` | Disable online pricing updates | - | `CF_PRICING_OFFLINE=1` |
+| `CF_PRICING_TIMEOUT_MS` | Pricing estimate deadline in milliseconds. Accepts integers from `1` through `60000`; unset or invalid values fall back to `5000` | `5000` | `CF_PRICING_TIMEOUT_MS=10000` |
 | `BETTER_CCFLARE_MODELS_REFRESH_HOURS` | Hours between scheduled model catalog refreshes; `0` disables scheduled refresh entirely | `168` (7 days) | `BETTER_CCFLARE_MODELS_REFRESH_HOURS=48` |
 | `BETTER_CCFLARE_MODELS_OFFLINE` | Disable scheduled/manual model catalog refresh **and** passive `/v1/models` capture | - | `BETTER_CCFLARE_MODELS_OFFLINE=1` |
 | `BETTER_CCFLARE_MODELS_CACHE_DIR` | Directory for the persisted model catalog cache file. Use a persistent directory (not a tmpdir that's wiped on restart) to keep the refresh schedule stable across restarts | Platform tmp dir | `BETTER_CCFLARE_MODELS_CACHE_DIR=/var/lib/better-ccflare` |

--- a/packages/proxy/src/__tests__/usage-collector-lifecycle.test.ts
+++ b/packages/proxy/src/__tests__/usage-collector-lifecycle.test.ts
@@ -1,0 +1,565 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { logBus } from "@better-ccflare/logger";
+import type { LogEvent } from "@better-ccflare/types";
+import { isValidClaudeModel } from "../../../core/src/model-mappings";
+import { CLAUDE_MODEL_IDS } from "../../../core/src/models";
+import type { StartMessage } from "../worker-messages";
+
+interface PricingTokens {
+	inputTokens?: number;
+	outputTokens?: number;
+	cacheReadInputTokens?: number;
+	cacheCreationInputTokens?: number;
+}
+
+type PricingImplementation = (
+	model: string,
+	tokens: PricingTokens,
+) => Promise<number>;
+
+let pricingImplementation: PricingImplementation = async () => 0;
+const estimateCostUSD = mock((model: string, tokens: PricingTokens) =>
+	pricingImplementation(model, tokens),
+);
+
+mock.module("@better-ccflare/core", () => ({
+	BUFFER_SIZES: {
+		STREAM_TEE_MAX_BYTES: 1024 * 1024,
+		STREAM_USAGE_BUFFER_KB: 64,
+	},
+	CLAUDE_MODEL_IDS,
+	estimateCostUSD,
+	isValidClaudeModel,
+	TIME_CONSTANTS: {
+		HOUR: 60 * 60 * 1000,
+		MINUTE: 60 * 1000,
+		SECOND: 1000,
+		STREAM_TIMEOUT_DEFAULT: 60 * 1000,
+	},
+}));
+
+mock.module("@better-ccflare/database", () => ({
+	AsyncDbWriter: class {},
+	DatabaseOperations: class {},
+}));
+
+const { UsageCollector } = await import("../usage-collector");
+type UsageCollectorInstance = InstanceType<typeof UsageCollector>;
+
+const INACTIVITY_TIMEOUT_MS = 2 * 60 * 1000;
+
+interface TestHarness {
+	collector: UsageCollectorInstance;
+	saveRequestIds: string[];
+	payloads: Map<string, string>;
+	summaryCosts: Map<string, number | undefined>;
+	summaries: string[];
+}
+
+interface TestRequestState {
+	startMessage: StartMessage;
+	buffer: string;
+	chunks: Uint8Array[];
+	chunksBytes: number;
+}
+
+interface TestableCollector {
+	cleanupStaleRequests(): void;
+	missingStateWarnings: Set<string>;
+	pricingTimeoutMs: number;
+	requests: Map<string, TestRequestState>;
+}
+
+function makeStartMessage(
+	requestId: string,
+	overrides: Partial<StartMessage> = {},
+): StartMessage {
+	return {
+		type: "start",
+		messageId: `message-${requestId}`,
+		accountId: null,
+		method: "POST",
+		path: "/v1/messages",
+		timestamp: Date.now(),
+		requestHeaders: {},
+		requestBody: null,
+		project: null,
+		responseStatus: 200,
+		responseHeaders: { "content-type": "text/event-stream" },
+		isStream: true,
+		providerName: "anthropic",
+		accountBillingType: null,
+		accountAutoPauseOnOverageEnabled: null,
+		accountName: null,
+		agentUsed: null,
+		originalModel: null,
+		appliedModel: null,
+		comboName: null,
+		apiKeyId: null,
+		apiKeyName: null,
+		retryAttempt: 0,
+		failoverAttempts: 0,
+		...overrides,
+		requestId,
+	};
+}
+
+function createHarness(storePayloads = false): TestHarness {
+	const saveRequestIds: string[] = [];
+	const payloads = new Map<string, string>();
+	const summaryCosts = new Map<string, number | undefined>();
+	const summaries: string[] = [];
+	const pendingWrites = new Set<Promise<void>>();
+
+	const dbOps = {
+		async saveRequest(requestId: string): Promise<void> {
+			saveRequestIds.push(requestId);
+		},
+		async saveRequestPayloadRaw(
+			requestId: string,
+			payload: string,
+		): Promise<void> {
+			payloads.set(requestId, payload);
+		},
+	};
+
+	const asyncWriter = {
+		enqueue(task: () => Promise<void> | void): void {
+			const pending = Promise.resolve().then(task);
+			pendingWrites.add(pending);
+			void pending.finally(() => pendingWrites.delete(pending));
+		},
+		async dispose(): Promise<void> {
+			await Promise.allSettled([...pendingWrites]);
+		},
+		canAcceptPayload(): boolean {
+			return true;
+		},
+		enqueuePayload(
+			_requestId: string,
+			_bytes: number,
+			task: () => Promise<void> | void,
+		): boolean {
+			this.enqueue(task);
+			return true;
+		},
+	};
+
+	const collector = new UsageCollector(
+		dbOps as never,
+		asyncWriter as never,
+		() => storePayloads,
+		(summary) => {
+			summaries.push(summary.id);
+			summaryCosts.set(summary.id, summary.costUsd);
+		},
+	);
+
+	return { collector, saveRequestIds, payloads, summaries, summaryCosts };
+}
+
+function testable(collector: UsageCollectorInstance): TestableCollector {
+	return collector as unknown as TestableCollector;
+}
+
+function modelBearingChunk(): Uint8Array {
+	return new TextEncoder().encode(
+		'event: message_start\ndata: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","usage":{"input_tokens":5,"output_tokens":0}}}\n\n',
+	);
+}
+
+describe("UsageCollector request lifecycle", () => {
+	const realDateNow = Date.now;
+	const previousPricingTimeout = process.env.CF_PRICING_TIMEOUT_MS;
+	const previousStreamTimeout = process.env.CF_STREAM_TIMEOUT_MS;
+	let now = 1_700_000_000_000;
+	const collectors: UsageCollectorInstance[] = [];
+
+	beforeEach(() => {
+		now = 1_700_000_000_000;
+		Date.now = () => now;
+		delete process.env.CF_PRICING_TIMEOUT_MS;
+		process.env.CF_STREAM_TIMEOUT_MS = String(INACTIVITY_TIMEOUT_MS);
+		pricingImplementation = async () => 0;
+		estimateCostUSD.mockClear();
+	});
+
+	afterEach(() => {
+		for (const collector of collectors.splice(0)) collector.dispose();
+		Date.now = realDateNow;
+		if (previousPricingTimeout === undefined) {
+			delete process.env.CF_PRICING_TIMEOUT_MS;
+		} else {
+			process.env.CF_PRICING_TIMEOUT_MS = previousPricingTimeout;
+		}
+		if (previousStreamTimeout === undefined) {
+			delete process.env.CF_STREAM_TIMEOUT_MS;
+		} else {
+			process.env.CF_STREAM_TIMEOUT_MS = previousStreamTimeout;
+		}
+	});
+
+	function harness(storePayloads = false): TestHarness {
+		const value = createHarness(storePayloads);
+		collectors.push(value.collector);
+		return value;
+	}
+
+	it("keeps an actively chunking stream beyond two minutes and persists it on end", async () => {
+		const { collector, saveRequestIds, summaries } = harness();
+		collector.handleStart(makeStartMessage("active-stream"));
+
+		for (const elapsed of [30_000, 60_000, 90_000, 121_000]) {
+			now = 1_700_000_000_000 + elapsed;
+			collector.handleChunk(
+				"active-stream",
+				new TextEncoder().encode(": ping\n\n"),
+			);
+			testable(collector).cleanupStaleRequests();
+		}
+
+		expect(testable(collector).requests.has("active-stream")).toBe(true);
+		await collector.handleEnd({
+			type: "end",
+			requestId: "active-stream",
+			success: true,
+		});
+		await collector.drain();
+
+		expect(saveRequestIds).toEqual(["active-stream"]);
+		expect(summaries).toEqual(["active-stream"]);
+		expect(testable(collector).requests.has("active-stream")).toBe(false);
+	});
+
+	it("detaches a finalizing stream before pricing yields so capacity eviction cannot free it", async () => {
+		const { collector, payloads } = harness(true);
+		const requestBody = Buffer.from("old request body").toString("base64");
+		collector.handleStart(
+			makeStartMessage("finalizing-stream", {
+				requestBody,
+				requestHeaders: { "x-lifecycle": "old" },
+			}),
+		);
+		collector.handleChunk("finalizing-stream", modelBearingChunk());
+		const finalizingState =
+			testable(collector).requests.get("finalizing-stream");
+		expect(finalizingState).toBeDefined();
+
+		const endPromise = collector.handleEnd({
+			type: "end",
+			requestId: "finalizing-stream",
+			success: true,
+		});
+		const detachedBeforePricingResolved =
+			!testable(collector).requests.has("finalizing-stream");
+
+		now += 1;
+		for (let i = 0; i <= 10_000; i++) {
+			collector.handleStart(makeStartMessage(`race-capacity-${i}`));
+		}
+		const stateSurvivedCapacityEviction =
+			(finalizingState?.chunks.length ?? 0) > 0 &&
+			finalizingState?.startMessage.requestBody === requestBody &&
+			finalizingState?.startMessage.requestHeaders["x-lifecycle"] === "old";
+
+		await endPromise;
+		await collector.drain();
+
+		const savedPayload = JSON.parse(
+			payloads.get("finalizing-stream") ?? "null",
+		);
+		expect(detachedBeforePricingResolved).toBe(true);
+		expect(stateSurvivedCapacityEviction).toBe(true);
+		expect(savedPayload.request.body).toBe(requestBody);
+		expect(savedPayload.request.headers).toEqual({ "x-lifecycle": "old" });
+		expect(
+			Buffer.from(savedPayload.response.body, "base64").toString("utf8"),
+		).toContain("message_start");
+	});
+
+	it("does not delete a new same-ID lifecycle when the old finalizer completes", async () => {
+		const { collector, payloads } = harness(true);
+		const oldRequestBody = Buffer.from("old lifecycle").toString("base64");
+		const newRequestBody = Buffer.from("new lifecycle").toString("base64");
+		collector.handleStart(
+			makeStartMessage("reused-finalizing-id", {
+				requestBody: oldRequestBody,
+			}),
+		);
+		collector.handleChunk("reused-finalizing-id", modelBearingChunk());
+
+		const endPromise = collector.handleEnd({
+			type: "end",
+			requestId: "reused-finalizing-id",
+			success: true,
+		});
+		const detachedBeforeReuse = !testable(collector).requests.has(
+			"reused-finalizing-id",
+		);
+
+		now += 1;
+		collector.handleStart(
+			makeStartMessage("reused-finalizing-id", {
+				requestBody: newRequestBody,
+			}),
+		);
+		const newLifecycle = testable(collector).requests.get(
+			"reused-finalizing-id",
+		);
+		await endPromise;
+		await collector.drain();
+
+		const savedPayload = JSON.parse(
+			payloads.get("reused-finalizing-id") ?? "null",
+		);
+		expect(detachedBeforeReuse).toBe(true);
+		expect(testable(collector).requests.get("reused-finalizing-id")).toBe(
+			newLifecycle,
+		);
+		expect(newLifecycle?.startMessage.requestBody).toBe(newRequestBody);
+		expect(savedPayload.request.body).toBe(oldRequestBody);
+	});
+
+	it("bounds a hung pricing estimate and releases detached request state", async () => {
+		process.env.CF_PRICING_TIMEOUT_MS = "20";
+		pricingImplementation = () => new Promise<number>(() => {});
+		const { collector, saveRequestIds, summaryCosts } = harness(true);
+		const largeRequestBody = Buffer.alloc(256 * 1024, "r").toString("base64");
+		collector.handleStart(
+			makeStartMessage("pricing-timeout", {
+				requestBody: largeRequestBody,
+				requestHeaders: { "x-large-state": "true" },
+			}),
+		);
+		collector.handleChunk("pricing-timeout", modelBearingChunk());
+		collector.handleChunk(
+			"pricing-timeout",
+			new Uint8Array(128 * 1024).fill(120),
+		);
+		const detachedState = testable(collector).requests.get("pricing-timeout");
+		expect(detachedState?.chunksBytes).toBeGreaterThan(128 * 1024);
+		expect(detachedState?.startMessage.requestBody).toBe(largeRequestBody);
+
+		const pricingWarnings: LogEvent[] = [];
+		const onLog = (event: LogEvent) => {
+			if (
+				event.msg === "Pricing estimate timed out; using zero-cost fallback"
+			) {
+				pricingWarnings.push(event);
+			}
+		};
+		logBus.on("log", onLog);
+
+		try {
+			const endPromise = collector.handleEnd({
+				type: "end",
+				requestId: "pricing-timeout",
+				success: true,
+			});
+			const completedWithinBound = await Promise.race([
+				endPromise.then(() => true),
+				new Promise<false>((resolve) => setTimeout(() => resolve(false), 250)),
+			]);
+			if (completedWithinBound) await collector.drain();
+
+			expect(completedWithinBound).toBe(true);
+			expect(saveRequestIds).toContain("pricing-timeout");
+			expect(summaryCosts.get("pricing-timeout")).toBe(0);
+			expect(detachedState?.chunks).toEqual([]);
+			expect(detachedState?.chunksBytes).toBe(0);
+			expect(detachedState?.buffer).toBe("");
+			expect(detachedState?.startMessage.requestBody).toBeNull();
+			expect(detachedState?.startMessage.requestHeaders).toEqual({});
+			expect(pricingWarnings).toHaveLength(1);
+			expect(pricingWarnings[0]?.data).toEqual({
+				model: "claude-sonnet-4-5-20250929",
+				requestId: "pricing-timeout",
+				timeoutMs: 20,
+			});
+		} finally {
+			logBus.off("log", onLog);
+		}
+	});
+
+	it("clears the pricing deadline timer when estimation finishes quickly", async () => {
+		process.env.CF_PRICING_TIMEOUT_MS = "20";
+		pricingImplementation = async () => 0.25;
+		const { collector, summaryCosts } = harness();
+		const pricingWarnings: LogEvent[] = [];
+		const onLog = (event: LogEvent) => {
+			if (
+				event.msg === "Pricing estimate timed out; using zero-cost fallback"
+			) {
+				pricingWarnings.push(event);
+			}
+		};
+		logBus.on("log", onLog);
+
+		try {
+			collector.handleStart(makeStartMessage("fast-pricing"));
+			collector.handleChunk("fast-pricing", modelBearingChunk());
+			await collector.handleEnd({
+				type: "end",
+				requestId: "fast-pricing",
+				success: true,
+			});
+			await collector.drain();
+			await new Promise((resolve) => setTimeout(resolve, 40));
+
+			expect(summaryCosts.get("fast-pricing")).toBe(0.25);
+			expect(pricingWarnings).toEqual([]);
+		} finally {
+			logBus.off("log", onLog);
+		}
+	});
+
+	it("falls back to the default pricing deadline for an invalid override", () => {
+		process.env.CF_PRICING_TIMEOUT_MS = "60001";
+		const { collector } = harness();
+		expect(testable(collector).pricingTimeoutMs).toBe(5_000);
+	});
+
+	it("evicts a stream that exceeds the inactivity timeout", async () => {
+		const { collector, saveRequestIds } = harness();
+		collector.handleStart(makeStartMessage("inactive-stream"));
+
+		now += INACTIVITY_TIMEOUT_MS + 1;
+		testable(collector).cleanupStaleRequests();
+
+		expect(testable(collector).requests.has("inactive-stream")).toBe(false);
+		await collector.handleEnd({
+			type: "end",
+			requestId: "inactive-stream",
+			success: false,
+			error: "downstream disconnected",
+		});
+		await collector.drain();
+		expect(saveRequestIds).toEqual([]);
+	});
+
+	it("retains the capacity safeguard and frees the oldest evicted state", () => {
+		const { collector } = harness(true);
+		const oldestBody = Buffer.from("oldest request").toString("base64");
+		collector.handleStart(
+			makeStartMessage("capacity-oldest", {
+				requestBody: oldestBody,
+				requestHeaders: { "x-oldest": "true" },
+				responseHeaders: { "x-response": "oldest" },
+			}),
+		);
+		collector.handleChunk(
+			"capacity-oldest",
+			new TextEncoder().encode("partial-event"),
+		);
+		const oldestState = testable(collector).requests.get("capacity-oldest");
+		expect(oldestState).toBeDefined();
+		expect(oldestState?.chunks.length).toBe(1);
+		expect(oldestState?.buffer).toBe("partial-event");
+
+		now += 1;
+		for (let i = 0; i < 9_999; i++) {
+			collector.handleStart(makeStartMessage(`capacity-filler-${i}`));
+		}
+		collector.handleStart(makeStartMessage("capacity-newest"));
+
+		expect(testable(collector).requests.size).toBe(9_001);
+		expect(testable(collector).requests.has("capacity-oldest")).toBe(false);
+		expect(testable(collector).requests.has("capacity-newest")).toBe(true);
+		expect(oldestState?.chunks).toEqual([]);
+		expect(oldestState?.chunksBytes).toBe(0);
+		expect(oldestState?.buffer).toBe("");
+		expect(oldestState?.startMessage.requestBody).toBeNull();
+		expect(oldestState?.startMessage.requestHeaders).toEqual({});
+		expect(oldestState?.startMessage.responseHeaders).toEqual({});
+	});
+
+	it("warns only once for repeated chunks after state is missing", async () => {
+		const { collector } = harness();
+		const warnings: string[] = [];
+		const onLog = (event: LogEvent) => {
+			if (event.level === "WARN" && event.msg.includes("missing-stream")) {
+				warnings.push(event.msg);
+			}
+		};
+		logBus.on("log", onLog);
+
+		try {
+			for (let i = 0; i < 100; i++) {
+				collector.handleChunk("missing-stream", new Uint8Array([i]));
+			}
+			await collector.handleEnd({
+				type: "end",
+				requestId: "missing-stream",
+				success: false,
+				error: "stream state was already evicted",
+			});
+		} finally {
+			logBus.off("log", onLog);
+		}
+
+		expect(warnings).toHaveLength(1);
+		expect(testable(collector).missingStateWarnings.size).toBe(1);
+	});
+
+	it("keeps exactly the newest 1000 missing-state warning tombstones in FIFO order", () => {
+		const { collector } = harness();
+		for (let i = 0; i < 1_100; i++) {
+			collector.handleChunk(`unknown-${i}`, new Uint8Array([i % 256]));
+		}
+
+		const tombstones = testable(collector).missingStateWarnings;
+		expect(tombstones.size).toBe(1_000);
+		expect(tombstones.has("unknown-99")).toBe(false);
+		expect(tombstones.has("unknown-100")).toBe(true);
+		expect(tombstones.has("unknown-1099")).toBe(true);
+
+		const warnings: string[] = [];
+		const onLog = (event: LogEvent) => {
+			if (event.level === "WARN" && event.msg.includes("unknown-")) {
+				warnings.push(event.msg);
+			}
+		};
+		logBus.on("log", onLog);
+		try {
+			collector.handleChunk("unknown-100", new Uint8Array([1]));
+			collector.handleChunk("unknown-0", new Uint8Array([2]));
+		} finally {
+			logBus.off("log", onLog);
+		}
+
+		expect(warnings).toEqual(["No state found for request unknown-0"]);
+	});
+
+	it("resets missing-state warning eligibility when a request ID is reused", async () => {
+		const { collector } = harness();
+		const warnings: string[] = [];
+		const onLog = (event: LogEvent) => {
+			if (event.level === "WARN" && event.msg.includes("reused-warning-id")) {
+				warnings.push(event.msg);
+			}
+		};
+		logBus.on("log", onLog);
+
+		try {
+			collector.handleChunk("reused-warning-id", new Uint8Array([1]));
+			collector.handleChunk("reused-warning-id", new Uint8Array([2]));
+			collector.handleStart(makeStartMessage("reused-warning-id"));
+			expect(
+				testable(collector).missingStateWarnings.has("reused-warning-id"),
+			).toBe(false);
+			await collector.handleEnd({
+				type: "end",
+				requestId: "reused-warning-id",
+				success: true,
+			});
+			collector.handleChunk("reused-warning-id", new Uint8Array([3]));
+		} finally {
+			logBus.off("log", onLog);
+		}
+
+		expect(warnings).toEqual([
+			"No state found for request reused-warning-id",
+			"No state found for request reused-warning-id",
+		]);
+	});
+});

--- a/packages/proxy/src/__tests__/usage-collector-lifecycle.test.ts
+++ b/packages/proxy/src/__tests__/usage-collector-lifecycle.test.ts
@@ -3,7 +3,7 @@ import { logBus } from "@better-ccflare/logger";
 import type { LogEvent } from "@better-ccflare/types";
 import { isValidClaudeModel } from "../../../core/src/model-mappings";
 import { CLAUDE_MODEL_IDS } from "../../../core/src/models";
-import type { StartMessage } from "../worker-messages";
+import type { EndMessage, StartMessage } from "../worker-messages";
 
 interface PricingTokens {
 	inputTokens?: number;
@@ -50,10 +50,12 @@ const INACTIVITY_TIMEOUT_MS = 2 * 60 * 1000;
 
 interface TestHarness {
 	collector: UsageCollectorInstance;
+	payloadDrops: number[];
 	saveRequestIds: string[];
 	payloads: Map<string, string>;
 	summaryCosts: Map<string, number | undefined>;
 	summaries: string[];
+	writerState: { disposed: boolean };
 }
 
 interface TestRequestState {
@@ -61,11 +63,22 @@ interface TestRequestState {
 	buffer: string;
 	chunks: Uint8Array[];
 	chunksBytes: number;
+	chunksTruncated: boolean;
+	payloadReleased: boolean;
+	retainedPayloadBytes: number;
+	usage: {
+		model?: string;
+		outputTokens?: number;
+	};
 }
 
 interface TestableCollector {
+	_handleEndInternal(msg: EndMessage): Promise<void>;
+	activePayloadBytes: number;
 	cleanupStaleRequests(): void;
 	missingStateWarnings: Set<string>;
+	pendingPayloadBytes: number;
+	pendingPayloadCount: number;
 	pricingTimeoutMs: number;
 	requests: Map<string, TestRequestState>;
 }
@@ -107,8 +120,10 @@ function makeStartMessage(
 function createHarness(storePayloads = false): TestHarness {
 	const saveRequestIds: string[] = [];
 	const payloads = new Map<string, string>();
+	const payloadDrops: number[] = [];
 	const summaryCosts = new Map<string, number | undefined>();
 	const summaries: string[] = [];
+	const writerState = { disposed: false };
 	const pendingWrites = new Set<Promise<void>>();
 
 	const dbOps = {
@@ -131,9 +146,13 @@ function createHarness(storePayloads = false): TestHarness {
 		},
 		async dispose(): Promise<void> {
 			await Promise.allSettled([...pendingWrites]);
+			writerState.disposed = true;
 		},
 		canAcceptPayload(): boolean {
 			return true;
+		},
+		recordPayloadDrop(bytes: number): void {
+			payloadDrops.push(bytes);
 		},
 		enqueuePayload(
 			_requestId: string,
@@ -155,7 +174,15 @@ function createHarness(storePayloads = false): TestHarness {
 		},
 	);
 
-	return { collector, saveRequestIds, payloads, summaries, summaryCosts };
+	return {
+		collector,
+		payloadDrops,
+		saveRequestIds,
+		payloads,
+		summaries,
+		summaryCosts,
+		writerState,
+	};
 }
 
 function testable(collector: UsageCollectorInstance): TestableCollector {
@@ -231,7 +258,7 @@ describe("UsageCollector request lifecycle", () => {
 		expect(testable(collector).requests.has("active-stream")).toBe(false);
 	});
 
-	it("detaches a finalizing stream before pricing yields so capacity eviction cannot free it", async () => {
+	it("snapshots a finalizing payload before pricing yields and promptly releases its request state", async () => {
 		const { collector, payloads } = harness(true);
 		const requestBody = Buffer.from("old request body").toString("base64");
 		collector.handleStart(
@@ -257,10 +284,11 @@ describe("UsageCollector request lifecycle", () => {
 		for (let i = 0; i <= 10_000; i++) {
 			collector.handleStart(makeStartMessage(`race-capacity-${i}`));
 		}
-		const stateSurvivedCapacityEviction =
-			(finalizingState?.chunks.length ?? 0) > 0 &&
-			finalizingState?.startMessage.requestBody === requestBody &&
-			finalizingState?.startMessage.requestHeaders["x-lifecycle"] === "old";
+		const payloadStateReleasedBeforePricingResolved =
+			finalizingState?.chunks.length === 0 &&
+			finalizingState.chunksBytes === 0 &&
+			finalizingState.startMessage.requestBody === null &&
+			Object.keys(finalizingState.startMessage.requestHeaders).length === 0;
 
 		await endPromise;
 		await collector.drain();
@@ -269,12 +297,46 @@ describe("UsageCollector request lifecycle", () => {
 			payloads.get("finalizing-stream") ?? "null",
 		);
 		expect(detachedBeforePricingResolved).toBe(true);
-		expect(stateSurvivedCapacityEviction).toBe(true);
+		expect(payloadStateReleasedBeforePricingResolved).toBe(true);
 		expect(savedPayload.request.body).toBe(requestBody);
 		expect(savedPayload.request.headers).toEqual({ "x-lifecycle": "old" });
 		expect(
 			Buffer.from(savedPayload.response.body, "base64").toString("utf8"),
 		).toContain("message_start");
+	});
+
+	it("bounds serialized payloads waiting behind pricing", async () => {
+		process.env.CF_PRICING_TIMEOUT_MS = "60000";
+		pricingImplementation = () => new Promise<number>(() => {});
+		const { collector, payloadDrops, payloads } = harness(true);
+		const requestBody = Buffer.from("bounded payload").toString("base64");
+
+		// Simulate the collector-local pending-finalizer capacity already being full.
+		testable(collector).pendingPayloadCount = 1_000;
+		collector.handleStart(
+			makeStartMessage("bounded-finalizer", {
+				requestBody,
+				requestHeaders: { "x-payload": "bounded" },
+			}),
+		);
+		collector.handleChunk("bounded-finalizer", modelBearingChunk());
+		const state = testable(collector).requests.get("bounded-finalizer");
+
+		const endPromise = collector.handleEnd({
+			type: "end",
+			requestId: "bounded-finalizer",
+			success: true,
+		});
+
+		expect(state?.startMessage.requestBody).toBeNull();
+		expect(state?.startMessage.requestHeaders).toEqual({});
+		expect(state?.chunks).toEqual([]);
+		expect(payloadDrops).toHaveLength(1);
+		expect(testable(collector).pendingPayloadCount).toBe(1_000);
+
+		await collector.drain();
+		await endPromise;
+		expect(payloads.has("bounded-finalizer")).toBe(false);
 	});
 
 	it("does not delete a new same-ID lifecycle when the old finalizer completes", async () => {
@@ -381,6 +443,77 @@ describe("UsageCollector request lifecycle", () => {
 		}
 	});
 
+	it("drain forces current pricing waits to zero without waiting for the configured deadline", async () => {
+		process.env.CF_PRICING_TIMEOUT_MS = "60000";
+		pricingImplementation = () => new Promise<number>(() => {});
+		const { collector, summaryCosts } = harness();
+		collector.handleStart(makeStartMessage("drain-pricing"));
+		collector.handleChunk("drain-pricing", modelBearingChunk());
+		const endPromise = collector.handleEnd({
+			type: "end",
+			requestId: "drain-pricing",
+			success: true,
+		});
+
+		const drainedPromptly = await Promise.race([
+			collector.drain().then(() => true),
+			new Promise<false>((resolve) => setTimeout(() => resolve(false), 250)),
+		]);
+		await endPromise;
+
+		expect(drainedPromptly).toBe(true);
+		expect(summaryCosts.get("drain-pricing")).toBe(0);
+	});
+
+	it("drain waits for handleEnd work registered while its first snapshot settles", async () => {
+		process.env.CF_PRICING_TIMEOUT_MS = "60000";
+		pricingImplementation = () => new Promise<number>(() => {});
+		const { collector, saveRequestIds, summaries, writerState } = harness();
+		for (const requestId of ["drain-first", "drain-second"]) {
+			collector.handleStart(makeStartMessage(requestId));
+			collector.handleChunk(requestId, modelBearingChunk());
+		}
+
+		let releaseSecond = () => {};
+		const secondGate = new Promise<void>((resolve) => {
+			releaseSecond = resolve;
+		});
+		const target = testable(collector);
+		const originalHandleEnd = target._handleEndInternal.bind(collector);
+		target._handleEndInternal = async (msg: EndMessage) => {
+			if (msg.requestId === "drain-second") await secondGate;
+			return originalHandleEnd(msg);
+		};
+
+		const firstEnd = collector.handleEnd({
+			type: "end",
+			requestId: "drain-first",
+			success: true,
+		});
+		const drainPromise = collector.drain();
+		const secondEnd = collector.handleEnd({
+			type: "end",
+			requestId: "drain-second",
+			success: true,
+		});
+
+		try {
+			const returnedBeforeSecondSettled = await Promise.race([
+				drainPromise.then(() => true),
+				new Promise<false>((resolve) => setTimeout(() => resolve(false), 30)),
+			]);
+			expect(returnedBeforeSecondSettled).toBe(false);
+			expect(writerState.disposed).toBe(false);
+		} finally {
+			releaseSecond();
+		}
+
+		await Promise.all([firstEnd, secondEnd, drainPromise]);
+		expect(saveRequestIds.sort()).toEqual(["drain-first", "drain-second"]);
+		expect(summaries.sort()).toEqual(["drain-first", "drain-second"]);
+		expect(writerState.disposed).toBe(true);
+	});
+
 	it("clears the pricing deadline timer when estimation finishes quickly", async () => {
 		process.env.CF_PRICING_TIMEOUT_MS = "20";
 		pricingImplementation = async () => 0.25;
@@ -413,10 +546,30 @@ describe("UsageCollector request lifecycle", () => {
 		}
 	});
 
-	it("falls back to the default pricing deadline for an invalid override", () => {
-		process.env.CF_PRICING_TIMEOUT_MS = "60001";
-		const { collector } = harness();
-		expect(testable(collector).pricingTimeoutMs).toBe(5_000);
+	it("accepts only integer pricing deadlines in the inclusive supported range", () => {
+		const cases: Array<{
+			configured: string | undefined;
+			expected: number;
+		}> = [
+			{ configured: "1", expected: 1 },
+			{ configured: "60000", expected: 60_000 },
+			{ configured: "0", expected: 5_000 },
+			{ configured: "60001", expected: 5_000 },
+			{ configured: "1.5", expected: 5_000 },
+			{ configured: "not-a-number", expected: 5_000 },
+			{ configured: undefined, expected: 5_000 },
+		];
+
+		for (const { configured, expected } of cases) {
+			if (configured === undefined) {
+				delete process.env.CF_PRICING_TIMEOUT_MS;
+			} else {
+				process.env.CF_PRICING_TIMEOUT_MS = configured;
+			}
+
+			const { collector } = harness();
+			expect(testable(collector).pricingTimeoutMs).toBe(expected);
+		}
 	});
 
 	it("evicts a stream that exceeds the inactivity timeout", async () => {
@@ -435,6 +588,166 @@ describe("UsageCollector request lifecycle", () => {
 		});
 		await collector.drain();
 		expect(saveRequestIds).toEqual([]);
+	});
+
+	it("keeps parser state but permanently releases payload capture for an old active stream", async () => {
+		const { collector, payloads, saveRequestIds } = harness(true);
+		const requestBody = Buffer.from("old active request").toString("base64");
+		collector.handleStart(
+			makeStartMessage("old-active-stream", {
+				requestBody,
+				requestHeaders: { "x-old-active": "true" },
+				responseHeaders: { "x-response": "old-active" },
+			}),
+		);
+		collector.handleChunk("old-active-stream", modelBearingChunk());
+		const state = testable(collector).requests.get("old-active-stream");
+		expect(state?.chunks.length).toBeGreaterThan(0);
+
+		now += 2 * 60 * 1000 + 1;
+		collector.handleChunk(
+			"old-active-stream",
+			new TextEncoder().encode(": keep-alive\n\n"),
+		);
+		testable(collector).cleanupStaleRequests();
+
+		expect(testable(collector).requests.has("old-active-stream")).toBe(true);
+		expect(state?.payloadReleased).toBe(true);
+		expect(state?.startMessage.requestBody).toBeNull();
+		expect(state?.startMessage.requestHeaders).toEqual({});
+		expect(state?.startMessage.responseHeaders).toEqual({});
+		expect(state?.chunks).toEqual([]);
+		expect(state?.chunksBytes).toBe(0);
+		expect(state?.chunksTruncated).toBe(true);
+
+		collector.handleChunk(
+			"old-active-stream",
+			new TextEncoder().encode(
+				'event: message_delta\ndata: {"type":"message_delta","usage":{"output_tokens":7}}\n\n',
+			),
+		);
+		expect(state?.usage.outputTokens).toBe(7);
+		expect(state?.chunks).toEqual([]);
+		expect(state?.chunksBytes).toBe(0);
+
+		await collector.handleEnd({
+			type: "end",
+			requestId: "old-active-stream",
+			success: true,
+		});
+		await collector.drain();
+
+		expect(saveRequestIds).toEqual(["old-active-stream"]);
+		expect(payloads.has("old-active-stream")).toBe(false);
+	});
+
+	it("releases one active request payload when its next chunk would exceed the global byte budget", async () => {
+		const { collector, payloadDrops } = harness(true);
+		const requestBody = Buffer.from("budgeted request body").toString("base64");
+		collector.handleStart(
+			makeStartMessage("active-budget", {
+				requestBody,
+				requestHeaders: { "x-active-budget": "true" },
+			}),
+		);
+		const state = testable(collector).requests.get("active-budget");
+		const retainedBeforeChunk = state?.retainedPayloadBytes ?? 0;
+		expect(retainedBeforeChunk).toBe(Buffer.byteLength(requestBody));
+
+		const nearCap = 100 * 1024 * 1024 - 1;
+		testable(collector).activePayloadBytes = nearCap;
+		collector.handleChunk("active-budget", modelBearingChunk());
+
+		expect(state?.payloadReleased).toBe(true);
+		expect(state?.startMessage.requestBody).toBeNull();
+		expect(state?.startMessage.requestHeaders).toEqual({});
+		expect(state?.chunks).toEqual([]);
+		expect(state?.chunksBytes).toBe(0);
+		expect(state?.retainedPayloadBytes).toBe(0);
+		expect(testable(collector).activePayloadBytes).toBe(
+			nearCap - retainedBeforeChunk,
+		);
+		expect(state?.usage.outputTokens).toBe(0);
+		expect(payloadDrops).toHaveLength(1);
+	});
+
+	it("accounts active payload bytes through capture and prompt finalization release", async () => {
+		const { collector } = harness(true);
+		const requestBody = Buffer.from("accounted request").toString("base64");
+		collector.handleStart(
+			makeStartMessage("payload-accounting", { requestBody }),
+		);
+		const state = testable(collector).requests.get("payload-accounting");
+		expect(testable(collector).activePayloadBytes).toBe(
+			Buffer.byteLength(requestBody),
+		);
+
+		const chunk = new TextEncoder().encode(": ping\n\n");
+		collector.handleChunk("payload-accounting", chunk);
+		expect(state?.retainedPayloadBytes).toBe(
+			Buffer.byteLength(requestBody) + chunk.byteLength,
+		);
+		expect(testable(collector).activePayloadBytes).toBe(
+			Buffer.byteLength(requestBody) + chunk.byteLength,
+		);
+
+		await collector.handleEnd({
+			type: "end",
+			requestId: "payload-accounting",
+			success: true,
+		});
+		expect(testable(collector).activePayloadBytes).toBe(0);
+	});
+
+	it("copies a captured chunk out of an oversized backing buffer", () => {
+		const { collector } = harness(true);
+		collector.handleStart(makeStartMessage("chunk-view-copy"));
+		const encoded = modelBearingChunk();
+		const backing = new Uint8Array(1024 * 1024);
+		const offset = 127;
+		backing.set(encoded, offset);
+		const view = new Uint8Array(backing.buffer, offset, encoded.byteLength);
+
+		collector.handleChunk("chunk-view-copy", view);
+
+		const state = testable(collector).requests.get("chunk-view-copy");
+		const stored = state?.chunks[0];
+		expect(stored?.byteLength).toBe(view.byteLength);
+		expect(stored?.buffer).not.toBe(backing.buffer);
+		expect(stored?.buffer.byteLength).toBe(view.byteLength);
+		expect(state?.chunksBytes).toBe(view.byteLength);
+		expect(state?.retainedPayloadBytes).toBe(view.byteLength);
+		expect(state?.usage.model).toBe("claude-sonnet-4-5-20250929");
+		expect(state?.usage.outputTokens).toBe(0);
+	});
+
+	it("does not retain request bodies or chunks while payload storage is disabled", async () => {
+		const { collector } = harness(false);
+		const requestBody = Buffer.from("disabled payload").toString("base64");
+		collector.handleStart(
+			makeStartMessage("payload-disabled", {
+				requestBody,
+				requestHeaders: { "x-disabled": "true" },
+			}),
+		);
+		const state = testable(collector).requests.get("payload-disabled");
+		expect(state?.payloadReleased).toBe(true);
+		expect(state?.startMessage.requestBody).toBeNull();
+		expect(state?.startMessage.requestHeaders).toEqual({});
+		expect(state?.retainedPayloadBytes).toBe(0);
+		expect(testable(collector).activePayloadBytes).toBe(0);
+
+		collector.handleChunk("payload-disabled", modelBearingChunk());
+		expect(state?.chunks).toEqual([]);
+		expect(state?.chunksBytes).toBe(0);
+		expect(state?.usage.outputTokens).toBe(0);
+		expect(testable(collector).activePayloadBytes).toBe(0);
+
+		await collector.handleEnd({
+			type: "end",
+			requestId: "payload-disabled",
+			success: true,
+		});
 	});
 
 	it("retains the capacity safeguard and frees the oldest evicted state", () => {

--- a/packages/proxy/src/usage-collector.ts
+++ b/packages/proxy/src/usage-collector.ts
@@ -43,6 +43,13 @@ interface RequestState {
 	providerFinalOutputTokens?: number;
 	shouldSkipLogging?: boolean;
 	currentEvent?: string; // Track SSE event type across chunks
+	payloadReleased: boolean;
+	retainedPayloadBytes: number;
+}
+
+interface PreparedPayload {
+	json: string;
+	bytes: number;
 }
 
 const log = new Logger("UsageCollector");
@@ -54,6 +61,13 @@ const DEFAULT_PRICING_TIMEOUT_MS = 5_000;
 const MAX_PRICING_TIMEOUT_MS = 60_000;
 const MAX_RESPONSE_BODY_BYTES = 256 * 1024; // 256KB - cap stored response body
 const MAX_REQUEST_BODY_BYTES = 4 * 1024 * 1024; // 4MB - afterburn needs full conversation history
+const REQUEST_PAYLOAD_RETENTION_MS = 2 * 60 * 1000;
+const MAX_ACTIVE_PAYLOAD_BYTES = 100 * 1024 * 1024;
+// Detached finalizers are outside requests-map capacity. Bound their serialized
+// payload snapshots to the same count/byte envelope as AsyncDbWriter's payload
+// queue so a pricing outage cannot retain unbounded conversation bodies.
+const MAX_PENDING_PAYLOAD_COUNT = 1000;
+const MAX_PENDING_PAYLOAD_BYTES = 100 * 1024 * 1024;
 
 // Check if a request should be logged
 function shouldLogRequest(path: string, status: number): boolean {
@@ -376,11 +390,12 @@ function processStreamChunk(
 	}
 }
 
-/** Free memory held by a request state before deletion */
-function freeRequestState(state: RequestState): void {
+/** Release payload-only fields while retaining the stream parser/token state. */
+function releasePayloadState(state: RequestState): void {
 	state.chunks.length = 0;
 	state.chunksBytes = 0;
-	state.buffer = "";
+	state.chunksTruncated = true;
+	state.payloadReleased = true;
 	// Release request body and headers held in startMessage.
 	// Without this, orphaned requests retain full request bodies until the
 	// inactivity cleanup configured by CF_STREAM_TIMEOUT_MS runs. See #67.
@@ -404,7 +419,12 @@ export class UsageCollector {
 	private readonly requests = new Map<string, RequestState>();
 	private readonly missingStateWarnings = new Set<string>();
 	private readonly pendingHandleEnds = new Set<Promise<void>>();
+	private readonly pendingPricingFallbacks = new Set<() => void>();
 	private cleanupInterval: Timer | null = null;
+	private draining = false;
+	private activePayloadBytes = 0;
+	private pendingPayloadBytes = 0;
+	private pendingPayloadCount = 0;
 
 	private readonly maxBufferSize: number;
 	private readonly pricingTimeoutMs: number;
@@ -433,6 +453,11 @@ export class UsageCollector {
 		// A reused request ID is a new lifecycle and should be eligible for a fresh
 		// missing-state warning if it is later evicted.
 		this.missingStateWarnings.delete(msg.requestId);
+		const replacedState = this.requests.get(msg.requestId);
+		if (replacedState) {
+			this.freeRequestState(replacedState);
+			this.requests.delete(msg.requestId);
+		}
 
 		// Check if we should skip logging this request
 		const shouldSkip = !shouldLogRequest(msg.path, msg.responseStatus);
@@ -457,7 +482,7 @@ export class UsageCollector {
 
 				for (let i = 0; i < toRemove; i++) {
 					const [id, state] = sortedByAge[i];
-					freeRequestState(state);
+					this.freeRequestState(state);
 					this.requests.delete(id);
 				}
 			}
@@ -476,6 +501,8 @@ export class UsageCollector {
 			lastActivity: now,
 			createdAt: now,
 			shouldSkipLogging: shouldSkip,
+			payloadReleased: false,
+			retainedPayloadBytes: 0,
 		};
 
 		// Use agent from message if provided
@@ -534,6 +561,27 @@ export class UsageCollector {
 			state.billingType = planProviders.has(msg.providerName) ? "plan" : "api";
 		}
 
+		if (this.getStorePayloads()) {
+			const requestBodyBytes = msg.requestBody
+				? Buffer.byteLength(msg.requestBody)
+				: 0;
+			if (
+				this.activePayloadBytes + requestBodyBytes >
+				MAX_ACTIVE_PAYLOAD_BYTES
+			) {
+				this.asyncWriter.recordPayloadDrop(requestBodyBytes);
+				log.warn(
+					`Active payload budget exceeded; disabling payload capture for ${msg.requestId} (request_bytes=${requestBodyBytes}, active_payload_bytes=${this.activePayloadBytes})`,
+				);
+				this.releaseRequestPayload(state);
+			} else {
+				state.retainedPayloadBytes = requestBodyBytes;
+				this.activePayloadBytes += requestBodyBytes;
+			}
+		} else {
+			this.releaseRequestPayload(state);
+		}
+
 		this.requests.set(msg.requestId, state);
 
 		// Skip all database operations for ignored requests
@@ -559,20 +607,34 @@ export class UsageCollector {
 		}
 
 		const storePayloads = this.getStorePayloads();
+		if (!storePayloads && !state.payloadReleased) {
+			this.releaseRequestPayload(state);
+		}
 
 		// Store chunk for later payload saving (capped at MAX_RESPONSE_BODY_BYTES)
-		if (storePayloads && !state.chunksTruncated) {
-			if (state.chunksBytes + data.byteLength <= MAX_RESPONSE_BODY_BYTES) {
-				state.chunks.push(data);
-				state.chunksBytes += data.byteLength;
+		if (storePayloads && !state.payloadReleased && !state.chunksTruncated) {
+			const remaining = MAX_RESPONSE_BODY_BYTES - state.chunksBytes;
+			const bytesToCapture = Math.min(data.byteLength, Math.max(0, remaining));
+			if (this.activePayloadBytes + bytesToCapture > MAX_ACTIVE_PAYLOAD_BYTES) {
+				this.asyncWriter.recordPayloadDrop(
+					state.retainedPayloadBytes + bytesToCapture,
+				);
+				log.warn(
+					`Active payload budget exceeded; disabling payload capture for ${requestId} (incoming_bytes=${bytesToCapture}, request_payload_bytes=${state.retainedPayloadBytes}, active_payload_bytes=${this.activePayloadBytes})`,
+				);
+				this.releaseRequestPayload(state);
 			} else {
-				// Store partial chunk up to the limit
-				const remaining = MAX_RESPONSE_BODY_BYTES - state.chunksBytes;
-				if (remaining > 0) {
-					state.chunks.push(data.slice(0, remaining));
-					state.chunksBytes += remaining;
+				if (bytesToCapture > 0) {
+					// Always copy: an incoming view can cover only a few bytes of a much
+					// larger backing ArrayBuffer. Retaining the view would defeat byte
+					// accounting by keeping the entire backing allocation alive.
+					const captured = data.slice(0, bytesToCapture);
+					state.chunks.push(captured);
+					state.chunksBytes += bytesToCapture;
+					state.retainedPayloadBytes += bytesToCapture;
+					this.activePayloadBytes += bytesToCapture;
 				}
-				state.chunksTruncated = true;
+				if (bytesToCapture < data.byteLength) state.chunksTruncated = true;
 			}
 		}
 
@@ -593,7 +655,16 @@ export class UsageCollector {
 	 * queue to completion before process exit.
 	 */
 	async drain(): Promise<void> {
-		await Promise.allSettled([...this.pendingHandleEnds]);
+		this.draining = true;
+		for (const forceFallback of [...this.pendingPricingFallbacks]) {
+			forceFallback();
+		}
+		// handleEnd can register more work while an earlier snapshot is settling.
+		// Keep taking snapshots until the finalizer set is genuinely quiescent so
+		// writer disposal cannot race later metadata/payload enqueues.
+		while (this.pendingHandleEnds.size > 0) {
+			await Promise.allSettled([...this.pendingHandleEnds]);
+		}
 		await this.asyncWriter.dispose();
 	}
 
@@ -621,7 +692,7 @@ export class UsageCollector {
 
 		// Skip all database operations for ignored requests
 		if (state.shouldSkipLogging) {
-			freeRequestState(state);
+			this.freeRequestState(state);
 			return;
 		}
 
@@ -649,6 +720,12 @@ export class UsageCollector {
 			}
 		}
 
+		// Payload serialization must happen before pricing yields. Once the bounded
+		// snapshot is reserved, the detached finalizer no longer needs to retain the
+		// original multi-megabyte request/chunk/header graph.
+		let preparedPayload = this.preparePayloadForFinalization(state, msg);
+		this.freeRequestState(state);
+
 		// Calculate total tokens and cost
 		if (state.usage.model) {
 			const model = state.usage.model;
@@ -669,17 +746,25 @@ export class UsageCollector {
 				(state.usage.cacheReadInputTokens || 0) +
 				(state.usage.cacheCreationInputTokens || 0);
 
-			state.usage.costUsd = await this.estimateCostWithDeadline(
-				startMessage.requestId,
-				model,
-				() =>
-					estimateCostUSD(model, {
-						inputTokens: state.usage.inputTokens,
-						outputTokens: finalOutputTokens,
-						cacheReadInputTokens: state.usage.cacheReadInputTokens,
-						cacheCreationInputTokens: state.usage.cacheCreationInputTokens,
-					}),
-			);
+			try {
+				state.usage.costUsd = await this.estimateCostWithDeadline(
+					startMessage.requestId,
+					model,
+					() =>
+						estimateCostUSD(model, {
+							inputTokens: state.usage.inputTokens,
+							outputTokens: finalOutputTokens,
+							cacheReadInputTokens: state.usage.cacheReadInputTokens,
+							cacheCreationInputTokens: state.usage.cacheCreationInputTokens,
+						}),
+				);
+			} catch (error) {
+				if (preparedPayload) {
+					this.releasePreparedPayload(preparedPayload);
+					preparedPayload = null;
+				}
+				throw error;
+			}
 
 			// Calculate tokens per second - zai specific vs other providers
 			if (finalOutputTokens > 0) {
@@ -831,91 +916,11 @@ export class UsageCollector {
 		});
 
 		const requestId = startMessage.requestId;
-		const storePayloads = this.getStorePayloads();
-		if (storePayloads) {
-			// Preflight backpressure check — skip serialization entirely if the
-			// writer is already overloaded. The metadata write above already
-			// captured the request; only the payload is dropped.
-			const estimatedRequestBytes = startMessage.requestBody?.length ?? 0;
-			const estimatedResponseBytes =
-				msg.responseBody?.length ?? state.chunksBytes ?? 0;
-			const estimatedPayloadBytes =
-				estimatedRequestBytes + estimatedResponseBytes + 2048;
-
-			if (!this.asyncWriter.canAcceptPayload(estimatedPayloadBytes)) {
-				this.asyncWriter.recordPayloadDrop(estimatedPayloadBytes);
-				log.warn(
-					`Backpressure: skipping payload persistence for ${requestId} (estimated_bytes=${estimatedPayloadBytes})`,
-				);
-			} else {
-				// Save payload - eagerly serialize to break closure references
-				let responseBody: string | null = null;
-
-				if (msg.responseBody) {
-					// Non-streaming response
-					responseBody = msg.responseBody;
-				} else if (state.chunks.length > 0) {
-					// Streaming response - combine chunks
-					const combined = combineChunks(state.chunks);
-					if (combined.length > 0) {
-						responseBody = combined.toString("base64");
-					}
-				}
-
-				// Cap request body to prevent unbounded payload storage
-				let requestBody = startMessage.requestBody;
-				if (requestBody) {
-					const rawBytes = Buffer.byteLength(requestBody, "base64");
-					if (rawBytes > MAX_REQUEST_BODY_BYTES) {
-						requestBody = Buffer.from(requestBody, "base64")
-							.subarray(0, MAX_REQUEST_BODY_BYTES)
-							.toString("base64");
-					}
-				}
-
-				const payloadJson = JSON.stringify({
-					request: {
-						headers: startMessage.requestHeaders,
-						body: requestBody,
-					},
-					response: {
-						status: startMessage.responseStatus,
-						headers: startMessage.responseHeaders,
-						body: responseBody,
-					},
-					meta: {
-						accountId: startMessage.accountId || NO_ACCOUNT_ID,
-						timestamp: startMessage.timestamp,
-						success: msg.success,
-						isStream: startMessage.isStream,
-						retry: startMessage.retryAttempt,
-						project: state.project ?? undefined,
-					},
-				});
-
-				// Null out large references now that we have the serialized JSON
-				responseBody = null;
-
-				const payloadBytes = Buffer.byteLength(payloadJson);
-				const accepted = this.asyncWriter.enqueuePayload(
-					requestId,
-					payloadBytes,
-					async () => {
-						try {
-							await this.dbOps.saveRequestPayloadRaw(requestId, payloadJson);
-						} catch (error) {
-							log.error(`Failed to save payload for ${requestId}:`, error);
-						}
-					},
-				);
-				if (!accepted) {
-					log.warn(
-						`Payload write rejected post-serialization for ${requestId} (bytes=${payloadBytes})`,
-					);
-				}
-			}
+		if (preparedPayload) {
+			this.enqueuePreparedPayload(requestId, preparedPayload);
+			preparedPayload = null;
 		}
-		freeRequestState(state);
+		this.freeRequestState(state);
 
 		// Log if we have usage
 		if (state.usage.model && startMessage.accountId !== NO_ACCOUNT_ID) {
@@ -971,11 +976,156 @@ export class UsageCollector {
 		this.onSummary(summary);
 	}
 
+	private releaseRequestPayload(state: RequestState): void {
+		this.activePayloadBytes = Math.max(
+			0,
+			this.activePayloadBytes - state.retainedPayloadBytes,
+		);
+		state.retainedPayloadBytes = 0;
+		releasePayloadState(state);
+	}
+
+	private freeRequestState(state: RequestState): void {
+		this.releaseRequestPayload(state);
+		state.buffer = "";
+	}
+
+	private preparePayloadForFinalization(
+		state: RequestState,
+		msg: EndMessage,
+	): PreparedPayload | null {
+		if (!this.getStorePayloads() || state.payloadReleased) return null;
+
+		const { startMessage } = state;
+		const estimatedRequestBytes = startMessage.requestBody?.length ?? 0;
+		const estimatedResponseBytes =
+			msg.responseBody?.length ?? state.chunksBytes;
+		const estimatedPayloadBytes =
+			estimatedRequestBytes + estimatedResponseBytes + 2048;
+		const estimatedPendingBytes =
+			this.pendingPayloadBytes + estimatedPayloadBytes;
+
+		if (
+			this.pendingPayloadCount >= MAX_PENDING_PAYLOAD_COUNT ||
+			estimatedPendingBytes > MAX_PENDING_PAYLOAD_BYTES ||
+			!this.asyncWriter.canAcceptPayload(estimatedPendingBytes)
+		) {
+			this.asyncWriter.recordPayloadDrop(estimatedPayloadBytes);
+			log.warn(
+				`Backpressure: skipping payload persistence for ${startMessage.requestId} (estimated_bytes=${estimatedPayloadBytes}, pending_finalizer_bytes=${this.pendingPayloadBytes}, pending_finalizer_count=${this.pendingPayloadCount})`,
+			);
+			return null;
+		}
+
+		let responseBody: string | null = null;
+		if (msg.responseBody) {
+			responseBody = msg.responseBody;
+		} else if (state.chunks.length > 0) {
+			const combined = combineChunks(state.chunks);
+			if (combined.length > 0) responseBody = combined.toString("base64");
+		}
+
+		let requestBody = startMessage.requestBody;
+		if (requestBody) {
+			const rawBytes = Buffer.byteLength(requestBody, "base64");
+			if (rawBytes > MAX_REQUEST_BODY_BYTES) {
+				requestBody = Buffer.from(requestBody, "base64")
+					.subarray(0, MAX_REQUEST_BODY_BYTES)
+					.toString("base64");
+			}
+		}
+
+		const payloadJson = JSON.stringify({
+			request: {
+				headers: startMessage.requestHeaders,
+				body: requestBody,
+			},
+			response: {
+				status: startMessage.responseStatus,
+				headers: startMessage.responseHeaders,
+				body: responseBody,
+			},
+			meta: {
+				accountId: startMessage.accountId || NO_ACCOUNT_ID,
+				timestamp: startMessage.timestamp,
+				success: msg.success,
+				isStream: startMessage.isStream,
+				retry: startMessage.retryAttempt,
+				project: state.project ?? undefined,
+			},
+		});
+		responseBody = null;
+
+		const payloadBytes = Buffer.byteLength(payloadJson);
+		const totalPendingBytes = this.pendingPayloadBytes + payloadBytes;
+		if (
+			totalPendingBytes > MAX_PENDING_PAYLOAD_BYTES ||
+			!this.asyncWriter.canAcceptPayload(totalPendingBytes)
+		) {
+			this.asyncWriter.recordPayloadDrop(payloadBytes);
+			log.warn(
+				`Backpressure: skipping payload persistence for ${startMessage.requestId} after serialization (bytes=${payloadBytes}, pending_finalizer_bytes=${this.pendingPayloadBytes})`,
+			);
+			return null;
+		}
+
+		this.pendingPayloadBytes = totalPendingBytes;
+		this.pendingPayloadCount++;
+		return { json: payloadJson, bytes: payloadBytes };
+	}
+
+	private enqueuePreparedPayload(
+		requestId: string,
+		payload: PreparedPayload,
+	): void {
+		try {
+			const accepted = this.asyncWriter.enqueuePayload(
+				requestId,
+				payload.bytes,
+				async () => {
+					try {
+						await this.dbOps.saveRequestPayloadRaw(requestId, payload.json);
+					} catch (error) {
+						log.error(`Failed to save payload for ${requestId}:`, error);
+					}
+				},
+			);
+			if (!accepted) {
+				log.warn(
+					`Payload write rejected post-serialization for ${requestId} (bytes=${payload.bytes})`,
+				);
+			}
+		} finally {
+			this.releasePreparedPayload(payload);
+		}
+	}
+
+	private releasePreparedPayload(payload: PreparedPayload): void {
+		this.pendingPayloadBytes = Math.max(
+			0,
+			this.pendingPayloadBytes - payload.bytes,
+		);
+		this.pendingPayloadCount = Math.max(0, this.pendingPayloadCount - 1);
+	}
+
 	private cleanupStaleRequests(): void {
 		const now = Date.now();
 		let removedCount = 0;
 
-		// 1. Remove inactive requests (orphaned). A stream may legitimately run
+		// 1. Bound payload retention independently of stream lifetime. Active
+		// streams keep their parser/token state, but pings cannot keep multi-MB
+		// request bodies and captured response chunks alive indefinitely.
+		for (const [id, state] of this.requests) {
+			const age = now - state.createdAt;
+			if (!state.payloadReleased && age > REQUEST_PAYLOAD_RETENTION_MS) {
+				log.warn(
+					`Request ${id} is still active after ${Math.round(age / 1000)}s; releasing retained payload fields`,
+				);
+				this.releaseRequestPayload(state);
+			}
+		}
+
+		// 2. Remove inactive requests (orphaned). A stream may legitimately run
 		// for much longer than the inactivity timeout, so lifecycle age alone must
 		// never evict it while chunks (including provider pings) are still arriving.
 		for (const [id, state] of this.requests) {
@@ -984,13 +1134,13 @@ export class UsageCollector {
 				log.warn(
 					`Request ${id} appears orphaned (no activity for ${Math.round(inactivity / 1000)}s), removing...`,
 				);
-				freeRequestState(state);
+				this.freeRequestState(state);
 				this.requests.delete(id);
 				removedCount++;
 			}
 		}
 
-		// 2. Enforce size limit by evicting oldest entries
+		// 3. Enforce size limit by evicting oldest entries
 		if (this.requests.size > MAX_REQUESTS_MAP_SIZE) {
 			const excess = this.requests.size - MAX_REQUESTS_MAP_SIZE;
 			const sortedByAge = Array.from(this.requests.entries()).sort(
@@ -1003,7 +1153,7 @@ export class UsageCollector {
 
 			for (let i = 0; i < excess; i++) {
 				const [id, state] = sortedByAge[i];
-				freeRequestState(state);
+				this.freeRequestState(state);
 				this.requests.delete(id);
 				removedCount++;
 			}
@@ -1021,9 +1171,25 @@ export class UsageCollector {
 		model: string,
 		estimate: () => Promise<number>,
 	): Promise<number> {
+		if (this.draining) {
+			log.warn(
+				"Pricing estimate skipped during drain; using zero-cost fallback",
+				{
+					model,
+					requestId,
+				},
+			);
+			return 0;
+		}
+
 		let timeoutHandle: Timer | undefined;
-		const timeout = new Promise<number>((resolve) => {
+		let settled = false;
+		let resolveFallback: (value: number) => void = () => {};
+		const fallback = new Promise<number>((resolve) => {
+			resolveFallback = resolve;
 			timeoutHandle = setTimeout(() => {
+				if (settled) return;
+				settled = true;
 				log.warn("Pricing estimate timed out; using zero-cost fallback", {
 					model,
 					requestId,
@@ -1032,11 +1198,33 @@ export class UsageCollector {
 				resolve(0);
 			}, this.pricingTimeoutMs);
 		});
+		const forceFallback = () => {
+			if (settled) return;
+			settled = true;
+			log.warn(
+				"Pricing estimate cancelled during drain; using zero-cost fallback",
+				{ model, requestId },
+			);
+			resolveFallback(0);
+		};
+		this.pendingPricingFallbacks.add(forceFallback);
 
-		const estimatePromise = Promise.resolve().then(estimate);
+		const estimatePromise = Promise.resolve()
+			.then(estimate)
+			.then(
+				(value) => {
+					settled = true;
+					return value;
+				},
+				(error) => {
+					settled = true;
+					throw error;
+				},
+			);
 		try {
-			return await Promise.race([estimatePromise, timeout]);
+			return await Promise.race([estimatePromise, fallback]);
 		} finally {
+			this.pendingPricingFallbacks.delete(forceFallback);
 			if (timeoutHandle) clearTimeout(timeoutHandle);
 		}
 	}

--- a/packages/proxy/src/usage-collector.ts
+++ b/packages/proxy/src/usage-collector.ts
@@ -34,7 +34,7 @@ interface RequestState {
 		tokensPerSecond?: number;
 	};
 	lastActivity: number;
-	createdAt: number; // TTL tracking
+	createdAt: number; // Capacity eviction ordering
 	agentUsed?: string;
 	project?: string | null;
 	billingType?: string;
@@ -49,7 +49,9 @@ const log = new Logger("UsageCollector");
 
 // Limits to prevent unbounded growth
 const MAX_REQUESTS_MAP_SIZE = 10000;
-const REQUEST_TTL_MS = 2 * 60 * 1000; // 2 minutes - hard limit for request lifecycle
+const MAX_MISSING_STATE_WARNINGS = 1000;
+const DEFAULT_PRICING_TIMEOUT_MS = 5_000;
+const MAX_PRICING_TIMEOUT_MS = 60_000;
 const MAX_RESPONSE_BODY_BYTES = 256 * 1024; // 256KB - cap stored response body
 const MAX_REQUEST_BODY_BYTES = 4 * 1024 * 1024; // 4MB - afterburn needs full conversation history
 
@@ -60,6 +62,15 @@ function shouldLogRequest(path: string, status: number): boolean {
 		return false;
 	}
 	return true;
+}
+
+function getPricingTimeoutMs(): number {
+	const configured = Number(process.env.CF_PRICING_TIMEOUT_MS);
+	return Number.isSafeInteger(configured) &&
+		configured >= 1 &&
+		configured <= MAX_PRICING_TIMEOUT_MS
+		? configured
+		: DEFAULT_PRICING_TIMEOUT_MS;
 }
 
 // Project names are persisted to a single TEXT column and surfaced in the UI.
@@ -371,8 +382,8 @@ function freeRequestState(state: RequestState): void {
 	state.chunksBytes = 0;
 	state.buffer = "";
 	// Release request body and headers held in startMessage.
-	// Without this, orphaned requests retain full request bodies
-	// for the TTL duration (up to 2 minutes). See #67.
+	// Without this, orphaned requests retain full request bodies until the
+	// inactivity cleanup configured by CF_STREAM_TIMEOUT_MS runs. See #67.
 	state.startMessage.requestBody = null;
 	state.startMessage.requestHeaders = {};
 	state.startMessage.responseHeaders = {};
@@ -391,10 +402,12 @@ export interface UsageCollectorHealth {
  */
 export class UsageCollector {
 	private readonly requests = new Map<string, RequestState>();
+	private readonly missingStateWarnings = new Set<string>();
 	private readonly pendingHandleEnds = new Set<Promise<void>>();
 	private cleanupInterval: Timer | null = null;
 
 	private readonly maxBufferSize: number;
+	private readonly pricingTimeoutMs: number;
 	private readonly timeoutMs: number;
 
 	constructor(
@@ -408,6 +421,7 @@ export class UsageCollector {
 				process.env.CF_STREAM_USAGE_BUFFER_KB ||
 					BUFFER_SIZES.STREAM_USAGE_BUFFER_KB,
 			) * 1024;
+		this.pricingTimeoutMs = getPricingTimeoutMs();
 		this.timeoutMs = Number(
 			process.env.CF_STREAM_TIMEOUT_MS || TIME_CONSTANTS.STREAM_TIMEOUT_DEFAULT,
 		);
@@ -416,6 +430,10 @@ export class UsageCollector {
 	}
 
 	handleStart(msg: StartMessage): void {
+		// A reused request ID is a new lifecycle and should be eligible for a fresh
+		// missing-state warning if it is later evicted.
+		this.missingStateWarnings.delete(msg.requestId);
+
 		// Check if we should skip logging this request
 		const shouldSkip = !shouldLogRequest(msg.path, msg.responseStatus);
 
@@ -438,7 +456,8 @@ export class UsageCollector {
 				);
 
 				for (let i = 0; i < toRemove; i++) {
-					const [id] = sortedByAge[i];
+					const [id, state] = sortedByAge[i];
+					freeRequestState(state);
 					this.requests.delete(id);
 				}
 			}
@@ -535,7 +554,7 @@ export class UsageCollector {
 	handleChunk(requestId: string, data: Uint8Array): void {
 		const state = this.requests.get(requestId);
 		if (!state) {
-			log.warn(`No state found for request ${requestId}`);
+			this.warnMissingState(requestId);
 			return;
 		}
 
@@ -589,17 +608,20 @@ export class UsageCollector {
 	private async _handleEndInternal(msg: EndMessage): Promise<void> {
 		const state = this.requests.get(msg.requestId);
 		if (!state) {
-			log.warn(`No state found for request ${msg.requestId}`);
+			this.warnMissingState(msg.requestId);
 			return;
 		}
+		// Atomically transfer ownership to this finalizer before its first await.
+		// This keeps capacity cleanup from freeing the state while pricing resolves,
+		// and prevents this lifecycle from later deleting a reused request ID.
+		this.requests.delete(msg.requestId);
 
 		const { startMessage } = state;
 		const responseTime = Date.now() - startMessage.timestamp;
 
 		// Skip all database operations for ignored requests
 		if (state.shouldSkipLogging) {
-			// Clean up state without logging
-			this.requests.delete(msg.requestId);
+			freeRequestState(state);
 			return;
 		}
 
@@ -629,6 +651,7 @@ export class UsageCollector {
 
 		// Calculate total tokens and cost
 		if (state.usage.model) {
+			const model = state.usage.model;
 			// Use provider's authoritative count if available, fallback to computed
 			const finalOutputTokens =
 				state.providerFinalOutputTokens ??
@@ -646,12 +669,17 @@ export class UsageCollector {
 				(state.usage.cacheReadInputTokens || 0) +
 				(state.usage.cacheCreationInputTokens || 0);
 
-			state.usage.costUsd = await estimateCostUSD(state.usage.model, {
-				inputTokens: state.usage.inputTokens,
-				outputTokens: finalOutputTokens,
-				cacheReadInputTokens: state.usage.cacheReadInputTokens,
-				cacheCreationInputTokens: state.usage.cacheCreationInputTokens,
-			});
+			state.usage.costUsd = await this.estimateCostWithDeadline(
+				startMessage.requestId,
+				model,
+				() =>
+					estimateCostUSD(model, {
+						inputTokens: state.usage.inputTokens,
+						outputTokens: finalOutputTokens,
+						cacheReadInputTokens: state.usage.cacheReadInputTokens,
+						cacheCreationInputTokens: state.usage.cacheCreationInputTokens,
+					}),
+			);
 
 			// Calculate tokens per second - zai specific vs other providers
 			if (finalOutputTokens > 0) {
@@ -941,29 +969,15 @@ export class UsageCollector {
 			state.usage.cacheCreationInputTokens,
 		);
 		this.onSummary(summary);
-
-		// Clean up
-		this.requests.delete(msg.requestId);
 	}
 
 	private cleanupStaleRequests(): void {
 		const now = Date.now();
 		let removedCount = 0;
 
-		// 1. Remove TTL-expired requests (hard limit)
-		for (const [id, state] of this.requests) {
-			const age = now - state.createdAt;
-			if (age > REQUEST_TTL_MS) {
-				log.warn(
-					`Request ${id} exceeded TTL (age: ${Math.round(age / 1000)}s, limit: ${REQUEST_TTL_MS / 1000}s), removing...`,
-				);
-				freeRequestState(state);
-				this.requests.delete(id);
-				removedCount++;
-			}
-		}
-
-		// 2. Remove inactive requests (orphaned)
+		// 1. Remove inactive requests (orphaned). A stream may legitimately run
+		// for much longer than the inactivity timeout, so lifecycle age alone must
+		// never evict it while chunks (including provider pings) are still arriving.
 		for (const [id, state] of this.requests) {
 			const inactivity = now - state.lastActivity;
 			if (inactivity > this.timeoutMs) {
@@ -976,7 +990,7 @@ export class UsageCollector {
 			}
 		}
 
-		// 3. Enforce size limit by evicting oldest entries
+		// 2. Enforce size limit by evicting oldest entries
 		if (this.requests.size > MAX_REQUESTS_MAP_SIZE) {
 			const excess = this.requests.size - MAX_REQUESTS_MAP_SIZE;
 			const sortedByAge = Array.from(this.requests.entries()).sort(
@@ -999,6 +1013,45 @@ export class UsageCollector {
 			log.info(
 				`requests.size=${this.requests.size} after cleanup (removed=${removedCount})`,
 			);
+		}
+	}
+
+	private async estimateCostWithDeadline(
+		requestId: string,
+		model: string,
+		estimate: () => Promise<number>,
+	): Promise<number> {
+		let timeoutHandle: Timer | undefined;
+		const timeout = new Promise<number>((resolve) => {
+			timeoutHandle = setTimeout(() => {
+				log.warn("Pricing estimate timed out; using zero-cost fallback", {
+					model,
+					requestId,
+					timeoutMs: this.pricingTimeoutMs,
+				});
+				resolve(0);
+			}, this.pricingTimeoutMs);
+		});
+
+		const estimatePromise = Promise.resolve().then(estimate);
+		try {
+			return await Promise.race([estimatePromise, timeout]);
+		} finally {
+			if (timeoutHandle) clearTimeout(timeoutHandle);
+		}
+	}
+
+	private warnMissingState(requestId: string): void {
+		if (this.missingStateWarnings.has(requestId)) return;
+
+		log.warn(`No state found for request ${requestId}`);
+		this.missingStateWarnings.add(requestId);
+
+		if (this.missingStateWarnings.size > MAX_MISSING_STATE_WARNINGS) {
+			const oldestRequestId = this.missingStateWarnings.keys().next().value;
+			if (oldestRequestId !== undefined) {
+				this.missingStateWarnings.delete(oldestRequestId);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Keeps active stream usage state alive for long-running SSE responses, bounds payload and pricing finalization memory/time, and makes usage-collector drain wait until finalizers are quiescent.

This is the core UsageCollector unit extracted from draft #308. It intentionally excludes:
- models.dev catalogue single-flight/timeout (`#315`)
- server stream force-close / CLI signal ownership (`#314`)
- the broader `#308` shutdown-sequence rewrite

## Behavior

- Active streams survive beyond the previous fixed lifetime when chunks continue arriving.
- Inactive streams are still evicted.
- Payload capture has global byte budgets and exact-sized typed-array copies.
- Detached finalizers cannot delete a reused request ID.
- Hung pricing estimates are deadline-bounded; drain forces current pricing waits to zero and keeps snapshotting until handleEnd work is quiescent.
- Documents `CF_PRICING_TIMEOUT_MS`.

## Provenance

- Source commits: `70a2debf`, `2ff84399` (usage-collector subset), `e7923a99`
- Original draft: #308

## Validation

- `bun test packages/proxy/src/__tests__/usage-collector-lifecycle.test.ts`: 19 passed
- `bun run build`: passed
- `bun run lint`: passed with existing warnings
- `bun run typecheck`: passed
- `bun run format`: passed
- `git diff --check`: passed

No real provider endpoints were called.