### PR TITLE
fix(codex): preserve tool_choice and tool-result translation fidelity

### DIFF
--- a/packages/providers/src/providers/codex/provider.continuation-characterization.test.ts
+++ b/packages/providers/src/providers/codex/provider.continuation-characterization.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Characterization tests for the Codex request transform under agentic /
+ * multi-subagent ("ultracode / workflow") conversation shapes.
+ *
+ * These do NOT assert desired behavior — they pin down what the CURRENT
+ * transform emits, so we can see (and later fix) the mechanisms that make the
+ * Codex path spawn far more subagent turns, and cache far worse, than the
+ * native Anthropic path. Each `REVEAL:` test documents a suspected defect.
+ */
+import { describe, expect, test } from "bun:test";
+import { CodexProvider } from "./provider";
+
+const CONTINUATION_NUDGE = "Continue the user's original request now";
+
+interface CodexBody {
+	model: string;
+	input: Array<Record<string, unknown>>;
+	store: boolean;
+	instructions?: string;
+	tools?: Array<Record<string, unknown>>;
+}
+
+function makeRequest(body: unknown): Request {
+	return new Request("https://example.com/v1/messages", {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify(body),
+	});
+}
+
+async function transform(body: unknown): Promise<CodexBody> {
+	const provider = new CodexProvider();
+	const out = await provider.transformRequestBody(makeRequest(body), undefined);
+	return (await out.json()) as CodexBody;
+}
+
+function nudges(input: CodexBody["input"]): number {
+	return input.filter(
+		(it) =>
+			it.role === "user" &&
+			Array.isArray(it.content) &&
+			(it.content as Array<Record<string, unknown>>).some(
+				(c) =>
+					typeof c.text === "string" && c.text.includes(CONTINUATION_NUDGE),
+			),
+	).length;
+}
+
+const outputs = (input: CodexBody["input"]) =>
+	input.filter((it) => it.type === "function_call_output");
+const calls = (input: CodexBody["input"]) =>
+	input.filter((it) => it.type === "function_call");
+
+describe("Codex transform — continuation nudge behavior", () => {
+	test("nudge fires once when a Skill result ends the active turn", async () => {
+		const body = await transform({
+			model: "claude-opus-4-8",
+			max_tokens: 10,
+			messages: [
+				{ role: "user", content: "run /ce-plan" },
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "tool_use",
+							id: "call_skill_1",
+							name: "Skill",
+							input: { skill: "ce-plan" },
+						},
+					],
+				},
+				{
+					role: "user",
+					content: [
+						{
+							type: "tool_result",
+							tool_use_id: "call_skill_1",
+							content: [{ type: "text", text: "loaded" }],
+						},
+					],
+				},
+			],
+		});
+		expect(nudges(body.input)).toBe(1);
+	});
+
+	test("nudge does NOT fire for a replayed Skill result in mid-history", async () => {
+		const body = await transform({
+			model: "claude-opus-4-8",
+			max_tokens: 10,
+			messages: [
+				{ role: "user", content: "run /ce-plan" },
+				{
+					role: "assistant",
+					content: [
+						{ type: "tool_use", id: "call_skill_1", name: "Skill", input: {} },
+					],
+				},
+				{
+					role: "user",
+					content: [
+						{
+							type: "tool_result",
+							tool_use_id: "call_skill_1",
+							content: [{ type: "text", text: "loaded" }],
+						},
+					],
+				},
+				{ role: "assistant", content: "Now doing the work." },
+				{ role: "user", content: "thanks, continue" },
+			],
+		});
+		expect(nudges(body.input)).toBe(0);
+	});
+
+	// REVEAL: whether concurrent Skill invocations in one turn each get a nudge,
+	// and how the guard interacts with parallel fan-out.
+	test("REVEAL: two Skill results ending the turn — how many nudges?", async () => {
+		const body = await transform({
+			model: "claude-opus-4-8",
+			max_tokens: 10,
+			messages: [
+				{ role: "user", content: "load two skills" },
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "tool_use",
+							id: "call_skill_a",
+							name: "Skill",
+							input: { skill: "a" },
+						},
+						{
+							type: "tool_use",
+							id: "call_skill_b",
+							name: "Skill",
+							input: { skill: "b" },
+						},
+					],
+				},
+				{
+					role: "user",
+					content: [
+						{
+							type: "tool_result",
+							tool_use_id: "call_skill_a",
+							content: [{ type: "text", text: "a loaded" }],
+						},
+						{
+							type: "tool_result",
+							tool_use_id: "call_skill_b",
+							content: [{ type: "text", text: "b loaded" }],
+						},
+					],
+				},
+			],
+		});
+		console.log(
+			`[characterization] two-skill nudge count = ${nudges(body.input)}`,
+		);
+		expect(nudges(body.input)).toBeGreaterThanOrEqual(0);
+	});
+});
+
+describe("Codex transform — subagent (Task) tool_result fidelity", () => {
+	test("parallel Task fan-out: all call_ids pair with non-empty outputs", async () => {
+		const body = await transform({
+			model: "claude-opus-4-8",
+			max_tokens: 10,
+			messages: [
+				{ role: "user", content: "review these files" },
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "tool_use",
+							id: "t1",
+							name: "Task",
+							input: { prompt: "review a" },
+						},
+						{
+							type: "tool_use",
+							id: "t2",
+							name: "Task",
+							input: { prompt: "review b" },
+						},
+						{
+							type: "tool_use",
+							id: "t3",
+							name: "Task",
+							input: { prompt: "review c" },
+						},
+					],
+				},
+				{
+					role: "user",
+					content: [
+						{
+							type: "tool_result",
+							tool_use_id: "t1",
+							content: [{ type: "text", text: "finding a" }],
+						},
+						{
+							type: "tool_result",
+							tool_use_id: "t2",
+							content: [{ type: "text", text: "finding b" }],
+						},
+						{
+							type: "tool_result",
+							tool_use_id: "t3",
+							content: [{ type: "text", text: "finding c" }],
+						},
+					],
+				},
+			],
+		});
+		expect(
+			calls(body.input)
+				.map((c) => c.call_id)
+				.sort(),
+		).toEqual(["t1", "t2", "t3"]);
+		const outs = outputs(body.input);
+		expect(outs.map((o) => o.call_id).sort()).toEqual(["t1", "t2", "t3"]);
+		for (const o of outs)
+			expect((o.output as string).length).toBeGreaterThan(0);
+	});
+
+	test("non-text image tool_result uses a bounded placeholder", async () => {
+		const body = await transform({
+			model: "claude-opus-4-8",
+			max_tokens: 10,
+			messages: [
+				{ role: "user", content: "run a subagent" },
+				{
+					role: "assistant",
+					content: [{ type: "tool_use", id: "t1", name: "Task", input: {} }],
+				},
+				{
+					role: "user",
+					content: [
+						{
+							type: "tool_result",
+							tool_use_id: "t1",
+							content: [
+								{
+									type: "image",
+									source: {
+										type: "base64",
+										media_type: "image/png",
+										data: "AAAA",
+									},
+								},
+							],
+						},
+					],
+				},
+			],
+		});
+		const out = outputs(body.input)[0];
+		expect(out?.output).toBe(
+			"[image content not supported in Codex tool results]",
+		);
+		expect(out?.output).not.toContain("AAAA");
+	});
+
+	test("tool_reference result blocks are preserved as JSON", async () => {
+		const body = await transform({
+			model: "claude-opus-4-8",
+			max_tokens: 10,
+			messages: [
+				{ role: "user", content: "load tools" },
+				{
+					role: "assistant",
+					content: [
+						{ type: "tool_use", id: "t1", name: "ToolSearch", input: {} },
+					],
+				},
+				{
+					role: "user",
+					content: [
+						{
+							type: "tool_result",
+							tool_use_id: "t1",
+							content: [
+								{ type: "tool_reference", tool_name: "TaskCreate" },
+								{ type: "tool_reference", tool_name: "TaskUpdate" },
+							],
+						},
+					],
+				},
+			],
+		});
+		const out = outputs(body.input)[0];
+		expect(out?.output).toBe(
+			'{"type":"tool_reference","tool_name":"TaskCreate"}\n' +
+				'{"type":"tool_reference","tool_name":"TaskUpdate"}',
+		);
+	});
+});
+
+describe("Codex transform — prompt-cache prefix stability", () => {
+	// The nudge is injected as a NEW input item. If it lands anywhere but the tail,
+	// it shifts the prefix that Codex prompt-caches, and every following turn misses.
+	test("continuation nudge is appended at the tail (prefix before it is stable)", async () => {
+		const body = await transform({
+			model: "claude-opus-4-8",
+			max_tokens: 10,
+			messages: [
+				{ role: "user", content: "run /ce-plan" },
+				{
+					role: "assistant",
+					content: [
+						{ type: "tool_use", id: "call_skill_1", name: "Skill", input: {} },
+					],
+				},
+				{
+					role: "user",
+					content: [
+						{
+							type: "tool_result",
+							tool_use_id: "call_skill_1",
+							content: [{ type: "text", text: "loaded" }],
+						},
+					],
+				},
+			],
+		});
+		const last = body.input[body.input.length - 1];
+		expect(nudges([last])).toBe(1);
+	});
+});

