### PR TITLE
fix(alerts): PostgreSQL-compatible conflict clause + crash hardening

### DIFF
--- a/packages/http-api/src/services/__tests__/auth-failure-alert.test.ts
+++ b/packages/http-api/src/services/__tests__/auth-failure-alert.test.ts
@@ -3,7 +3,9 @@ import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { EventEmitter } from "node:events";
 import type { Config } from "@better-ccflare/config";
 import { alertEvents, authFailureEvents } from "@better-ccflare/core";
+import type { BunSqlAdapter as BunSqlAdapterType } from "@better-ccflare/database";
 import { BunSqlAdapter, ensureSchema } from "@better-ccflare/database";
+import type { RequestResponse } from "@better-ccflare/types";
 import { AlertService } from "../alerts";
 
 async function waitFor(predicate: () => boolean): Promise<void> {
@@ -14,15 +16,21 @@ async function waitFor(predicate: () => boolean): Promise<void> {
 	throw new Error("Timed out waiting for auth-failure alert processing");
 }
 
-function makeConfig(): Config {
+function makeConfig(
+	overrides: Partial<{
+		requestTokens: number;
+		webhookUrl: string;
+	}> = {},
+): Config {
 	return Object.assign(new EventEmitter(), {
 		getAlertDailySpendUsd: () => 0,
 		getAlertTokensPerHour: () => 0,
-		getAlertRequestTokens: () => 0,
+		getAlertRequestTokens: () => overrides.requestTokens ?? 0,
 		getAlertAnomalyEnabled: () => false,
 		getAlertAnomalyIntervalMinutes: () => 15,
 		getAlertCooldownMinutes: () => 60,
-		getAlertWebhookUrl: () => "http://127.0.0.1:9999/webhook",
+		getAlertWebhookUrl: () =>
+			overrides.webhookUrl ?? "http://127.0.0.1:9999/webhook",
 	}) as unknown as Config;
 }
 
@@ -85,5 +93,116 @@ describe("AlertService auth_failure events", () => {
 		expect(await service.listAlerts()).toHaveLength(1);
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 		expect(emitted).toHaveLength(1);
+	});
+});
+
+/**
+ * Fake adapter that records the SQL sent to `.run()`. Simulates the PostgreSQL
+ * dialect (isSQLite === false) so we can assert the dialect-aware conflict
+ * clause without a live PG server.
+ */
+class RecordingPgAdapter implements BunSqlAdapterType {
+	readonly isSQLite = false;
+	readonly runStatements: string[] = [];
+
+	async get<T>(_sql: string, _params?: unknown[]): Promise<T | null> {
+		return null;
+	}
+	async query<T>(_sql: string, _params?: unknown[]): Promise<T[]> {
+		return [];
+	}
+	async run(sql: string, _params?: unknown[]): Promise<void> {
+		this.runStatements.push(sql);
+		// Reject if the caller sent SQLite-only syntax — mirrors PG's behavior.
+		if (/INSERT OR IGNORE/i.test(sql)) {
+			throw new Error('syntax error at or near "OR"');
+		}
+	}
+}
+
+/**
+ * Fake adapter that always fails on `.run()`, to verify a persistence failure
+ * is swallowed and never rejects the event-handler promise (which would crash
+ * the proxy — the original v3.5.40 incident).
+ */
+class FailingPgAdapter extends RecordingPgAdapter {
+	async run(_sql: string, _params?: unknown[]): Promise<void> {
+		throw new Error("simulated PG outage");
+	}
+}
+
+describe("AlertService persistAndEmit (issue #326)", () => {
+	let originalFetch: typeof globalThis.fetch;
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+		globalThis.fetch = mock(
+			async () => new Response(null, { status: 204 }),
+		) as unknown as typeof fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	function makeHighTokenRequest(): RequestResponse {
+		return {
+			id: "req-1",
+			timestamp: new Date().toISOString(),
+			method: "POST",
+			path: "/v1/messages",
+			accountUsed: "account-1",
+			statusCode: 200,
+			success: true,
+			errorMessage: null,
+			responseTimeMs: 100,
+			failoverAttempts: 0,
+			model: "claude-3",
+			totalTokens: 1_000_000,
+			inputTokens: 1_000_000,
+			cacheReadInputTokens: 0,
+			cacheCreationInputTokens: 0,
+			outputTokens: 0,
+			costUsd: 0,
+			project: null,
+		};
+	}
+
+	it("uses PostgreSQL ON CONFLICT syntax instead of INSERT OR IGNORE", async () => {
+		const adapter = new RecordingPgAdapter();
+		const service = new AlertService(
+			adapter as unknown as BunSqlAdapterType,
+			makeConfig({ requestTokens: 1 }),
+		);
+		service.start();
+		try {
+			await service.evaluateRequest(makeHighTokenRequest());
+			const insertStmt = adapter.runStatements.find((s) =>
+				/INTO alerts/.test(s),
+			);
+			expect(insertStmt).toBeDefined();
+			expect(insertStmt).toMatch(/ON CONFLICT\s*\(id\)\s*DO NOTHING/i);
+			expect(insertStmt).not.toMatch(/INSERT OR IGNORE/i);
+		} finally {
+			service.stop();
+		}
+	});
+
+	it("swallows persistence failures instead of crashing the proxy", async () => {
+		const adapter = new FailingPgAdapter();
+		const service = new AlertService(
+			adapter as unknown as BunSqlAdapterType,
+			makeConfig({ requestTokens: 1 }),
+		);
+		service.start();
+		try {
+			// Must not throw — the listener is invoked from an async event
+			// handler whose rejection would crash Bun with exit code 1.
+			await expect(
+				service.evaluateRequest(makeHighTokenRequest()),
+			).resolves.toBeUndefined();
+		} finally {
+			service.stop();
+		}
 	});
 });

