### PR TITLE
fix(build): allow typecheck on a clean checkout before workers are generated

### DIFF
--- a/packages/database/src/inline-incremental-vacuum-worker.d.ts
+++ b/packages/database/src/inline-incremental-vacuum-worker.d.ts
@@ -1,0 +1,1 @@
+export declare const EMBEDDED_INCREMENTAL_VACUUM_WORKER_CODE: string;

--- a/packages/database/src/inline-integrity-check-worker.d.ts
+++ b/packages/database/src/inline-integrity-check-worker.d.ts
@@ -1,0 +1,1 @@
+export declare const EMBEDDED_INTEGRITY_CHECK_WORKER_CODE: string;

--- a/packages/database/src/inline-vacuum-worker.d.ts
+++ b/packages/database/src/inline-vacuum-worker.d.ts
@@ -1,0 +1,1 @@
+export declare const EMBEDDED_VACUUM_WORKER_CODE: string;


### PR DESCRIPTION
## Summary
- On a fresh clone, `bun run typecheck` fails before `bun run build` has generated the inline worker modules, because the imports have no type declarations to resolve against.
- Adds ambient `.d.ts` stubs for the three gitignored generated database worker modules so `tsc` can resolve them pre-build.

## Behavior
- `bun run typecheck` now succeeds on a clean checkout, before any build step runs.
- After `bun run build` generates the real `.ts` worker modules, the stubs coexist without conflict and typecheck still passes.
- No runtime behavior changes; only ambient type declarations are added.

## Provenance
- Source: c9f70ed3 (fix: allow typecheck without generated workers) — only the three new `.d.ts` files were ported; the commit's unrelated test-fixture formatting tweaks were intentionally excluded.

## Validation
- Red state (before fix, clean checkout, no build): `bun run typecheck` failed with `Found 3 errors in 2 files` (TS2307 Cannot find module for `./inline-incremental-vacuum-worker`, `./inline-vacuum-worker`, `./inline-integrity-check-worker`).
- Green state (after adding the 3 `.d.ts` stubs, still no build): `bun run typecheck` passed with 0 errors.
- Coexistence check: ran `bun run build` (generates the real `.ts` files alongside the new `.d.ts` stubs), then `bun run typecheck` again: still 0 errors.
- `bun run lint`: 211 pre-existing warnings (unchanged baseline), 0 errors, none attributable to the new files.
- `bun run format`: no changes needed to the new files.
- `git diff --check`: clean, no whitespace errors.
- No real provider endpoints were called.