### PR TITLE
fix(proxy): single-flight recovery probes after rate-limit cooldown

### DIFF
--- a/packages/proxy/src/handlers/__tests__/rate-limit-cooldown-reentry.test.ts
+++ b/packages/proxy/src/handlers/__tests__/rate-limit-cooldown-reentry.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import type { Account } from "@better-ccflare/types";
+import type { ProxyContext } from "../proxy-types";
+import {
+	applyRateLimitCooldown,
+	completeRateLimitProbe,
+	getRateLimitProbeAdmission,
+	resetRateLimitProbeGatesForTests,
+} from "../rate-limit-cooldown";
+
+const NOW = Date.UTC(2026, 6, 9, 3, 0, 0);
+const realDateNow = Date.now;
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "acc-1",
+		name: "mature-account",
+		provider: "anthropic",
+		api_key: null,
+		refresh_token: "rt",
+		access_token: "at",
+		expires_at: NOW + 3_600_000,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: NOW,
+		rate_limited_until: null,
+		rate_limited_at: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		custom_endpoint: null,
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		consecutive_rate_limits: 0,
+		...overrides,
+	} as Account;
+}
+
+function makeCtx(opts: { rateLimited: boolean; resetTime?: number }) {
+	const calls = {
+		markRateLimited: [] as Array<{ until: number; reason: string }>,
+	};
+	const ctx = {
+		provider: {
+			name: "anthropic",
+			parseRateLimit: () => ({
+				isRateLimited: opts.rateLimited,
+				resetTime: opts.resetTime,
+				statusHeader: opts.rateLimited ? "rate_limited" : undefined,
+				remaining: undefined,
+			}),
+			isStreamingResponse: () => false,
+		},
+		dbOps: {
+			markAccountRateLimited: async (
+				_accountId: string,
+				until: number,
+				reason: string,
+			) => {
+				calls.markRateLimited.push({ until, reason });
+				return 9;
+			},
+			updateAccountUsage: mock(() => {}),
+			updateAccountRateLimitMeta: mock(() => {}),
+			getAdapter: () => ({ run: async () => {} }),
+		},
+		asyncWriter: {
+			enqueue: (job: () => void | Promise<void>) => void job(),
+		},
+	} as unknown as ProxyContext;
+	return { ctx, calls };
+}
+
+afterEach(() => {
+	Date.now = realDateNow;
+	resetRateLimitProbeGatesForTests();
+});
+
+describe("mature cooldown re-entry / single-flight probe", () => {
+	it("does not gate ordinary accounts (below the mature streak threshold)", () => {
+		Date.now = () => NOW;
+		const account = makeAccount({
+			consecutive_rate_limits: 4,
+			rate_limited_until: NOW - 1,
+		});
+
+		expect(getRateLimitProbeAdmission(account)).toBe("not_required");
+	});
+
+	it("does not gate accounts still within an active cooldown window", () => {
+		Date.now = () => NOW;
+		const account = makeAccount({
+			consecutive_rate_limits: 9,
+			rate_limited_until: NOW + 60_000,
+		});
+
+		expect(getRateLimitProbeAdmission(account)).toBe("not_required");
+	});
+
+	it("treats the exact cooldown boundary as expired", () => {
+		Date.now = () => NOW;
+		const account = makeAccount({
+			consecutive_rate_limits: 9,
+			rate_limited_until: NOW,
+		});
+
+		expect(getRateLimitProbeAdmission(account)).toBe("admitted");
+	});
+
+	it("admits only one concurrent probe for a mature expired cooldown", () => {
+		Date.now = () => NOW;
+		const account = makeAccount({
+			consecutive_rate_limits: 9,
+			rate_limited_until: NOW - 1,
+		});
+
+		expect(getRateLimitProbeAdmission(account)).toBe("admitted");
+		// A second concurrent request selecting the same account is suppressed
+		// and must fall through to the next account instead of stampeding it.
+		expect(getRateLimitProbeAdmission(account)).toBe("suppressed");
+		expect(getRateLimitProbeAdmission(account)).toBe("suppressed");
+	});
+
+	it("releases the probe lease when the probe succeeds", () => {
+		Date.now = () => NOW;
+		const account = makeAccount({
+			consecutive_rate_limits: 9,
+			rate_limited_until: NOW - 1,
+		});
+
+		expect(getRateLimitProbeAdmission(account)).toBe("admitted");
+		completeRateLimitProbe(account, "recovered");
+		expect(getRateLimitProbeAdmission(account)).toBe("admitted");
+	});
+
+	it("releases the probe lease when cooldown is reapplied via a fresh 429", () => {
+		Date.now = () => NOW;
+		const account = makeAccount({
+			consecutive_rate_limits: 9,
+			rate_limited_until: NOW - 1,
+		});
+		const { ctx } = makeCtx({ rateLimited: true });
+
+		expect(getRateLimitProbeAdmission(account)).toBe("admitted");
+		applyRateLimitCooldown(account, { resetTime: NOW + 120_000 }, ctx);
+		Date.now = () => NOW + 120_001;
+
+		// The reapplied cooldown released the old lease. Once it expires again,
+		// and the streak is still mature, a fresh probe is admitted.
+		expect(getRateLimitProbeAdmission(account)).toBe("admitted");
+	});
+
+	it("releases an abandoned probe immediately", () => {
+		Date.now = () => NOW;
+		const account = makeAccount({
+			consecutive_rate_limits: 9,
+			rate_limited_until: NOW - 1,
+		});
+
+		expect(getRateLimitProbeAdmission(account)).toBe("admitted");
+		completeRateLimitProbe(account, "abandoned");
+		expect(getRateLimitProbeAdmission(account)).toBe("admitted");
+	});
+
+	it("self-heals a leaked probe after the bounded lease window expires", () => {
+		Date.now = () => NOW;
+		const account = makeAccount({
+			consecutive_rate_limits: 9,
+			rate_limited_until: NOW - 1,
+		});
+
+		expect(getRateLimitProbeAdmission(account)).toBe("admitted");
+		// Never completed, simulating a crash or unhandled path. Self-heals once
+		// the lease window elapses.
+		Date.now = () => NOW + 120_001;
+		expect(getRateLimitProbeAdmission(account)).toBe("admitted");
+	});
+
+	it("evicts the oldest lease once the in-memory map hits the cap", () => {
+		Date.now = () => NOW;
+		const first = makeAccount({
+			id: "acc-evict-me",
+			consecutive_rate_limits: 9,
+			rate_limited_until: NOW - 1,
+		});
+		expect(getRateLimitProbeAdmission(first)).toBe("admitted");
+
+		// Fill the map with distinct accounts up to the eviction cap so the
+		// oldest lease (acc-evict-me) gets pruned.
+		const MAX_PROBE_GATES = 10_000;
+		for (let i = 0; i < MAX_PROBE_GATES; i++) {
+			const acct = makeAccount({
+				id: `acc-fill-${i}`,
+				consecutive_rate_limits: 9,
+				rate_limited_until: NOW - 1,
+			});
+			getRateLimitProbeAdmission(acct);
+		}
+
+		// The original account's lease was evicted, so a fresh probe is admitted
+		// again instead of being suppressed.
+		expect(getRateLimitProbeAdmission(first)).toBe("admitted");
+	});
+});