--- a/packages/http-api/src/services/alerts.ts
+++ b/packages/http-api/src/services/alerts.ts
@@ -547,29 +547,47 @@ export class AlertService {
 		);
 		if (existing) return;
 
-		await this.db.run(
-			`
-			INSERT OR IGNORE INTO alerts (
-				id, timestamp, type, severity, title, message, value, threshold,
-				account, model, project, request_id, acknowledged
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		`,
-			[
-				alert.id,
-				alert.timestamp,
-				alert.type,
-				alert.severity,
-				alert.title,
-				alert.message,
-				alert.value,
-				alert.threshold,
-				alert.account,
-				alert.model,
-				alert.project,
-				alert.requestId,
-				alert.acknowledged ? 1 : 0,
-			],
-		);
+		// INSERT OR IGNORE is SQLite-only; PostgreSQL uses ON CONFLICT DO NOTHING.
+		// The pre-check above makes the conflict clause functionally redundant, but
+		// keeping it defends against a race between the SELECT and INSERT.
+		const conflictClause = this.db.isSQLite ? "INSERT OR IGNORE" : "INSERT";
+		const onConflictClause = this.db.isSQLite
+			? ""
+			: "ON CONFLICT (id) DO NOTHING";
+		try {
+			await this.db.run(
+				`
+				${conflictClause} INTO alerts (
+					id, timestamp, type, severity, title, message, value, threshold,
+					account, model, project, request_id, acknowledged
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				${onConflictClause}
+			`,
+				[
+					alert.id,
+					alert.timestamp,
+					alert.type,
+					alert.severity,
+					alert.title,
+					alert.message,
+					alert.value,
+					alert.threshold,
+					alert.account,
+					alert.model,
+					alert.project,
+					alert.requestId,
+					alert.acknowledged ? 1 : 0,
+				],
+			);
+		} catch (error) {
+			// Alerts are best-effort telemetry — a persistence failure must not
+			// terminate the proxy (the listener is invoked from an async event
+			// handler, so an unhandled rejection crashes Bun with exit code 1).
+			log.error(
+				`Failed to persist ${alert.type} alert: ${(error as Error).message}`,
+			);
+			return;
+		}
 		const event: AlertEvt = { type: "alert", payload: alert };
 		alertEvents.emit("event", event);
 		if (webhookUrl) {


### PR DESCRIPTION
## Summary
- `AlertService.persistAndEmit()` sent SQLite-only `INSERT OR IGNORE` to PostgreSQL, crashing the proxy (`CrashLoopBackOff`, exit code 1) when an `auth_failure` alert fired on PG (issue #326). The query is now dialect-aware: SQLite keeps `INSERT OR IGNORE`, PostgreSQL uses `INSERT ... ON CONFLICT (id) DO NOTHING` via `this.db.isSQLite`.
- Wrapped the alert insert in `try/catch` so a persistence failure logs and returns instead of rejecting the async event-handler promise (which is what terminated Bun and took down the proxy).
- Added regression tests: a PG-dialect fake asserts the emitted SQL uses `ON CONFLICT DO NOTHING` (never `INSERT OR IGNORE`), and a failing-adapter test asserts `evaluateRequest` resolves rather than throwing.

## Test plan
- [x] `bun test packages/http-api/src/services/__tests__/` — 119 pass
- [x] `bun run lint && bun run typecheck && bun run format`

Fixes #326