--- a/packages/providers/src/providers/codex/provider.fidelity.test.ts
+++ b/packages/providers/src/providers/codex/provider.fidelity.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Fidelity tests for the Codex request transform: these assert DESIRED
+ * behavior for the translation-parity gaps identified in the 2026-07 fan-out
+ * incident review. A failing test here is a confirmed defect; once fixed,
+ * these serve as permanent regressions.
+ *
+ * Covered dimensions:
+ *  - tool_result content robustness (missing/null/non-array content)
+ *  - source-order preservation of blocks within a message
+ *  - disable_parallel_tool_use mapping
+ *  - Skill continuation nudge in mixed parallel final turns
+ *  - prompt_cache_key hygiene (length, casing, modern UUID versions)
+ *  - bounded serialization of oversized structured blocks
+ *  - tool_choice strictness (unknown variants, missing tools)
+ *  - is_error signal preservation
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { CODEX_PROMPT_CACHE_KEY_ENV, CodexProvider } from "./provider";
+
+const CONTINUATION_NUDGE = "Continue the user's original request now";
+
+interface CodexBody {
+	model: string;
+	input: Array<Record<string, unknown>>;
+	store: boolean;
+	instructions?: string;
+	tools?: Array<Record<string, unknown>>;
+	tool_choice?: unknown;
+	parallel_tool_calls?: boolean;
+	prompt_cache_key?: string;
+}
+
+function makeRequest(body: unknown): Request {
+	return new Request("https://example.com/v1/messages", {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify(body),
+	});
+}
+
+async function transform(body: unknown): Promise<CodexBody> {
+	const provider = new CodexProvider();
+	const out = await provider.transformRequestBody(makeRequest(body), undefined);
+	return (await out.json()) as CodexBody;
+}
+
+const outputs = (input: CodexBody["input"]) =>
+	input.filter((it) => it.type === "function_call_output");
+
+function nudges(input: CodexBody["input"]): number {
+	return input.filter(
+		(it) =>
+			it.role === "user" &&
+			Array.isArray(it.content) &&
+			(it.content as Array<Record<string, unknown>>).some(
+				(c) =>
+					typeof c.text === "string" && c.text.includes(CONTINUATION_NUDGE),
+			),
+	).length;
+}
+
+/** Minimal valid history: one Task call awaiting its result. */
+function taskTurn(
+	resultContent: unknown,
+	extra: Record<string, unknown> = {},
+): unknown {
+	return {
+		model: "claude-opus-4-8",
+		max_tokens: 10,
+		messages: [
+			{ role: "user", content: "run it" },
+			{
+				role: "assistant",
+				content: [{ type: "tool_use", id: "t1", name: "Task", input: {} }],
+			},
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "t1",
+						...(resultContent === "__omit__" ? {} : { content: resultContent }),
+						...extra,
+					},
+				],
+			},
+		],
+	};
+}
+
+afterEach(() => {
+	delete process.env[CODEX_PROMPT_CACHE_KEY_ENV];
+});
+
+describe("Codex transform, tool_result content robustness", () => {
+	test("missing content field degrades to empty output, not a dropped translation", async () => {
+		const body = await transform(taskTurn("__omit__"));
+		// A throw here is swallowed upstream and the RAW Anthropic body is
+		// forwarded to Codex; body.input would be undefined in that case.
+		expect(Array.isArray(body.input)).toBe(true);
+		expect(outputs(body.input)[0]?.output).toBe("");
+	});
+
+	test("null content degrades to empty output", async () => {
+		const body = await transform(taskTurn(null));
+		expect(Array.isArray(body.input)).toBe(true);
+		expect(outputs(body.input)[0]?.output).toBe("");
+	});
+
+	test("non-array object content degrades to empty output", async () => {
+		const body = await transform(taskTurn({ oops: true }));
+		expect(Array.isArray(body.input)).toBe(true);
+		expect(outputs(body.input)[0]?.output).toBe("");
+	});
+
+	test("null elements inside a content array are skipped, text survives", async () => {
+		const body = await transform(
+			taskTurn([null, { type: "text", text: "ok" }]),
+		);
+		expect(Array.isArray(body.input)).toBe(true);
+		expect(outputs(body.input)[0]?.output).toBe("ok");
+	});
+});
+
+describe("Codex transform, source-order preservation", () => {
+	test("user message with tool_result then text keeps the result before the text", async () => {
+		const body = await transform({
+			model: "claude-opus-4-8",
+			max_tokens: 10,
+			messages: [
+				{ role: "user", content: "run it" },
+				{
+					role: "assistant",
+					content: [{ type: "tool_use", id: "t1", name: "Task", input: {} }],
+				},
+				{
+					role: "user",
+					content: [
+						{
+							type: "tool_result",
+							tool_use_id: "t1",
+							content: [{ type: "text", text: "finding" }],
+						},
+						{ type: "text", text: "now summarize the finding" },
+					],
+				},
+			],
+		});
+		const outputIdx = body.input.findIndex(
+			(it) => it.type === "function_call_output",
+		);
+		const followupIdx = body.input.findIndex(
+			(it) =>
+				it.role === "user" &&
+				Array.isArray(it.content) &&
+				(it.content as Array<Record<string, unknown>>).some(
+					(c) => c.text === "now summarize the finding",
+				),
+		);
+		expect(outputIdx).toBeGreaterThanOrEqual(0);
+		expect(followupIdx).toBeGreaterThanOrEqual(0);
+		expect(outputIdx).toBeLessThan(followupIdx);
+	});
+
+	test("assistant message with tool_use then text keeps the call before the text", async () => {
+		const body = await transform({
+			model: "claude-opus-4-8",
+			max_tokens: 10,
+			messages: [
+				{ role: "user", content: "go" },
+				{
+					role: "assistant",
+					content: [
+						{ type: "tool_use", id: "t1", name: "Bash", input: {} },
+						{ type: "text", text: "dispatched, waiting" },
+					],
+				},
+				{
+					role: "user",
+					content: [
+						{
+							type: "tool_result",
+							tool_use_id: "t1",
+							content: [{ type: "text", text: "done" }],
+						},
+					],
+				},
+			],
+		});
+		const callIdx = body.input.findIndex((it) => it.type === "function_call");
+		const textIdx = body.input.findIndex(
+			(it) =>
+				it.role === "assistant" &&
+				Array.isArray(it.content) &&
+				(it.content as Array<Record<string, unknown>>).some(
+					(c) => c.text === "dispatched, waiting",
+				),
+		);
+		expect(callIdx).toBeGreaterThanOrEqual(0);
+		expect(textIdx).toBeGreaterThanOrEqual(0);
+		expect(callIdx).toBeLessThan(textIdx);
+	});
+});
+
+describe("Codex transform, disable_parallel_tool_use mapping", () => {
+	const base = {
+		model: "claude-opus-4-8",
+		max_tokens: 10,
+		messages: [{ role: "user", content: "hi" }],
+		tools: [{ name: "Read", input_schema: { type: "object" } }],
+	};
+
+	test("auto + disable_parallel_tool_use maps to parallel_tool_calls false", async () => {
+		const body = await transform({
+			...base,
+			tool_choice: { type: "auto", disable_parallel_tool_use: true },
+		});
+		expect(body.tool_choice).toBe("auto");
+		expect(body.parallel_tool_calls).toBe(false);
+	});
+
+	test("any + disable_parallel_tool_use maps to required + parallel_tool_calls false", async () => {
+		const body = await transform({
+			...base,
+			tool_choice: { type: "any", disable_parallel_tool_use: true },
+		});
+		expect(body.tool_choice).toBe("required");
+		expect(body.parallel_tool_calls).toBe(false);
+	});
+
+	test("absent flag leaves parallel_tool_calls unset", async () => {
+		const body = await transform({
+			...base,
+			tool_choice: { type: "auto" },
+		});
+		expect(body.parallel_tool_calls).toBeUndefined();
+	});
+});
+
+describe("Codex transform, Skill nudge in mixed parallel final turns", () => {
+	function skillPlusTaskTurn(order: "skill-first" | "skill-last"): unknown {
+		const skillResult = {
+			type: "tool_result",
+			tool_use_id: "s1",
+			content: [{ type: "text", text: "skill loaded" }],
+		};
+		const taskResult = {
+			type: "tool_result",
+			tool_use_id: "t1",
+			content: [{ type: "text", text: "task done" }],
+		};
+		return {
+			model: "claude-opus-4-8",
+			max_tokens: 10,
+			messages: [
+				{ role: "user", content: "go" },
+				{
+					role: "assistant",
+					content: [
+						{ type: "tool_use", id: "s1", name: "Skill", input: {} },
+						{ type: "tool_use", id: "t1", name: "Task", input: {} },
+					],
+				},
+				{
+					role: "user",
+					content:
+						order === "skill-first"
+							? [skillResult, taskResult]
+							: [taskResult, skillResult],
+				},
+			],
+		};
+	}
+
+	test("skill result followed by a task result still nudges exactly once", async () => {
+		const body = await transform(skillPlusTaskTurn("skill-first"));
+		expect(nudges(body.input)).toBe(1);
+	});
+
+	test("skill result as the last of mixed results nudges exactly once", async () => {
+		const body = await transform(skillPlusTaskTurn("skill-last"));
+		expect(nudges(body.input)).toBe(1);
+	});
+
+	test("nudge lands at the tail so the cached prefix stays stable", async () => {
+		const body = await transform(skillPlusTaskTurn("skill-first"));
+		expect(nudges([body.input[body.input.length - 1]])).toBe(1);
+	});
+});
+
+describe("Codex transform, prompt_cache_key hygiene", () => {
+	function withSession(sessionId: string): unknown {
+		return {
+			model: "claude-opus-4-8",
+			max_tokens: 10,
+			messages: [{ role: "user", content: "hi" }],
+			metadata: { user_id: JSON.stringify({ session_id: sessionId }) },
+		};
+	}
+
+	test("generated key fits the 64-char API bound", async () => {
+		process.env[CODEX_PROMPT_CACHE_KEY_ENV] = "1";
+		const body = await transform(
+			withSession("123e4567-e89b-42d3-a456-426614174000"),
+		);
+		expect(typeof body.prompt_cache_key).toBe("string");
+		expect((body.prompt_cache_key as string).length).toBeLessThanOrEqual(64);
+	});
+
+	test("UUID casing is normalized to a single key", async () => {
+		process.env[CODEX_PROMPT_CACHE_KEY_ENV] = "1";
+		const lower = await transform(
+			withSession("123e4567-e89b-42d3-a456-426614174abc"),
+		);
+		const upper = await transform(
+			withSession("123E4567-E89B-42D3-A456-426614174ABC"),
+		);
+		expect(lower.prompt_cache_key).toBe(upper.prompt_cache_key as string);
+	});
+
+	test("UUIDv7 session ids are accepted", async () => {
+		process.env[CODEX_PROMPT_CACHE_KEY_ENV] = "1";
+		const body = await transform(
+			withSession("01890a5d-ac96-774b-bcce-b302099a8057"),
+		);
+		expect(typeof body.prompt_cache_key).toBe("string");
+	});
+});
+
+describe("Codex transform, bounded structured block serialization", () => {
+	test("oversized structured blocks are omitted with a bounded marker", async () => {
+		const bigData = "A".repeat(200_000);
+		const body = await transform(
+			taskTurn([
+				{
+					type: "document",
+					source: {
+						type: "base64",
+						media_type: "application/pdf",
+						data: bigData,
+					},
+				},
+			]),
+		);
+		const out = outputs(body.input)[0]?.output as string;
+		expect(out.length).toBeLessThan(10_000);
+		expect(out).not.toContain(bigData);
+		expect(out).toContain("omitted");
+	});
+
+	test("small structured blocks remain fully serialized", async () => {
+		const body = await transform(
+			taskTurn([{ type: "tool_reference", tool_name: "TaskCreate" }]),
+		);
+		expect(outputs(body.input)[0]?.output).toBe(
+			'{"type":"tool_reference","tool_name":"TaskCreate"}',
+		);
+	});
+});
+
+describe("Codex transform, tool_choice strictness", () => {
+	test("unknown tool_choice variants are rejected, not coerced to a forced tool", async () => {
+		const provider = new CodexProvider();
+		const request = makeRequest({
+			model: "claude-opus-4-8",
+			max_tokens: 10,
+			messages: [{ role: "user", content: "hi" }],
+			tools: [{ name: "Read", input_schema: { type: "object" } }],
+			tool_choice: { type: "bogus", name: "Read" },
+		});
+		await expect(
+			provider.transformRequestBody(request, undefined),
+		).rejects.toThrow(/tool_choice/);
+	});
+
+	test("named tool_choice without any tools is rejected", async () => {
+		const provider = new CodexProvider();
+		const request = makeRequest({
+			model: "claude-opus-4-8",
+			max_tokens: 10,
+			messages: [{ role: "user", content: "hi" }],
+			tool_choice: { type: "tool", name: "Read" },
+		});
+		await expect(
+			provider.transformRequestBody(request, undefined),
+		).rejects.toThrow(/tool_choice/);
+	});
+});
+
+describe("Codex transform, is_error signal preservation", () => {
+	test("errored tool results carry an explicit error marker", async () => {
+		const body = await transform(
+			taskTurn([{ type: "text", text: "boom" }], { is_error: true }),
+		);
+		expect(outputs(body.input)[0]?.output).toBe("[tool error] boom");
+	});
+
+	test("successful tool results carry no marker", async () => {
+		const body = await transform(taskTurn([{ type: "text", text: "fine" }]));
+		expect(outputs(body.input)[0]?.output).toBe("fine");
+	});
+});

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -2017,33 +2017,30 @@ describe("CodexProvider.transformRequestBody", () => {
 			{ type: "tool", name: "Read" },
 			{ type: "function", name: "Read" },
 		],
-	] as const)(
-		"maps Anthropic tool_choice %j to Codex",
-		async (toolChoice, expected) => {
-			const provider = new CodexProvider();
-			const request = new Request("https://example.com/v1/messages", {
-				method: "POST",
-				headers: { "content-type": "application/json" },
-				body: JSON.stringify({
-					model: "claude-opus-4-8",
-					max_tokens: 10,
-					messages: [{ role: "user", content: "read a file" }],
-					tools: [
-						{
-							name: "Read",
-							description: "Read a file.",
-							input_schema: { type: "object" },
-						},
-					],
-					tool_choice: toolChoice,
-				}),
-			});
+	] as const)("maps Anthropic tool_choice %j to Codex", async (toolChoice, expected) => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-opus-4-8",
+				max_tokens: 10,
+				messages: [{ role: "user", content: "read a file" }],
+				tools: [
+					{
+						name: "Read",
+						description: "Read a file.",
+						input_schema: { type: "object" },
+					},
+				],
+				tool_choice: toolChoice,
+			}),
+		});
 
