### PR TITLE
fix(database): only tolerate duplicate-column races in PG migrations

### DIFF
--- a/packages/database/src/migrations-pg-add-column.test.ts
+++ b/packages/database/src/migrations-pg-add-column.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the duplicate-column error discrimination in runMigrationsPg's
+ * ADD COLUMN loop. Upstream previously swallowed every ALTER TABLE ADD
+ * COLUMN failure with a blanket try/catch + warn log, which also hid real
+ * failures (permissions, lock timeout) behind a benign-looking warning and
+ * let startup continue with a missing column.
+ *
+ * These tests exercise `addColumnTolerant` (exported for testing) directly
+ * against a minimal fake adapter, rather than mocking every SQL statement
+ * in the much larger `runMigrationsPg`.
+ */
+import { describe, expect, it } from "bun:test";
+import { addColumnTolerant } from "./migrations-pg";
+
+const COL = {
+	table: "accounts",
+	column: "cross_region_mode",
+	definition:
+		"ALTER TABLE accounts ADD COLUMN cross_region_mode TEXT DEFAULT 'geographic'",
+};
+
+function makePgError(code: string, message = "pg error"): Error {
+	return Object.assign(new Error(message), { code });
+}
+
+/** Minimal fake adapter exposing only what addColumnTolerant needs. */
+function makeFakeAdapter(options: {
+	unsafeImpl: () => Promise<unknown>;
+	columnExistsResult?: boolean;
+}) {
+	return {
+		unsafe: options.unsafeImpl,
+		get: async () => ({
+			exists: options.columnExistsResult ? 1 : 0,
+		}),
+		// biome-ignore lint/suspicious/noExplicitAny: fake adapter for testing
+	} as any;
+}
+
+describe("addColumnTolerant", () => {
+	it("succeeds silently when the ALTER TABLE succeeds", async () => {
+		let calls = 0;
+		const adapter = makeFakeAdapter({
+			unsafeImpl: async () => {
+				calls++;
+				return undefined;
+			},
+		});
+
+		await expect(addColumnTolerant(adapter, COL)).resolves.toBeUndefined();
+		expect(calls).toBe(1);
+	});
+
+	it("tolerates SQLSTATE 42701 (duplicate_column) when the column now exists", async () => {
+		const adapter = makeFakeAdapter({
+			unsafeImpl: async () => {
+				throw makePgError("42701", 'column "cross_region_mode" already exists');
+			},
+			columnExistsResult: true,
+		});
+
+		await expect(addColumnTolerant(adapter, COL)).resolves.toBeUndefined();
+	});
+
+	it("rethrows on SQLSTATE 42701 if the column does not actually exist", async () => {
+		const adapter = makeFakeAdapter({
+			unsafeImpl: async () => {
+				throw makePgError("42701", 'column "cross_region_mode" already exists');
+			},
+			columnExistsResult: false,
+		});
+
+		await expect(addColumnTolerant(adapter, COL)).rejects.toMatchObject({
+			code: "42701",
+		});
+	});
+
+	it("rethrows on non-duplicate-column errors (e.g. permissions)", async () => {
+		const adapter = makeFakeAdapter({
+			unsafeImpl: async () => {
+				throw makePgError("42501", "permission denied for table accounts");
+			},
+		});
+
+		await expect(addColumnTolerant(adapter, COL)).rejects.toMatchObject({
+			code: "42501",
+		});
+	});
+
+	it("rethrows on errors with no SQLSTATE code (e.g. lock timeout)", async () => {
+		const adapter = makeFakeAdapter({
+			unsafeImpl: async () => {
+				throw new Error("canceling statement due to lock timeout");
+			},
+		});
+
+		await expect(addColumnTolerant(adapter, COL)).rejects.toThrow(
+			"canceling statement due to lock timeout",
+		);
+	});
+});

