### PR TITLE
feat: explicit outbound forward-proxy support (BETTER_CCFLARE_OUTBOUND_PROXY)

### DIFF
--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -55,6 +55,7 @@ import { Config } from "@better-ccflare/config";
 import {
 	CLAUDE_MODEL_IDS,
 	getVersionSync,
+	installOutboundProxy,
 	levenshteinDistance,
 	NETWORK,
 	shutdown,
@@ -959,8 +960,13 @@ Examples:
 	}
 
 	// Initialize DI container and services for commands that need them
-	container.registerInstance(SERVICE_KEYS.Config, new Config());
+	const cliConfig = new Config();
+	container.registerInstance(SERVICE_KEYS.Config, cliConfig);
 	container.registerInstance(SERVICE_KEYS.Logger, new Logger("CLI"));
+
+	// Route CLI outbound fetches (OAuth exchange, API key validation, etc.)
+	// through the configured forward proxy, same as the server process.
+	installOutboundProxy(() => cliConfig.getOutboundProxy());
 
 	// Initialize database factory with minimal configuration for CLI commands
 	// CLI commands don't need expensive integrity checks

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -637,8 +637,9 @@ export default async function startServer(options?: {
 	installOutboundProxy(() => config.getOutboundProxy());
 	const outboundProxyUrl = config.getOutboundProxy();
 	if (outboundProxyUrl) {
+		const { protocol, host } = new URL(outboundProxyUrl);
 		new Logger("OutboundProxy").info(
-			`Outbound proxy enabled: ${outboundProxyUrl}`,
+			`Outbound proxy enabled: ${protocol}//${host}`,
 		);
 	}
 	const runtime = config.getRuntime();

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -7,6 +7,7 @@ import {
 	getVersion,
 	HTTP_STATUS,
 	initializeNanoGPTPricingIfAccountsExist,
+	installOutboundProxy,
 	NETWORK,
 	registerCleanup,
 	registerDisposable,
@@ -633,6 +634,13 @@ export default async function startServer(options?: {
 
 	// Initialize components
 	const config = container.resolve<Config>(SERVICE_KEYS.Config);
+	installOutboundProxy(() => config.getOutboundProxy());
+	const outboundProxyUrl = config.getOutboundProxy();
+	if (outboundProxyUrl) {
+		new Logger("OutboundProxy").info(
+			`Outbound proxy enabled: ${outboundProxyUrl}`,
+		);
+	}
 	const runtime = config.getRuntime();
 	// Override port if provided
 	if (port !== runtime.port) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -147,6 +147,21 @@ These environment variables are not stored in the configuration file and must be
 | `CF_STREAM_USAGE_BUFFER_KB` | Stream usage buffer size in KB | `64` | `CF_STREAM_USAGE_BUFFER_KB=128` |
 | `CF_STREAM_TIMEOUT_MS` | Stream processing timeout in milliseconds | `60000` (1 minute) | `CF_STREAM_TIMEOUT_MS=120000` |
 | `PAYLOAD_ENCRYPTION_KEY` | Optional 64-char hex key (32 bytes / AES-256) enabling AES-256-GCM encryption-at-rest for the `request_payloads` table. See [security.md](security.md#payload-encryption-at-rest). | unset (plaintext) | `PAYLOAD_ENCRYPTION_KEY=$(openssl rand -hex 32)` |
+| `BETTER_CCFLARE_OUTBOUND_PROXY` | Routes all outbound HTTP(S) traffic through a forward proxy | unset | `BETTER_CCFLARE_OUTBOUND_PROXY=http://127.0.0.1:3636` |
+
+## Outbound Proxy
+
+better-ccflare can route all of its outbound HTTP(S) traffic — provider requests, OAuth flows, usage polling, and webhooks — through an explicit forward proxy using HTTP CONNECT. This is useful for enterprises that want every egress connection from better-ccflare to pass through a security/inspection proxy.
+
+Configure it via the `BETTER_CCFLARE_OUTBOUND_PROXY` environment variable (or the equivalent `outbound_proxy` config file key); env var takes precedence over the config file value, matching the pattern used elsewhere in this doc. A dedicated variable is used instead of the conventional `HTTPS_PROXY`/`HTTP_PROXY` because those affect every process on the machine by convention — a dedicated variable lets operators scope the proxy to just this application (e.g. via MDM/provisioning) without redirecting traffic for every other tool.
+
+Loopback destinations (`localhost`, `127.0.0.1`, `::1`) are always exempt and never routed through the configured proxy, so local testing setups (e.g. a local Ollama or LiteLLM instance) keep working unaffected.
+
+If the forward proxy performs TLS interception (MITM), such as an LLM security/inspection gateway, its CA certificate must be trusted by the Node/Bun process. Set `NODE_EXTRA_CA_CERTS` as a real environment variable at process launch — not inside a `.env` file loaded at runtime — since it must be present before the process starts.
+
+This setting operates at the transport layer and is unrelated to a per-account `custom_endpoint`, which is a URL/routing-level override rather than a proxy.
+
+Coverage spans both the running server process and CLI-only commands that never start the server (e.g. `better-ccflare --add-account`, `--reauthenticate`) — account management and OAuth flows invoked directly from the CLI are proxied the same way; the one carve-out is the embedded database-maintenance worker threads, which run in their own global scope outside this wrapper, but they make no outbound HTTP requests themselves so no traffic escapes unproxied through them.
 
 ## Alerts
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,7 +155,7 @@ better-ccflare can route all of its outbound HTTP(S) traffic — provider reques
 
 Configure it via the `BETTER_CCFLARE_OUTBOUND_PROXY` environment variable (or the equivalent `outbound_proxy` config file key); env var takes precedence over the config file value, matching the pattern used elsewhere in this doc. A dedicated variable is used instead of the conventional `HTTPS_PROXY`/`HTTP_PROXY` because those affect every process on the machine by convention — a dedicated variable lets operators scope the proxy to just this application (e.g. via MDM/provisioning) without redirecting traffic for every other tool.
 
-Loopback destinations (`localhost`, `127.0.0.1`, `::1`) are always exempt and never routed through the configured proxy, so local testing setups (e.g. a local Ollama or LiteLLM instance) keep working unaffected.
+Loopback destinations (`localhost`, `127.0.0.0/8` addresses, `::1`) are always exempt and never routed through the configured proxy, so local testing setups (e.g. a local Ollama or LiteLLM instance) keep working unaffected.
 
 If the forward proxy performs TLS interception (MITM), such as an LLM security/inspection gateway, its CA certificate must be trusted by the Node/Bun process. Set `NODE_EXTRA_CA_CERTS` as a real environment variable at process launch — not inside a `.env` file loaded at runtime — since it must be present before the process starts.
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -314,7 +314,7 @@ export class Config extends EventEmitter {
 		try {
 			return validateEndpointUrl(candidate, "outbound_proxy");
 		} catch (error) {
-			log.warn(`Invalid outbound proxy URL: ${candidate}. Ignoring.`, error);
+			log.warn("Invalid outbound proxy URL. Ignoring.", error);
 			return undefined;
 		}
 	}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -9,6 +9,7 @@ import {
 	type StrategyName,
 	TIME_CONSTANTS,
 	ValidationError,
+	validateEndpointUrl,
 	validateNumber,
 	validateString,
 } from "@better-ccflare/core";
@@ -88,6 +89,7 @@ export interface ConfigData {
 	alert_anomaly_interval_minutes?: number;
 	alert_cooldown_minutes?: number;
 	alert_webhook_url?: string;
+	outbound_proxy?: string;
 	// Database configuration
 	db_wal_mode?: boolean;
 	db_busy_timeout_ms?: number;
@@ -301,6 +303,20 @@ export class Config extends EventEmitter {
 
 	setDefaultAgentModel(model: string): void {
 		this.set("default_agent_model", model);
+	}
+
+	getOutboundProxy(): string | undefined {
+		const candidate =
+			process.env.BETTER_CCFLARE_OUTBOUND_PROXY ?? this.data.outbound_proxy;
+		if (!candidate) {
+			return undefined;
+		}
+		try {
+			return validateEndpointUrl(candidate, "outbound_proxy");
+		} catch (error) {
+			log.warn(`Invalid outbound proxy URL: ${candidate}. Ignoring.`, error);
+			return undefined;
+		}
 	}
 
 	private clamp(n: number, min: number, max: number): number {

--- a/packages/config/src/outbound-proxy-config.test.ts
+++ b/packages/config/src/outbound-proxy-config.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Config } from "./index";
+
+const ENV_KEYS = ["BETTER_CCFLARE_OUTBOUND_PROXY"] as const;
+
+const ORIGINAL_ENV: Record<string, string | undefined> = {};
+for (const key of ENV_KEYS) {
+	ORIGINAL_ENV[key] = process.env[key];
+}
+
+function makeConfig(): { config: Config; cleanup: () => void } {
+	const dir = mkdtempSync(join(tmpdir(), "better-ccflare-config-"));
+	return {
+		config: new Config(join(dir, "config.json")),
+		cleanup: () => rmSync(dir, { recursive: true, force: true }),
+	};
+}
+
+describe("outbound proxy config setting", () => {
+	afterEach(() => {
+		for (const key of ENV_KEYS) {
+			const original = ORIGINAL_ENV[key];
+			if (original === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = original;
+			}
+		}
+	});
+
+	it("returns undefined when unset everywhere", () => {
+		delete process.env.BETTER_CCFLARE_OUTBOUND_PROXY;
+		const { config, cleanup } = makeConfig();
+
+		try {
+			expect(config.getOutboundProxy()).toBeUndefined();
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("returns the env var value, with trailing slash stripped", () => {
+		process.env.BETTER_CCFLARE_OUTBOUND_PROXY = "http://127.0.0.1:3636/";
+		const { config, cleanup } = makeConfig();
+
+		try {
+			expect(config.getOutboundProxy()).toBe("http://127.0.0.1:3636");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("returns the config-file value when the env var is unset", () => {
+		delete process.env.BETTER_CCFLARE_OUTBOUND_PROXY;
+		const { config, cleanup } = makeConfig();
+
+		try {
+			config.set("outbound_proxy", "http://proxy.example.com:8080");
+			expect(config.getOutboundProxy()).toBe("http://proxy.example.com:8080");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("prefers the env var over the config-file value", () => {
+		process.env.BETTER_CCFLARE_OUTBOUND_PROXY = "http://127.0.0.1:3636";
+		const { config, cleanup } = makeConfig();
+
+		try {
+			config.set("outbound_proxy", "http://proxy.example.com:8080");
+			expect(config.getOutboundProxy()).toBe("http://127.0.0.1:3636");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("returns undefined for an invalid URL instead of throwing", () => {
+		process.env.BETTER_CCFLARE_OUTBOUND_PROXY = "not-a-url";
+		const { config, cleanup } = makeConfig();
+
+		try {
+			expect(() => config.getOutboundProxy()).not.toThrow();
+			expect(config.getOutboundProxy()).toBeUndefined();
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("returns undefined for a disallowed protocol instead of throwing", () => {
+		process.env.BETTER_CCFLARE_OUTBOUND_PROXY = "ftp://example.com";
+		const { config, cleanup } = makeConfig();
+
+		try {
+			expect(() => config.getOutboundProxy()).not.toThrow();
+			expect(config.getOutboundProxy()).toBeUndefined();
+		} finally {
+			cleanup();
+		}
+	});
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,6 +73,10 @@ export {
 	MODEL_SHORT_NAMES,
 } from "./models";
 export {
+	installOutboundProxy,
+	uninstallOutboundProxy,
+} from "./outbound-proxy";
+export {
 	estimateCostUSD,
 	getModelRates,
 	initializeNanoGPTPricingIfAccountsExist,

--- a/packages/core/src/outbound-proxy.test.ts
+++ b/packages/core/src/outbound-proxy.test.ts
@@ -82,6 +82,24 @@ describe("outbound-proxy", () => {
 		expect(proxy.requestLines.length).toBe(0);
 	});
 
+	it("excludes any 127.0.0.0/8 address from proxying", async () => {
+		const proxy = startFakeProxy();
+		cleanups.push(() => proxy.server.stop(true));
+
+		installOutboundProxy(() => `http://127.0.0.1:${proxy.port}`);
+
+		// 127.0.0.2 has no route on most machines (no loopback alias configured),
+		// so the direct request is expected to fail/time out — what matters is
+		// that the fake proxy never sees it, proving the exemption kicked in
+		// before any connection attempt was routed through the proxy.
+		try {
+			await fetch("http://127.0.0.2:1/", { signal: AbortSignal.timeout(500) });
+		} catch {
+			// Expected: no route to 127.0.0.2 on this host.
+		}
+		expect(proxy.requestLines.length).toBe(0);
+	});
+
 	it("is a no-op when the resolver returns undefined", async () => {
 		const proxy = startFakeProxy();
 		cleanups.push(() => proxy.server.stop(true));

--- a/packages/core/src/outbound-proxy.test.ts
+++ b/packages/core/src/outbound-proxy.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+	installOutboundProxy,
+	uninstallOutboundProxy,
+} from "@better-ccflare/core";
+
+interface FakeProxy {
+	server: ReturnType<typeof Bun.listen>;
+	port: number;
+	requestLines: string[];
+}
+
+interface FetchInitWithProxy extends RequestInit {
+	proxy?: string;
+}
+
+function startFakeProxy(): FakeProxy {
+	const requestLines: string[] = [];
+	const server = Bun.listen({
+		hostname: "127.0.0.1",
+		port: 0,
+		socket: {
+			data(socket, chunk) {
+				const text = Buffer.from(chunk).toString("utf8");
+				const firstLine = text.split("\r\n")[0] ?? "";
+				requestLines.push(firstLine);
+				socket.write("HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n\r\n");
+				socket.end();
+			},
+		},
+	});
+	return { server, port: server.port ?? 0, requestLines };
+}
+
+describe("outbound-proxy", () => {
+	const cleanups: Array<() => void> = [];
+
+	afterEach(() => {
+		uninstallOutboundProxy();
+		for (const cleanup of cleanups.splice(0)) {
+			cleanup();
+		}
+	});
+
+	it("routes external requests through the resolved proxy", async () => {
+		const proxy = startFakeProxy();
+		cleanups.push(() => proxy.server.stop(true));
+
+		installOutboundProxy(() => `http://127.0.0.1:${proxy.port}`);
+
+		const response = await fetch("https://outbound-proxy-test.invalid/x");
+		expect(response.status).toBe(502);
+		expect(proxy.requestLines.length).toBeGreaterThan(0);
+		expect(proxy.requestLines[0]).toStartWith(
+			"CONNECT outbound-proxy-test.invalid:443",
+		);
+	});
+
+	it("excludes loopback destinations from proxying", async () => {
+		const proxy = startFakeProxy();
+		cleanups.push(() => proxy.server.stop(true));
+
+		const localServer = Bun.serve({
+			hostname: "127.0.0.1",
+			port: 0,
+			fetch() {
+				return new Response("local-ok", {
+					status: 200,
+					headers: { "x-marker": "local" },
+				});
+			},
+		});
+		cleanups.push(() => localServer.stop(true));
+
+		installOutboundProxy(() => `http://127.0.0.1:${proxy.port}`);
+
+		const response = await fetch(
+			`http://127.0.0.1:${localServer.port}/anything`,
+		);
+		expect(response.status).toBe(200);
+		expect(response.headers.get("x-marker")).toBe("local");
+		expect(proxy.requestLines.length).toBe(0);
+	});
+
+	it("is a no-op when the resolver returns undefined", async () => {
+		const proxy = startFakeProxy();
+		cleanups.push(() => proxy.server.stop(true));
+
+		const localServer = Bun.serve({
+			hostname: "127.0.0.1",
+			port: 0,
+			fetch() {
+				return new Response("local-ok", { status: 200 });
+			},
+		});
+		cleanups.push(() => localServer.stop(true));
+
+		installOutboundProxy(() => undefined);
+
+		const response = await fetch(`http://127.0.0.1:${localServer.port}/`);
+		expect(response.status).toBe(200);
+		expect(proxy.requestLines.length).toBe(0);
+	});
+
+	it("never overrides a caller-supplied proxy option", async () => {
+		const proxyA = startFakeProxy();
+		cleanups.push(() => proxyA.server.stop(true));
+		const proxyB = startFakeProxy();
+		cleanups.push(() => proxyB.server.stop(true));
+
+		installOutboundProxy(() => `http://127.0.0.1:${proxyA.port}`);
+
+		const response = await fetch("https://outbound-proxy-test.invalid/y", {
+			proxy: `http://127.0.0.1:${proxyB.port}`,
+		} satisfies FetchInitWithProxy);
+
+		expect(response.status).toBe(502);
+		expect(proxyB.requestLines.length).toBeGreaterThan(0);
+		expect(proxyA.requestLines.length).toBe(0);
+	});
+});

--- a/packages/core/src/outbound-proxy.ts
+++ b/packages/core/src/outbound-proxy.ts
@@ -1,0 +1,120 @@
+/**
+ * Bun's `fetch()` supports a per-request `proxy` option at runtime, but it is
+ * not declared on bun-types' ambient `RequestInit`, so we extend it locally.
+ */
+interface FetchInitWithProxy extends RequestInit {
+	proxy?: string;
+}
+
+type FetchLike = typeof fetch;
+
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+let originalFetch: FetchLike | undefined;
+let resolveProxy: (() => string | undefined) | undefined;
+
+function extractHostname(input: RequestInfo | URL): string | undefined {
+	try {
+		if (typeof input === "string") {
+			return new URL(input).hostname;
+		}
+		if (input instanceof URL) {
+			return input.hostname;
+		}
+		if (input instanceof Request) {
+			return new URL(input.url).hostname;
+		}
+		return undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function isLoopbackHost(hostname: string): boolean {
+	return LOOPBACK_HOSTS.has(hostname);
+}
+
+/**
+ * Installs a global wrapper around `globalThis.fetch` that routes outbound
+ * requests through an explicit forward proxy, as resolved by `resolver()`.
+ *
+ * WHY a global fetch wrapper rather than plumbing a `proxy` parameter through
+ * each call site: an egress security/inspection proxy is only useful if it
+ * covers ALL outbound traffic — provider requests, OAuth token exchange,
+ * usage polling, webhooks, etc. Threading a proxy option through every call
+ * site individually risks silently missing a code path (now or in a future
+ * change) and creating a bypass hole in the security boundary. Wrapping
+ * `fetch` once, globally, guarantees coverage regardless of which module
+ * initiates the request.
+ *
+ * Loopback destinations (localhost, 127.0.0.1, ::1) are always excluded from
+ * proxying, so the app's own local traffic — e.g. calls to a local
+ * Ollama/LiteLLM server an operator is running for testing — never gets
+ * routed through an external proxy that has no route back to the local
+ * machine.
+ *
+ * Calling this function more than once (e.g. if startup logic runs twice, or
+ * across tests) does not double-wrap `fetch`; it just swaps out which
+ * resolver the existing wrapper uses.
+ */
+export function installOutboundProxy(resolver: () => string | undefined): void {
+	resolveProxy = resolver;
+
+	if (originalFetch) {
+		// Already wrapped — only the resolver needed updating.
+		return;
+	}
+
+	originalFetch = globalThis.fetch;
+	const capturedOriginalFetch = originalFetch;
+
+	function wrapperFn(
+		input: RequestInfo | URL,
+		init?: RequestInit,
+	): Promise<Response> {
+		const initWithProxy = init as FetchInitWithProxy | undefined;
+
+		// Caller's own explicit choice always wins.
+		if (initWithProxy?.proxy) {
+			return capturedOriginalFetch(input, init);
+		}
+
+		const hostname = extractHostname(input);
+		if (hostname === undefined) {
+			// Fail open: never throw from inside the wrapper due to URL parsing.
+			return capturedOriginalFetch(input, init);
+		}
+
+		if (isLoopbackHost(hostname)) {
+			return capturedOriginalFetch(input, init);
+		}
+
+		const proxyUrl = resolveProxy?.();
+		if (!proxyUrl) {
+			return capturedOriginalFetch(input, init);
+		}
+
+		const nextInit: FetchInitWithProxy = { ...init, proxy: proxyUrl };
+		return capturedOriginalFetch(input, nextInit as RequestInit);
+	}
+
+	// Preserve extra properties Bun attaches to fetch (e.g. `preconnect`), by
+	// assigning them FROM the original fetch ONTO the wrapper — never the
+	// reverse, which would overwrite the wrapper's own callable behavior.
+	const wrapper = Object.assign(wrapperFn, capturedOriginalFetch);
+
+	globalThis.fetch = wrapper;
+}
+
+/**
+ * Test-only helper: restores `globalThis.fetch` to the original, pre-wrap
+ * reference and clears wrap state, so repeated installs in the same process
+ * (e.g. across test files) stay isolated from each other.
+ */
+export function uninstallOutboundProxy(): void {
+	if (originalFetch) {
+		globalThis.fetch = originalFetch;
+	}
+	originalFetch = undefined;
+	resolveProxy = undefined;
+}

--- a/packages/core/src/outbound-proxy.ts
+++ b/packages/core/src/outbound-proxy.ts
@@ -9,6 +9,7 @@ interface FetchInitWithProxy extends RequestInit {
 type FetchLike = typeof fetch;
 
 const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+const IPV4_LOOPBACK_RE = /^127\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
 
 let originalFetch: FetchLike | undefined;
 let resolveProxy: (() => string | undefined) | undefined;
@@ -31,7 +32,7 @@ function extractHostname(input: RequestInfo | URL): string | undefined {
 }
 
 function isLoopbackHost(hostname: string): boolean {
-	return LOOPBACK_HOSTS.has(hostname);
+	return LOOPBACK_HOSTS.has(hostname) || IPV4_LOOPBACK_RE.test(hostname);
 }
 
 /**
@@ -47,7 +48,7 @@ function isLoopbackHost(hostname: string): boolean {
  * `fetch` once, globally, guarantees coverage regardless of which module
  * initiates the request.
  *
- * Loopback destinations (localhost, 127.0.0.1, ::1) are always excluded from
+ * Loopback destinations (localhost, 127.0.0.0/8, ::1) are always excluded from
  * proxying, so the app's own local traffic — e.g. calls to a local
  * Ollama/LiteLLM server an operator is running for testing — never gets
  * routed through an external proxy that has no route back to the local


### PR DESCRIPTION
## Motivation

Enterprise environments frequently route outbound traffic through TLS-intercepting security gateways (DLP, secret scanning, LLM traffic inspection — e.g. Prompt Security, Zscaler, Netskope) or corporate egress proxies in restricted networks. In these deployments, all LLM traffic leaving better-ccflare must transit an explicit HTTP forward proxy (CONNECT).

Today the only way to achieve this is the standard `HTTPS_PROXY` env var, which Bun's fetch does honor — but with drawbacks in managed environments:

- Deployed machine-wide, it redirects every Bun/Node application on the host, not just better-ccflare.
- Bun applies `HTTPS_PROXY` to plain-http and loopback destinations as well, and reads `NO_PROXY` only at process launch, so fine-grained scoping is awkward.
- Per-process wrapper scripts are fragile to enforce across a fleet.

The per-account `custom_endpoint` (#130) covers reverse-proxy-style gateways by swapping the base URL, but explicit forward proxies are a different integration mode that cannot be expressed per account.

## What this adds

- `BETTER_CCFLARE_OUTBOUND_PROXY` env var (+ `outbound_proxy` config-file key; env takes precedence). When set, all outbound HTTP(S) traffic — provider requests, OAuth flows, usage polling, webhooks — is routed through the proxy via Bun's per-request `fetch(url, { proxy })` option.
- Implemented as a global fetch wrapper (`packages/core/src/outbound-proxy.ts`) installed at startup in both the server and CLI entry points, so CLI-only flows (`--add-account` OAuth exchange, reauthentication) are covered too.
- Loopback destinations (`localhost`, `127.0.0.1`, `::1`) are always exempt; a caller-supplied `proxy` option always wins; unset means strict no-op (zero behavior change, fully backward compatible).
- TLS-intercepting proxies still need their CA trusted at process start via `NODE_EXTRA_CA_CERTS` — documented in `docs/configuration.md` along with the new settings.
- Known boundary (documented): the embedded database-maintenance worker threads run outside the wrapper, but they make no outbound HTTP requests.

## Why a global wrapper instead of plumbing `proxy` through call sites

An egress inspection proxy is only useful if coverage is total. Threading the option through every fetch call site risks silently missing a path — now or in a future change — and opening a bypass hole in the security boundary. Wrapping once guarantees coverage. The wrapper is idempotent (re-install only swaps the resolver), fails open on unparseable URLs, and preserves Bun's `fetch.preconnect`.

## Testing

- 10 new bun:test cases: 4 wrapper tests using real loopback sockets — a fake forward proxy asserts the received `CONNECT <host>:443` request line — covering proxied/loopback-exempt/no-op/caller-precedence, plus 6 config tests for precedence and URL validation (invalid values log a warning and disable the feature, never throw).
- Live smoke: a built server started with the variable pointing at a local fake proxy emitted `CONNECT api.anthropic.com:443` for a proxied `/v1/messages` request, while loopback API traffic stayed direct.
- `bun test packages/core packages/config`: 120 pass / 0 fail. `bun run lint && bun run typecheck && bun run format`: clean.
- Tests use only loopback sockets and RFC 2606 `.invalid` hostnames — no external traffic.