### PR TITLE
Fix auto-refresh probes triggering false account auto-pause under usage throttling

### DIFF
--- a/packages/proxy/src/__tests__/auto-refresh-529-not-counted.test.ts
+++ b/packages/proxy/src/__tests__/auto-refresh-529-not-counted.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Regression test: AutoRefreshScheduler must not count a 529 (overloaded_error)
+ * probe response toward its consecutive-failure pause threshold.
+ *
+ * Production incident: a usage-throttled-but-otherwise-healthy account's
+ * five_hour window resets, the scheduler probes it, and (before the
+ * applyUsageThrottling probe-exemption fix in proxy.ts) gets back our own
+ * synthetic 529 from createUsageThrottledResponse. sendDummyMessage treated
+ * that 529 exactly like any other non-401 failure and counted it toward
+ * FAILURE_THRESHOLD, eventually auto-pausing the account
+ * (pause_reason='failure_threshold') even though nothing was actually broken.
+ *
+ * This test exercises sendDummyMessage's response-status handling directly
+ * (mocking global fetch, since the method makes its own internal HTTP call)
+ * as defense-in-depth alongside the proxy.ts-level throttle exemption tested
+ * in auto-refresh-throttle-exemption.test.ts.
+ */
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { AutoRefreshScheduler } from "../auto-refresh-scheduler";
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function makeDb() {
+	const runCalls: Array<[string, unknown[]]> = [];
+	return {
+		run: mock(async (sql: string, params: unknown[]) => {
+			runCalls.push([sql, params]);
+		}),
+		query: mock(async () => []),
+		runCalls,
+	};
+}
+
+function makeProxyContext() {
+	return {
+		runtime: { port: 8080, clientId: "test-client" },
+		refreshInFlight: new Map(),
+	};
+}
+
+type SendDummyMessageArg = {
+	id: string;
+	name: string;
+	provider: string;
+	refresh_token: string;
+	access_token: string | null;
+	expires_at: number | null;
+	rate_limit_reset: number | null;
+	custom_endpoint: string | null;
+	paused: number;
+	auto_pause_on_overage_enabled: number;
+	pause_reason: string | null;
+};
+
+type TestableScheduler = AutoRefreshScheduler & {
+	sendDummyMessage(accountRow: SendDummyMessageArg): Promise<boolean>;
+	consecutiveFailures: Map<string, number>;
+	FAILURE_THRESHOLD: number;
+};
+
+async function makeScheduler(
+	db: ReturnType<typeof makeDb>,
+): Promise<TestableScheduler> {
+	const { AutoRefreshScheduler } = await import("../auto-refresh-scheduler");
+	return new AutoRefreshScheduler(
+		db as never,
+		makeProxyContext() as never,
+	) as TestableScheduler;
+}
+
+function makeAccountRow(
+	overrides: Partial<SendDummyMessageArg> = {},
+): SendDummyMessageArg {
+	return {
+		id: "acc-mb",
+		name: "MB",
+		provider: "anthropic",
+		refresh_token: "refresh-token",
+		access_token: "access-token",
+		// Beyond the auto-refresh 401/expiry branches — not exercised on the
+		// 529/500 failure paths, but kept realistic.
+		expires_at: Date.now() + 3 * 60 * 60 * 1000,
+		rate_limit_reset: null,
+		custom_endpoint: null,
+		paused: 0,
+		auto_pause_on_overage_enabled: 0,
+		pause_reason: null,
+		...overrides,
+	};
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+let realFetch: typeof fetch;
+
+beforeEach(() => {
+	realFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+	globalThis.fetch = realFetch;
+});
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe("AutoRefreshScheduler.sendDummyMessage — 529 is not a counted failure", () => {
+	it("does not increment consecutiveFailures on a 529 overloaded_error probe response", async () => {
+		globalThis.fetch = mock(async () =>
+			jsonResponse(529, {
+				type: "error",
+				error: {
+					type: "overloaded_error",
+					message: "Usage throttling is delaying requests for account(s): MB.",
+				},
+			}),
+		) as unknown as typeof fetch;
+
+		const db = makeDb();
+		const scheduler = await makeScheduler(db);
+		const accountRow = makeAccountRow();
+
+		const result = await scheduler.sendDummyMessage(accountRow);
+
+		expect(result).toBe(false);
+		expect(scheduler.consecutiveFailures.get(accountRow.id)).toBeUndefined();
+		const pauseCall = db.runCalls.find(
+			([sql]) => sql.includes("paused = 1") && sql.includes("accounts"),
+		);
+		expect(pauseCall).toBeUndefined();
+	});
+
+	it("never pauses the account even after FAILURE_THRESHOLD consecutive 529 probe responses", async () => {
+		globalThis.fetch = mock(async () =>
+			jsonResponse(529, {
+				type: "error",
+				error: { type: "overloaded_error", message: "throttled" },
+			}),
+		) as unknown as typeof fetch;
+
+		const db = makeDb();
+		const scheduler = await makeScheduler(db);
+		const accountRow = makeAccountRow();
+
+		for (let i = 0; i < scheduler.FAILURE_THRESHOLD + 2; i++) {
+			await scheduler.sendDummyMessage(accountRow);
+		}
+
+		expect(scheduler.consecutiveFailures.get(accountRow.id)).toBeUndefined();
+		const pauseCall = db.runCalls.find(
+			([sql, params]) =>
+				sql.includes("paused = 1") &&
+				Array.isArray(params) &&
+				params[0] === accountRow.id,
+		);
+		expect(pauseCall).toBeUndefined();
+	});
+
+	it("control: a genuine (non-529) failure still counts and pauses at FAILURE_THRESHOLD", async () => {
+		globalThis.fetch = mock(async () =>
+			jsonResponse(500, {
+				type: "error",
+				error: { type: "api_error", message: "internal server error" },
+			}),
+		) as unknown as typeof fetch;
+
+		const db = makeDb();
+		const scheduler = await makeScheduler(db);
+		const accountRow = makeAccountRow();
+
+		for (let i = 0; i < scheduler.FAILURE_THRESHOLD; i++) {
+			await scheduler.sendDummyMessage(accountRow);
+		}
+
+		expect(scheduler.consecutiveFailures.get(accountRow.id)).toBeUndefined();
+		const pauseCall = db.runCalls.find(
+			([sql, params]) =>
+				sql.includes("paused = 1") &&
+				Array.isArray(params) &&
+				params[0] === accountRow.id,
+		);
+		// Counter is cleared by recordRefreshFailure immediately after the pause
+		// UPDATE — its absence here (unlike the 529 tests) is only meaningful
+		// together with the pause call actually having fired, asserted below.
+		expect(pauseCall).toBeDefined();
+	});
+
+	it("control: a genuine failure counter is untouched by an intervening 529 (neither incremented nor reset)", async () => {
+		const db = makeDb();
+		const scheduler = await makeScheduler(db);
+		const accountRow = makeAccountRow();
+
+		globalThis.fetch = mock(async () =>
+			jsonResponse(500, {
+				type: "error",
+				error: { type: "api_error", message: "internal server error" },
+			}),
+		) as unknown as typeof fetch;
+		// One genuine failure below threshold.
+		for (let i = 0; i < scheduler.FAILURE_THRESHOLD - 1; i++) {
+			await scheduler.sendDummyMessage(accountRow);
+		}
+		expect(scheduler.consecutiveFailures.get(accountRow.id)).toBe(
+			scheduler.FAILURE_THRESHOLD - 1,
+		);
+
+		// An intervening 529 must not touch the counter at all.
+		globalThis.fetch = mock(async () =>
+			jsonResponse(529, {
+				type: "error",
+				error: { type: "overloaded_error", message: "throttled" },
+			}),
+		) as unknown as typeof fetch;
+		await scheduler.sendDummyMessage(accountRow);
+		expect(scheduler.consecutiveFailures.get(accountRow.id)).toBe(
+			scheduler.FAILURE_THRESHOLD - 1,
+		);
+	});
+});

--- a/packages/proxy/src/__tests__/auto-refresh-throttle-exemption.test.ts
+++ b/packages/proxy/src/__tests__/auto-refresh-throttle-exemption.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Regression test for the usage-throttling / auto-refresh interaction bug:
+ *
+ * When usage-throttling is enabled, a throttled-but-healthy account's
+ * five_hour window reset triggers the auto-refresh scheduler to send a
+ * synthetic probe (AutoRefreshScheduler.sendDummyMessage). That probe is
+ * force-routed to the account via `x-better-ccflare-account-id` and carries
+ * `x-better-ccflare-bypass-session: true` + `x-better-ccflare-auto-refresh: true`
+ * so it bypasses the pause/rate-limit checks in selectAccountsForRequest — but
+ * before the fix, `applyUsageThrottling` in proxy.ts did NOT know about those
+ * headers and threw the probe into the `throttled` bucket anyway, producing
+ * our own synthetic 529 (createUsageThrottledResponse). The scheduler then
+ * misread that 529 as an endpoint failure and counted it toward its
+ * consecutive-failure pause threshold (see auto-refresh-failure-threshold /
+ * auto-refresh-scheduler.ts recordRefreshFailure), eventually auto-pausing a
+ * perfectly healthy — merely throttled — account.
+ *
+ * The fix exempts internal synthetic probes (auto-refresh + cache-keepalive)
+ * from usage-throttling entirely in proxy.ts's applyUsageThrottling.
+ */
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { usageCache } from "@better-ccflare/providers";
+import type { Account } from "@better-ccflare/types";
+import type { ProxyContext } from "../handlers";
+import { handleProxy } from "../proxy";
+import * as usageCollectorModule from "../usage-collector";
+
+/**
+ * Unlike the auto-refresh probe marker, `x-better-ccflare-keepalive` is not
+ * checked by response-handler.ts's `shouldProcessRequest` — a keepalive
+ * replay's response still gets logged via the usage collector. Stub it out
+ * so the keepalive exemption test doesn't depend on a real, initialized
+ * UsageCollector singleton.
+ */
+function stubUsageCollector() {
+	return spyOn(usageCollectorModule, "getUsageCollector").mockReturnValue({
+		handleStart: mock(() => {}),
+		handleChunk: mock(() => {}),
+		handleEnd: mock(() => Promise.resolve()),
+	} as unknown as usageCollectorModule.UsageCollector);
+}
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "acc-mb",
+		name: "MB",
+		provider: "test-provider",
+		api_key: null,
+		refresh_token: "refresh-token",
+		access_token: "access-token",
+		// Comfortably beyond TOKEN_SAFETY_WINDOW_MS (30 min) so getValidAccessToken
+		// returns the access token directly without attempting a network refresh.
+		expires_at: Date.now() + 3 * 60 * 60 * 1000,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: Date.now(),
+		rate_limited_until: null,
+		rate_limited_reason: null,
+		rate_limited_at: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		requires_reauth: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: true,
+		auto_pause_on_overage_enabled: false,
+		peak_hours_pause_enabled: false,
+		custom_endpoint: null,
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		billing_type: null,
+		pause_reason: null,
+		refresh_token_issued_at: null,
+		consecutive_rate_limits: 0,
+		...overrides,
+	};
+}
+
+/**
+ * A fully-mocked, unregistered provider name ("test-provider") so
+ * `getProvider(account.provider)` in proxy-operations.ts resolves to
+ * `undefined` and falls back to `ctx.provider` — giving the test full,
+ * deterministic control over header prep / response processing without
+ * depending on any real provider's upstream-shape assumptions.
+ */
+function makeContext(account: Account): ProxyContext {
+	return {
+		strategy: {
+			select: (accounts: Account[]) => accounts,
+		} as never,
+		dbOps: {
+			getAllAccounts: mock(async () => [account]),
+			getActiveComboForFamily: mock(async () => null),
+		} as never,
+		runtime: { port: 8080, clientId: "test" } as never,
+		config: {
+			getUsageThrottlingFiveHourEnabled: () => true,
+			getUsageThrottlingWeeklyEnabled: () => true,
+			getSystemPromptCacheTtl1h: () => false,
+			getAgentFrontmatterModelFallback: () => false,
+		} as never,
+		provider: {
+			name: "test-provider",
+			canHandle: () => true,
+			buildUrl: () => "https://fake.local/v1/messages",
+			prepareHeaders: () => new Headers(),
+			transformRequestBody: undefined,
+			processResponse: async (r: Response) => r,
+			parseRateLimit: () => ({
+				isRateLimited: false,
+				resetTime: undefined,
+				statusHeader: undefined,
+				remaining: undefined,
+			}),
+			isStreamingResponse: () => false,
+		} as never,
+		refreshInFlight: new Map(),
+		// No-op enqueue: background bookkeeping jobs are never invoked, so this
+		// test does not need to mock ctx.dbOps.getAdapter/updateAccountUsage/etc.
+		asyncWriter: { enqueue: mock(() => {}) } as never,
+	};
+}
+
+function makeThrottledRequest(headers: Record<string, string> = {}): Request {
+	return new Request("https://proxy.local/v1/messages", {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			...headers,
+		},
+		body: JSON.stringify({
+			model: "claude-haiku-4-5",
+			messages: [{ role: "user", content: "hi" }],
+			max_tokens: 10,
+		}),
+	});
+}
+
+describe("handleProxy usage throttling — synthetic probe exemption", () => {
+	afterEach(() => {
+		usageCache.delete("acc-mb");
+	});
+
+	function setThrottled(now: number) {
+		const resetAt = new Date(now + 2 * 60 * 60 * 1000).toISOString();
+		usageCache.set("acc-mb", {
+			five_hour: { utilization: 80, resets_at: resetAt },
+			seven_day: { utilization: 10, resets_at: null },
+		});
+	}
+
+	it("still returns 529 for a normal (non-probe) request when the account is usage-throttled (control)", async () => {
+		const account = makeAccount();
+		const now = Date.UTC(2026, 3, 28, 12, 0, 0);
+		setThrottled(now);
+
+		const realDateNow = Date.now;
+		Date.now = () => now;
+		try {
+			const request = makeThrottledRequest();
+			const response = await handleProxy(
+				request,
+				new URL(request.url),
+				makeContext(account),
+			);
+
+			expect(response.status).toBe(529);
+			expect(response.headers.get("Retry-After")).toBe("60");
+		} finally {
+			Date.now = realDateNow;
+		}
+	});
+
+	it("does NOT usage-throttle an auto-refresh probe — the throttled-but-healthy account is still reached", async () => {
+		const account = makeAccount();
+		const now = Date.UTC(2026, 3, 28, 12, 0, 0);
+		setThrottled(now);
+
+		const realDateNow = Date.now;
+		Date.now = () => now;
+		try {
+			// Mirrors the exact headers AutoRefreshScheduler.sendDummyMessage sends:
+			// force-routed to the account, bypass-session, and the auto-refresh marker.
+			const request = makeThrottledRequest({
+				"x-better-ccflare-account-id": account.id,
+				"x-better-ccflare-bypass-session": "true",
+				"x-better-ccflare-auto-refresh": "true",
+			});
+
+			const realFetch = globalThis.fetch;
+			globalThis.fetch = mock(
+				async () =>
+					new Response(JSON.stringify({ type: "message", id: "msg_1" }), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+			) as unknown as typeof fetch;
+			try {
+				const response = await handleProxy(
+					request,
+					new URL(request.url),
+					makeContext(account),
+				);
+
+				// Before the fix this was 529 (our own createUsageThrottledResponse),
+				// which the auto-refresh scheduler counted as an endpoint failure.
+				expect(response.status).not.toBe(529);
+				expect(response.status).toBe(200);
+			} finally {
+				globalThis.fetch = realFetch;
+			}
+		} finally {
+			Date.now = realDateNow;
+		}
+	});
+
+	it("does NOT usage-throttle a cache-keepalive replay probe either", async () => {
+		const account = makeAccount();
+		const now = Date.UTC(2026, 3, 28, 12, 0, 0);
+		setThrottled(now);
+
+		// Unlike the auto-refresh header, x-better-ccflare-keepalive does not
+		// suppress usage-collector logging in response-handler.ts, so a real
+		// (mocked) UsageCollector must be available for forwardToClient to run.
+		const collectorSpy = stubUsageCollector();
+
+		const realDateNow = Date.now;
+		Date.now = () => now;
+		try {
+			const request = makeThrottledRequest({
+				"x-better-ccflare-account-id": account.id,
+				"x-better-ccflare-bypass-session": "true",
+				"x-better-ccflare-keepalive": "true",
+			});
+
+			const realFetch = globalThis.fetch;
+			globalThis.fetch = mock(
+				async () =>
+					new Response(JSON.stringify({ type: "message", id: "msg_1" }), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+			) as unknown as typeof fetch;
+			try {
+				const response = await handleProxy(
+					request,
+					new URL(request.url),
+					makeContext(account),
+				);
+
+				expect(response.status).not.toBe(529);
+				expect(response.status).toBe(200);
+			} finally {
+				globalThis.fetch = realFetch;
+			}
+		} finally {
+			Date.now = realDateNow;
+			collectorSpy.mockRestore();
+		}
+	});
+});

--- a/packages/proxy/src/auto-refresh-scheduler.ts
+++ b/packages/proxy/src/auto-refresh-scheduler.ts
@@ -659,6 +659,21 @@ export class AutoRefreshScheduler {
 				// Ignore error reading body
 			}
 
+			// A 529 (overloaded_error) is a deliberate throttle/overload signal —
+			// either better-ccflare's own usage-throttling (should no longer reach
+			// here now that the probe is exempted in applyUsageThrottling, but kept
+			// as defense in depth) or a transient upstream overload from the
+			// provider itself. Neither indicates the endpoint is broken, so it must
+			// NOT count toward the consecutive-failure pause threshold: doing so
+			// previously auto-paused a healthy-but-throttled account the instant
+			// its usage window reset and the scheduler re-probed it.
+			if (response.status === 529) {
+				log.warn(
+					`Auto-refresh probe for ${accountRow.name} received 529 (overloaded/throttled) — not counting toward the ${this.FAILURE_THRESHOLD}-failure pause threshold`,
+				);
+				return false;
+			}
+
 			// Track consecutive failures for this account (for non-401 errors too)
 			await this.recordRefreshFailure(
 				accountRow.id,

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -244,6 +244,24 @@ export async function handleProxy(
 			return { available: accounts, throttled: [] as Account[] };
 		}
 
+		// Internal synthetic probes (auto-refresh window-reset checks, cache
+		// keepalive replays) must never be usage-throttled. They exist
+		// specifically to hit the real endpoint and observe state changes
+		// (window resets, recovered accounts) — the same reason
+		// selectAccountsForRequest already lets them bypass pause/rate-limit
+		// checks (see account-selector.ts's isAutoRefreshBypass). Without this
+		// exemption, a throttled-but-healthy account's own synthetic probe gets
+		// our own 529 back; the auto-refresh scheduler then misreads that as an
+		// endpoint failure and counts it toward its consecutive-failure pause
+		// threshold (recordRefreshFailure), auto-pausing a healthy account the
+		// instant its usage window resets and the scheduler re-probes it.
+		const isSyntheticProbe =
+			req.headers.get("x-better-ccflare-auto-refresh") === "true" ||
+			req.headers.get("x-better-ccflare-keepalive") === "true";
+		if (isSyntheticProbe) {
+			return { available: accounts, throttled: [] as Account[] };
+		}
+
 		const now = Date.now();
 		const available: Account[] = [];
 		const throttled: Account[] = [];


### PR DESCRIPTION
## Root Cause

When usage-throttling (`usage_throttling_weekly_enabled`/`usage_throttling_five_hour_enabled`) is on, a legitimately throttled-but-otherwise-healthy account gets auto-paused through this chain:

1. Account is usage-throttled for a weekly/model-scoped window.
2. Its `five_hour` window resets, so `AutoRefreshScheduler` treats it as a "new window" and fires a synthetic probe, force-routed to that account (`x-better-ccflare-account-id`) with `x-better-ccflare-bypass-session: true` so it bypasses the pause/rate-limit checks in `selectAccountsForRequest`.
3. `applyUsageThrottling` in `proxy.ts` had no equivalent bypass — it throttled the probe like any other request and returned better-ccflare's **own** 529 `overloaded_error` (`createUsageThrottledResponse`).
4. `sendDummyMessage` logs `Auto-refresh message failed ... 529` and counts it via `recordRefreshFailure` — a 529 was treated exactly like a genuine broken-endpoint failure.
5. After 5 consecutive window-reset cycles, the scheduler pauses the account (`pause_reason='failure_threshold'`) even though nothing is actually broken.

Cascade risk: every usage-throttled account eventually hits this the moment its `five_hour` window resets.

## The Fix

Two layers, both minimal:

1. **`packages/proxy/src/proxy.ts`** — `applyUsageThrottling` now exempts internal synthetic probes entirely: when the request carries `x-better-ccflare-auto-refresh` or `x-better-ccflare-keepalive` (both pre-existing loop-prevention headers, already set by `auto-refresh-scheduler.ts` and `cache-keepalive-scheduler.ts` respectively for issue #199 — this PR is the first site to *check* them for usage-throttling), the request is never throttled and reaches the real account.
2. **`packages/proxy/src/auto-refresh-scheduler.ts`** — `sendDummyMessage` no longer counts a 529 response toward `FAILURE_THRESHOLD` at all, as defense in depth (a deliberate throttle/overload signal is not evidence the endpoint is broken, whether it's our own throttle or a genuine transient upstream 529).

The happy path for normal client requests is byte-identical (the exemption only fires on the two internal marker headers). Genuine failures still count and still pause the account at the threshold — pinned by a control test.

## Validation

Two new regression-test files, both TDD (proved to fail without the fix via `git stash`, pass with it):

- `packages/proxy/src/__tests__/auto-refresh-throttle-exemption.test.ts` — full `handleProxy` integration test. 2/3 tests fail without the `proxy.ts` fix; the 3rd (plain client request, no probe headers) is an unaffected control that passes either way.
- `packages/proxy/src/__tests__/auto-refresh-529-not-counted.test.ts` — direct `sendDummyMessage` unit tests. 3/4 fail without the scheduler fix; the control test (a genuine 500 still counts toward the pause threshold) passes either way, proving the fix doesn't over-broaden the exemption.

Full suite: +7 tests, 0 regressions (`bun test packages/proxy` → 579 pass / 45 fail, same 45 pre-existing failures present on unmodified `main` too — confirmed via `git stash` comparison, unrelated `DatabaseFactory`/date-mock issues in the local test env). `bun run lint && bun run typecheck && bun run format` all clean.