--- a/packages/database/src/migrations-pg.ts
+++ b/packages/database/src/migrations-pg.ts
@@ -4,6 +4,14 @@ import type { BunSqlAdapter } from "./adapters/bun-sql-adapter";
 const log = new Logger("DatabaseMigrations-PG");
 
 /**
+ * PostgreSQL SQLSTATE for duplicate_column. Bun's `Bun.SQL` PostgresError
+ * surfaces the raw Postgres SQLSTATE code on `.code` (there is no separate
+ * `sqlState` field, unlike the MySQL error class), so this is safe to match
+ * directly rather than sniffing the error message.
+ */
+const PG_DUPLICATE_COLUMN = "42701";
+
+/**
  * Check if a column exists in a PostgreSQL table using information_schema
  */
 async function columnExists(
@@ -311,15 +319,59 @@ export async function ensureSchemaPg(adapter: BunSqlAdapter): Promise<void> {
 }
 
 /**
+ * A column to add to an existing table, expressed as an ALTER TABLE
+ * definition (used by the ADD COLUMN backfill loop in runMigrationsPg).
+ */
+interface ColumnToAdd {
+	table: string;
+	column: string;
+	definition: string;
+}
+
+/**
+ * Run a single ADD COLUMN migration, tolerating only the expected
+ * concurrent-instance race (another process winning the race to add the
+ * same column, surfaced as SQLSTATE 42701 duplicate_column). Any other
+ * failure (permissions, lock timeout, etc) is rethrown so startup aborts
+ * loudly instead of silently continuing with a missing column that later
+ * writes (e.g. RequestRepository) would fail against on every request.
+ *
+ * Exported for testing.
+ */
+export async function addColumnTolerant(
+	adapter: BunSqlAdapter,
+	col: ColumnToAdd,
+): Promise<void> {
+	try {
+		await adapter.unsafe(col.definition);
+		log.info(`Added column ${col.table}.${col.column}`);
+	} catch (error) {
+		const code = (error as { code?: string } | undefined)?.code;
+		if (code !== PG_DUPLICATE_COLUMN) {
+			// Not the known duplicate-column race: a genuine failure
+			// (permissions, lock timeout, etc). Don't swallow it, a
+			// missing column here means unconditional inserts against
+			// it (e.g. RequestRepository) will fail on every write.
+			throw error;
+		}
+		// Another instance won the race to add this column concurrently.
+		// Re-verify it actually landed before treating this as a no-op.
+		const nowExists = await columnExists(adapter, col.table, col.column);
+		if (!nowExists) {
+			throw error;
+		}
+		log.info(
+			`Column ${col.table}.${col.column} already added by a concurrent migration`,
+		);
+	}
+}
+
+/**
  * Run PostgreSQL-specific migrations
  */
 export async function runMigrationsPg(adapter: BunSqlAdapter): Promise<void> {
 	// Add columns that might be missing from older schema versions
-	const columnsToAdd: Array<{
-		table: string;
-		column: string;
-		definition: string;
-	}> = [
+	const columnsToAdd: ColumnToAdd[] = [
 		{
 			table: "accounts",
 			column: "cross_region_mode",
@@ -450,14 +502,7 @@ export async function runMigrationsPg(adapter: BunSqlAdapter): Promise<void> {
 	for (const col of columnsToAdd) {
 		const exists = await columnExists(adapter, col.table, col.column);
 		if (!exists) {
-			try {
-				await adapter.unsafe(col.definition);
-				log.info(`Added column ${col.table}.${col.column}`);
-			} catch (error) {
-				log.warn(
-					`Could not add column ${col.table}.${col.column}: ${(error as Error).message}`,
-				);
-			}
+			await addColumnTolerant(adapter, col);
 		}
 	}
 


### PR DESCRIPTION
## Summary
- `runMigrationsPg`'s ADD COLUMN backfill loop previously caught and warn-logged every ALTER TABLE error, treating real failures (permissions, lock timeout) the same as the benign concurrent-instance race. That let startup continue with a missing column, so every later write against it (e.g. `RequestRepository`) would fail silently on every request.
- Now only PostgreSQL SQLSTATE `42701` (`duplicate_column`, the expected race when two instances add the same column concurrently) is tolerated, and only after re-verifying via `information_schema` that the column actually exists. Any other error, or a `42701` where the column still doesn't exist, is rethrown and aborts startup loudly.

## Behavior
- ALTER TABLE ADD COLUMN failures with SQLSTATE `42701` are tolerated only if `information_schema` confirms the column now exists (the expected concurrent-migration race).
- A `42701` error where the column still does not exist is rethrown (rare, but treated as a real failure rather than a silent no-op).
- Any non-`42701` error (permissions, lock timeout, connection issues, etc) is rethrown immediately, aborting startup instead of continuing with a broken schema.
- The ADD COLUMN try/catch logic is extracted into an exported `addColumnTolerant` helper for direct unit testing.

## Provenance
- Source: `a8b0bbd8` (fork commit, hand-ported onto current upstream `migrations-pg.ts` since the fork's `columnsToAdd` list and surrounding structure had diverged)

## Validation
- New focused test file `packages/database/src/migrations-pg-add-column.test.ts` (5 tests) exercises `addColumnTolerant` against a mocked adapter: ALTER succeeds, `42701` tolerated when column exists, `42701` rethrown when column absent, non-`42701` PG error rethrown, error with no SQLSTATE code rethrown. Confirmed red (fails with `Export named 'addColumnTolerant' not found`) before implementation, green (5 pass) after.
- Full database suite: `bun test packages/database` → 181 pass, 2 fail (both `incremental-vacuum-adaptive.test.ts` timeouts, confirmed pre-existing by re-running with the fix stashed out — identical failures on unmodified upstream code, unrelated to this change).
- Gates: `bun run build` (regenerates worker stubs), `bun run lint` (0 new errors, pre-existing 211 warnings unchanged), `bun run typecheck` (clean), `bun run format` (no diff beyond this change), `git diff --check` (clean).
- No real provider endpoints were called.