### PR TITLE
security: gate internal-probe markers behind a process-local secret

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -934,6 +934,7 @@ export default async function startServer(options?: {
 	await initProxy(() => config.getStorePayloads());
 
 	// Proxy context
+	const internalProbeSecret = crypto.randomUUID();
 	const proxyContext: ProxyContext = {
 		strategy,
 		dbOps,
@@ -942,6 +943,7 @@ export default async function startServer(options?: {
 		provider,
 		refreshInFlight: new Map(),
 		asyncWriter,
+		internalProbeSecret,
 	};
 	modelCatalogProxyContext = proxyContext;
 

--- a/packages/http-common/src/headers.ts
+++ b/packages/http-common/src/headers.ts
@@ -33,6 +33,10 @@ export function sanitizeRequestHeaders(original: Headers): Headers {
 	h.delete("authorization");
 	h.delete("x-api-key");
 	h.delete("cookie");
+	// keep in sync with INTERNAL_PROBE_SECRET_HEADER
+	// (@better-ccflare/proxy already depends on http-common, so importing the
+	// proxy package's constant here would create an import cycle)
+	h.delete("x-better-ccflare-internal-probe-secret");
 	return h;
 }
 

--- a/packages/proxy/src/__tests__/auto-refresh-probe-filter.test.ts
+++ b/packages/proxy/src/__tests__/auto-refresh-probe-filter.test.ts
@@ -145,6 +145,7 @@ describe("response-handler — shouldProcessRequest suppresses auto-refresh prob
 				isStreamingResponse: () => false,
 			} as never,
 			config: { getStorePayloads: () => false } as never,
+			internalProbeSecret: "test-secret",
 		};
 
 		const response = new Response(JSON.stringify({ type: "message" }), {
@@ -154,6 +155,7 @@ describe("response-handler — shouldProcessRequest suppresses auto-refresh prob
 
 		const requestHeaders = new Headers({
 			"x-better-ccflare-auto-refresh": "true",
+			"x-better-ccflare-internal-probe-secret": "test-secret",
 		});
 
 		await forwardToClient(
@@ -276,6 +278,7 @@ describe("proxy.ts — pool-exhausted path skips usageCollector for auto-refresh
 			} as never,
 			refreshInFlight: new Map(),
 			asyncWriter: { enqueue: mock(() => {}) } as never,
+			internalProbeSecret: "test-secret",
 		};
 
 		const probeRequest = new Request("https://proxy.local/v1/messages", {
@@ -283,6 +286,7 @@ describe("proxy.ts — pool-exhausted path skips usageCollector for auto-refresh
 			headers: {
 				"Content-Type": "application/json",
 				"x-better-ccflare-auto-refresh": "true",
+				"x-better-ccflare-internal-probe-secret": "test-secret",
 			},
 			body: JSON.stringify({
 				model: "claude-haiku-4-5",

--- a/packages/proxy/src/__tests__/auto-refresh-throttle-exemption.test.ts
+++ b/packages/proxy/src/__tests__/auto-refresh-throttle-exemption.test.ts
@@ -124,6 +124,7 @@ function makeContext(account: Account): ProxyContext {
 		// No-op enqueue: background bookkeeping jobs are never invoked, so this
 		// test does not need to mock ctx.dbOps.getAdapter/updateAccountUsage/etc.
 		asyncWriter: { enqueue: mock(() => {}) } as never,
+		internalProbeSecret: "test-secret",
 	};
 }
 
@@ -191,6 +192,7 @@ describe("handleProxy usage throttling — synthetic probe exemption", () => {
 				"x-better-ccflare-account-id": account.id,
 				"x-better-ccflare-bypass-session": "true",
 				"x-better-ccflare-auto-refresh": "true",
+				"x-better-ccflare-internal-probe-secret": "test-secret",
 			});
 
 			const realFetch = globalThis.fetch;
@@ -237,6 +239,7 @@ describe("handleProxy usage throttling — synthetic probe exemption", () => {
 				"x-better-ccflare-account-id": account.id,
 				"x-better-ccflare-bypass-session": "true",
 				"x-better-ccflare-keepalive": "true",
+				"x-better-ccflare-internal-probe-secret": "test-secret",
 			});
 
 			const realFetch = globalThis.fetch;
@@ -262,6 +265,88 @@ describe("handleProxy usage throttling — synthetic probe exemption", () => {
 		} finally {
 			Date.now = realDateNow;
 			collectorSpy.mockRestore();
+		}
+	});
+
+	it("still throttles a forged auto-refresh marker that lacks the internal-probe secret header (issue #335)", async () => {
+		const account = makeAccount();
+		const now = Date.UTC(2026, 3, 28, 12, 0, 0);
+		setThrottled(now);
+
+		const realDateNow = Date.now;
+		Date.now = () => now;
+		try {
+			// An external client cannot mint x-better-ccflare-internal-probe-secret
+			// (process-local, never sent to clients) — without it the marker alone
+			// must not grant the throttling exemption.
+			const request = makeThrottledRequest({
+				"x-better-ccflare-account-id": account.id,
+				"x-better-ccflare-bypass-session": "true",
+				"x-better-ccflare-auto-refresh": "true",
+			});
+			const response = await handleProxy(
+				request,
+				new URL(request.url),
+				makeContext(account),
+			);
+
+			expect(response.status).toBe(529);
+			expect(response.headers.get("Retry-After")).toBe("60");
+		} finally {
+			Date.now = realDateNow;
+		}
+	});
+
+	it("still throttles a forged auto-refresh marker sent with a wrong internal-probe secret (issue #335)", async () => {
+		const account = makeAccount();
+		const now = Date.UTC(2026, 3, 28, 12, 0, 0);
+		setThrottled(now);
+
+		const realDateNow = Date.now;
+		Date.now = () => now;
+		try {
+			const request = makeThrottledRequest({
+				"x-better-ccflare-account-id": account.id,
+				"x-better-ccflare-bypass-session": "true",
+				"x-better-ccflare-auto-refresh": "true",
+				"x-better-ccflare-internal-probe-secret": "nope",
+			});
+			const response = await handleProxy(
+				request,
+				new URL(request.url),
+				makeContext(account),
+			);
+
+			expect(response.status).toBe(529);
+			expect(response.headers.get("Retry-After")).toBe("60");
+		} finally {
+			Date.now = realDateNow;
+		}
+	});
+
+	it("still throttles a forged cache-keepalive marker that lacks the internal-probe secret header (issue #335)", async () => {
+		const account = makeAccount();
+		const now = Date.UTC(2026, 3, 28, 12, 0, 0);
+		setThrottled(now);
+
+		const realDateNow = Date.now;
+		Date.now = () => now;
+		try {
+			const request = makeThrottledRequest({
+				"x-better-ccflare-account-id": account.id,
+				"x-better-ccflare-bypass-session": "true",
+				"x-better-ccflare-keepalive": "true",
+			});
+			const response = await handleProxy(
+				request,
+				new URL(request.url),
+				makeContext(account),
+			);
+
+			expect(response.status).toBe(529);
+			expect(response.headers.get("Retry-After")).toBe("60");
+		} finally {
+			Date.now = realDateNow;
 		}
 	});
 });

--- a/packages/proxy/src/__tests__/response-handler-anthropic-terminal-recovery.test.ts
+++ b/packages/proxy/src/__tests__/response-handler-anthropic-terminal-recovery.test.ts
@@ -44,6 +44,7 @@ function nativeAnthropicCtx(providerName = "anthropic"): ProxyContext {
 		},
 		refreshInFlight: new Map<string, Promise<string>>(),
 		asyncWriter: {},
+		internalProbeSecret: "test-secret",
 	} as unknown as ProxyContext;
 }
 
@@ -89,6 +90,7 @@ describe("forwardToClient Anthropic terminal recovery integration", () => {
 		const requestHeaders = new Headers({
 			"anthropic-version": "2023-06-01",
 			"x-better-ccflare-auto-refresh": "true",
+			"x-better-ccflare-internal-probe-secret": "test-secret",
 		});
 
 		await expect(forwardClosedStream({ requestHeaders })).resolves.toBe(
@@ -163,6 +165,7 @@ describe("forwardToClient Anthropic terminal recovery integration", () => {
 	it("leaves non-native, non-Anthropic, and non-Messages streams unchanged", async () => {
 		const filteredHeaders = new Headers({
 			"x-better-ccflare-auto-refresh": "true",
+			"x-better-ccflare-internal-probe-secret": "test-secret",
 		});
 		const nativeHeaders = new Headers(filteredHeaders);
 		nativeHeaders.set("anthropic-version", "2023-06-01");
@@ -188,6 +191,7 @@ describe("forwardToClient Anthropic terminal recovery integration", () => {
 		const nativeHeaders = new Headers({
 			"anthropic-version": "2023-06-01",
 			"x-better-ccflare-auto-refresh": "true",
+			"x-better-ccflare-internal-probe-secret": "test-secret",
 		});
 
 		await expect(

--- a/packages/proxy/src/auto-refresh-scheduler.ts
+++ b/packages/proxy/src/auto-refresh-scheduler.ts
@@ -10,7 +10,11 @@ import { Logger } from "@better-ccflare/logger";
 import { fetchUsageData, getProvider } from "@better-ccflare/providers";
 import type { Account } from "@better-ccflare/types";
 import { TOKEN_SAFETY_WINDOW_MS } from "./constants";
-import { extractAuthFailureReason, getValidAccessToken } from "./handlers";
+import {
+	extractAuthFailureReason,
+	getValidAccessToken,
+	INTERNAL_PROBE_SECRET_HEADER,
+} from "./handlers";
 import type { ProxyContext } from "./proxy";
 
 const log = new Logger("AutoRefreshScheduler");
@@ -398,6 +402,8 @@ export class AutoRefreshScheduler {
 				// bug 2). Mirrors the existing x-better-ccflare-keepalive
 				// pattern used by cache-keepalive-scheduler.ts.
 				"x-better-ccflare-auto-refresh": "true",
+				[INTERNAL_PROBE_SECRET_HEADER]:
+					this.proxyContext.internalProbeSecret ?? "",
 			});
 
 			// Try sending with multiple models if needed

--- a/packages/proxy/src/cache-body-store.ts
+++ b/packages/proxy/src/cache-body-store.ts
@@ -88,6 +88,7 @@ const STRIP_HEADERS = new Set([
 	"x-better-ccflare-bypass-session",
 	"x-better-ccflare-skip-cache",
 	"x-better-ccflare-keepalive",
+	"x-better-ccflare-internal-probe-secret",
 	"content-length",
 	"transfer-encoding",
 	"accept-encoding",

--- a/packages/proxy/src/cache-keepalive-scheduler.ts
+++ b/packages/proxy/src/cache-keepalive-scheduler.ts
@@ -3,6 +3,7 @@ import type { Config } from "@better-ccflare/config";
 import { registerHeartbeat } from "@better-ccflare/core";
 import { Logger } from "@better-ccflare/logger";
 import { cacheBodyStore } from "./cache-body-store";
+import { INTERNAL_PROBE_SECRET_HEADER } from "./handlers";
 import type { ProxyContext } from "./proxy";
 
 const log = new Logger("CacheKeepaliveScheduler");
@@ -131,6 +132,10 @@ export class CacheKeepaliveScheduler {
 			//  1. Visibility: request logger can identify synthetic requests
 			//  2. Loop prevention: proxy skips staging to avoid infinite replay cycle
 			replayHeaders.set("x-better-ccflare-keepalive", "true");
+			replayHeaders.set(
+				INTERNAL_PROBE_SECRET_HEADER,
+				this.proxyContext.internalProbeSecret ?? "",
+			);
 			const proxyPort = this.proxyContext.runtime.port;
 			const protocol =
 				process.env.SSL_KEY_PATH && process.env.SSL_CERT_PATH

--- a/packages/proxy/src/handlers/__tests__/proxy-operations-failover.test.ts
+++ b/packages/proxy/src/handlers/__tests__/proxy-operations-failover.test.ts
@@ -98,6 +98,7 @@ function makeProxyContext(): ProxyContext {
 		refreshInFlight: new Map(),
 		asyncWriter: { enqueue: mock(() => {}) } as never,
 		config: { getStorePayloads: () => true } as never,
+		internalProbeSecret: "test-secret",
 	};
 }
 
@@ -1115,6 +1116,7 @@ describe("proxyWithAccount — 529 in-place retry", () => {
 			headers: {
 				"Content-Type": "application/json",
 				"x-better-ccflare-keepalive": "true",
+				"x-better-ccflare-internal-probe-secret": "test-secret",
 			},
 		});
 		await proxyWithAccount(

--- a/packages/proxy/src/handlers/__tests__/proxy-operations-out-of-credits.test.ts
+++ b/packages/proxy/src/handlers/__tests__/proxy-operations-out-of-credits.test.ts
@@ -108,6 +108,7 @@ function makeProxyContextWithAsyncExec(): ProxyContext {
 			}),
 		} as never,
 		config: { getStorePayloads: () => true } as never,
+		internalProbeSecret: "test-secret",
 	};
 }
 
@@ -208,6 +209,7 @@ describe("proxyWithAccount — out_of_credits (issue #261)", () => {
 			headers: {
 				"Content-Type": "application/json",
 				"x-better-ccflare-keepalive": "true",
+				"x-better-ccflare-internal-probe-secret": "test-secret",
 			},
 		});
 

--- a/packages/proxy/src/handlers/__tests__/request-handler-strip-headers.test.ts
+++ b/packages/proxy/src/handlers/__tests__/request-handler-strip-headers.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { makeProxyRequest } from "../request-handler";
+
+/**
+ * Regression for tombii#336 / Greptile P1 "Probe Secret Reaches Provider Path":
+ * the internal probe secret (and the marker headers it gates) must be stripped
+ * before the request is forwarded upstream, so a provider or custom endpoint
+ * never receives the process-local capability secret.
+ */
+describe("makeProxyRequest strips internal control headers before provider forward", () => {
+	let realFetch: typeof globalThis.fetch;
+	let sentHeaders: Headers | undefined;
+
+	beforeEach(() => {
+		realFetch = globalThis.fetch;
+		sentHeaders = undefined;
+		globalThis.fetch = mock(async (input: unknown, init?: RequestInit) => {
+			sentHeaders =
+				input instanceof Request
+					? new Headers(input.headers)
+					: new Headers(init?.headers);
+			return new Response("ok", { status: 200 });
+		}) as unknown as typeof globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = realFetch;
+	});
+
+	it("does not forward the probe secret or markers on the headers-param path", async () => {
+		const headers = new Headers({
+			"x-better-ccflare-internal-probe-secret": "s3cr3t",
+			"x-better-ccflare-auto-refresh": "true",
+			"x-better-ccflare-keepalive": "true",
+			authorization: "Bearer token",
+			"content-type": "application/json",
+		});
+		await makeProxyRequest(
+			"https://api.anthropic.com/v1/messages",
+			"POST",
+			headers,
+			undefined,
+			false,
+		);
+		expect(
+			sentHeaders?.get("x-better-ccflare-internal-probe-secret"),
+		).toBeNull();
+		expect(sentHeaders?.get("x-better-ccflare-auto-refresh")).toBeNull();
+		expect(sentHeaders?.get("x-better-ccflare-keepalive")).toBeNull();
+		// unrelated headers still forwarded
+		expect(sentHeaders?.get("authorization")).toBe("Bearer token");
+		expect(sentHeaders?.get("content-type")).toBe("application/json");
+	});
+
+	it("does not forward the probe secret on the Request-target path", async () => {
+		const req = new Request("https://api.anthropic.com/v1/messages", {
+			method: "POST",
+			headers: {
+				"x-better-ccflare-internal-probe-secret": "s3cr3t",
+				"x-better-ccflare-keepalive": "true",
+				authorization: "Bearer token",
+			},
+		});
+		await makeProxyRequest(req);
+		expect(
+			sentHeaders?.get("x-better-ccflare-internal-probe-secret"),
+		).toBeNull();
+		expect(sentHeaders?.get("x-better-ccflare-keepalive")).toBeNull();
+		expect(sentHeaders?.get("authorization")).toBe("Bearer token");
+	});
+});

--- a/packages/proxy/src/handlers/__tests__/response-processor.test.ts
+++ b/packages/proxy/src/handlers/__tests__/response-processor.test.ts
@@ -150,6 +150,7 @@ function makeCtxWithReason(opts: {
 				void job();
 			},
 		},
+		internalProbeSecret: "test-secret",
 	} as unknown as ProxyContext;
 
 	return { ctx, calls };
@@ -425,7 +426,10 @@ describe("processProxyResponse — 529 overload reason", () => {
 			},
 		);
 		const requestMeta = {
-			headers: new Headers({ "x-better-ccflare-keepalive": "true" }),
+			headers: new Headers({
+				"x-better-ccflare-keepalive": "true",
+				"x-better-ccflare-internal-probe-secret": "test-secret",
+			}),
 		};
 
 		await processProxyResponse(response, account, ctx, undefined, requestMeta);

--- a/packages/proxy/src/handlers/index.ts
+++ b/packages/proxy/src/handlers/index.ts
@@ -34,7 +34,13 @@ export {
 	proxyUnauthenticated,
 	proxyWithAccount,
 } from "./proxy-operations";
-export { ERROR_MESSAGES, type ProxyContext, TIMING } from "./proxy-types";
+export {
+	ERROR_MESSAGES,
+	INTERNAL_PROBE_SECRET_HEADER,
+	isInternalProbe,
+	type ProxyContext,
+	TIMING,
+} from "./proxy-types";
 export {
 	createRequestMetadata,
 	prepareRequestBody,

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -26,7 +26,11 @@ import { RequestBodyContext } from "../request-body-context";
 import { forwardToClient } from "../response-handler";
 import { isModelRewrite } from "../worker-messages";
 import { markFamilyExhausted } from "./model-capacity";
-import { ERROR_MESSAGES, type ProxyContext } from "./proxy-types";
+import {
+	ERROR_MESSAGES,
+	isInternalProbe,
+	type ProxyContext,
+} from "./proxy-types";
 import { applyRateLimitCooldown } from "./rate-limit-cooldown";
 import { makeProxyRequest, validateProviderPath } from "./request-handler";
 import { handleProxyError, processProxyResponse } from "./response-processor";
@@ -588,12 +592,7 @@ export async function proxyWithAccount(
 		//   - auto-refresh probes — same loop-prevention concern, plus these
 		//     hit known-cooled accounts and shouldn't pollute the staged-body cache
 		//     (issue #199, bug 2).
-		// Both checks are truthy (not strict-equality) to preserve the original
-		// keepalive guard's behaviour: any non-empty header value triggers the
-		// skip, matching what `!req.headers.get(...)` returned before.
-		const isSyntheticInternal =
-			!!req.headers.get("x-better-ccflare-keepalive") ||
-			!!req.headers.get("x-better-ccflare-auto-refresh");
+		const isSyntheticInternal = isInternalProbe(req.headers, ctx);
 		if (!isSyntheticInternal) {
 			cacheBodyStore.stageRequest(
 				requestMeta.id,
@@ -891,8 +890,7 @@ export async function proxyWithAccount(
 					}
 				}
 
-				const isKeepalive =
-					req.headers.get("x-better-ccflare-keepalive") === "true";
+				const isKeepalive = isInternalProbe(req.headers, ctx, "keepalive");
 				if (isKeepalive) {
 					return null;
 				}
@@ -948,8 +946,7 @@ export async function proxyWithAccount(
 						// account at the same instant. Applying real cooldowns
 						// here drains the pool to zero routable accounts even
 						// though no real user-facing rate limit was hit.
-						const isKeepalive =
-							req.headers.get("x-better-ccflare-keepalive") === "true";
+						const isKeepalive = isInternalProbe(req.headers, ctx, "keepalive");
 						if (isKeepalive) {
 							log.warn(
 								`Keepalive replay for ${account.name} got 429 — skipping cooldown (synthetic burst, not a real per-account rate limit)`,
@@ -1097,8 +1094,7 @@ export async function proxyWithAccount(
 					// Same keepalive-skip as the no-fallback path above: synthetic
 					// keepalive bursts can trip Anthropic's per-IP limit even when
 					// individual accounts are healthy.
-					const isKeepalive =
-						req.headers.get("x-better-ccflare-keepalive") === "true";
+					const isKeepalive = isInternalProbe(req.headers, ctx, "keepalive");
 					if (isKeepalive) {
 						log.warn(
 							`Keepalive replay for ${account.name} got 429 (post-model-list) — skipping cooldown`,

--- a/packages/proxy/src/handlers/proxy-types.ts
+++ b/packages/proxy/src/handlers/proxy-types.ts
@@ -14,6 +14,7 @@ export interface ProxyContext {
 	provider: Provider;
 	refreshInFlight: Map<string, Promise<string>>;
 	asyncWriter: AsyncDbWriter;
+	internalProbeSecret?: string;
 }
 
 /** Error messages used throughout the proxy module */
@@ -39,3 +40,29 @@ export const HEADERS = {
 	CONTENT_TYPE: "Content-Type",
 	AUTHORIZATION: "Authorization",
 } as const;
+
+/** Header carrying the process-local secret that gates internal-probe markers */
+export const INTERNAL_PROBE_SECRET_HEADER =
+	"x-better-ccflare-internal-probe-secret";
+
+/**
+ * Determines whether a request is a legitimate internal probe (auto-refresh
+ * or cache-keepalive) rather than an external client forging the marker
+ * headers. Requires the process-local secret to match in addition to the
+ * marker header(s).
+ */
+export function isInternalProbe(
+	headers: Headers | null | undefined,
+	ctx: Pick<ProxyContext, "internalProbeSecret">,
+	marker: "auto-refresh" | "keepalive" | "any" = "any",
+): boolean {
+	if (!headers || !ctx.internalProbeSecret) return false;
+	if (headers.get(INTERNAL_PROBE_SECRET_HEADER) !== ctx.internalProbeSecret)
+		return false;
+	const hasAutoRefresh =
+		headers.get("x-better-ccflare-auto-refresh") === "true";
+	const hasKeepalive = headers.get("x-better-ccflare-keepalive") === "true";
+	if (marker === "auto-refresh") return hasAutoRefresh;
+	if (marker === "keepalive") return hasKeepalive;
+	return hasAutoRefresh || hasKeepalive;
+}

--- a/packages/proxy/src/handlers/request-handler.ts
+++ b/packages/proxy/src/handlers/request-handler.ts
@@ -3,7 +3,19 @@ import { TIME_CONSTANTS, ValidationError } from "@better-ccflare/core";
 import type { Provider } from "@better-ccflare/providers";
 import type { RequestMeta } from "@better-ccflare/types";
 import { chatGptCloudflareCookieJar } from "../chatgpt-cloudflare-cookies";
-import { ERROR_MESSAGES } from "./proxy-types";
+import { ERROR_MESSAGES, INTERNAL_PROBE_SECRET_HEADER } from "./proxy-types";
+
+/**
+ * Internal proxy control headers that must NEVER be forwarded to the upstream
+ * provider: they gate privileged proxy behaviour (see isInternalProbe), and a
+ * provider or custom endpoint that received them — the probe secret above all —
+ * could replay them with a marker to forge privileged requests.
+ */
+function stripInternalControlHeaders(headers: Headers): void {
+	headers.delete(INTERNAL_PROBE_SECRET_HEADER);
+	headers.delete("x-better-ccflare-auto-refresh");
+	headers.delete("x-better-ccflare-keepalive");
+}
 
 /**
  * Creates request metadata for tracking and analytics
@@ -99,6 +111,7 @@ export async function makeProxyRequest(
 		if (target instanceof Request) {
 			const targetUrl = target.url;
 			const mutableHeaders = new Headers(target.headers);
+			stripInternalControlHeaders(mutableHeaders);
 			chatGptCloudflareCookieJar.applyCookieHeader(targetUrl, mutableHeaders);
 
 			const response = await fetch(
@@ -112,6 +125,7 @@ export async function makeProxyRequest(
 		}
 
 		const mutableHeaders = new Headers(headers);
+		stripInternalControlHeaders(mutableHeaders);
 		chatGptCloudflareCookieJar.applyCookieHeader(target, mutableHeaders);
 
 		const response = await fetch(target, {

--- a/packages/proxy/src/handlers/response-processor.ts
+++ b/packages/proxy/src/handlers/response-processor.ts
@@ -6,7 +6,7 @@ import {
 	usageCache,
 } from "@better-ccflare/providers";
 import type { Account, RateLimitReason } from "@better-ccflare/types";
-import type { ProxyContext } from "./proxy-types";
+import { isInternalProbe, type ProxyContext } from "./proxy-types";
 import {
 	applyRateLimitCooldown,
 	completeRateLimitProbe,
@@ -289,8 +289,7 @@ export async function processProxyResponse(
 		// pool to zero routable accounts even though no user-visible quota
 		// was actually exhausted. Loop-prevention header set by
 		// cache-keepalive-scheduler.ts; only synthetic replays carry it.
-		const isKeepalive =
-			requestMeta?.headers?.get("x-better-ccflare-keepalive") === "true";
+		const isKeepalive = isInternalProbe(requestMeta?.headers, ctx, "keepalive");
 		if (isKeepalive) {
 			log.warn(
 				`Keepalive replay for ${account.name} got ${response.status} — skipping cooldown (synthetic burst, not a real per-account rate limit)`,

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -18,6 +18,7 @@ import {
 	getModelFamilyExhaustionInfo,
 	getUsageThrottleUntil,
 	interceptAndModifyRequest,
+	isInternalProbe,
 	isRefreshTokenLikelyExpired,
 	type ProxyContext,
 	prepareRequestBody,
@@ -255,9 +256,7 @@ export async function handleProxy(
 		// endpoint failure and counts it toward its consecutive-failure pause
 		// threshold (recordRefreshFailure), auto-pausing a healthy account the
 		// instant its usage window resets and the scheduler re-probes it.
-		const isSyntheticProbe =
-			req.headers.get("x-better-ccflare-auto-refresh") === "true" ||
-			req.headers.get("x-better-ccflare-keepalive") === "true";
+		const isSyntheticProbe = isInternalProbe(req.headers, ctx);
 		if (isSyntheticProbe) {
 			return { available: accounts, throttled: [] as Account[] };
 		}
@@ -356,8 +355,11 @@ export async function handleProxy(
 		// reflecting any real client impact (issue #199, bug 2). The keepalive
 		// scheduler already gets the equivalent treatment via its loop-prevention
 		// header path; this brings auto-refresh in line.
-		const isAutoRefreshProbe =
-			req.headers.get("x-better-ccflare-auto-refresh") === "true";
+		const isAutoRefreshProbe = isInternalProbe(
+			req.headers,
+			ctx,
+			"auto-refresh",
+		);
 		if (!isAutoRefreshProbe) {
 			// Log to request history via usage collector
 			getUsageCollector().handleStart({

--- a/packages/proxy/src/response-handler.ts
+++ b/packages/proxy/src/response-handler.ts
@@ -14,7 +14,7 @@ import {
 	ANTHROPIC_TERMINAL_RECOVERY_GRACE_MS,
 	createAnthropicTerminalRecoveryStream,
 } from "./anthropic-terminal-recovery";
-import type { ProxyContext } from "./handlers";
+import { isInternalProbe, type ProxyContext } from "./handlers";
 import { applyRateLimitCooldown } from "./handlers/rate-limit-cooldown";
 import { createSseRateLimitSniffer } from "./handlers/sse-rate-limit-sniffer";
 import { ingestModelsListing } from "./model-catalog";
@@ -165,8 +165,11 @@ export async function forwardToClient(
 	//     pollutes the user-visible 503/200 metrics on the dashboard with
 	//     internal scheduler activity. Header set by AutoRefreshScheduler
 	//     mirrors the existing keepalive pattern.
-	const isAutoRefreshProbe =
-		requestHeaders.get("x-better-ccflare-auto-refresh") === "true";
+	const isAutoRefreshProbe = isInternalProbe(
+		requestHeaders,
+		ctx,
+		"auto-refresh",
+	);
 	const isSyntheticCountTokens =
 		path === "/v1/messages/count_tokens" &&
 		(ctx.provider.name === "openai-compatible" ||


### PR DESCRIPTION
Closes #335.

## Root Cause
The internal-probe markers `x-better-ccflare-auto-refresh` and `x-better-ccflare-keepalive` were trusted from any client. They gate several privileged behaviours, so a forged marker on a normal `/v1/messages` request let an authenticated client:
- **bypass usage-throttling** (`proxy.ts` — the originally-flagged site), and
- **suppress per-account rate-limit cooldowns** (`response-processor.ts`, and the no-fallback / all-models-exhausted 429 branches in `proxy-operations.ts`) and **the 529 in-place retry safety net** (`proxy-operations.ts`) — i.e. keep an exhausted account routable for *all* users, or knock a healthy one out of rotation with a single 529.

## The Fix
- Mint a process-local secret (`crypto.randomUUID()`) once at startup, thread it through `ProxyContext`, and attach it (a new `x-better-ccflare-internal-probe-secret` header) **only** on the two schedulers' own loopback probes.
- New `isInternalProbe(headers, ctx, marker)` helper requires the secret to match **in addition to** the marker; every read-site now goes through it (privilege sites gated; benign telemetry/logging sites converted too, so no marker-only check remains). Fails closed.
- **Leak prevention:** `sanitizeRequestHeaders` and the cache-body-store `STRIP_HEADERS` drop the secret, so it never lands in request history / the dashboard.
- Behaviour is unchanged when throttling is off (the outer guard short-circuits before the check) and for the schedulers' own probes (they carry the secret).

## Validation
New regression tests in `auto-refresh-throttle-exemption.test.ts`: a forged marker **without** the secret — and with a **wrong** secret — stays throttled (529); a probe **with** the matching secret is exempted; plus a non-probe control. These assert `529` where unpatched `main` returns `200`. `typecheck` + `lint` clean; `bun test packages/proxy` shows 0 regressions vs the `bff80105` baseline (+3 net new passing). 5 existing tests that exercised the real code paths with bare markers were updated to carry the secret.

## Note
The secret is compared with `!==` (not constant-time). For a random 128-bit secret over HTTP on a single-process self-hosted proxy, timing extraction is impractical — happy to switch to `timingSafeEqual` if you'd prefer.

## Out of scope (forward lead)
While auditing I found `x-better-ccflare-bypass-session` + `x-better-ccflare-account-id` (`account-selector.ts`) grant a comparable client-forgeable bypass (reaching an overage-paused / rate-limited account). Left untouched here since it's outside the two markers #335 tracks — flagging for a separate scope decision.