--- a/packages/proxy/src/handlers/rate-limit-cooldown.ts
+++ b/packages/proxy/src/handlers/rate-limit-cooldown.ts
@@ -9,6 +9,91 @@ import type { ProxyContext } from "./proxy-types";
 
 const log = new Logger("RateLimitCooldown");
 
+const MATURE_COOLDOWN_STREAK = 5;
+const PROBE_LEASE_MS = 2 * 60 * 1000;
+const MAX_PROBE_GATES = 10_000;
+const probeLeases = new Map<string, number>();
+
+export type RateLimitProbeAdmission =
+	| "not_required"
+	| "admitted"
+	| "suppressed";
+
+function pruneProbeLeases(now: number): void {
+	for (const [accountId, leaseUntil] of probeLeases) {
+		if (leaseUntil <= now) probeLeases.delete(accountId);
+	}
+	while (probeLeases.size >= MAX_PROBE_GATES) {
+		const oldest = probeLeases.keys().next().value;
+		if (oldest === undefined) break;
+		probeLeases.delete(oldest);
+	}
+}
+
+/**
+ * Admits one process-local recovery probe after a mature cooldown expires.
+ * Ordinary accounts and accounts still cooling down are not gated.
+ *
+ * Rationale: once an account has racked up a long streak of consecutive
+ * 429s, its cooldown expiry is often optimistic relative to the upstream
+ * quota window. Letting every concurrently selected request pile onto that
+ * account the instant the cooldown clears re-triggers the same 429 storm
+ * that produced the streak. Gating to a single in-flight probe lets one
+ * request find out whether the account has actually recovered while the
+ * rest fall through to the next account in the selection order.
+ */
+export function getRateLimitProbeAdmission(
+	account: Account,
+	now: number = Date.now(),
+): RateLimitProbeAdmission {
+	const expiredMatureCooldown =
+		account.consecutive_rate_limits >= MATURE_COOLDOWN_STREAK &&
+		account.rate_limited_until != null &&
+		account.rate_limited_until <= now;
+	if (!expiredMatureCooldown) return "not_required";
+
+	pruneProbeLeases(now);
+	const existingLease = probeLeases.get(account.id);
+	if (existingLease && existingLease > now) {
+		log.debug(
+			`[ccflare] account=${account.name} cooldown_probe_suppressed lease_until=${new Date(existingLease).toISOString()}`,
+		);
+		return "suppressed";
+	}
+
+	const leaseUntil = now + PROBE_LEASE_MS;
+	probeLeases.set(account.id, leaseUntil);
+	log.info(
+		`[ccflare] account=${account.name} cooldown_probe_admitted streak=${account.consecutive_rate_limits} lease_until=${new Date(leaseUntil).toISOString()}`,
+	);
+	return "admitted";
+}
+
+/**
+ * Releases the single-flight probe lease for an account, if one is held.
+ * Must be called on every terminal outcome of a probed request: success
+ * (recovered), a fresh cooldown being reapplied, or the request being
+ * abandoned (exception, or the account being skipped mid-loop).
+ */
+export function completeRateLimitProbe(
+	account: Account,
+	outcome: "recovered" | "cooldown_reapplied" | "abandoned",
+): void {
+	if (!probeLeases.delete(account.id)) return;
+	if (outcome === "recovered") {
+		log.info(
+			`[ccflare] account=${account.name} cooldown_probe_recovery_success`,
+		);
+	} else if (outcome === "abandoned") {
+		log.debug(`[ccflare] account=${account.name} cooldown_probe_abandoned`);
+	}
+}
+
+/** Test-only: clears all in-memory probe leases between test cases. */
+export function resetRateLimitProbeGatesForTests(): void {
+	probeLeases.clear();
+}
+
 /**
  * Single entry point for applying a 429-driven cooldown to an account.
  * Computes exponential-backoff cooldown capped by upstream reset (if any), updates
@@ -52,6 +137,13 @@ export function applyRateLimitCooldown(
 	account.rate_limited_until = cooldownUntil;
 	account.rate_limited_at = now;
 	account.consecutive_rate_limits = nextCount;
+	const wasRecoveryProbe = probeLeases.has(account.id);
+	completeRateLimitProbe(account, "cooldown_reapplied");
+	if (wasRecoveryProbe) {
+		log.info(
+			`[ccflare] account=${account.name} cooldown_probe_reapplied reason=${reason} until=${new Date(cooldownUntil).toISOString()}`,
+		);
+	}
 
 	ctx.asyncWriter.enqueue(async () => {
 		const persistedCount = await ctx.dbOps.markAccountRateLimited(

--- a/packages/proxy/src/handlers/response-processor.ts
+++ b/packages/proxy/src/handlers/response-processor.ts
@@ -7,7 +7,10 @@ import {
 } from "@better-ccflare/providers";
 import type { Account, RateLimitReason } from "@better-ccflare/types";
 import type { ProxyContext } from "./proxy-types";
-import { applyRateLimitCooldown } from "./rate-limit-cooldown";
+import {
+	applyRateLimitCooldown,
+	completeRateLimitProbe,
+} from "./rate-limit-cooldown";
 
 const log = new Logger("ResponseProcessor");
 
@@ -320,6 +323,7 @@ export async function processProxyResponse(
 	}
 
 	if (!rateLimitInfo.isRateLimited && !skipAccountMetadata) {
+		completeRateLimitProbe(account, response.ok ? "recovered" : "abandoned");
 		// (a) Stability reset — gated only on rate_limited_at.
 		// clearExpiredRateLimits nulls rate_limited_until without touching rate_limited_at,
 		// so we must not gate on rate_limited_until or we'd miss accounts already cleared

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -28,6 +28,10 @@ import {
 	validateProviderPath,
 } from "./handlers";
 import {
+	completeRateLimitProbe,
+	getRateLimitProbeAdmission,
+} from "./handlers/rate-limit-cooldown";
+import {
 	buildSessionRejectResponse,
 	recordSessionRequest,
 } from "./session-governor";
@@ -472,21 +476,35 @@ export async function handleProxy(
 			);
 		}
 
-		response = await proxyWithAccount(
-			req,
-			url,
-			accounts[i],
-			requestMeta,
-			finalBodyBuffer,
-			finalCreateBodyStream,
-			i,
-			ctx,
-			modelOverride,
-			apiKeyId,
-			apiKeyName,
-			requestBodyContext,
-			!filteredComboInfo?.comboName && i === accounts.length - 1,
-		);
+		const probeAdmission = getRateLimitProbeAdmission(accounts[i]);
+		if (probeAdmission === "suppressed") {
+			// A mature cooldown just expired for this account and another
+			// concurrent request is already probing it. Skip straight to the
+			// next account instead of stampeding the recovering account.
+			continue;
+		}
+
+		try {
+			response = await proxyWithAccount(
+				req,
+				url,
+				accounts[i],
+				requestMeta,
+				finalBodyBuffer,
+				finalCreateBodyStream,
+				i,
+				ctx,
+				modelOverride,
+				apiKeyId,
+				apiKeyName,
+				requestBodyContext,
+				!filteredComboInfo?.comboName && i === accounts.length - 1,
+			);
+		} finally {
+			if (probeAdmission === "admitted") {
+				completeRateLimitProbe(accounts[i], "abandoned");
+			}
+		}
 
 		if (response) {
 			return response;
@@ -525,21 +543,32 @@ export async function handleProxy(
 				`Fallback: trying ${fallbackAccounts.length} SessionStrategy accounts`,
 			);
 			for (let i = 0; i < fallbackAccounts.length; i++) {
-				response = await proxyWithAccount(
-					req,
-					url,
-					fallbackAccounts[i],
-					requestMeta,
-					finalBodyBuffer,
-					finalCreateBodyStream,
-					i,
-					ctx,
-					undefined, // No model override for fallback path
-					apiKeyId,
-					apiKeyName,
-					requestBodyContext,
-					i === fallbackAccounts.length - 1,
-				);
+				const probeAdmission = getRateLimitProbeAdmission(fallbackAccounts[i]);
+				if (probeAdmission === "suppressed") {
+					continue;
+				}
+
+				try {
+					response = await proxyWithAccount(
+						req,
+						url,
+						fallbackAccounts[i],
+						requestMeta,
+						finalBodyBuffer,
+						finalCreateBodyStream,
+						i,
+						ctx,
+						undefined, // No model override for fallback path
+						apiKeyId,
+						apiKeyName,
+						requestBodyContext,
+						i === fallbackAccounts.length - 1,
+					);
+				} finally {
+					if (probeAdmission === "admitted") {
+						completeRateLimitProbe(fallbackAccounts[i], "abandoned");
+					}
+				}
 
 				if (response) {
 					return response;


### PR DESCRIPTION
## Summary
- After an account's rate-limit cooldown expires following a mature streak of consecutive 429s, only one process-local recovery probe request is admitted per account within a 2-minute lease window.
- Other requests that concurrently select the same account while it is being probed skip it and fall through to the next account instead of stampeding the recovering account, which was re-triggering the same 429 storm that produced the streak.

## Behavior
- Only accounts with `consecutive_rate_limits >= 5` and an expired `rate_limited_until` are gated; ordinary accounts and accounts still cooling down are unaffected.
- The first concurrent request that selects such an account is `admitted` and proceeds normally; any other concurrent selection of the same account is `suppressed` and the proxy's account loop moves on to the next account.
- The probe lease is released via `completeRateLimitProbe` on:
  - success (`recovered`, called from the response processor when a response is not rate-limited),
  - a fresh cooldown being reapplied (`cooldown_reapplied`, called from `applyRateLimitCooldown`),
  - abandonment (`abandoned`, called from a `finally` block around the `proxyWithAccount` call in the two account-iteration loops in `proxy.ts`, covering exceptions and any other unhandled exit).
- A bounded self-heal: if a probe lease is somehow never released, it expires naturally after the 2-minute lease window and a fresh probe is admitted then.
- An eviction cap (`MAX_PROBE_GATES = 10_000`) prunes the oldest lease from the in-memory map once it grows too large, preventing an unbounded memory leak.

## Provenance
- Source: ea53510a7ec781e8a719e6afbcf71fd2ede0f876 ("fix: single-flight cooldown recovery probes")
- Hand-ported onto current upstream `proxy.ts`, which has a simpler account-iteration loop than the fork (no cache-pacing wrapper calls that exist only in the fork).

## Validation
- New focused test file `packages/proxy/src/handlers/__tests__/rate-limit-cooldown-reentry.test.ts`: 9 tests, 16 assertions, all passing. Confirmed these tests fail against pre-fix upstream code (missing exports `resetRateLimitProbeGatesForTests`, `getRateLimitProbeAdmission`, `completeRateLimitProbe`) before implementing the fix.
- `bun test packages/proxy/src/handlers`: 187 pass, 0 fail (17 files).
- `bun test packages/proxy/src`: 425 pass, 0 fail (36 files).
- `bun run build`, `bun run lint`, `bun run typecheck`, `bun run format`: all clean (lint shows the pre-existing 211 warnings baseline, no new errors or warnings on changed files; format made no changes).
- `git diff --check`: clean.
- No real provider endpoints were called.