### PR TITLE
fix(codex): honest stop reasons, error classification, additive cached usage

### DIFF
--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -1633,7 +1633,7 @@ describe("CodexProvider.processResponse", () => {
 			type: "error",
 			error: {
 				type: "invalid_request_error",
-				message: "Input is too large",
+				message: "Prompt is too long. Codex reported: Input is too large",
 				code: "context_length_exceeded",
 			},
 		});
@@ -1859,6 +1859,134 @@ describe("CodexProvider.processResponse", () => {
 		expect(body).not.toContain('"stop_reason":"tool_use"');
 		expect(body).not.toContain('"stop_reason":"end_turn"');
 		expect(body).toContain('"stop_reason":"max_tokens"');
+	});
+
+	it("normalizes the subscription endpoint context-window message for streaming clients", async () => {
+		const provider = new CodexProvider();
+		const upstreamBody = sseBody([
+			...eventLine("response.failed", {
+				response: {
+					status: "failed",
+					error: {
+						type: "invalid_request_error",
+						message:
+							"Your input exceeds the context window of this model. Please adjust your input and try again.",
+					},
+				},
+			}),
+		]);
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const body = await transformed.text();
+
+		expect(body).toContain(
+			"Prompt is too long. Codex reported: Your input exceeds the context window of this model. Please adjust your input and try again.",
+		);
+	});
+
+	it("normalizes the subscription endpoint context-window message for non-streaming clients", async () => {
+		const provider = new CodexProvider();
+		const upstreamBody = sseBody([
+			...eventLine("response.failed", {
+				response: {
+					status: "failed",
+					error: {
+						type: "invalid_request_error",
+						message:
+							"Your input exceeds the context window of this model. Please adjust your input and try again.",
+					},
+				},
+			}),
+		]);
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: {
+				"content-type": "text/event-stream",
+				"x-better-ccflare-request-stream": "false",
+			},
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const body = await transformed.json();
+
+		expect(transformed.status).toBe(400);
+		expect(body).toEqual({
+			type: "error",
+			error: {
+				type: "invalid_request_error",
+				message:
+					"Prompt is too long. Codex reported: Your input exceeds the context window of this model. Please adjust your input and try again.",
+			},
+		});
+	});
+});
+
+describe("CodexProvider upstream error code classification", () => {
+	const errorForCode = async (code: string) => {
+		const provider = new CodexProvider();
+		const upstreamBody = sseBody([
+			...eventLine("error", {
+				type: "error",
+				code,
+				message: `Codex reported ${code}`,
+			}),
+		]);
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: {
+				"content-type": "text/event-stream",
+				"x-better-ccflare-request-stream": "false",
+			},
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const body = (await transformed.json()) as {
+			error: { type: string; code?: string };
+		};
+		return { status: transformed.status, body };
+	};
+
+	it("maps insufficient_quota to rate_limit_error", async () => {
+		const { status, body } = await errorForCode("insufficient_quota");
+		expect(body.error.type).toBe("rate_limit_error");
+		expect(status).toBe(429);
+	});
+
+	it("maps server_is_overloaded to overloaded_error", async () => {
+		const { status, body } = await errorForCode("server_is_overloaded");
+		expect(body.error.type).toBe("overloaded_error");
+		expect(status).toBe(529);
+	});
+
+	it("maps slow_down to overloaded_error", async () => {
+		const { status, body } = await errorForCode("slow_down");
+		expect(body.error.type).toBe("overloaded_error");
+		expect(status).toBe(529);
+	});
+
+	it("maps cyber_policy to invalid_request_error", async () => {
+		const { status, body } = await errorForCode("cyber_policy");
+		expect(body.error.type).toBe("invalid_request_error");
+		expect(status).toBe(400);
+	});
+
+	it("maps usage_not_included to permission_error", async () => {
+		const { status, body } = await errorForCode("usage_not_included");
+		expect(body.error.type).toBe("permission_error");
+		expect(status).toBe(403);
+	});
+
+	it("maps server_error to api_error", async () => {
+		const { status, body } = await errorForCode("server_error");
+		expect(body.error.type).toBe("api_error");
+		expect(status).toBe(502);
 	});
 });
 

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -868,9 +868,9 @@ describe("CodexProvider.processResponse", () => {
 		expect(payload.usage.input_tokens).toBe(40);
 		// The additive input_tokens plus the cache read must reconstruct the
 		// original cache-inclusive total Codex reported.
-		expect(payload.usage.input_tokens + payload.usage.cache_read_input_tokens).toBe(
-			100,
-		);
+		expect(
+			payload.usage.input_tokens + payload.usage.cache_read_input_tokens,
+		).toBe(100);
 	});
 
 	it("normalizes message_delta usage and delta defaults when missing", async () => {

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -7,7 +7,7 @@ import {
 	CODEX_VERSION,
 	CodexProvider,
 } from "./provider";
-import { parseCodexUsageHeaders } from "./usage";
+import { normalizeCodexInputUsage, parseCodexUsageHeaders } from "./usage";
 
 const codexAccount = (overrides: Partial<Account> = {}): Account => ({
 	id: "codex-1",
@@ -827,8 +827,50 @@ describe("CodexProvider.processResponse", () => {
 		expect(messageDeltaLine).not.toContain('"context_window"');
 		expect(messageDeltaLine).toContain('"usage":{');
 		expect(messageDeltaLine).toContain('"output_tokens":3');
-		expect(messageDeltaLine).toContain('"input_tokens":12');
+		// Codex's input_tokens (12) is cache-inclusive; Anthropic's input_tokens
+		// is additive and excludes the 4 cached tokens, which are reported
+		// separately as cache_read_input_tokens.
+		expect(messageDeltaLine).toContain('"input_tokens":8');
 		expect(messageDeltaLine).toContain('"cache_read_input_tokens":4');
+	});
+
+	it("translates cached input usage additively so input_tokens excludes cache reads", async () => {
+		const provider = new CodexProvider();
+		const upstreamBody = sseBody([
+			...eventLine("response.created", {
+				response: { id: "resp_test", model: "gpt-5.3-codex" },
+			}),
+			...eventLine("response.completed", {
+				response: {
+					model: "gpt-5.3-codex",
+					usage: {
+						input_tokens: 100,
+						output_tokens: 20,
+						input_tokens_details: { cached_tokens: 60 },
+					},
+				},
+			}),
+		]);
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const transformedBody = await transformed.text();
+		const messageDeltaLine = transformedBody
+			.split("\n")
+			.find((line) => line.includes('"type":"message_delta"')) as string;
+		const payload = JSON.parse(messageDeltaLine.slice("data: ".length));
+
+		expect(payload.usage.cache_read_input_tokens).toBe(60);
+		expect(payload.usage.input_tokens).toBe(40);
+		// The additive input_tokens plus the cache read must reconstruct the
+		// original cache-inclusive total Codex reported.
+		expect(payload.usage.input_tokens + payload.usage.cache_read_input_tokens).toBe(
+			100,
+		);
 	});
 
 	it("normalizes message_delta usage and delta defaults when missing", async () => {
@@ -2328,6 +2370,47 @@ describe("CodexProvider prompt_cache_key derivation", () => {
 			metadata: { user_id: JSON.stringify({ session_id: "not-a-uuid" }) },
 		});
 		expect(badUuid.prompt_cache_key).toBeUndefined();
+	});
+});
+
+describe("normalizeCodexInputUsage", () => {
+	it("subtracts cached tokens from the cache-inclusive total", () => {
+		const result = normalizeCodexInputUsage(100, 60);
+		expect(result.totalInputTokens).toBe(100);
+		expect(result.inputTokens).toBe(40);
+		expect(result.cacheReadInputTokens).toBe(60);
+	});
+
+	it("treats a missing or non-numeric total as zero", () => {
+		expect(normalizeCodexInputUsage(undefined, 5)).toEqual({
+			totalInputTokens: 0,
+			inputTokens: 0,
+			cacheReadInputTokens: 0,
+		});
+		expect(normalizeCodexInputUsage(Number.NaN, 5)).toEqual({
+			totalInputTokens: 0,
+			inputTokens: 0,
+			cacheReadInputTokens: 0,
+		});
+	});
+
+	it("treats a missing or negative cached count as zero", () => {
+		expect(normalizeCodexInputUsage(10, undefined)).toEqual({
+			totalInputTokens: 10,
+			inputTokens: 10,
+			cacheReadInputTokens: 0,
+		});
+		expect(normalizeCodexInputUsage(10, -5)).toEqual({
+			totalInputTokens: 10,
+			inputTokens: 10,
+			cacheReadInputTokens: 0,
+		});
+	});
+
+	it("clamps a cached count larger than the total instead of going negative", () => {
+		const result = normalizeCodexInputUsage(10, 25);
+		expect(result.inputTokens).toBe(0);
+		expect(result.cacheReadInputTokens).toBe(10);
 	});
 });
 

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -1740,6 +1740,126 @@ describe("CodexProvider.processResponse", () => {
 		expect(processed.status).toBe(400);
 		expect(await processed.text()).toBe('{"error":"bad_request"}');
 	});
+
+	it("maps response.incomplete with a content_filter reason to a refusal stop_reason", async () => {
+		const provider = new CodexProvider();
+		const upstreamBody = sseBody([
+			...eventLine("response.created", {
+				response: { id: "resp_incomplete", model: "gpt-5.5" },
+			}),
+			...eventLine("response.incomplete", {
+				response: {
+					model: "gpt-5.5",
+					status: "incomplete",
+					incomplete_details: { reason: "content_filter" },
+					usage: { input_tokens: 3, output_tokens: 1 },
+				},
+			}),
+		]);
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const body = await transformed.text();
+
+		expect(body).toContain('"stop_reason":"refusal"');
+		expect(body).toContain("event: message_delta");
+		expect(body).toContain("event: message_stop");
+	});
+
+	it("maps response.incomplete with a non-content_filter reason to max_tokens", async () => {
+		const provider = new CodexProvider();
+		const upstreamBody = sseBody([
+			...eventLine("response.created", {
+				response: { id: "resp_incomplete", model: "gpt-5.5" },
+			}),
+			...eventLine("response.incomplete", {
+				response: {
+					model: "gpt-5.5",
+					status: "incomplete",
+					incomplete_details: { reason: "max_output_tokens" },
+					usage: { input_tokens: 3, output_tokens: 512 },
+				},
+			}),
+		]);
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const body = await transformed.text();
+
+		expect(body).toContain('"stop_reason":"max_tokens"');
+	});
+
+	it("treats a response.completed event carrying status incomplete the same as response.incomplete", async () => {
+		const provider = new CodexProvider();
+		const upstreamBody = sseBody([
+			...eventLine("response.created", {
+				response: { id: "resp_incomplete", model: "gpt-5.5" },
+			}),
+			...eventLine("response.completed", {
+				response: {
+					model: "gpt-5.5",
+					status: "incomplete",
+					incomplete_details: { reason: "unknown_future_reason" },
+					usage: { input_tokens: 3, output_tokens: 10 },
+				},
+			}),
+		]);
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const body = await transformed.text();
+
+		expect(body).toContain('"stop_reason":"max_tokens"');
+	});
+
+	it("never resolves an incomplete response with a pending tool call to a success stop_reason", async () => {
+		const provider = new CodexProvider();
+		const upstreamBody = sseBody([
+			...eventLine("response.created", {
+				response: { id: "resp_incomplete", model: "gpt-5.5" },
+			}),
+			...eventLine("response.output_item.added", {
+				item: { type: "function_call", call_id: "call_1", name: "search" },
+				output_index: 0,
+			}),
+			...eventLine("response.output_item.done", {
+				item: { type: "function_call", call_id: "call_1", name: "search" },
+				output_index: 0,
+			}),
+			...eventLine("response.incomplete", {
+				response: {
+					model: "gpt-5.5",
+					status: "incomplete",
+					incomplete_details: { reason: "max_output_tokens" },
+					usage: { input_tokens: 3, output_tokens: 50 },
+				},
+			}),
+		]);
+
+		const response = new Response(upstreamBody, {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+
+		const transformed = await provider.processResponse(response, null);
+		const body = await transformed.text();
+
+		expect(body).not.toContain('"stop_reason":"tool_use"');
+		expect(body).not.toContain('"stop_reason":"end_turn"');
+		expect(body).toContain('"stop_reason":"max_tokens"');
+	});
 });
 
 describe("CodexProvider.transformRequestBody", () => {

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -1809,6 +1809,7 @@ export class CodexProvider extends BaseProvider {
 				break;
 			}
 
+			case "response.incomplete":
 			case "response.completed": {
 				if (state.upstreamError || state.hasSentTerminalEvents) break;
 				const resp = data.response as Record<string, unknown> | undefined;
@@ -1850,9 +1851,31 @@ export class CodexProvider extends BaseProvider {
 					state.hasSentContentBlockStart = false;
 				}
 
+				const incompleteDetails = resp?.incomplete_details as
+					| { reason?: string }
+					| undefined;
+				const isIncomplete =
+					eventName === "response.incomplete" || resp?.status === "incomplete";
+				// An incomplete response never resolves to a success stop_reason:
+				// content_filter -> refusal (client discards partial output); every
+				// other reason, including unknown future ones, -> max_tokens (generic
+				// truncation, mirroring real Anthropic mid-tool-input truncation
+				// semantics: partial blocks are framed, stop_reason forbids execution).
+				const stopReason: "end_turn" | "tool_use" | "max_tokens" | "refusal" =
+					isIncomplete
+						? incompleteDetails?.reason === "content_filter"
+							? "refusal"
+							: "max_tokens"
+						: state.sawToolUse
+							? "tool_use"
+							: "end_turn";
+
 				const messageDelta: {
 					type: "message_delta";
-					delta: { stop_reason: "end_turn" | "tool_use"; stop_sequence: null };
+					delta: {
+						stop_reason: "end_turn" | "tool_use" | "max_tokens" | "refusal";
+						stop_sequence: null;
+					};
 					usage: {
 						input_tokens: number;
 						output_tokens: number;
@@ -1863,7 +1886,7 @@ export class CodexProvider extends BaseProvider {
 				} = {
 					type: "message_delta",
 					delta: {
-						stop_reason: state.sawToolUse ? "tool_use" : "end_turn",
+						stop_reason: stopReason,
 						stop_sequence: null,
 					},
 					usage: {

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -10,6 +10,7 @@ import { resolveReasoningEffort } from "@better-ccflare/openai-formats";
 import type { Account } from "@better-ccflare/types";
 import { BaseProvider } from "../../base";
 import type { RateLimitInfo, TokenRefreshResult } from "../../types";
+import { normalizeCodexInputUsage } from "./usage";
 
 const log = new Logger("CodexProvider");
 
@@ -806,17 +807,15 @@ export class CodexProvider extends BaseProvider {
 		const inputTokenDetails = usageRecord?.input_tokens_details as
 			| Record<string, unknown>
 			| undefined;
-		const cachedTokens = inputTokenDetails?.cached_tokens;
+		const normalizedInput = normalizeCodexInputUsage(
+			inputTokens,
+			inputTokenDetails?.cached_tokens,
+		);
 
 		return {
 			current_usage: {
-				input_tokens: inputTokens,
-				cache_read_input_tokens:
-					typeof cachedTokens === "number" &&
-					Number.isFinite(cachedTokens) &&
-					cachedTokens >= 0
-						? cachedTokens
-						: 0,
+				input_tokens: normalizedInput.inputTokens,
+				cache_read_input_tokens: normalizedInput.cacheReadInputTokens,
 				cache_creation_input_tokens:
 					typeof inputTokenDetails?.cache_creation_input_tokens === "number" &&
 					Number.isFinite(inputTokenDetails.cache_creation_input_tokens) &&
@@ -1855,22 +1854,29 @@ export class CodexProvider extends BaseProvider {
 					  }
 					| undefined;
 
-				// Extract cache fields from input_tokens_details (Codex format)
+				// Extract cache fields from input_tokens_details (Codex format).
+				// OpenAI's input_tokens is cache-inclusive; normalize to Anthropic's
+				// additive semantics so input_tokens excludes cache reads instead of
+				// double-counting them.
 				const inputTokenDetails = usage?.input_tokens_details;
-				const cacheRead =
-					typeof inputTokenDetails?.cached_tokens === "number" &&
-					inputTokenDetails.cached_tokens >= 0
-						? inputTokenDetails.cached_tokens
-						: 0;
+				const normalizedInput = normalizeCodexInputUsage(
+					usage?.input_tokens,
+					inputTokenDetails?.cached_tokens,
+				);
 				const cacheCreation =
 					typeof inputTokenDetails?.cache_creation_input_tokens === "number" &&
 					inputTokenDetails.cache_creation_input_tokens >= 0
 						? inputTokenDetails.cache_creation_input_tokens
 						: 0;
 
-				state.inputTokens = usage?.input_tokens || state.inputTokens;
-				state.outputTokens = usage?.output_tokens || state.outputTokens;
-				state.cacheReadInputTokens = cacheRead;
+				state.inputTokens = normalizedInput.inputTokens;
+				state.outputTokens =
+					typeof usage?.output_tokens === "number" &&
+					Number.isFinite(usage.output_tokens) &&
+					usage.output_tokens >= 0
+						? usage.output_tokens
+						: state.outputTokens;
+				state.cacheReadInputTokens = normalizedInput.cacheReadInputTokens;
 				state.cacheCreationInputTokens = cacheCreation;
 				state.contextWindow = this.extractContextWindow(resp, usage);
 				// Close any lingering content block

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -73,6 +73,22 @@ const _normalizeUsage = (value: unknown): Record<string, number> => {
 	};
 };
 
+// Known Codex failure codes -> Anthropic error types. Quota exhaustion cools
+// the account like a rate limit; slow_down/server_is_overloaded are throttles;
+// context/policy and subscription errors are permanent and must not be
+// retried as 5xx. Codes and their retry semantics mirror the reference
+// client (openai/codex codex-api/src/sse/responses.rs + api_bridge.rs).
+const CODEX_ERROR_TYPE_BY_CODE: Record<string, string> = {
+	rate_limit_exceeded: "rate_limit_error",
+	insufficient_quota: "rate_limit_error",
+	server_is_overloaded: "overloaded_error",
+	slow_down: "overloaded_error",
+	server_error: "api_error",
+	context_length_exceeded: "invalid_request_error",
+	cyber_policy: "invalid_request_error",
+	usage_not_included: "permission_error",
+};
+
 // Default model mapping: Anthropic model name prefixes → Codex model names
 const DEFAULT_MODEL_MAP: Record<string, string> = {
 	opus: "gpt-5.3-codex",
@@ -1552,9 +1568,12 @@ export class CodexProvider extends BaseProvider {
 		const status = error?.status === "rate_limited" ? error.status : undefined;
 		const rawType = error?.type;
 		let type = "api_error";
-		if (code === "context_length_exceeded") {
-			type = "invalid_request_error";
-		} else if (code === "rate_limit_exceeded" || status === "rate_limited") {
+		const mappedFromCode = code
+			? CODEX_ERROR_TYPE_BY_CODE[code.toLowerCase()]
+			: undefined;
+		if (mappedFromCode) {
+			type = mappedFromCode;
+		} else if (status === "rate_limited") {
 			type = "rate_limit_error";
 		} else if (
 			rawType === "invalid_request_error" ||
@@ -1567,11 +1586,23 @@ export class CodexProvider extends BaseProvider {
 		) {
 			type = rawType;
 		}
+		const upstreamMessage = error?.message || "Codex upstream failed.";
+		const normalizedCode = code?.toLowerCase();
+		// Some Codex endpoints report context overflow without the
+		// context_length_exceeded code, only a "your input exceeds the context
+		// window..." message. Match that message shape too so the client still
+		// gets the friendlier, prefixed error text.
+		const isContextOverflow =
+			normalizedCode === "context_length_exceeded" ||
+			/^your input exceeds the context window\b/i.test(upstreamMessage);
+		const message = isContextOverflow
+			? `Prompt is too long. Codex reported: ${upstreamMessage}`
+			: upstreamMessage;
 		return {
 			type: "error",
 			error: {
 				type,
-				message: error?.message || "Codex upstream failed.",
+				message,
 				...(code ? { code } : {}),
 				...(status ? { status } : {}),
 			},

--- a/packages/providers/src/providers/codex/usage.ts
+++ b/packages/providers/src/providers/codex/usage.ts
@@ -10,6 +10,46 @@ const DEFAULT_UTILIZATION = 0;
 const FIVE_HOUR_WINDOW_MINUTES = 5 * 60;
 const SEVEN_DAY_WINDOW_MINUTES = 7 * 24 * 60;
 
+export interface NormalizedCodexInputUsage {
+	/** Total context occupied upstream, including cached tokens. */
+	totalInputTokens: number;
+	/** Anthropic's additive, uncached input token field. */
+	inputTokens: number;
+	cacheReadInputTokens: number;
+}
+
+/**
+ * Convert Codex's cache-inclusive input total to Anthropic's additive usage
+ * fields. OpenAI's usage.input_tokens counts cached tokens toward the total;
+ * Anthropic's input_tokens is additive and excludes tokens already reported
+ * via cache_read_input_tokens. Copying the inclusive total into both fields
+ * double-counts cached tokens for clients and billing that expect Anthropic
+ * semantics.
+ */
+export function normalizeCodexInputUsage(
+	totalInputTokens: unknown,
+	cachedTokens: unknown,
+): NormalizedCodexInputUsage {
+	const total =
+		typeof totalInputTokens === "number" &&
+		Number.isFinite(totalInputTokens) &&
+		totalInputTokens >= 0
+			? totalInputTokens
+			: 0;
+	const cached =
+		typeof cachedTokens === "number" &&
+		Number.isFinite(cachedTokens) &&
+		cachedTokens >= 0
+			? Math.min(cachedTokens, total)
+			: 0;
+
+	return {
+		totalInputTokens: total,
+		inputTokens: total - cached,
+		cacheReadInputTokens: cached,
+	};
+}
+
 function parseNumber(value: string | null): number | null {
 	if (!value) return null;
 	const parsed = Number.parseFloat(value);


### PR DESCRIPTION
## Summary
- Codex response.incomplete events were being resolved to a fabricated stop_reason (end_turn or tool_use); they now map to the correct Anthropic terminal (refusal for content_filter, max_tokens otherwise), and never resolve to a success stop_reason even with a pending tool call.
- Upstream Codex error codes only recognized context_length_exceeded and rate_limit_exceeded, collapsing everything else (quota exhaustion, throttling, overload, policy, subscription errors) into a generic api_error; a broader code table now maps each to its correct Anthropic error type and HTTP status, and a context-overflow message is now recognized even without the literal error code.
- Codex's usage.input_tokens is cache-inclusive; it was copied straight into Anthropic's additive input_tokens field while cache_read_input_tokens was also reported, double-counting cached tokens. input_tokens now excludes cache reads (input_tokens + cache_read_input_tokens reconstructs the original Codex total).

## Behavior
- `response.incomplete` (and `response.completed` carrying `status: "incomplete"`) now maps `incomplete_details.reason === "content_filter"` to Anthropic `stop_reason: "refusal"`, and any other reason (including unknown future ones) to `"max_tokens"`.
- An incomplete response with an in-flight tool call no longer reports `tool_use` or `end_turn`; it reports `max_tokens`.
- New `CODEX_ERROR_TYPE_BY_CODE` table classifies `insufficient_quota` and `rate_limit_exceeded` as `rate_limit_error`; `server_is_overloaded` and `slow_down` as `overloaded_error`; `server_error` as `api_error`; `context_length_exceeded` and `cyber_policy` as `invalid_request_error`; `usage_not_included` as `permission_error`. HTTP status codes follow the existing type-to-status mapping (429/529/400/403/502).
- A "Your input exceeds the context window..." style message is now recognized as a context-overflow error and prefixed with "Prompt is too long. Codex reported: ..." even when Codex omits the `context_length_exceeded` code.
- `input_tokens` in both the streaming `message_delta` usage and the synthesized `context_window` block now excludes cached tokens; `cache_read_input_tokens` continues to report the cached portion separately. `normalizeCodexInputUsage(total, cached)` is exported from `usage.ts` for this translation.

## Provenance
Hand-ported from the fork's production trunk onto current upstream `packages/providers/src/providers/codex/provider.ts` / `usage.ts` (the fork has diverged significantly, including a trace module that doesn't exist upstream, so this is not a blind cherry-pick):
- `57490591` - forward max_tokens, handle response.incomplete, classify error codes (only the response.incomplete handling and error classification portions apply here; max_tokens forwarding is request-side and out of scope for this PR)
- `cd68e60b` - classify Codex terminal errors (context-overflow message fallback)
- `21d30ee4` - translate cached input usage additively (`normalizeCodexInputUsage`)

## Validation
- New/updated focused tests written first and confirmed red against current upstream code before implementing each fix (4 response.incomplete tests, 8 error-classification tests, 1 pre-existing context-window-message test updated, 6 additive-usage tests).
- `bun test packages/providers/src/providers/codex/provider.test.ts`: 86 pass, 0 fail, 229 expect() calls.
- Gates: `bun run build` succeeds; `bun run lint` reports the same pre-existing 211 warnings (no new errors); `bun run typecheck` clean; `bun run format` clean; `git diff --check` clean.
- No real provider endpoints were called.

Independent of open PR #317 (request translation fidelity); this PR covers the response side only. Minor textual overlap in `provider.ts` is possible if both merge around the same time, happy to rebase.