-			const transformed = await provider.transformRequestBody(request);
-			const body = await transformed.json();
-			expect(body.tool_choice).toEqual(expected);
-		},
-	);
+		const transformed = await provider.transformRequestBody(request);
+		const body = await transformed.json();
+		expect(body.tool_choice).toEqual(expected);
+	});
 
 	it("preserves explicit tool_choice precedence over StructuredOutput fallback", async () => {
 		const provider = new CodexProvider();
@@ -2214,7 +2211,7 @@ describe("CodexProvider prompt_cache_key derivation", () => {
 			transform({
 				metadata: { user_id: JSON.stringify({ session_id: sessionId }) },
 			});
-const lower = await withSession("11111111-1111-4111-8111-111111111111");
+		const lower = await withSession("11111111-1111-4111-8111-111111111111");
 		const upper = await withSession(
 			"11111111-1111-4111-8111-111111111111".toUpperCase(),
 		);

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -1943,6 +1943,71 @@ describe("CodexProvider.transformRequestBody", () => {
 
 		expect(body.model).toBe("gpt-5.4-mini");
 	});
+
+	it("forces StructuredOutput tool_choice when the Claude Code schema tool is present", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-haiku-4-5-20251001",
+				max_tokens: 10,
+				messages: [{ role: "user", content: "return structured output" }],
+				tools: [
+					{
+						name: "StructuredOutput",
+						description: "Return the validated payload.",
+						input_schema: {
+							type: "object",
+							additionalProperties: false,
+							properties: { ok: { type: "boolean" } },
+							required: ["ok"],
+						},
+					},
+				],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request, undefined);
+		const body = await transformed.json();
+
+		expect(body.tools.map((t: { name: string }) => t.name)).toContain(
+			"StructuredOutput",
+		);
+		expect(body.tool_choice).toEqual({
+			type: "function",
+			name: "StructuredOutput",
+		});
+	});
+
+	it("does not force tool_choice for ordinary tool-enabled requests", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-haiku-4-5-20251001",
+				max_tokens: 10,
+				messages: [{ role: "user", content: "read a file" }],
+				tools: [
+					{
+						name: "Read",
+						description: "Read a file.",
+						input_schema: {
+							type: "object",
+							properties: { file_path: { type: "string" } },
+							required: ["file_path"],
+						},
+					},
+				],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request, undefined);
+		const body = await transformed.json();
+
+		expect(body.tool_choice).toBeUndefined();
+	});
 });
 
 describe("CodexProvider prompt_cache_key derivation", () => {

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -2214,7 +2214,7 @@ describe("CodexProvider prompt_cache_key derivation", () => {
 			transform({
 				metadata: { user_id: JSON.stringify({ session_id: sessionId }) },
 			});
-		const lower = await withSession("11111111-1111-4111-8111-111111111111");
+const lower = await withSession("11111111-1111-4111-8111-111111111111");
 		const upper = await withSession(
 			"11111111-1111-4111-8111-111111111111".toUpperCase(),
 		);

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -2008,6 +2008,92 @@ describe("CodexProvider.transformRequestBody", () => {
 
 		expect(body.tool_choice).toBeUndefined();
 	});
+
+	it.each([
+		[{ type: "auto" }, "auto"],
+		[{ type: "any" }, "required"],
+		[{ type: "none" }, "none"],
+		[
+			{ type: "tool", name: "Read" },
+			{ type: "function", name: "Read" },
+		],
+	] as const)(
+		"maps Anthropic tool_choice %j to Codex",
+		async (toolChoice, expected) => {
+			const provider = new CodexProvider();
+			const request = new Request("https://example.com/v1/messages", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					model: "claude-opus-4-8",
+					max_tokens: 10,
+					messages: [{ role: "user", content: "read a file" }],
+					tools: [
+						{
+							name: "Read",
+							description: "Read a file.",
+							input_schema: { type: "object" },
+						},
+					],
+					tool_choice: toolChoice,
+				}),
+			});
+
+			const transformed = await provider.transformRequestBody(request);
+			const body = await transformed.json();
+			expect(body.tool_choice).toEqual(expected);
+		},
+	);
+
+	it("preserves explicit tool_choice precedence over StructuredOutput fallback", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-opus-4-8",
+				max_tokens: 10,
+				messages: [{ role: "user", content: "return text" }],
+				tools: [
+					{
+						name: "StructuredOutput",
+						description: "Return structured output.",
+						input_schema: { type: "object" },
+					},
+				],
+				tool_choice: { type: "none" },
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request);
+		const body = await transformed.json();
+		expect(body.tool_choice).toBe("none");
+	});
+
+	it("rejects a named tool_choice that is absent from tools", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-opus-4-8",
+				max_tokens: 10,
+				messages: [{ role: "user", content: "search" }],
+				tools: [
+					{
+						name: "Read",
+						description: "Read a file.",
+						input_schema: { type: "object" },
+					},
+				],
+				tool_choice: { type: "tool", name: "WebSearch" },
+			}),
+		});
+
+		await expect(provider.transformRequestBody(request)).rejects.toThrow(
+			"tool_choice references unknown tool: WebSearch",
+		);
+	});
 });
 
 describe("CodexProvider prompt_cache_key derivation", () => {

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -53,6 +53,10 @@ export const CODEX_USER_AGENT = `codex-cli/${CODEX_VERSION} (Windows 10.0.26100;
 export const CODEX_PING_MODEL = "gpt-5-codex";
 const CODEX_SYNTHETIC_COUNT_TOKENS_URL =
 	"https://better-ccflare.local/codex/count_tokens";
+// Structured (non-text) tool_result blocks larger than this are replaced with
+// a size marker: replaying megabyte payloads (e.g. base64 documents) into
+// every subsequent turn bloats context and destroys prompt-cache reuse.
+const CODEX_MAX_STRUCTURED_BLOCK_CHARS = 8_192;
 
 const _normalizeUsage = (value: unknown): Record<string, number> => {
 	const usage =
@@ -176,6 +180,7 @@ interface CodexRequest {
 		| "required"
 		| "none"
 		| { type: "function"; name: string };
+	parallel_tool_calls?: boolean;
 }
 
 // ── Anthropic request types ───────────────────────────────────────────────────
@@ -195,6 +200,7 @@ interface AnthropicToolUse {
 interface AnthropicToolResult {
 	type: "tool_result";
 	tool_use_id: string;
+	is_error?: boolean;
 	content:
 		| string
 		| Array<{
@@ -220,11 +226,11 @@ interface AnthropicTool {
 	input_schema?: Record<string, unknown>;
 }
 
-type AnthropicToolChoice =
-	| { type: "auto" }
-	| { type: "any" }
-	| { type: "none" }
-	| { type: "tool"; name: string };
+interface AnthropicToolChoice {
+	type: "auto" | "any" | "none" | "tool";
+	name?: string;
+	disable_parallel_tool_use?: boolean;
+}
 
 interface AnthropicRequest {
 	model: string;
@@ -648,37 +654,70 @@ export class CodexProvider extends BaseProvider {
 			.join("\n\n");
 	}
 
-private convertToolChoice(
+	private convertToolChoice(
 		choice: AnthropicToolChoice | undefined,
 		tools: readonly CodexTool[],
 	): CodexRequest["tool_choice"] | undefined {
 		if (!choice) return undefined;
+		if (typeof choice !== "object") {
+			throw new ValidationError("tool_choice must be an object");
+		}
 		if (choice.type === "auto") return "auto";
 		if (choice.type === "any") return "required";
 		if (choice.type === "none") return "none";
-		if (!tools.some((tool) => tool.name === choice.name)) {
-			throw new ValidationError(
-				`tool_choice references unknown tool: ${choice.name}`,
-			);
+		if (choice.type === "tool") {
+			if (
+				typeof choice.name !== "string" ||
+				!tools.some((tool) => tool.name === choice.name)
+			) {
+				throw new ValidationError(
+					`tool_choice references unknown tool: ${choice.name}`,
+				);
+			}
+			return { type: "function", name: choice.name };
 		}
-		return { type: "function", name: choice.name };
+		throw new ValidationError(
+			`tool_choice has unsupported type: ${String(
+				(choice as { type?: unknown }).type,
+			)}`,
+		);
 	}
 
 	private serializeToolResultContent(
 		content: AnthropicToolResult["content"],
 	): string {
 		if (typeof content === "string") return content;
-		return content
-			.map((block) => {
-				if (block.type === "text" && typeof block.text === "string") {
-					return block.text;
-				}
-				if (block.type === "image") {
-					return "[image content not supported in Codex tool results]";
-				}
-				return JSON.stringify(block);
-			})
-			.join("\n");
+		// External input can violate the declared type (missing, null, object);
+		// degrade to an empty output rather than throwing, because a throw here
+		// is swallowed by transformRequestBody and forwards the untranslated
+		// Anthropic body upstream.
+		if (!Array.isArray(content)) return "";
+		const parts: string[] = [];
+		for (const block of content) {
+			if (!block || typeof block !== "object") continue;
+			if (block.type === "text" && typeof block.text === "string") {
+				parts.push(block.text);
+				continue;
+			}
+			if (block.type === "image") {
+				parts.push("[image content not supported in Codex tool results]");
+				continue;
+			}
+			let serialized: string;
+			try {
+				serialized = JSON.stringify(block) ?? "";
+			} catch {
+				continue;
+			}
+			if (serialized.length > CODEX_MAX_STRUCTURED_BLOCK_CHARS) {
+				parts.push(
+					`[${String(block.type ?? "unknown")} content omitted: ${serialized.length} chars]`,
+				);
+				continue;
+			}
+			parts.push(serialized);
+		}
+		return parts.join("\n");
 	}
 
 	private convertMessage(
@@ -703,47 +742,50 @@ private convertToolChoice(
 			return items;
 		}
 
-		// Complex content array — may contain tool_use, tool_result, text
-		const textBlocks: CodexContentItem[] = [];
-		const functionCalls: CodexFunctionCallItem[] = [];
-		const functionCallOutputs: CodexFunctionCallOutputItem[] = [];
+		// Complex content array: may contain tool_use, tool_result, text.
+		// Preserve source order so Codex sees the same block chronology the
+		// client sent: outputs stay adjacent to their calls, and follow-up text
+		// stays after the results it refers to. Consecutive text blocks batch
+		// into one message wrapper; function_call* are top-level items.
+		let pendingText: CodexContentItem[] = [];
+		const flushText = () => {
+			if (pendingText.length === 0) return;
+			items.push({ role, content: pendingText } as CodexMessage);
+			pendingText = [];
+		};
 
 		for (const block of msg.content) {
+			if (!block || typeof block !== "object") continue;
 			if (block.type === "text") {
 				const contentType = role === "assistant" ? "output_text" : "input_text";
-				textBlocks.push({
+				pendingText.push({
 					type: contentType,
 					text: block.text,
 				} as CodexContentItem);
 			} else if (block.type === "tool_use") {
-				functionCalls.push({
+				flushText();
+				items.push({
 					type: "function_call",
 					call_id: block.id,
 					name: block.name,
 					arguments: JSON.stringify(
 						this.sanitizeToolUseInput(block.name, block.input),
 					),
+					status: "completed",
 				});
 			} else if (block.type === "tool_result") {
-				functionCallOutputs.push({
+				flushText();
+				const serialized = this.serializeToolResultContent(block.content);
+				items.push({
 					type: "function_call_output",
 					call_id: block.tool_use_id,
-					output: this.serializeToolResultContent(block.content),
+					output:
+						block.is_error === true ? `[tool error] ${serialized}` : serialized,
 					status: "completed",
 				});
 			}
 		}
-
-		// Text content goes in a message wrapper; function_call* are top-level items
-		if (textBlocks.length > 0) {
-			items.push({ role, content: textBlocks } as CodexMessage);
-		}
-		for (const fc of functionCalls) {
-			items.push({ ...fc, status: "completed" });
-		}
-		for (const fco of functionCallOutputs) {
-			items.push(fco);
-		}
+		flushText();
 
 		return items;
 	}
@@ -1067,9 +1109,9 @@ private convertToolChoice(
 		// Convert messages
 		const input: CodexRequest["input"] = [];
 		const skillCallIds = new Set<string>();
+		let skillCompletedInFinalMessage = false;
 		for (const [msgIndex, msg] of body.messages.entries()) {
-			const items = this.convertMessage(msg);
-			for (const [itemIndex, item] of items.entries()) {
+			for (const item of this.convertMessage(msg)) {
 				input.push(item);
 				if ("type" in item && item.type === "function_call") {
 					if (item.name === "Skill") {
@@ -1081,23 +1123,27 @@ private convertToolChoice(
 					skillCallIds.has(item.call_id)
 				) {
 					skillCallIds.delete(item.call_id);
-					if (
-						msgIndex !== body.messages.length - 1 ||
-						itemIndex !== items.length - 1
-					) {
-						continue;
+					if (msgIndex === body.messages.length - 1) {
+						skillCompletedInFinalMessage = true;
 					}
-					input.push({
-						role: "user",
-						content: [
-							{
-								type: "input_text",
-								text: "The requested Skill tool has loaded additional instructions. Continue the user's original request now, applying those instructions. Do not wait for another user message.",
-							},
-						],
-					});
 				}
 			}
+		}
+		// A Skill result in the active turn means new instructions just loaded.
+		// Native Claude continues on its own; Codex often stops, so append one
+		// nudge. Tail placement keeps the cached prefix stable, and firing on
+		// any final-turn Skill result (not only a trailing one) covers parallel
+		// fan-out turns that mix Skill and other tool results.
+		if (skillCompletedInFinalMessage) {
+			input.push({
+				role: "user",
+				content: [
+					{
+						type: "input_text",
+						text: "The requested Skill tool has loaded additional instructions. Continue the user's original request now, applying those instructions. Do not wait for another user message.",
+					},
+				],
+			});
 		}
 
 		// Convert tools
@@ -1143,12 +1189,12 @@ private convertToolChoice(
 		if (promptCacheKey) {
 			codexRequest.prompt_cache_key = promptCacheKey;
 		}
+		const explicitToolChoice = this.convertToolChoice(
+			body.tool_choice,
+			tools ?? [],
+		);
 		if (tools) {
 			codexRequest.tools = tools;
-			const explicitToolChoice = this.convertToolChoice(
-				body.tool_choice,
-				tools,
-			);
 			if (explicitToolChoice) {
 				codexRequest.tool_choice = explicitToolChoice;
 			} else if (tools.some((t) => t.name === "StructuredOutput")) {
@@ -1160,6 +1206,9 @@ private convertToolChoice(
 					type: "function",
 					name: "StructuredOutput",
 				};
+			}
+			if (body.tool_choice?.disable_parallel_tool_use === true) {
+				codexRequest.parallel_tool_calls = false;
 			}
 		}
 

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -170,7 +170,12 @@ interface CodexRequest {
 	reasoning?: { effort: string };
 	instructions?: string;
 	tools?: CodexTool[];
-	prompt_cache_key?: string;
+prompt_cache_key?: string;
+	tool_choice?:
+		| "auto"
+		| "required"
+		| "none"
+		| { type: "function"; name: string };
 }
 
 // ── Anthropic request types ───────────────────────────────────────────────────
@@ -1103,6 +1108,16 @@ export class CodexProvider extends BaseProvider {
 		}
 		if (tools) {
 			codexRequest.tools = tools;
+			// Claude Code schema agents provide a StructuredOutput tool but do not set
+			// Anthropic tool_choice. Native Claude reliably follows the hidden schema
+			// instruction; Codex models often end_turn with text instead. Force the
+			// function when this sentinel tool is present to preserve workflow semantics.
+			if (tools.some((t) => t.name === "StructuredOutput")) {
+				codexRequest.tool_choice = {
+					type: "function",
+					name: "StructuredOutput",
+				};
+			}
 		}
 
 		return codexRequest;

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -170,7 +170,7 @@ interface CodexRequest {
 	reasoning?: { effort: string };
 	instructions?: string;
 	tools?: CodexTool[];
-prompt_cache_key?: string;
+	prompt_cache_key?: string;
 	tool_choice?:
 		| "auto"
 		| "required"
@@ -214,6 +214,12 @@ interface AnthropicTool {
 	input_schema?: Record<string, unknown>;
 }
 
+type AnthropicToolChoice =
+	| { type: "auto" }
+	| { type: "any" }
+	| { type: "none" }
+	| { type: "tool"; name: string };
+
 interface AnthropicRequest {
 	model: string;
 	max_tokens: number;
@@ -221,6 +227,7 @@ interface AnthropicRequest {
 	system?: string | { type: string; text: string }[];
 	stream?: boolean;
 	tools?: AnthropicTool[];
+	tool_choice?: AnthropicToolChoice;
 	reasoning?: { effort?: string };
 	/** Claude Code sends a JSON-encoded object with a session_id here. */
 	metadata?: { user_id?: string };
@@ -633,6 +640,22 @@ export class CodexProvider extends BaseProvider {
 			.filter((b) => b.type === "text")
 			.map((b) => b.text)
 			.join("\n\n");
+	}
+
+private convertToolChoice(
+		choice: AnthropicToolChoice | undefined,
+		tools: readonly CodexTool[],
+	): CodexRequest["tool_choice"] | undefined {
+		if (!choice) return undefined;
+		if (choice.type === "auto") return "auto";
+		if (choice.type === "any") return "required";
+		if (choice.type === "none") return "none";
+		if (!tools.some((tool) => tool.name === choice.name)) {
+			throw new ValidationError(
+				`tool_choice references unknown tool: ${choice.name}`,
+			);
+		}
+		return { type: "function", name: choice.name };
 	}
 
 	private convertMessage(
@@ -1108,11 +1131,17 @@ export class CodexProvider extends BaseProvider {
 		}
 		if (tools) {
 			codexRequest.tools = tools;
-			// Claude Code schema agents provide a StructuredOutput tool but do not set
-			// Anthropic tool_choice. Native Claude reliably follows the hidden schema
-			// instruction; Codex models often end_turn with text instead. Force the
-			// function when this sentinel tool is present to preserve workflow semantics.
-			if (tools.some((t) => t.name === "StructuredOutput")) {
+			const explicitToolChoice = this.convertToolChoice(
+				body.tool_choice,
+				tools,
+			);
+			if (explicitToolChoice) {
+				codexRequest.tool_choice = explicitToolChoice;
+			} else if (tools.some((t) => t.name === "StructuredOutput")) {
+				// Claude Code schema agents provide a StructuredOutput tool but do not set
+				// Anthropic tool_choice. Native Claude reliably follows the hidden schema
+				// instruction; Codex models often end_turn with text instead. Force the
+				// function when this sentinel tool is present to preserve workflow semantics.
 				codexRequest.tool_choice = {
 					type: "function",
 					name: "StructuredOutput",

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -195,7 +195,13 @@ interface AnthropicToolUse {
 interface AnthropicToolResult {
 	type: "tool_result";
 	tool_use_id: string;
-	content: string | AnthropicTextContent[];
+	content:
+		| string
+		| Array<{
+				type: string;
+				text?: string;
+				[key: string]: unknown;
+		  }>;
 }
 
 type AnthropicContentBlock =
@@ -658,6 +664,23 @@ private convertToolChoice(
 		return { type: "function", name: choice.name };
 	}
 
+	private serializeToolResultContent(
+		content: AnthropicToolResult["content"],
+	): string {
+		if (typeof content === "string") return content;
+		return content
+			.map((block) => {
+				if (block.type === "text" && typeof block.text === "string") {
+					return block.text;
+				}
+				if (block.type === "image") {
+					return "[image content not supported in Codex tool results]";
+				}
+				return JSON.stringify(block);
+			})
+			.join("\n");
+	}
+
 	private convertMessage(
 		msg: AnthropicMessage,
 	): (CodexMessage | CodexFunctionCallItem | CodexFunctionCallOutputItem)[] {
@@ -702,19 +725,10 @@ private convertToolChoice(
 					),
 				});
 			} else if (block.type === "tool_result") {
-				const outputText =
-					typeof block.content === "string"
-						? block.content
-						: Array.isArray(block.content)
-							? block.content
-									.filter((b) => b.type === "text")
-									.map((b) => b.text)
-									.join("\n")
-							: "";
 				functionCallOutputs.push({
 					type: "function_call_output",
 					call_id: block.tool_use_id,
-					output: outputText,
+					output: this.serializeToolResultContent(block.content),
 					status: "completed",
 				});
 			}


### PR DESCRIPTION
## Summary

Hardens Codex Anthropic-to-Responses request translation for tool choice and tool results so schema agents, explicit tool_choice, structured tool outputs, and Skill continuation nudges survive the conversion path.

This is a focused current-main replacement for the upstream-generic request-translation portion of draft #302. It intentionally excludes fork-only pacing, session governor, response-phase tracing, cache diagnosis, and deployment behavior still present on the original #302 branch.

## Behavior

- Force `tool_choice` to `StructuredOutput` when that sentinel tool is present and no explicit Anthropic tool_choice is set.
- Map Anthropic `auto` / `any` / `none` / named tool choices, and preserve explicit choice over the StructuredOutput fallback.
- Map `disable_parallel_tool_use` to `parallel_tool_calls: false`.
- Preserve structured tool-result blocks, including non-text content, with bounded serialization for oversized payloads.
- Mark `is_error` tool results so the model can distinguish failure from success.
- Keep Skill continuation nudges at the tail of the active turn.
- Keep current-main prompt-cache-key derivation unchanged.

## Provenance

- Source commits: `f5ae7829`, `99ad9b36`, `80d551a5`, `7187c2f4`
- Original draft: #302
- Related ready work already split out:
  - #312 subscription max-token contract
  - #310 usage-refresh max_output_tokens omission
  - #306 prompt cache key (already merged)

## Validation

- `bun test packages/providers/src/providers/codex`: 105 passed
- `bun run build`: passed
- `bun run lint`: passed with 211 existing warnings
- `bun run typecheck`: passed
- `bun run format`: passed
- `git diff --check`: passed

No real provider endpoints were called.