### PR TITLE
docs: document ALERT_* env vars and alerts feature

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,6 +148,24 @@ These environment variables are not stored in the configuration file and must be
 | `CF_STREAM_TIMEOUT_MS` | Stream processing timeout in milliseconds | `60000` (1 minute) | `CF_STREAM_TIMEOUT_MS=120000` |
 | `PAYLOAD_ENCRYPTION_KEY` | Optional 64-char hex key (32 bytes / AES-256) enabling AES-256-GCM encryption-at-rest for the `request_payloads` table. See [security.md](security.md#payload-encryption-at-rest). | unset (plaintext) | `PAYLOAD_ENCRYPTION_KEY=$(openssl rand -hex 32)` |
 
+## Alerts
+
+better-ccflare can emit threshold and anomaly alerts and deliver them via webhook and the dashboard. Alerts are persisted to the same database as requests and deduplicated per cooldown bucket; persistence is best-effort — a database failure is logged and skipped rather than failing the request or crashing the proxy. All `ALERT_*` env vars have equivalent config-file fields (`alert_daily_spend_usd`, `alert_tokens_per_hour`, `alert_request_tokens`, `alert_anomaly_enabled`, `alert_anomaly_interval_minutes`, `alert_cooldown_minutes`, `alert_webhook_url`); env vars take precedence.
+
+| Variable | Purpose | Default | Example |
+|----------|---------|---------|---------|
+| `ALERT_DAILY_SPEND_USD` | Fire a warning alert when aggregate spend since local midnight meets or exceeds this USD amount. Clamped to `[0, 1000000]`; `0` disables | `0` | `ALERT_DAILY_SPEND_USD=25` |
+| `ALERT_TOKENS_PER_HOUR` | Fire a warning alert when total tokens consumed in the trailing hour meets or exceeds this count. `0` disables | `0` | `ALERT_TOKENS_PER_HOUR=500000` |
+| `ALERT_REQUEST_TOKENS` | Fire a critical alert when a single request's total token count meets or exceeds this value. `0` disables | `0` | `ALERT_REQUEST_TOKENS=200000` |
+| `ALERT_ANOMALY_ENABLED` | Run periodic anomaly detection over recent requests (token outliers, output blowups, runaway loops, model misrouting). Accepts `1`/`true`/`0`/`false` | `false` | `ALERT_ANOMALY_ENABLED=true` |
+| `ALERT_ANOMALY_INTERVAL_MINUTES` | Cadence of anomaly-detection sweeps, in minutes. Clamped to `[5, 1440]` | `15` | `ALERT_ANOMALY_INTERVAL_MINUTES=30` |
+| `ALERT_COOLDOWN_MINUTES` | Per-alert-type-and-scope cooldown bucket size in minutes — within a bucket, only the first alert is persisted and delivered (no SSE storms or duplicate webhooks). Clamped to `[1, 1440]` | `60` | `ALERT_COOLDOWN_MINUTES=120` |
+| `ALERT_WEBHOOK_URL` | `http(s)` URL to receive `POST` deliveries of `{ type: "alert", alert: { ... } }`. Unset = no webhook delivery. Must be a valid URL or the setter rejects it | unset | `ALERT_WEBHOOK_URL=https://example.com/alerts` |
+
+In addition to threshold alerts, an `auth_failure` alert (severity `critical`) fires automatically when an OAuth account's refresh token fails definitively (e.g. `invalid_grant`) and the account is marked `requires_reauth`. It is deduplicated by the same cooldown bucket as the threshold alerts.
+
+Alerts are listed on the dashboard and via the API; unacknowledged counts surface in `/health`. Persistence uses dialect-appropriate conflict handling (`INSERT OR IGNORE` on SQLite, `ON CONFLICT (id) DO NOTHING` on PostgreSQL), so alerts work identically on both backends.
+
 ## Database Configuration
 
 better-ccflare supports two database backends:


### PR DESCRIPTION
## Summary
- The `ALERT_*` environment variables (`ALERT_DAILY_SPEND_USD`, `ALERT_TOKENS_PER_HOUR`, `ALERT_REQUEST_TOKENS`, `ALERT_ANOMALY_ENABLED`, `ALERT_ANOMALY_INTERVAL_MINUTES`, `ALERT_COOLDOWN_MINUTES`, `ALERT_WEBHOOK_URL`) and the `auth_failure` alert type were never documented in the main configuration reference (`docs/configuration.md`) — only mentioned in the README acknowledgements.
- Added an **Alerts** section covering each variable (purpose, default, clamp range, example), the webhook payload shape, cooldown-bucket dedup behavior, and the dialect-aware persistence (`INSERT OR IGNORE` on SQLite, `ON CONFLICT (id) DO NOTHING` on PostgreSQL — the latter being the fix from #327).

Docs-only change; no code or behavior changes.

## Test plan
- [x] Reviewed against `packages/config/src/index.ts` getters — defaults, clamps, and config-file field names all match