### PR TITLE
fix(logger): surface WARN and ERROR on console in headless serve mode

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -27,7 +27,7 @@ import {
 	SessionAffinityStrategy,
 	SessionStrategy,
 } from "@better-ccflare/load-balancer";
-import { Logger } from "@better-ccflare/logger";
+import { Logger, setConsoleLogging } from "@better-ccflare/logger";
 import { handleResponsesRequest } from "@better-ccflare/openai-responses-adapter";
 import {
 	CODEX_DEFAULT_ENDPOINT,
@@ -543,6 +543,9 @@ export default async function startServer(options?: {
 	sslKeyPath?: string;
 	sslCertPath?: string;
 }) {
+	// Headless serve mode has no TUI to protect: route WARN/ERROR (and any
+	// enabled level) to the console so journald/terminal actually see them.
+	setConsoleLogging(true);
 	// Return existing server if already running
 	if (serverInstance) {
 		const existingPort = serverInstance.port;

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -35,6 +35,20 @@ function normalizeLogData(data: any): any {
 	return data;
 }
 
+let consoleLoggingOverride: boolean | null = null;
+
+/**
+ * Force console output on (or off) for every logger, regardless of debug
+ * mode. The interactive TUI silences console logging so log lines do not
+ * corrupt the screen, but headless serve mode has no TUI: journald or the
+ * operator's terminal is exactly where WARN/ERROR lines belong. Without
+ * this, production warnings (runaway fan-out, session budgets) are
+ * invisible outside the dashboard log bus.
+ */
+export function setConsoleLogging(enabled: boolean | null): void {
+	consoleLoggingOverride = enabled;
+}
+
 export class Logger {
 	private level: LogLevel;
 	private prefix: string;
@@ -115,7 +129,7 @@ export class Logger {
 			};
 			logBus.emit("log", event);
 			logFileWriter?.write(event);
-			if (!this.silentConsole) console.log(msg);
+			if (consoleLoggingOverride ?? !this.silentConsole) console.log(msg);
 		}
 	}
 
@@ -132,7 +146,7 @@ export class Logger {
 			};
 			logBus.emit("log", event);
 			logFileWriter?.write(event);
-			if (!this.silentConsole) console.log(msg);
+			if (consoleLoggingOverride ?? !this.silentConsole) console.log(msg);
 		}
 	}
 
@@ -149,7 +163,7 @@ export class Logger {
 			};
 			logBus.emit("log", event);
 			logFileWriter?.write(event);
-			if (!this.silentConsole) console.warn(msg);
+			if (consoleLoggingOverride ?? !this.silentConsole) console.warn(msg);
 		}
 	}
 
@@ -166,7 +180,7 @@ export class Logger {
 			};
 			logBus.emit("log", event);
 			logFileWriter?.write(event);
-			if (!this.silentConsole) console.error(msg);
+			if (consoleLoggingOverride ?? !this.silentConsole) console.error(msg);
 		}
 	}
 

--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import type { LogEvent } from "@better-ccflare/types";
-import { Logger, LogLevel, logBus } from "./index";
+import { Logger, LogLevel, logBus, setConsoleLogging } from "./index";
 
 describe("Logger error serialization", () => {
 	let captured: LogEvent[] = [];
@@ -142,6 +142,34 @@ describe("Logger env LOG_LEVEL handling", () => {
 			expect(spy).not.toHaveBeenCalled();
 		} finally {
 			spy.mockRestore();
+		}
+	});
+});
+
+describe("setConsoleLogging override", () => {
+	afterEach(() => {
+		setConsoleLogging(null);
+		delete process.env.LOG_LEVEL;
+	});
+
+	it("silences console by default outside debug mode, override restores it", () => {
+		process.env.LOG_LEVEL = "warn";
+		const logger = new Logger("test");
+		const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			logger.warn("invisible by default");
+			expect(warnSpy).toHaveBeenCalledTimes(0);
+
+			// Headless serve mode: warnings must reach the console/journal.
+			setConsoleLogging(true);
+			logger.warn("visible with override");
+			expect(warnSpy).toHaveBeenCalledTimes(1);
+
+			setConsoleLogging(null);
+			logger.warn("silent again");
+			expect(warnSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			warnSpy.mockRestore();
 		}
 	});
 });


### PR DESCRIPTION
## Summary
Headless `bun start` never printed WARN/ERROR log lines to the terminal or journald because the logger silences all console output unless debug mode is enabled. That protection is meant for the interactive TUI, but it also blinded production monitoring in serve mode: runaway fan-out warnings, session governor budget warnings, and other operational alerts only ever reached the internal log bus/file, never the console.

## Behavior
- Added `setConsoleLogging(enabled: boolean | null)` to `@better-ccflare/logger`: a module-level override consulted by `debug`/`info`/`warn`/`error`. When set to `true`, console output is forced on regardless of the per-instance `silentConsole` state; `null` restores default (debug-mode-only) behavior.
- Server startup (`apps/server/src/server.ts`) now calls `setConsoleLogging(true)` at the top of `startServer()`, so headless serve mode always surfaces enabled log levels (including WARN/ERROR) to the console/journald.
- The interactive TUI path is untouched: it never calls `setConsoleLogging`, so its default silent-console behavior is unchanged.

## Provenance
- Source: 63605968da31e59d25a9c538732d2f3d2952fd45 (fork commit "fix(logger): surface WARN/ERROR on console in headless serve mode")

## Validation
- Wrote the ported test first (`setConsoleLogging override` in `packages/logger/src/logger.test.ts`) and confirmed it failed against current upstream code: `SyntaxError: Export named 'setConsoleLogging' not found in module '.../packages/logger/src/index.ts'`.
- After implementing the fix: `bun test packages/logger` → 14 pass, 0 fail, 24 expect() calls.
- `bun test apps/server/src/server.test.ts` → 2 pass, 0 fail, 6 expect() calls (no regression).
- `bun run build` → succeeded, no generated inline-worker files were modified.
- `bun run lint` → 211 pre-existing warnings (unchanged baseline), no new errors.
- `bun run typecheck` → clean.
- `bun run format` → no changes needed (already formatted).
- `git diff --check` → clean.
- No real provider endpoints were called.