### PR TITLE
feat(dashboard): routing settings card — strategy selector + model-scoped capacity routing toggle

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -507,6 +507,26 @@ export class Config extends EventEmitter {
 		return "off";
 	}
 
+	/**
+	 * Report where the effective model-scoped capacity routing mode comes from,
+	 * mirroring the precedence in getModelScopedCapacityRouting():
+	 * a valid MODEL_SCOPED_CAPACITY_ROUTING env value wins ("env"), else a valid
+	 * config-file field ("file"), else the built-in default ("default"). The
+	 * dashboard uses "env" to lock the control, because a POST that writes the
+	 * file field is ineffective while the env var overrides it.
+	 */
+	getModelScopedCapacityRoutingSource(): "env" | "file" | "default" {
+		const fromEnv = process.env.MODEL_SCOPED_CAPACITY_ROUTING;
+		if (isValidModelScopedCapacityRoutingMode(fromEnv)) {
+			return "env";
+		}
+		const fromFile = this.data.model_scoped_capacity_routing;
+		if (isValidModelScopedCapacityRoutingMode(fromFile)) {
+			return "file";
+		}
+		return "default";
+	}
+
 	setModelScopedCapacityRouting(mode: ModelScopedCapacityRoutingMode): void {
 		if (!isValidModelScopedCapacityRoutingMode(mode)) {
 			throw new ValidationError(

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -260,19 +260,19 @@ export class Config extends EventEmitter {
 	}
 
 	getStrategy(): StrategyName {
-		// First check environment variable
-		const envStrategy = process.env.LB_STRATEGY;
-		if (envStrategy && isValidStrategy(envStrategy)) {
-			return envStrategy;
-		}
+		return this.resolveStrategy().value;
+	}
 
-		// Then check config file
-		const configStrategy = this.data.lb_strategy;
-		if (configStrategy && isValidStrategy(configStrategy)) {
-			return configStrategy;
-		}
-
-		return DEFAULT_STRATEGY;
+	/**
+	 * Report where the effective load-balancing strategy comes from, mirroring
+	 * the precedence in getStrategy(): a valid LB_STRATEGY env value wins
+	 * ("env"), else a valid config-file field ("file"), else the built-in
+	 * default ("default"). The dashboard uses "env" to lock the strategy
+	 * control, because a POST that writes the file field is ineffective while
+	 * the env var overrides it.
+	 */
+	getStrategySource(): "env" | "file" | "default" {
+		return this.resolveStrategy().source;
 	}
 
 	setStrategy(strategy: StrategyName): void {
@@ -516,6 +516,23 @@ export class Config extends EventEmitter {
 			return { value: fileValue, source: "file" };
 		}
 		return { value: defaultValue, source: "default" };
+	}
+
+	/**
+	 * Resolve the effective load-balancing strategy plus its source, using the
+	 * same env > file > default precedence getStrategy() has always used.
+	 * Backs both getStrategy() and getStrategySource() so they cannot drift.
+	 */
+	private resolveStrategy(): {
+		value: StrategyName;
+		source: "env" | "file" | "default";
+	} {
+		return this.resolveEnvFileSetting(
+			process.env.LB_STRATEGY,
+			this.data.lb_strategy,
+			isValidStrategy,
+			DEFAULT_STRATEGY,
+		);
 	}
 
 	private resolveModelScopedCapacityRouting(): {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -495,16 +495,43 @@ export class Config extends EventEmitter {
 		this.set("usage_throttling_weekly_enabled", value);
 	}
 
+	/**
+	 * Shared env > file > default precedence resolver: a valid environment
+	 * value wins ("env"), else a valid config-file value ("file"), else
+	 * `defaultValue` ("default"). Used by getModelScopedCapacityRouting() /
+	 * getModelScopedCapacityRoutingSource() so the two can never drift, and
+	 * is reusable for other env+file-backed string settings (e.g. a future
+	 * getStrategySource() for LB_STRATEGY).
+	 */
+	private resolveEnvFileSetting<T extends string>(
+		envValue: string | undefined,
+		fileValue: T | undefined,
+		isValid: (value: string) => value is T,
+		defaultValue: T,
+	): { value: T; source: "env" | "file" | "default" } {
+		if (envValue !== undefined && isValid(envValue)) {
+			return { value: envValue, source: "env" };
+		}
+		if (fileValue !== undefined && isValid(fileValue)) {
+			return { value: fileValue, source: "file" };
+		}
+		return { value: defaultValue, source: "default" };
+	}
+
+	private resolveModelScopedCapacityRouting(): {
+		value: ModelScopedCapacityRoutingMode;
+		source: "env" | "file" | "default";
+	} {
+		return this.resolveEnvFileSetting(
+			process.env.MODEL_SCOPED_CAPACITY_ROUTING,
+			this.data.model_scoped_capacity_routing,
+			isValidModelScopedCapacityRoutingMode,
+			"off",
+		);
+	}
+
 	getModelScopedCapacityRouting(): ModelScopedCapacityRoutingMode {
-		const fromEnv = process.env.MODEL_SCOPED_CAPACITY_ROUTING;
-		if (isValidModelScopedCapacityRoutingMode(fromEnv)) {
-			return fromEnv;
-		}
-		const fromFile = this.data.model_scoped_capacity_routing;
-		if (isValidModelScopedCapacityRoutingMode(fromFile)) {
-			return fromFile;
-		}
-		return "off";
+		return this.resolveModelScopedCapacityRouting().value;
 	}
 
 	/**
@@ -516,15 +543,7 @@ export class Config extends EventEmitter {
 	 * file field is ineffective while the env var overrides it.
 	 */
 	getModelScopedCapacityRoutingSource(): "env" | "file" | "default" {
-		const fromEnv = process.env.MODEL_SCOPED_CAPACITY_ROUTING;
-		if (isValidModelScopedCapacityRoutingMode(fromEnv)) {
-			return "env";
-		}
-		const fromFile = this.data.model_scoped_capacity_routing;
-		if (isValidModelScopedCapacityRoutingMode(fromFile)) {
-			return "file";
-		}
-		return "default";
+		return this.resolveModelScopedCapacityRouting().source;
 	}
 
 	setModelScopedCapacityRouting(mode: ModelScopedCapacityRoutingMode): void {

--- a/packages/config/src/model-scoped-capacity-routing.test.ts
+++ b/packages/config/src/model-scoped-capacity-routing.test.ts
@@ -99,4 +99,55 @@ describe("getModelScopedCapacityRouting / setModelScopedCapacityRouting", () => 
 			cleanup();
 		}
 	});
+
+	it("reports source 'default' when neither env nor file is set", () => {
+		const { config, cleanup } = makeConfig();
+		try {
+			expect(config.getModelScopedCapacityRoutingSource()).toBe("default");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("reports source 'file' when only the config-file field is set", () => {
+		const { config, cleanup } = makeConfig();
+		try {
+			config.setModelScopedCapacityRouting("exhausted");
+			expect(config.getModelScopedCapacityRoutingSource()).toBe("file");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("reports source 'env' when a valid env override is present", () => {
+		process.env.MODEL_SCOPED_CAPACITY_ROUTING = "exhausted";
+		const { config, cleanup } = makeConfig();
+		try {
+			expect(config.getModelScopedCapacityRoutingSource()).toBe("env");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("reports source 'env' even when a config-file value is also set", () => {
+		process.env.MODEL_SCOPED_CAPACITY_ROUTING = "off";
+		const { config, cleanup } = makeConfig();
+		try {
+			config.setModelScopedCapacityRouting("exhausted");
+			expect(config.getModelScopedCapacityRoutingSource()).toBe("env");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("reports source 'file' when an invalid env value falls back to the file", () => {
+		process.env.MODEL_SCOPED_CAPACITY_ROUTING = "always";
+		const { config, cleanup } = makeConfig();
+		try {
+			config.setModelScopedCapacityRouting("exhausted");
+			expect(config.getModelScopedCapacityRoutingSource()).toBe("file");
+		} finally {
+			cleanup();
+		}
+	});
 });

--- a/packages/config/src/model-scoped-capacity-routing.test.ts
+++ b/packages/config/src/model-scoped-capacity-routing.test.ts
@@ -56,6 +56,17 @@ describe("getModelScopedCapacityRouting / setModelScopedCapacityRouting", () => 
 		}
 	});
 
+	it("falls back to the file value when an invalid env value is set and a file value exists", () => {
+		process.env.MODEL_SCOPED_CAPACITY_ROUTING = "always";
+		const { config, cleanup } = makeConfig();
+		try {
+			config.setModelScopedCapacityRouting("exhausted");
+			expect(config.getModelScopedCapacityRouting()).toBe("exhausted");
+		} finally {
+			cleanup();
+		}
+	});
+
 	it("honors a config-file override set via setModelScopedCapacityRouting", () => {
 		const { config, cleanup } = makeConfig();
 		try {

--- a/packages/config/src/strategy-source.test.ts
+++ b/packages/config/src/strategy-source.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { StrategyName } from "@better-ccflare/core";
+import { Config } from "./index";
+
+function makeConfig(): { config: Config; cleanup: () => void } {
+	const dir = mkdtempSync(join(tmpdir(), "better-ccflare-config-"));
+	return {
+		config: new Config(join(dir, "config.json")),
+		cleanup: () => rmSync(dir, { recursive: true, force: true }),
+	};
+}
+
+/**
+ * Unlike model_scoped_capacity_routing, Config#loadConfig() eagerly seeds a
+ * brand-new config file with `{ lb_strategy: DEFAULT_STRATEGY }` (index.ts
+ * loadConfig()). So a freshly created Config already has a valid file value
+ * and getStrategySource() reports "file", never "default" — the "default"
+ * source is only reachable when the on-disk file predates the lb_strategy
+ * field (e.g. hand-edited or written by an older version). This helper
+ * reproduces that pre-existing-file case.
+ */
+function makeConfigFromRawFile(raw: Record<string, unknown>): {
+	config: Config;
+	cleanup: () => void;
+} {
+	const dir = mkdtempSync(join(tmpdir(), "better-ccflare-config-"));
+	const configPath = join(dir, "config.json");
+	writeFileSync(configPath, JSON.stringify(raw), "utf8");
+	return {
+		config: new Config(configPath),
+		cleanup: () => rmSync(dir, { recursive: true, force: true }),
+	};
+}
+
+describe("getStrategy / getStrategySource", () => {
+	const originalEnv = process.env.LB_STRATEGY;
+
+	beforeEach(() => {
+		delete process.env.LB_STRATEGY;
+	});
+
+	afterEach(() => {
+		if (originalEnv === undefined) {
+			delete process.env.LB_STRATEGY;
+		} else {
+			process.env.LB_STRATEGY = originalEnv;
+		}
+	});
+
+	it("reports source 'file' for a freshly created config (loadConfig eagerly seeds lb_strategy)", () => {
+		const { config, cleanup } = makeConfig();
+		try {
+			expect(config.getStrategy()).toBe(StrategyName.Session);
+			expect(config.getStrategySource()).toBe("file");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("reports source 'default' when the on-disk file predates the lb_strategy field", () => {
+		const { config, cleanup } = makeConfigFromRawFile({});
+		try {
+			expect(config.getStrategy()).toBe(StrategyName.Session);
+			expect(config.getStrategySource()).toBe("default");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("honors a valid env override", () => {
+		process.env.LB_STRATEGY = StrategyName.LeastUsed;
+		const { config, cleanup } = makeConfig();
+		try {
+			expect(config.getStrategy()).toBe(StrategyName.LeastUsed);
+			expect(config.getStrategySource()).toBe("env");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("falls back to the default for an invalid env value when the file predates lb_strategy", () => {
+		process.env.LB_STRATEGY = "not-a-real-strategy";
+		const { config, cleanup } = makeConfigFromRawFile({});
+		try {
+			expect(config.getStrategy()).toBe(StrategyName.Session);
+			expect(config.getStrategySource()).toBe("default");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("falls back to the file value when an invalid env value is set and a file value exists", () => {
+		process.env.LB_STRATEGY = "not-a-real-strategy";
+		const { config, cleanup } = makeConfig();
+		try {
+			config.setStrategy(StrategyName.SessionDrainSoonest);
+			expect(config.getStrategy()).toBe(StrategyName.SessionDrainSoonest);
+			expect(config.getStrategySource()).toBe("file");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("honors a config-file override set via setStrategy", () => {
+		const { config, cleanup } = makeConfig();
+		try {
+			config.setStrategy(StrategyName.SessionAffinity);
+			expect(config.getStrategy()).toBe(StrategyName.SessionAffinity);
+			expect(config.getStrategySource()).toBe("file");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("prioritizes the env override over a config-file value", () => {
+		process.env.LB_STRATEGY = StrategyName.Session;
+		const { config, cleanup } = makeConfig();
+		try {
+			config.setStrategy(StrategyName.SessionDrainSoonest);
+			expect(config.getStrategy()).toBe(StrategyName.Session);
+			expect(config.getStrategySource()).toBe("env");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("throws on an invalid strategy passed to the setter", () => {
+		const { config, cleanup } = makeConfig();
+		try {
+			expect(() =>
+				config.setStrategy(
+					// biome-ignore lint/suspicious/noExplicitAny: exercising the runtime guard
+					"not-a-real-strategy" as any,
+				),
+			).toThrow();
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("reports source 'env' even when a config-file value is also set", () => {
+		process.env.LB_STRATEGY = StrategyName.Session;
+		const { config, cleanup } = makeConfig();
+		try {
+			config.setStrategy(StrategyName.SessionDrainSoonest);
+			expect(config.getStrategySource()).toBe("env");
+		} finally {
+			cleanup();
+		}
+	});
+});

--- a/packages/dashboard-web/src/api.ts
+++ b/packages/dashboard-web/src/api.ts
@@ -1394,17 +1394,23 @@ class API extends HttpClient {
 		}
 	}
 
-	async getStrategy(): Promise<string> {
+	async getStrategy(): Promise<{
+		strategy: string;
+		strategySource: "env" | "file" | "default";
+	}> {
 		const startTime = Date.now();
 		const url = "/api/config/strategy";
 
 		this.logger.debug(`→ GET ${url}`);
 
 		try {
-			const data = await this.get<{ strategy: string }>(url);
+			const data = await this.get<{
+				strategy: string;
+				strategySource: "env" | "file" | "default";
+			}>(url);
 			const duration = Date.now() - startTime;
 			this.logger.debug(`← GET ${url} - 200 (${duration}ms)`);
-			return data.strategy;
+			return data;
 		} catch (error) {
 			const duration = Date.now() - startTime;
 			this.logger.error(`✗ GET ${url} - ERROR (${duration}ms)`, {

--- a/packages/dashboard-web/src/api.ts
+++ b/packages/dashboard-web/src/api.ts
@@ -1868,6 +1868,53 @@ class API extends HttpClient {
 		}
 	}
 
+	async getModelCapacityRouting(): Promise<{
+		mode: "off" | "exhausted";
+		source: "env" | "file" | "default";
+	}> {
+		const startTime = Date.now();
+		const url = "/api/config/model-capacity-routing";
+
+		this.logger.debug(`→ GET ${url}`);
+
+		try {
+			const response = await this.get<{
+				mode: "off" | "exhausted";
+				source: "env" | "file" | "default";
+			}>(url);
+			const duration = Date.now() - startTime;
+			this.logger.debug(`← GET ${url} - 200 (${duration}ms)`);
+			return response;
+		} catch (error) {
+			const duration = Date.now() - startTime;
+			this.logger.error(`✗ GET ${url} - ERROR (${duration}ms)`, {
+				error: error instanceof Error ? error.message : String(error),
+				stack: error instanceof Error ? error.stack : undefined,
+			});
+			throw error;
+		}
+	}
+
+	async setModelCapacityRouting(mode: "off" | "exhausted"): Promise<void> {
+		const startTime = Date.now();
+		const url = "/api/config/model-capacity-routing";
+
+		this.logger.debug(`→ POST ${url}`, { mode });
+
+		try {
+			await this.post(url, { mode });
+			const duration = Date.now() - startTime;
+			this.logger.debug(`← POST ${url} - 200 (${duration}ms)`);
+		} catch (error) {
+			const duration = Date.now() - startTime;
+			this.logger.error(`✗ POST ${url} - ERROR (${duration}ms)`, {
+				error: error instanceof Error ? error.message : String(error),
+				stack: error instanceof Error ? error.stack : undefined,
+			});
+			throw error;
+		}
+	}
+
 	async cleanupNow(): Promise<{
 		removedRequests: number;
 		removedPayloads: number;

--- a/packages/dashboard-web/src/components/SettingsTab.tsx
+++ b/packages/dashboard-web/src/components/SettingsTab.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { CacheKeepaliveCard } from "./overview/CacheKeepaliveCard";
 import { DataRetentionCard } from "./overview/DataRetentionCard";
+import { RoutingCard } from "./overview/RoutingCard";
 import { SystemCacheTtlCard } from "./overview/SystemCacheTtlCard";
 import { UsageThrottlingCard } from "./overview/UsageThrottlingCard";
 
@@ -9,6 +10,7 @@ export const SettingsTab = React.memo(() => {
 		<div className="space-y-6">
 			{/* Configuration Cards Grid */}
 			<div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+				<RoutingCard />
 				<CacheKeepaliveCard />
 				<SystemCacheTtlCard />
 				<UsageThrottlingCard />

--- a/packages/dashboard-web/src/components/overview/RoutingCard.test.tsx
+++ b/packages/dashboard-web/src/components/overview/RoutingCard.test.tsx
@@ -60,8 +60,24 @@ describe("RoutingCardView", () => {
 		expect(html).toContain("MODEL_SCOPED_CAPACITY_ROUTING");
 	});
 
-	it("leaves the switch enabled and hides the badge for file/default sources", () => {
+	it("locks the switch off and shows an env-locked badge when mode is off and source is env", () => {
+		const html = render({ capacityMode: "off", capacitySource: "env" });
+		expect(html).toContain('aria-checked="false"');
+		expect(html).toContain("data-disabled");
+		expect(html).toContain("env-locked");
+	});
+
+	it("leaves the switch enabled and hides the badge for the file source", () => {
 		const html = render({ capacityMode: "exhausted", capacitySource: "file" });
+		expect(html).not.toContain("env-locked");
+		expect(html).not.toContain("data-disabled");
+	});
+
+	it("leaves the switch enabled and hides the badge for the default source", () => {
+		const html = render({
+			capacityMode: "exhausted",
+			capacitySource: "default",
+		});
 		expect(html).not.toContain("env-locked");
 		expect(html).not.toContain("data-disabled");
 	});

--- a/packages/dashboard-web/src/components/overview/RoutingCard.test.tsx
+++ b/packages/dashboard-web/src/components/overview/RoutingCard.test.tsx
@@ -6,13 +6,19 @@
  */
 import { describe, expect, it } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
-import { RoutingCardView, type RoutingCardViewProps } from "./RoutingCard";
+import {
+	getStrategySelectItems,
+	RoutingCardView,
+	type RoutingCardViewProps,
+	type StrategySelectItem,
+} from "./RoutingCard";
 
 function render(overrides: Partial<RoutingCardViewProps> = {}): string {
 	const props: RoutingCardViewProps = {
 		strategy: "session",
 		onStrategyChange: () => {},
 		strategyDisabled: false,
+		strategySource: "default",
 		capacityMode: "off",
 		capacitySource: "default",
 		onCapacityChange: () => {},
@@ -80,5 +86,78 @@ describe("RoutingCardView", () => {
 		});
 		expect(html).not.toContain("env-locked");
 		expect(html).not.toContain("data-disabled");
+	});
+
+	it("locks the strategy select and shows an env-locked badge when strategySource is env", () => {
+		const html = render({ strategy: "session", strategySource: "env" });
+		expect(html).toContain("env-locked");
+		// The capacity switch is enabled here (default "default" source), so
+		// this uniquely proves the strategy select itself is disabled.
+		expect(html).toContain("data-disabled");
+		// Badge tooltip points the user at the overriding env var.
+		expect(html).toContain("LB_STRATEGY");
+	});
+
+	it("leaves the strategy select enabled and hides its badge for the file source", () => {
+		const html = render({ strategy: "session", strategySource: "file" });
+		expect(html).not.toContain("env-locked");
+		expect(html).not.toContain("data-disabled");
+	});
+
+	it("leaves the strategy select enabled and hides its badge for the default source", () => {
+		const html = render({ strategy: "session", strategySource: "default" });
+		expect(html).not.toContain("env-locked");
+		expect(html).not.toContain("data-disabled");
+	});
+
+	it("associates the strategy label with its Select trigger via htmlFor/id", () => {
+		const html = render();
+		expect(html).toContain('for="routing-strategy"');
+		expect(html).toContain('id="routing-strategy"');
+	});
+
+	it("associates the capacity label with its Switch via htmlFor/id", () => {
+		const html = render();
+		expect(html).toContain('for="routing-capacity"');
+		expect(html).toContain('id="routing-capacity"');
+	});
+
+	it("does not throw when the effective strategy is not one of the listed options", () => {
+		// least-used/session-affinity are valid StrategyName values that are
+		// deliberately not offered (see STRATEGY_OPTIONS), but the server can
+		// still report them as the effective strategy (env/config/older
+		// default). The view must render without error in that case.
+		const html = render({ strategy: "least-used" });
+		expect(html).toContain('role="combobox"');
+	});
+});
+
+describe("getStrategySelectItems", () => {
+	const listed: readonly StrategySelectItem[] = [
+		{ label: "Session", value: "session" },
+		{ label: "Session — drain soonest", value: "session-drain-soonest" },
+	];
+
+	it("returns only the two listed options when the current strategy is one of them", () => {
+		expect(getStrategySelectItems("session")).toEqual(listed);
+		expect(getStrategySelectItems("session-drain-soonest")).toEqual(listed);
+	});
+
+	it("appends the current strategy as a disabled item when it is not listed", () => {
+		expect(getStrategySelectItems("least-used")).toEqual([
+			...listed,
+			{ label: "least-used (current)", value: "least-used", disabled: true },
+		]);
+	});
+
+	it("appends session-affinity as a disabled item when it is the current strategy", () => {
+		expect(getStrategySelectItems("session-affinity")).toEqual([
+			...listed,
+			{
+				label: "session-affinity (current)",
+				value: "session-affinity",
+				disabled: true,
+			},
+		]);
 	});
 });

--- a/packages/dashboard-web/src/components/overview/RoutingCard.test.tsx
+++ b/packages/dashboard-web/src/components/overview/RoutingCard.test.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Gili Tzabari. All rights reserved.
+ *
+ * Licensed under the CAT Commercial License.
+ * See LICENSE.md in the project root for license terms.
+ */
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { RoutingCardView, type RoutingCardViewProps } from "./RoutingCard";
+
+function render(overrides: Partial<RoutingCardViewProps> = {}): string {
+	const props: RoutingCardViewProps = {
+		strategy: "session",
+		onStrategyChange: () => {},
+		strategyDisabled: false,
+		capacityMode: "off",
+		capacitySource: "default",
+		onCapacityChange: () => {},
+		capacityDisabled: false,
+		...overrides,
+	};
+	return renderToStaticMarkup(<RoutingCardView {...props} />);
+}
+
+describe("RoutingCardView", () => {
+	it("renders both the strategy selector and the capacity switch", () => {
+		const html = render();
+		// The strategy Select renders as a Radix combobox trigger.
+		expect(html).toContain('role="combobox"');
+		expect(html).toContain("Load-balancing strategy");
+		// The capacity control renders as a Radix switch.
+		expect(html).toContain('role="switch"');
+		expect(html).toContain("Model-scoped capacity routing");
+	});
+
+	it("explains the drain-soonest tiebreaker in the strategy description", () => {
+		const html = render();
+		expect(html).toContain("priority becomes a tiebreaker");
+		// The safety note about not offering per-request spreading strategies.
+		expect(html).toContain("Only session-class strategies are shown");
+	});
+
+	it("reflects the exhausted capacity mode as a checked switch", () => {
+		const html = render({ capacityMode: "exhausted", capacitySource: "file" });
+		expect(html).toContain('aria-checked="true"');
+	});
+
+	it("reflects the off capacity mode as an unchecked switch", () => {
+		const html = render({ capacityMode: "off", capacitySource: "file" });
+		expect(html).toContain('aria-checked="false"');
+	});
+
+	it("locks the switch and shows an env-locked badge when the source is env", () => {
+		const html = render({ capacityMode: "exhausted", capacitySource: "env" });
+		expect(html).toContain("env-locked");
+		// Radix marks a disabled switch with data-disabled; the strategy select is
+		// enabled here, so this uniquely proves the switch itself is disabled.
+		expect(html).toContain("data-disabled");
+		// Badge tooltip points the user at the overriding env var.
+		expect(html).toContain("MODEL_SCOPED_CAPACITY_ROUTING");
+	});
+
+	it("leaves the switch enabled and hides the badge for file/default sources", () => {
+		const html = render({ capacityMode: "exhausted", capacitySource: "file" });
+		expect(html).not.toContain("env-locked");
+		expect(html).not.toContain("data-disabled");
+	});
+});

--- a/packages/dashboard-web/src/components/overview/RoutingCard.tsx
+++ b/packages/dashboard-web/src/components/overview/RoutingCard.tsx
@@ -1,0 +1,156 @@
+import {
+	useModelCapacityRouting,
+	useSetModelCapacityRouting,
+	useSetStrategy,
+	useStrategy,
+} from "../../hooks/queries";
+import { Badge } from "../ui/badge";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "../ui/card";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "../ui/select";
+import { Switch } from "../ui/switch";
+
+// Only session-class strategies are offered from the dashboard. Per-request
+// spreading strategies (least-used, session-affinity) can trip Claude's
+// anti-abuse systems and get accounts banned, so they are deliberately not
+// listed here even though StrategyName defines them.
+const STRATEGY_OPTIONS = [
+	{ label: "Session", value: "session" },
+	{ label: "Session — drain soonest", value: "session-drain-soonest" },
+];
+
+export interface RoutingCardViewProps {
+	strategy: string;
+	onStrategyChange: (strategy: string) => void;
+	strategyDisabled: boolean;
+	capacityMode: "off" | "exhausted";
+	capacitySource: "env" | "file" | "default";
+	onCapacityChange: (mode: "off" | "exhausted") => void;
+	capacityDisabled: boolean;
+}
+
+/**
+ * Presentational routing settings card. Kept free of data hooks so it can be
+ * rendered with plain props in tests (renderToStaticMarkup); RoutingCard wires
+ * it to react-query.
+ */
+export function RoutingCardView({
+	strategy,
+	onStrategyChange,
+	strategyDisabled,
+	capacityMode,
+	capacitySource,
+	onCapacityChange,
+	capacityDisabled,
+}: RoutingCardViewProps) {
+	const envLocked = capacitySource === "env";
+
+	return (
+		<Card className="card-hover">
+			<CardHeader>
+				<CardTitle>Routing</CardTitle>
+				<CardDescription>
+					Choose how requests are spread across accounts and whether accounts
+					that have exhausted a model's weekly capacity are skipped.
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
+				<div className="space-y-6">
+					<div className="space-y-2">
+						<div className="text-sm font-medium">Load-balancing strategy</div>
+						<div className="text-sm text-muted-foreground">
+							<span className="font-medium">Session</span> keeps each client on
+							one account for the session duration.{" "}
+							<span className="font-medium">Session — drain soonest</span>{" "}
+							shares the same session semantics but, at every fresh selection,
+							prefers the account whose weekly window resets soonest so capacity
+							is used before it expires; priority becomes a tiebreaker.
+						</div>
+						<Select
+							disabled={strategyDisabled}
+							value={strategy}
+							onValueChange={onStrategyChange}
+						>
+							<SelectTrigger className="w-64">
+								<SelectValue placeholder="Select strategy..." />
+							</SelectTrigger>
+							<SelectContent>
+								{STRATEGY_OPTIONS.map((opt) => (
+									<SelectItem key={opt.value} value={opt.value}>
+										{opt.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+						<div className="text-xs text-muted-foreground">
+							⚠️ Only session-class strategies are shown. Strategies that spread
+							individual requests across accounts can trigger Claude's
+							anti-abuse systems and risk account bans.
+						</div>
+					</div>
+
+					<div className="flex items-center justify-between gap-3">
+						<div className="space-y-1">
+							<div className="flex items-center gap-2">
+								<div className="text-sm font-medium">
+									Model-scoped capacity routing
+								</div>
+								{envLocked && (
+									<Badge
+										variant="outline"
+										title="Set by the MODEL_SCOPED_CAPACITY_ROUTING environment variable; change the env var to edit this."
+									>
+										env-locked
+									</Badge>
+								)}
+							</div>
+							<div className="text-sm text-muted-foreground">
+								Skip accounts whose per-model weekly cap is exhausted so clients
+								get a fast model_family_exhausted 429 instead of failover
+								retries that are guaranteed to fail.
+							</div>
+						</div>
+						<Switch
+							disabled={capacityDisabled || envLocked}
+							checked={capacityMode === "exhausted"}
+							onCheckedChange={(checked) =>
+								onCapacityChange(checked ? "exhausted" : "off")
+							}
+						/>
+					</div>
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+export function RoutingCard() {
+	const { data: strategy, isLoading: strategyLoading } = useStrategy();
+	const setStrategy = useSetStrategy();
+	const { data: capacity, isLoading: capacityLoading } =
+		useModelCapacityRouting();
+	const setCapacity = useSetModelCapacityRouting();
+
+	return (
+		<RoutingCardView
+			strategy={strategy ?? "session"}
+			onStrategyChange={(value) => setStrategy.mutate(value)}
+			strategyDisabled={strategyLoading || setStrategy.isPending}
+			capacityMode={capacity?.mode ?? "off"}
+			capacitySource={capacity?.source ?? "default"}
+			onCapacityChange={(mode) => setCapacity.mutate(mode)}
+			capacityDisabled={capacityLoading || setCapacity.isPending}
+		/>
+	);
+}

--- a/packages/dashboard-web/src/components/overview/RoutingCard.tsx
+++ b/packages/dashboard-web/src/components/overview/RoutingCard.tsx
@@ -1,3 +1,4 @@
+import { StrategyName } from "@better-ccflare/core";
 import {
 	useModelCapacityRouting,
 	useSetModelCapacityRouting,
@@ -12,6 +13,7 @@ import {
 	CardHeader,
 	CardTitle,
 } from "../ui/card";
+import { Label } from "../ui/label";
 import {
 	Select,
 	SelectContent,
@@ -24,16 +26,54 @@ import { Switch } from "../ui/switch";
 // Only session-class strategies are offered from the dashboard. Per-request
 // spreading strategies (least-used, session-affinity) can trip Claude's
 // anti-abuse systems and get accounts banned, so they are deliberately not
-// listed here even though StrategyName defines them.
-const STRATEGY_OPTIONS = [
-	{ label: "Session", value: "session" },
-	{ label: "Session — drain soonest", value: "session-drain-soonest" },
+// listed here even though StrategyName defines them. Values come from the
+// shared StrategyName enum (not hardcoded strings) so this list can never
+// drift from the authoritative 4 values in @better-ccflare/core.
+const STRATEGY_OPTIONS: ReadonlyArray<{ label: string; value: string }> = [
+	{ label: "Session", value: StrategyName.Session },
+	{
+		label: "Session — drain soonest",
+		value: StrategyName.SessionDrainSoonest,
+	},
 ];
+
+export interface StrategySelectItem {
+	label: string;
+	value: string;
+	disabled?: boolean;
+}
+
+/**
+ * Build the strategy Select's item list. The dashboard only offers the two
+ * session-class strategies above, but the server's effective strategy
+ * (getStrategy()) can be any of the four StrategyName values — settable via
+ * LB_STRATEGY, an older config file, or a hand-edited one. An out-of-list
+ * value used to leave the Select's trigger blank with no indication it was
+ * active, and selecting either listed option would silently overwrite it
+ * with no recovery path (routing-settings-ui-2026-07-20 review, rank 1).
+ * When the current strategy isn't one of the two listed options, it is
+ * appended as a disabled item labelled "<value> (current)" so its state is
+ * visible without being re-selectable; the two deliberate options stay
+ * selectable.
+ */
+export function getStrategySelectItems(
+	strategy: string,
+): readonly StrategySelectItem[] {
+	const isListed = STRATEGY_OPTIONS.some((opt) => opt.value === strategy);
+	if (isListed) {
+		return STRATEGY_OPTIONS;
+	}
+	return [
+		...STRATEGY_OPTIONS,
+		{ label: `${strategy} (current)`, value: strategy, disabled: true },
+	];
+}
 
 export interface RoutingCardViewProps {
 	strategy: string;
 	onStrategyChange: (strategy: string) => void;
 	strategyDisabled: boolean;
+	strategySource: "env" | "file" | "default";
 	capacityMode: "off" | "exhausted";
 	capacitySource: "env" | "file" | "default";
 	onCapacityChange: (mode: "off" | "exhausted") => void;
@@ -49,12 +89,15 @@ export function RoutingCardView({
 	strategy,
 	onStrategyChange,
 	strategyDisabled,
+	strategySource,
 	capacityMode,
 	capacitySource,
 	onCapacityChange,
 	capacityDisabled,
 }: RoutingCardViewProps) {
-	const envLocked = capacitySource === "env";
+	const strategyEnvLocked = strategySource === "env";
+	const capacityEnvLocked = capacitySource === "env";
+	const strategyItems = getStrategySelectItems(strategy);
 
 	return (
 		<Card className="card-hover">
@@ -68,7 +111,17 @@ export function RoutingCardView({
 			<CardContent>
 				<div className="space-y-6">
 					<div className="space-y-2">
-						<div className="text-sm font-medium">Load-balancing strategy</div>
+						<div className="flex items-center gap-2">
+							<Label htmlFor="routing-strategy">Load-balancing strategy</Label>
+							{strategyEnvLocked && (
+								<Badge
+									variant="outline"
+									title="Set by the LB_STRATEGY environment variable; change the env var to edit this."
+								>
+									env-locked
+								</Badge>
+							)}
+						</div>
 						<div className="text-sm text-muted-foreground">
 							<span className="font-medium">Session</span> keeps each client on
 							one account for the session duration.{" "}
@@ -78,16 +131,20 @@ export function RoutingCardView({
 							is used before it expires; priority becomes a tiebreaker.
 						</div>
 						<Select
-							disabled={strategyDisabled}
+							disabled={strategyDisabled || strategyEnvLocked}
 							value={strategy}
 							onValueChange={onStrategyChange}
 						>
-							<SelectTrigger className="w-64">
+							<SelectTrigger id="routing-strategy" className="w-64">
 								<SelectValue placeholder="Select strategy..." />
 							</SelectTrigger>
 							<SelectContent>
-								{STRATEGY_OPTIONS.map((opt) => (
-									<SelectItem key={opt.value} value={opt.value}>
+								{strategyItems.map((opt) => (
+									<SelectItem
+										key={opt.value}
+										value={opt.value}
+										disabled={opt.disabled}
+									>
 										{opt.label}
 									</SelectItem>
 								))}
@@ -103,10 +160,10 @@ export function RoutingCardView({
 					<div className="flex items-center justify-between gap-3">
 						<div className="space-y-1">
 							<div className="flex items-center gap-2">
-								<div className="text-sm font-medium">
+								<Label htmlFor="routing-capacity">
 									Model-scoped capacity routing
-								</div>
-								{envLocked && (
+								</Label>
+								{capacityEnvLocked && (
 									<Badge
 										variant="outline"
 										title="Set by the MODEL_SCOPED_CAPACITY_ROUTING environment variable; change the env var to edit this."
@@ -122,7 +179,8 @@ export function RoutingCardView({
 							</div>
 						</div>
 						<Switch
-							disabled={capacityDisabled || envLocked}
+							id="routing-capacity"
+							disabled={capacityDisabled || capacityEnvLocked}
 							checked={capacityMode === "exhausted"}
 							onCheckedChange={(checked) =>
 								onCapacityChange(checked ? "exhausted" : "off")
@@ -136,7 +194,7 @@ export function RoutingCardView({
 }
 
 export function RoutingCard() {
-	const { data: strategy, isLoading: strategyLoading } = useStrategy();
+	const { data: strategyData, isLoading: strategyLoading } = useStrategy();
 	const setStrategy = useSetStrategy();
 	const { data: capacity, isLoading: capacityLoading } =
 		useModelCapacityRouting();
@@ -144,7 +202,8 @@ export function RoutingCard() {
 
 	return (
 		<RoutingCardView
-			strategy={strategy ?? "session"}
+			strategy={strategyData?.strategy ?? "session"}
+			strategySource={strategyData?.strategySource ?? "default"}
 			onStrategyChange={(value) => setStrategy.mutate(value)}
 			strategyDisabled={strategyLoading || setStrategy.isPending}
 			capacityMode={capacity?.mode ?? "off"}

--- a/packages/dashboard-web/src/hooks/queries.ts
+++ b/packages/dashboard-web/src/hooks/queries.ts
@@ -515,6 +515,41 @@ export const useSetUsageThrottling = () => {
 	});
 };
 
+export const useStrategy = () => {
+	return useQuery({
+		queryKey: ["strategy"],
+		queryFn: () => api.getStrategy(),
+	});
+};
+
+export const useSetStrategy = () => {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (strategy: string) => api.setStrategy(strategy),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["strategy"] });
+		},
+	});
+};
+
+export const useModelCapacityRouting = () => {
+	return useQuery({
+		queryKey: ["model-capacity-routing"],
+		queryFn: () => api.getModelCapacityRouting(),
+	});
+};
+
+export const useSetModelCapacityRouting = () => {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (mode: "off" | "exhausted") =>
+			api.setModelCapacityRouting(mode),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["model-capacity-routing"] });
+		},
+	});
+};
+
 export const useCleanupNow = () => {
 	return useMutation({
 		mutationFn: () => api.cleanupNow(),

--- a/packages/dashboard-web/src/hooks/queries.ts
+++ b/packages/dashboard-web/src/hooks/queries.ts
@@ -528,6 +528,7 @@ export const useSetStrategy = () => {
 		mutationFn: (strategy: string) => api.setStrategy(strategy),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ["strategy"] });
+			queryClient.invalidateQueries({ queryKey: queryKeys.accounts() });
 		},
 	});
 };

--- a/packages/http-api/src/handlers/__tests__/config.test.ts
+++ b/packages/http-api/src/handlers/__tests__/config.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it, mock } from "bun:test";
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Config } from "@better-ccflare/config";
 import type { APIContext } from "@better-ccflare/types";
 import { createConfigHandlers } from "../config";
 
@@ -33,6 +37,7 @@ function makeConfig() {
 		setUsageThrottlingFiveHourEnabled: mock(() => {}),
 		setUsageThrottlingWeeklyEnabled: mock(() => {}),
 		getModelScopedCapacityRouting: () => "off" as const,
+		getModelScopedCapacityRoutingSource: () => "default" as const,
 		setModelScopedCapacityRouting: mock(() => {}),
 		getStrategy: () => "session",
 		setStrategy: mock(() => {}),
@@ -89,7 +94,7 @@ describe("createConfigHandlers", () => {
 		expect(config.setUsageThrottlingWeeklyEnabled).toHaveBeenCalledWith(true);
 	});
 
-	it("reports the current model capacity routing mode", async () => {
+	it("reports the current model capacity routing mode with its source", async () => {
 		const config = makeConfig();
 		const handlers = createConfigHandlers(config, {
 			port: 8080,
@@ -97,11 +102,12 @@ describe("createConfigHandlers", () => {
 		});
 
 		const response = handlers.getModelCapacityRouting();
-		const body = (await response.json()) as { mode: string };
+		const body = (await response.json()) as { mode: string; source: string };
 		expect(body.mode).toBe("off");
+		expect(body.source).toBe("default");
 	});
 
-	it("updates the model capacity routing mode from POST body", async () => {
+	it("updates the model capacity routing mode from POST body (200 + echo)", async () => {
 		const config = makeConfig();
 		const handlers = createConfigHandlers(config, {
 			port: 8080,
@@ -116,7 +122,13 @@ describe("createConfigHandlers", () => {
 			}),
 		);
 
-		expect(response.status).toBe(204);
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as {
+			success: boolean;
+			mode: string;
+		};
+		expect(body.success).toBe(true);
+		expect(body.mode).toBe("exhausted");
 		expect(config.setModelScopedCapacityRouting).toHaveBeenCalledWith(
 			"exhausted",
 		);
@@ -236,5 +248,102 @@ describe("createConfigHandlers", () => {
 
 		expect(response.status).toBe(400);
 		expect(config.setDefaultAgentModel).not.toHaveBeenCalled();
+	});
+});
+
+describe("model capacity routing source & effective mode (real config)", () => {
+	const originalEnv = process.env.MODEL_SCOPED_CAPACITY_ROUTING;
+	const tmpDirs: string[] = [];
+
+	function realConfig(): Config {
+		const dir = mkdtempSync(join(tmpdir(), "better-ccflare-handler-"));
+		tmpDirs.push(dir);
+		return new Config(join(dir, "config.json"));
+	}
+
+	function handlersWithRealConfig() {
+		return createConfigHandlers(realConfig(), {
+			port: 8080,
+			tlsEnabled: false,
+		});
+	}
+
+	afterEach(() => {
+		if (originalEnv === undefined) {
+			delete process.env.MODEL_SCOPED_CAPACITY_ROUTING;
+		} else {
+			process.env.MODEL_SCOPED_CAPACITY_ROUTING = originalEnv;
+		}
+		while (tmpDirs.length > 0) {
+			rmSync(tmpDirs.pop() as string, { recursive: true, force: true });
+		}
+	});
+
+	it("reports source 'default' and mode 'off' with no env or file", async () => {
+		delete process.env.MODEL_SCOPED_CAPACITY_ROUTING;
+		const handlers = handlersWithRealConfig();
+
+		const body = (await handlers.getModelCapacityRouting().json()) as {
+			mode: string;
+			source: string;
+		};
+		expect(body).toEqual({ mode: "off", source: "default" });
+	});
+
+	it("reports source 'file' after a POST writes the config file", async () => {
+		delete process.env.MODEL_SCOPED_CAPACITY_ROUTING;
+		const handlers = handlersWithRealConfig();
+
+		const postResponse = await handlers.setModelCapacityRouting(
+			new Request("http://localhost/api/config/model-capacity-routing", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ mode: "exhausted" }),
+			}),
+		);
+		expect(postResponse.status).toBe(200);
+		expect(await postResponse.json()).toEqual({
+			success: true,
+			mode: "exhausted",
+			source: "file",
+			effective: "exhausted",
+		});
+
+		const getBody = (await handlers.getModelCapacityRouting().json()) as {
+			mode: string;
+			source: string;
+		};
+		expect(getBody).toEqual({ mode: "exhausted", source: "file" });
+	});
+
+	it("reports source 'env' and effective env value when env overrides the file", async () => {
+		process.env.MODEL_SCOPED_CAPACITY_ROUTING = "exhausted";
+		const handlers = handlersWithRealConfig();
+
+		const body = (await handlers.getModelCapacityRouting().json()) as {
+			mode: string;
+			source: string;
+		};
+		expect(body).toEqual({ mode: "exhausted", source: "env" });
+	});
+
+	it("POST while env-locked succeeds but effective reflects the env value", async () => {
+		process.env.MODEL_SCOPED_CAPACITY_ROUTING = "exhausted";
+		const handlers = handlersWithRealConfig();
+
+		const postResponse = await handlers.setModelCapacityRouting(
+			new Request("http://localhost/api/config/model-capacity-routing", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ mode: "off" }),
+			}),
+		);
+		expect(postResponse.status).toBe(200);
+		expect(await postResponse.json()).toEqual({
+			success: true,
+			mode: "off",
+			source: "env",
+			effective: "exhausted",
+		});
 	});
 });

--- a/packages/http-api/src/handlers/__tests__/config.test.ts
+++ b/packages/http-api/src/handlers/__tests__/config.test.ts
@@ -40,6 +40,7 @@ function makeConfig() {
 		getModelScopedCapacityRoutingSource: () => "default" as const,
 		setModelScopedCapacityRouting: mock(() => {}),
 		getStrategy: () => "session",
+		getStrategySource: () => "default" as const,
 		setStrategy: mock(() => {}),
 		getDefaultAgentModel: () => "sonnet",
 		setDefaultAgentModel: mock(() => {}),
@@ -92,6 +93,22 @@ describe("createConfigHandlers", () => {
 			false,
 		);
 		expect(config.setUsageThrottlingWeeklyEnabled).toHaveBeenCalledWith(true);
+	});
+
+	it("reports the current strategy with its source", async () => {
+		const config = makeConfig();
+		const handlers = createConfigHandlers(config, {
+			port: 8080,
+			tlsEnabled: false,
+		});
+
+		const response = handlers.getStrategy();
+		const body = (await response.json()) as {
+			strategy: string;
+			strategySource: string;
+		};
+		expect(body.strategy).toBe("session");
+		expect(body.strategySource).toBe("default");
 	});
 
 	it("reports the current model capacity routing mode with its source", async () => {
@@ -345,5 +362,103 @@ describe("model capacity routing source & effective mode (real config)", () => {
 			source: "env",
 			effective: "exhausted",
 		});
+	});
+});
+
+describe("strategy source (real config)", () => {
+	const originalEnv = process.env.LB_STRATEGY;
+	const tmpDirs: string[] = [];
+
+	function realConfig(): Config {
+		const dir = mkdtempSync(join(tmpdir(), "better-ccflare-handler-"));
+		tmpDirs.push(dir);
+		return new Config(join(dir, "config.json"));
+	}
+
+	function handlersWithRealConfig() {
+		return createConfigHandlers(realConfig(), {
+			port: 8080,
+			tlsEnabled: false,
+		});
+	}
+
+	afterEach(() => {
+		if (originalEnv === undefined) {
+			delete process.env.LB_STRATEGY;
+		} else {
+			process.env.LB_STRATEGY = originalEnv;
+		}
+		while (tmpDirs.length > 0) {
+			rmSync(tmpDirs.pop() as string, { recursive: true, force: true });
+		}
+	});
+
+	it("reports source 'file' and strategy 'session' for a freshly created config", async () => {
+		// loadConfig() eagerly seeds a brand-new config file with
+		// `lb_strategy: DEFAULT_STRATEGY`, so a fresh Config already has a valid
+		// file value here — unlike model-capacity-routing, "default" is only
+		// reachable when the on-disk file predates the lb_strategy field.
+		delete process.env.LB_STRATEGY;
+		const handlers = handlersWithRealConfig();
+
+		const body = (await handlers.getStrategy().json()) as {
+			strategy: string;
+			strategySource: string;
+		};
+		expect(body).toEqual({ strategy: "session", strategySource: "file" });
+	});
+
+	it("reports source 'file' after a POST writes the config file", async () => {
+		delete process.env.LB_STRATEGY;
+		const handlers = handlersWithRealConfig();
+
+		const postResponse = await handlers.setStrategy(
+			new Request("http://localhost/api/config/strategy", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ strategy: "session-drain-soonest" }),
+			}),
+		);
+		expect(postResponse.status).toBe(200);
+
+		const getBody = (await handlers.getStrategy().json()) as {
+			strategy: string;
+			strategySource: string;
+		};
+		expect(getBody).toEqual({
+			strategy: "session-drain-soonest",
+			strategySource: "file",
+		});
+	});
+
+	it("reports source 'env' and the env strategy when LB_STRATEGY overrides the file", async () => {
+		process.env.LB_STRATEGY = "least-used";
+		const handlers = handlersWithRealConfig();
+
+		const body = (await handlers.getStrategy().json()) as {
+			strategy: string;
+			strategySource: string;
+		};
+		expect(body).toEqual({ strategy: "least-used", strategySource: "env" });
+	});
+
+	it("keeps reporting the env-sourced strategy after a POST that writes the (ineffective) file value", async () => {
+		process.env.LB_STRATEGY = "least-used";
+		const handlers = handlersWithRealConfig();
+
+		const postResponse = await handlers.setStrategy(
+			new Request("http://localhost/api/config/strategy", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ strategy: "session" }),
+			}),
+		);
+		expect(postResponse.status).toBe(200);
+
+		const getBody = (await handlers.getStrategy().json()) as {
+			strategy: string;
+			strategySource: string;
+		};
+		expect(getBody).toEqual({ strategy: "least-used", strategySource: "env" });
 	});
 });

--- a/packages/http-api/src/handlers/config.ts
+++ b/packages/http-api/src/handlers/config.ts
@@ -62,7 +62,14 @@ export function createConfigHandlers(
 		 */
 		getStrategy: (): Response => {
 			const strategy = config.getStrategy();
-			return jsonResponse({ strategy });
+			// strategySource mirrors the model-capacity-routing source field so
+			// the dashboard can lock the strategy control the same way when
+			// LB_STRATEGY overrides the config file. Additive field: existing
+			// consumers of `strategy` are unaffected.
+			return jsonResponse({
+				strategy,
+				strategySource: config.getStrategySource(),
+			});
 		},
 
 		/**

--- a/packages/http-api/src/handlers/config.ts
+++ b/packages/http-api/src/handlers/config.ts
@@ -246,6 +246,7 @@ export function createConfigHandlers(
 		getModelCapacityRouting: (): Response => {
 			return jsonResponse({
 				mode: config.getModelScopedCapacityRouting(),
+				source: config.getModelScopedCapacityRoutingSource(),
 			});
 		},
 
@@ -259,7 +260,16 @@ export function createConfigHandlers(
 				);
 			}
 			config.setModelScopedCapacityRouting(body.mode);
-			return new Response(null, { status: 204 });
+			// Report the post-set EFFECTIVE mode/source: a MODEL_SCOPED_CAPACITY_ROUTING
+			// env var still overrides the file we just wrote, so `effective` may differ
+			// from the requested `mode`. The dashboard uses this to warn that the write
+			// was ineffective while env-locked.
+			return jsonResponse({
+				success: true,
+				mode: body.mode,
+				source: config.getModelScopedCapacityRoutingSource(),
+				effective: config.getModelScopedCapacityRouting(),
+			});
 		},
 	};
 }


### PR DESCRIPTION
## Summary

PR #325 shipped two runtime-switchable routing features (`session-drain-soonest` strategy, `MODEL_SCOPED_CAPACITY_ROUTING`) with API endpoints but no dashboard surface — switching required curl or config-file edits. This adds a **Routing** card to the Settings tab wiring both switches to the existing endpoints, plus an honest env-lock indicator.

### Backend (commit 1)
- `GET /api/config/model-capacity-routing` now returns `{mode, source}` with `source: "env" | "file" | "default"` (new `getModelScopedCapacityRoutingSource()` beside the existing getter, same validation).
- `POST` returns `200 {success, mode, source, effective}` (was `204`) — `effective` reflects the post-write effective mode, so a client can detect that an env var overrides the file write (env takes precedence per `docs/configuration.md`). No new error paths; grep-verified no consumer relied on 204.

### Dashboard (commit 2)
- New `RoutingCard` (first in the Settings grid), mirroring the `UsageThrottlingCard` pattern (react-query hooks + card layout):
  - **Load-balancing strategy** select — deliberately offers only the two session-class strategies (`session`, `session-drain-soonest`) with a ⚠️ note; per-request spreading strategies are not listed (account-ban risk, per the docs warning). Description notes that under drain-soonest, priority becomes a tiebreaker.
  - **Model-scoped capacity routing** switch (`off` ↔ `exhausted`); when `source === "env"` the switch is disabled with an `env-locked` badge naming `MODEL_SCOPED_CAPACITY_ROUTING`.
- Client methods + `useStrategy`/`useSetStrategy`/`useModelCapacityRouting`/`useSetModelCapacityRouting` hooks; presentational `RoutingCardView` extracted for testability.

### Validation
- New tests: 5 config-package source-precedence cases, 4 handler cases (env/file/default + env-locked POST), 6 `RoutingCardView` render cases (`renderToStaticMarkup` pattern) — all green in isolation (`packages/dashboard-web/` 153/0, `packages/config/` 33/0, handler suite 14/0).
- Full `bun test`: fail count unchanged vs. clean main baseline (the pre-existing cross-file `mock.module` pollution set; none of the touched files appear in any failure stack). Lint/typecheck/format clean (only the 2 known dashboard-dist env errors when the dashboard isn't built).
- Manual E2E: built dashboard, live server — POSTs via API reflect in the UI and vice versa; both settings persist and take effect without restart.

### Note for reviewers
While validating against clean `main` (287e43a4): the full suite currently shows ~141 pre-existing failures caused by cross-file `mock.module` pollution (every affected suite passes in isolation — e.g. `async-writer.test.ts`, `integrity-storage-methods.test.ts`). Unrelated to this PR; happy to file a separate issue with the details.
