### PR TITLE
fix: detect and record premature SSE termination for all Anthropic-Messages-shaped streams

### DIFF
--- a/packages/database/src/database-operations.ts
+++ b/packages/database/src/database-operations.ts
@@ -958,6 +958,13 @@ OAuth tokens will need to be re-authenticated.
 		appliedModel?: string | null,
 		projectAttributionSource?: ProjectAttributionSource | null,
 		agentAttributionSource?: AgentAttributionSource | null,
+		streamTerminalState?:
+			| "complete"
+			| "recovered"
+			| "error"
+			| "truncated"
+			| "client_cancelled"
+			| null,
 	): Promise<void> {
 		await withDatabaseRetry(
 			() =>
@@ -982,6 +989,7 @@ OAuth tokens will need to be re-authenticated.
 					appliedModel,
 					projectAttributionSource,
 					agentAttributionSource,
+					streamTerminalState,
 				}),
 			this.retryConfig,
 			"saveRequest",

--- a/packages/database/src/migrations-pg.ts
+++ b/packages/database/src/migrations-pg.ts
@@ -120,7 +120,8 @@ export async function ensureSchemaPg(adapter: BunSqlAdapter): Promise<void> {
 			original_model TEXT,
 			applied_model TEXT,
 			project_attribution_source TEXT,
-			agent_attribution_source TEXT
+			agent_attribution_source TEXT,
+			stream_terminal_state TEXT
 		)
 	`);
 
@@ -501,6 +502,18 @@ export async function runMigrationsPg(adapter: BunSqlAdapter): Promise<void> {
 			column: "agent_attribution_source",
 			definition:
 				"ALTER TABLE requests ADD COLUMN agent_attribution_source TEXT",
+		},
+		{
+			// Real SSE termination state for Anthropic-Messages-shaped
+			// streaming responses — see packages/proxy/src/anthropic-terminal-recovery.ts
+			// for the producer side. One of "complete" | "recovered" | "error"
+			// | "truncated" | "client_cancelled" | NULL. NULL for non-streaming
+			// responses or streams not wrapped by the terminal-recovery
+			// observer. Production runs Postgres, so a sqlite-only migration
+			// would silently no-op here — both backends must be updated.
+			table: "requests",
+			column: "stream_terminal_state",
+			definition: "ALTER TABLE requests ADD COLUMN stream_terminal_state TEXT",
 		},
 		{
 			table: "request_payloads",

--- a/packages/database/src/migrations.ts
+++ b/packages/database/src/migrations.ts
@@ -156,7 +156,8 @@ export function ensureSchema(db: Database): void {
 			original_model TEXT,
 			applied_model TEXT,
 			project_attribution_source TEXT,
-			agent_attribution_source TEXT
+			agent_attribution_source TEXT,
+			stream_terminal_state TEXT
 		)
 	`);
 
@@ -972,6 +973,21 @@ export function runMigrations(db: Database, dbPath?: string): void {
 				"ALTER TABLE requests ADD COLUMN agent_attribution_source TEXT",
 			).run();
 			log.info("Added agent_attribution_source column to requests table");
+		}
+
+		// Add stream_terminal_state column if it doesn't exist
+		// Real SSE termination state for Anthropic-Messages-shaped streaming
+		// responses — distinct from the header-only `success` bit. One of
+		// "complete" | "recovered" | "error" | "truncated" | NULL. Persisted
+		// so operators can distinguish a synthetically-terminated stream
+		// (recovered) or a TCP-close mid-content (truncated) from a clean
+		// completion (complete). NULL for non-streaming responses or streams
+		// that were not wrapped by the terminal-recovery observer.
+		if (!requestsColumnNames.includes("stream_terminal_state")) {
+			db.prepare(
+				"ALTER TABLE requests ADD COLUMN stream_terminal_state TEXT",
+			).run();
+			log.info("Added stream_terminal_state column to requests table");
 		}
 
 		// Add timestamp column to request_payloads if it doesn't exist

--- a/packages/database/src/repositories/request.repository.ts
+++ b/packages/database/src/repositories/request.repository.ts
@@ -85,6 +85,20 @@ export interface RequestData {
 	appliedModel?: string | null;
 	projectAttributionSource?: ProjectAttributionSource | null;
 	agentAttributionSource?: AgentAttributionSource | null;
+	/**
+	 * Real SSE termination state for Anthropic-Messages-shaped streams. One of
+	 * "complete" | "recovered" | "error" | "truncated" | "client_cancelled" |
+	 * null/undefined. Undefined/null for non-streaming responses or streams
+	 * not wrapped by the terminal-recovery observer. See
+	 * packages/proxy/src/anthropic-terminal-recovery.ts for the producer.
+	 */
+	streamTerminalState?:
+		| "complete"
+		| "recovered"
+		| "error"
+		| "truncated"
+		| "client_cancelled"
+		| null;
 	usage?: {
 		model?: string;
 		promptTokens?: number;
@@ -128,9 +142,10 @@ export class RequestRepository extends BaseRepository<RequestData> {
 				input_tokens, cache_read_input_tokens, cache_creation_input_tokens, output_tokens,
 				agent_used, output_tokens_per_second, api_key_id, api_key_name, project,
 				billing_type, combo_name, original_model, applied_model,
-				project_attribution_source, agent_attribution_source
+				project_attribution_source, agent_attribution_source,
+				stream_terminal_state
 			)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			ON CONFLICT (id) DO UPDATE SET
 				timestamp = EXCLUDED.timestamp,
 				method = EXCLUDED.method,
@@ -168,7 +183,13 @@ export class RequestRepository extends BaseRepository<RequestData> {
 				project = CASE WHEN ${projectWinsIncoming} THEN EXCLUDED.project ELSE requests.project END,
 				project_attribution_source = CASE WHEN ${projectWinsIncoming} THEN EXCLUDED.project_attribution_source ELSE requests.project_attribution_source END,
 				agent_used = CASE WHEN ${agentWinsIncoming} THEN EXCLUDED.agent_used ELSE requests.agent_used END,
-				agent_attribution_source = CASE WHEN ${agentWinsIncoming} THEN EXCLUDED.agent_attribution_source ELSE requests.agent_attribution_source END
+				agent_attribution_source = CASE WHEN ${agentWinsIncoming} THEN EXCLUDED.agent_attribution_source ELSE requests.agent_attribution_source END,
+				-- stream_terminal_state uses preserve-first (COALESCE) — a later
+				-- re-finalization (e.g. updateUsage after handleEnd) shouldn't
+				-- blank out the real SSE termination state the handleEnd path
+				-- recorded. A null incoming value means "I have nothing new",
+				-- not "the stream was clean".
+				stream_terminal_state = COALESCE(EXCLUDED.stream_terminal_state, requests.stream_terminal_state)
 		`,
 			[
 				data.id,
@@ -201,6 +222,7 @@ export class RequestRepository extends BaseRepository<RequestData> {
 				data.appliedModel || null,
 				data.projectAttributionSource || null,
 				data.agentAttributionSource || null,
+				data.streamTerminalState ?? null,
 			],
 		);
 	}

--- a/packages/proxy/src/__tests__/anthropic-terminal-recovery.test.ts
+++ b/packages/proxy/src/__tests__/anthropic-terminal-recovery.test.ts
@@ -717,4 +717,30 @@ describe("createAnthropicTerminalRecoveryStream", () => {
 		expect(onTerminalState).toHaveBeenCalledTimes(1);
 		expect(onTerminalState).toHaveBeenCalledWith("complete");
 	});
+
+	it("emits 'error' via onTerminalState when upstream reader rejects mid-stream", async () => {
+		// Transport/stream-level rejection from upstream (e.g. connection
+		// reset, AbortError from upstream cancellation, fetch failure)
+		// must be classified as "error", NOT "truncated". A premature EOF
+		// looks similar on the wire (no message_stop, no error event) but
+		// carries no failure signal in-band — only a clean mid-content TCP
+		// close. The whole point of the stream_terminal_state column is
+		// to distinguish these two failure modes so an explicit upstream
+		// error isn't recorded as a silent truncation.
+		const source = controllableStream();
+		const onTerminalState = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(source.stream, {
+			gracePeriodMs: 20,
+			onTerminalState,
+		});
+		const reader = body.getReader();
+
+		source.controller().enqueue(bytes(terminalDelta));
+		await expect(reader.read()).resolves.toMatchObject({ done: false });
+		source.controller().error(new Error("upstream connection reset"));
+
+		await expect(reader.read()).rejects.toThrow("upstream connection reset");
+		expect(onTerminalState).toHaveBeenCalledTimes(1);
+		expect(onTerminalState).toHaveBeenCalledWith("error");
+	});
 });

--- a/packages/proxy/src/__tests__/anthropic-terminal-recovery.test.ts
+++ b/packages/proxy/src/__tests__/anthropic-terminal-recovery.test.ts
@@ -630,4 +630,91 @@ describe("createAnthropicTerminalRecoveryStream", () => {
 		expect(onCancelError).toHaveBeenCalledTimes(1);
 		expect(onCancelError).toHaveBeenCalledWith(cancelError, "timeout");
 	});
+
+	it("emits 'client_cancelled' via onTerminalState when downstream cancels before terminal events", async () => {
+		// Claude Code cancels streams routinely (Esc, tool interrupts).
+		// The wrapper must classify client-side cancellation distinctly
+		// from upstream failure or truncation, so response-handler can
+		// preserve the prior header-based success and avoid poisoning the
+		// success-rate metrics.
+		const source = controllableStream();
+		const onTerminalState = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(source.stream, {
+			gracePeriodMs: 50,
+			onTerminalState,
+		});
+		const reader = body.getReader();
+
+		source.controller().enqueue(bytes(terminalDelta));
+		await expect(reader.read()).resolves.toMatchObject({ done: false });
+		await reader.cancel("client disconnect");
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(onTerminalState).toHaveBeenCalledTimes(1);
+		expect(onTerminalState).toHaveBeenCalledWith("client_cancelled");
+	});
+
+	it("emits 'client_cancelled' even when no SSE events were observed", async () => {
+		// Cancelling before any bytes flow should still classify as
+		// client_cancelled, not truncated — disambiguates "client
+		// disconnected" from "upstream TCP closed mid-content".
+		const source = controllableStream();
+		const onTerminalState = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(source.stream, {
+			gracePeriodMs: 50,
+			onTerminalState,
+		});
+		const reader = body.getReader();
+
+		await reader.cancel("client disconnect");
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(onTerminalState).toHaveBeenCalledTimes(1);
+		expect(onTerminalState).toHaveBeenCalledWith("client_cancelled");
+	});
+
+	it("emits 'truncated' via onTerminalState when upstream EOF lands without a stop_reason", async () => {
+		// Mirrors the ccproxy2/anthropic 8-second 200 with 0 output tokens:
+		// stream closed mid-content with no terminal event ever observed.
+		const original =
+			'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n' +
+			'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}\n\n' +
+			'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n';
+		const onTerminalState = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(
+			immediateStream([bytes(original)]),
+			{ gracePeriodMs: 5, onTerminalState },
+		);
+
+		await expect(new Response(body).text()).resolves.toBe(original);
+		expect(onTerminalState).toHaveBeenCalledTimes(1);
+		expect(onTerminalState).toHaveBeenCalledWith("truncated");
+	});
+
+	it("emits 'recovered' via onTerminalState when stop_reason lands but message_stop never arrives", async () => {
+		const onTerminalState = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(
+			immediateStream([bytes(terminalDelta)]),
+			{ gracePeriodMs: 50, onTerminalState },
+		);
+
+		await expect(new Response(body).text()).resolves.toBe(
+			`${terminalDelta}${ANTHROPIC_MESSAGE_STOP_FRAME}`,
+		);
+		expect(onTerminalState).toHaveBeenCalledTimes(1);
+		expect(onTerminalState).toHaveBeenCalledWith("recovered");
+	});
+
+	it("emits 'complete' via onTerminalState when both stop_reason and message_stop are observed", async () => {
+		const onTerminalState = mock(() => undefined);
+		const original = `${terminalDelta}${messageStop}`;
+		const body = createAnthropicTerminalRecoveryStream(
+			immediateStream([bytes(original)]),
+			{ gracePeriodMs: 5, onTerminalState },
+		);
+
+		await expect(new Response(body).text()).resolves.toBe(original);
+		expect(onTerminalState).toHaveBeenCalledTimes(1);
+		expect(onTerminalState).toHaveBeenCalledWith("complete");
+	});
 });

--- a/packages/proxy/src/__tests__/response-handler-anthropic-terminal-recovery.test.ts
+++ b/packages/proxy/src/__tests__/response-handler-anthropic-terminal-recovery.test.ts
@@ -160,22 +160,33 @@ describe("forwardToClient Anthropic terminal recovery integration", () => {
 		}
 	});
 
-	it("leaves non-native, non-Anthropic, and non-Messages streams unchanged", async () => {
+	it("leaves non-Messages streams unchanged", async () => {
+		// Native anthropic was previously the only provider gated into the
+		// recovery wrapper. Generalization: the gate is now path+content-type+status
+		// only, so any anthropic-compatible provider speaking the same wire
+		// format (e.g. minimax) on /v1/messages with text/event-stream also
+		// gets the recovery synthesis. Non-Messages paths still bypass.
 		const filteredHeaders = new Headers({
 			"x-better-ccflare-auto-refresh": "true",
 		});
 		const nativeHeaders = new Headers(filteredHeaders);
 		nativeHeaders.set("anthropic-version", "2023-06-01");
 
+		// Missing anthropic-version header on native anthropic still gets
+		// recovery — the header is no longer part of the gate.
 		await expect(
 			forwardClosedStream({ requestHeaders: filteredHeaders }),
-		).resolves.toBe(terminalDelta);
+		).resolves.toBe(`${terminalDelta}${ANTHROPIC_MESSAGE_STOP_FRAME}`);
+		// anthropic-compatible on /v1/messages SSE: now enters the wrapper
+		// and synthesizes the closing message_stop. Previously this was
+		// silent-stream-truncation on minimax.
 		await expect(
 			forwardClosedStream({
 				requestHeaders: nativeHeaders,
 				providerName: "anthropic-compatible",
 			}),
-		).resolves.toBe(terminalDelta);
+		).resolves.toBe(`${terminalDelta}${ANTHROPIC_MESSAGE_STOP_FRAME}`);
+		// /v1/complete is a non-Messages path: still passthrough.
 		await expect(
 			forwardClosedStream({
 				requestHeaders: nativeHeaders,
@@ -202,5 +213,227 @@ describe("forwardToClient Anthropic terminal recovery integration", () => {
 				contentType: "application/json",
 			}),
 		).resolves.toBe(terminalDelta);
+	});
+});
+
+describe("forwardToClient SSE terminal-state propagation", () => {
+	function makeContentOnlyStream(): ReadableStream<Uint8Array> {
+		// Mid-content only — no terminal message_delta, no message_stop.
+		// Mirrors the ccmax/minimax IncompleteRead signature where bytes
+		// flow then the upstream TCP closes before any stop_reason lands.
+		const content =
+			'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n' +
+			'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}\n\n' +
+			'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n';
+		return immediateStream(bytes(content));
+	}
+
+	it("records success:false and state=truncated when SSE closes without any terminal event", async () => {
+		// Reproduces the header-only-success bug: a 200 OK with truncated
+		// content used to be silently recorded as success. The recovery
+		// wrapper now classifies it as "truncated" and response-handler
+		// records success:false.
+		const ends: Array<Record<string, unknown>> = [];
+		const collector = {
+			handleStart: mock(() => undefined),
+			handleChunk: mock(() => undefined),
+			handleEnd: mock((message: Record<string, unknown>) => {
+				ends.push(message);
+				return Promise.resolve();
+			}),
+		};
+		const collectorSpy = spyOn(
+			usageCollectorModule,
+			"getUsageCollector",
+		).mockReturnValue(
+			collector as unknown as usageCollectorModule.UsageCollector,
+		);
+
+		try {
+			const requestId = "truncated-request";
+			const response = await forwardToClient(
+				{
+					requestId,
+					method: "POST",
+					path: "/v1/messages",
+					account: null,
+					requestHeaders: new Headers({
+						"anthropic-version": "2023-06-01",
+					}),
+					requestBody: bytes("{}"),
+					response: new Response(makeContentOnlyStream(), {
+						status: 200,
+						headers: { "content-type": "text/event-stream" },
+					}),
+					timestamp: Date.now(),
+					retryAttempt: 0,
+					failoverAttempts: 0,
+				},
+				nativeAnthropicCtx(),
+			);
+
+			await expect(response.text()).resolves.toBe(
+				'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n' +
+					'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}\n\n' +
+					'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+			);
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(ends).toEqual([
+				expect.objectContaining({
+					requestId,
+					success: false,
+					error: "stream_truncated_mid_content",
+					streamTerminalState: "truncated",
+					type: "end",
+				}),
+			]);
+		} finally {
+			collectorSpy.mockRestore();
+		}
+	});
+
+	it("records state=truncated for anthropic-compatible providers (minimax coverage)", async () => {
+		// The original bug only affected provider.name !== "anthropic".
+		// Generalization: any provider on /v1/messages with SSE content-type
+		// gets the same detection. Verifies minimax-shaped providers
+		// surface the truncated state too.
+		const ends: Array<Record<string, unknown>> = [];
+		const collector = {
+			handleStart: mock(() => undefined),
+			handleChunk: mock(() => undefined),
+			handleEnd: mock((message: Record<string, unknown>) => {
+				ends.push(message);
+				return Promise.resolve();
+			}),
+		};
+		const collectorSpy = spyOn(
+			usageCollectorModule,
+			"getUsageCollector",
+		).mockReturnValue(
+			collector as unknown as usageCollectorModule.UsageCollector,
+		);
+
+		try {
+			const requestId = "truncated-anthropic-compatible";
+			const response = await forwardToClient(
+				{
+					requestId,
+					method: "POST",
+					path: "/v1/messages",
+					account: null,
+					// Notably NO anthropic-version header — the gate no longer
+					// requires it.
+					requestHeaders: new Headers({}),
+					requestBody: bytes("{}"),
+					response: new Response(makeContentOnlyStream(), {
+						status: 200,
+						headers: { "content-type": "text/event-stream" },
+					}),
+					timestamp: Date.now(),
+					retryAttempt: 0,
+					failoverAttempts: 0,
+				},
+				nativeAnthropicCtx("anthropic-compatible"),
+			);
+
+			await expect(response.text()).resolves.toBe(
+				'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n' +
+					'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}\n\n' +
+					'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+			);
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(ends).toEqual([
+				expect.objectContaining({
+					requestId,
+					success: false,
+					error: "stream_truncated_mid_content",
+					streamTerminalState: "truncated",
+					type: "end",
+				}),
+			]);
+		} finally {
+			collectorSpy.mockRestore();
+		}
+	});
+
+	it("preserves success:true and records state=client_cancelled when the client disconnects mid-stream", async () => {
+		// Claude Code cancels streams routinely (Esc, tool interrupts,
+		// client aborts). Those are NOT upstream failures or proxy defects
+		// — recording them as success:false would poison the success-rate
+		// metrics at a much higher rate than the upstream TCP-close rate
+		// the bug fix addresses. The fix preserves the prior header-based
+		// success bit and surfaces the specific outcome via the new column.
+		const ends: Array<Record<string, unknown>> = [];
+		const collector = {
+			handleStart: mock(() => undefined),
+			handleChunk: mock(() => undefined),
+			handleEnd: mock((message: Record<string, unknown>) => {
+				ends.push(message);
+				return Promise.resolve();
+			}),
+		};
+		const collectorSpy = spyOn(
+			usageCollectorModule,
+			"getUsageCollector",
+		).mockReturnValue(
+			collector as unknown as usageCollectorModule.UsageCollector,
+		);
+
+		try {
+			const requestId = "client-cancelled-request";
+			const source = new ReadableStream<Uint8Array>({
+				start(controller) {
+					controller.enqueue(bytes(terminalDelta));
+				},
+			});
+			const response = await forwardToClient(
+				{
+					requestId,
+					method: "POST",
+					path: "/v1/messages",
+					account: null,
+					requestHeaders: new Headers({
+						"anthropic-version": "2023-06-01",
+					}),
+					requestBody: bytes("{}"),
+					response: new Response(source, {
+						status: 200,
+						headers: { "content-type": "text/event-stream" },
+					}),
+					timestamp: Date.now(),
+					retryAttempt: 0,
+					failoverAttempts: 0,
+				},
+				nativeAnthropicCtx(),
+			);
+
+			// Client disconnect — simulates user hitting Esc mid-response.
+			// We cancel the downstream reader directly and swallow any
+			// upstream-cancel rejection (the immediateStream source has
+			// already closed, so cancelling it surfaces "Invalid state" —
+			// irrelevant to the recording semantics we're testing).
+			const reader = response.body?.getReader();
+			await reader.cancel("client disconnect").catch(() => undefined);
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			// Find the end emitted with client_cancelled (the close path
+			// from cancel()) — there may be a subsequent error end from the
+			// upstream-cancel rejection, which is a separate concern.
+			const cancelEnd = ends.find(
+				(e) => e.streamTerminalState === "client_cancelled",
+			);
+			expect(cancelEnd).toBeDefined();
+			expect(cancelEnd).toMatchObject({
+				requestId,
+				// Header-based success preserved — not a proxy defect.
+				success: true,
+				streamTerminalState: "client_cancelled",
+				type: "end",
+			});
+		} finally {
+			collectorSpy.mockRestore();
+		}
 	});
 });

--- a/packages/proxy/src/anthropic-terminal-recovery.ts
+++ b/packages/proxy/src/anthropic-terminal-recovery.ts
@@ -554,6 +554,16 @@ export function createAnthropicTerminalRecoveryStream(
 				if (finalized) return;
 				finalized = true;
 				clearRecoveryTimer();
+				// reader.read() rejection is a transport/stream-level failure
+				// from upstream — distinct from a clean EOF (the `done:true`
+				// branch above) and distinct from a client-initiated cancel
+				// (handled in the `cancel()` handler, which sets
+				// `clientCancelled` and wins precedence). Without this flag,
+				// determineTerminalState() would classify the rejection as
+				// "truncated" — silently conflating a real upstream failure
+				// with a mid-content TCP close and poisoning the new
+				// stream_terminal_state column.
+				markTerminalFailure();
 				fireTerminalState();
 				controller.error(error);
 			}

--- a/packages/proxy/src/anthropic-terminal-recovery.ts
+++ b/packages/proxy/src/anthropic-terminal-recovery.ts
@@ -9,6 +9,30 @@ const MAX_PENDING_EVENT_CHARS = 64 * 1024;
 
 export type AnthropicTerminalRecoveryReason = "timeout" | "eof";
 
+/**
+ * Real outcome of an Anthropic-Messages-shaped SSE stream. The wrapper emits
+ * exactly one of these via `onTerminalState` when it finalizes — distinct from
+ * a header-level `response.ok` check, which only reflects the upstream's
+ * opening handshake. A 200 OK with a TCP close mid-content is `truncated`,
+ * not `complete`. Used by response-handler to record genuine success/failure.
+ */
+export type AnthropicTerminalState =
+	/** `message_stop` (and a stop_reason delta) was observed upstream. */
+	| "complete"
+	/** Stop_reason delta was seen but message_stop was missing — synthesized. */
+	| "recovered"
+	/** Stream surfaced an explicit `error` event or upstream threw. */
+	| "error"
+	/** Stream closed without ever reaching a terminal state (mid-content TCP close). */
+	| "truncated"
+	/**
+	 * Downstream cancelled before the upstream finished. Claude Code cancels
+	 * streams routinely (Esc, tool interrupts, client aborts). This is neither
+	 * an upstream failure nor a proxy defect — recorded as a distinct state
+	 * so it doesn't poison the success-rate metrics as a false-negative.
+	 */
+	| "client_cancelled";
+
 export interface AnthropicTerminalRecoveryOptions {
 	/** @internal Override only in deterministic unit tests. */
 	gracePeriodMs?: number;
@@ -17,6 +41,12 @@ export interface AnthropicTerminalRecoveryOptions {
 		error: unknown,
 		reason: AnthropicTerminalRecoveryReason,
 	) => void;
+	/**
+	 * Fired exactly once when the wrapper reaches a terminal state, before
+	 * downstream close/error. Observers may record the state but must not
+	 * interfere with the in-flight stream (errors are swallowed).
+	 */
+	onTerminalState?: (state: AnthropicTerminalState) => void;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -49,6 +79,14 @@ export function createAnthropicTerminalRecoveryStream(
 	let terminalFailureSeen = false;
 	let recoveryDisabled = false;
 	let unknownContentBlockOpen = false;
+	let recoveryHappened = false;
+	let terminalStateFired = false;
+	// Set when the *downstream* (client) cancels the stream before the
+	// upstream finished — distinct from upstream-driven TCP closes, which
+	// surface as `done:true` in pull(). Client cancels are not a proxy defect
+	// or upstream failure; recording them as `truncated` would poison the
+	// success metrics with routine Esc / tool-interrupt aborts.
+	let clientCancelled = false;
 	const openContentBlocks = new Set<number>();
 	let finalized = false;
 	let upstreamCancelPromise: Promise<void> | null = null;
@@ -106,6 +144,48 @@ export function createAnthropicTerminalRecoveryStream(
 		}
 	};
 
+	const determineTerminalState = (): AnthropicTerminalState => {
+		// Client-initiated cancel takes precedence over every upstream-driven
+		// observation: Claude Code cancels streams routinely (Esc, tool
+		// interrupts, client aborts). Recording those as `truncated` would
+		// poison the success-rate metrics at a much higher rate than the
+		// 0.027% upstream TCP-close rate we're fixing here. This is not an
+		// upstream failure or a proxy defect — it's the client walking away
+		// mid-conversation. The caller (response-handler) preserves the
+		// pre-existing header-based success for this state, so the only
+		// observable change is the new column recording what happened.
+		if (clientCancelled) return "client_cancelled";
+		// Explicit upstream failure takes precedence over anything observed in
+		// the partial body — a mid-stream error event is the most authoritative
+		// signal we have, even if a stop_reason delta happened to land first.
+		if (terminalFailureSeen) return "error";
+		// Native completion: protocol endpoint (message_stop) was observed.
+		// stop_reason may or may not have been seen alongside it, but
+		// message_stop alone is sufficient to declare the stream complete.
+		if (messageStopSeen) return "complete";
+		// Stop_reason was seen but message_stop never arrived. If we
+		// synthesized the terminator the client receives a well-formed
+		// stream and we count it as recovered; otherwise the protocol
+		// endpoint was never reached and the bytes are unreliable.
+		if (terminalDeltaSeen) return recoveryHappened ? "recovered" : "truncated";
+		// Neither terminal delta nor message_stop nor an explicit error:
+		// upstream closed without ever reaching a terminal state. This is
+		// the mid-content TCP-close case that previously slipped past the
+		// header-only `response.ok` check.
+		return "truncated";
+	};
+
+	const fireTerminalState = (): void => {
+		if (terminalStateFired) return;
+		terminalStateFired = true;
+		const state = determineTerminalState();
+		try {
+			options.onTerminalState?.(state);
+		} catch {
+			// Observability must never interfere with an already-finalizing stream.
+		}
+	};
+
 	const appendMissingEventDelimiter = (delimiter: string): void => {
 		if (delimiter && downstreamController) {
 			downstreamController.enqueue(encoder.encode(delimiter));
@@ -138,9 +218,11 @@ export function createAnthropicTerminalRecoveryStream(
 			return;
 
 		finalized = true;
+		recoveryHappened = true;
 		clearRecoveryTimer();
 		appendMissingEventDelimiter(missingEventDelimiter);
 		downstreamController.enqueue(messageStopBytes.slice());
+		fireTerminalState();
 		downstreamController.close();
 		reportRecovery(reason);
 		cancelAfterForcedClose(
@@ -333,6 +415,7 @@ export function createAnthropicTerminalRecoveryStream(
 		finalized = true;
 		clearRecoveryTimer();
 		appendMissingEventDelimiter(missingEventDelimiter);
+		fireTerminalState();
 		downstreamController.close();
 		cancelAfterForcedClose(
 			"timeout",
@@ -460,6 +543,7 @@ export function createAnthropicTerminalRecoveryStream(
 					if (bufferedEventSuppliedMessageStop) {
 						appendMissingEventDelimiter(missingEventDelimiter);
 					}
+					fireTerminalState();
 					controller.close();
 					return;
 				}
@@ -470,6 +554,7 @@ export function createAnthropicTerminalRecoveryStream(
 				if (finalized) return;
 				finalized = true;
 				clearRecoveryTimer();
+				fireTerminalState();
 				controller.error(error);
 			}
 		},
@@ -478,6 +563,12 @@ export function createAnthropicTerminalRecoveryStream(
 			if (finalized) return;
 			finalized = true;
 			clearRecoveryTimer();
+			// Downstream (client) cancellation, not upstream failure. Set
+			// before firing so determineTerminalState classifies this as
+			// "client_cancelled" and response-handler preserves the prior
+			// header-based success — see comment in determineTerminalState.
+			clientCancelled = true;
+			fireTerminalState();
 			return cancelUpstream(reason);
 		},
 	});

--- a/packages/proxy/src/response-handler.ts
+++ b/packages/proxy/src/response-handler.ts
@@ -12,6 +12,7 @@ import type {
 } from "@better-ccflare/types";
 import {
 	ANTHROPIC_TERMINAL_RECOVERY_GRACE_MS,
+	type AnthropicTerminalState,
 	createAnthropicTerminalRecoveryStream,
 } from "./anthropic-terminal-recovery";
 import type { ProxyContext } from "./handlers";
@@ -278,10 +279,37 @@ export async function forwardToClient(
 
 		const onClose = (_buffered: Uint8Array[]): void => {
 			if (shouldProcessRequest) {
+				// For Anthropic-Messages-shaped SSE streams wrapped by the
+				// terminal-recovery wrapper, prefer the real observed SSE
+				// termination state over the header-only `response.ok` check —
+				// a 200 OK with a TCP close mid-content is truncated, not
+				// complete, and must not be recorded as a success. The wrapper
+				// fires `onTerminalState` synchronously before close/error, so
+				// the closure variable is already populated by the time we get
+				// here.
+				//
+				// Client-initiated cancels (Esc, tool interrupts) are passed
+				// through unchanged — preserve the prior header-based success
+				// so routine aborts don't poison the success metrics. The
+				// specific outcome is still recorded in `streamTerminalState`
+				// for observability.
+				const success = streamTerminalState
+					? streamTerminalState === "complete" ||
+						streamTerminalState === "recovered" ||
+						streamTerminalState === "client_cancelled"
+					: isExpectedResponse(path, response);
+				const error =
+					streamTerminalState === "truncated"
+						? "stream_truncated_mid_content"
+						: streamTerminalState === "error"
+							? "stream_in_band_error"
+							: undefined;
 				const endMsg: EndMessage = {
 					type: "end",
 					requestId,
-					success: isExpectedResponse(path, response),
+					success,
+					error,
+					streamTerminalState: streamTerminalState ?? null,
 				};
 				// Fire-and-forget: handleEnd is async for DB writes but we don't block streaming
 				fireAndForgetEnd(endMsg);
@@ -295,22 +323,30 @@ export async function forwardToClient(
 					requestId,
 					success: false,
 					error: err.message,
+					streamTerminalState: streamTerminalState ?? null,
 				};
 				fireAndForgetEnd(endMsg);
 			}
 		};
 
-		const isNativeAnthropicMessagesStream =
+		// Anthropic-Messages-shaped SSE response detection — covers native
+		// anthropic AND anthropic-compatible providers (e.g. minimax) which
+		// speak the same wire format on `/v1/messages`. Gated on path +
+		// content-type + 2xx status only; provider name and `anthropic-version`
+		// request header are deliberately excluded because the wire format is
+		// identical and a 200 with truncated content must not be silently
+		// recorded as success regardless of which upstream served it.
+		const isAnthropicMessagesSseResponse =
 			method === "POST" &&
 			path === "/v1/messages" &&
-			ctx.provider.name === "anthropic" &&
-			requestHeaders.has("anthropic-version") &&
 			response.ok &&
-			response.headers
+			(response.headers
 				.get("content-type")
 				?.toLowerCase()
-				.includes("text/event-stream");
-		const responseBody = isNativeAnthropicMessagesStream
+				.includes("text/event-stream") ??
+				false);
+		let streamTerminalState: AnthropicTerminalState | null = null;
+		const responseBody = isAnthropicMessagesSseResponse
 			? createAnthropicTerminalRecoveryStream(response.body, {
 					onRecovery(reason) {
 						log.warn("anthropic_terminal_message_stop_recovered", {
@@ -329,6 +365,24 @@ export async function forwardToClient(
 							reason,
 							errorType: error instanceof Error ? error.name : typeof error,
 						});
+					},
+					onTerminalState(state) {
+						streamTerminalState = state;
+						if (state === "truncated") {
+							log.warn("anthropic_stream_truncated_mid_content", {
+								requestId,
+								accountId: account?.id ?? null,
+								provider: ctx.provider.name,
+								statusCode: response.status,
+							});
+						} else if (state === "error") {
+							log.warn("anthropic_stream_in_band_error", {
+								requestId,
+								accountId: account?.id ?? null,
+								provider: ctx.provider.name,
+								statusCode: response.status,
+							});
+						}
 					},
 				})
 			: response.body;

--- a/packages/proxy/src/usage-collector.ts
+++ b/packages/proxy/src/usage-collector.ts
@@ -848,6 +848,7 @@ export class UsageCollector {
 					modelRewritten ? startMessage.appliedModel : null,
 					state.projectAttributionSource ?? null,
 					state.agentAttributionSource ?? null,
+					msg.streamTerminalState ?? null,
 				);
 			} catch (error) {
 				log.error(

--- a/packages/proxy/src/worker-messages.ts
+++ b/packages/proxy/src/worker-messages.ts
@@ -92,6 +92,23 @@ export interface EndMessage {
 	responseBody?: string | null; // base64 encoded, for non-streaming
 	success: boolean;
 	error?: string;
+	/**
+	 * Real observed SSE termination state for Anthropic-Messages-shaped
+	 * streaming responses. Null when the wrapper did not observe the stream
+	 * (non-streaming responses, non-Anthropic-Messages paths). One of:
+	 * "complete" | "recovered" | "error" | "truncated" | "client_cancelled".
+	 * Distinct from `success`: a recovered stream has `success:true` but a
+	 * non-null terminal state so operators can count synthetically-terminated
+	 * requests, and client_cancelled preserves the prior header-based success
+	 * bit to avoid regressing routine Esc / tool-interrupt success metrics.
+	 */
+	streamTerminalState?:
+		| "complete"
+		| "recovered"
+		| "error"
+		| "truncated"
+		| "client_cancelled"
+		| null;
 }
 
 export interface ControlMessage {


### PR DESCRIPTION
## Problem

`response-handler.ts:isExpectedResponse()` (lines 83-91) is a pure header check:

```ts
function isExpectedResponse(path: string, response: Response): boolean {
  if (path.startsWith("/.well-known/") && response.status === 404) return true;
  return response.ok;
}
```

That value flowed unchanged into `onClose` (`response-handler.ts:284`):

```ts
const onClose = (_buffered: Uint8Array[]): void => {
  if (shouldProcessRequest) {
    const endMsg: EndMessage = {
      type: "end",
      requestId,
      success: isExpectedResponse(path, response),
    };
    fireAndForgetEnd(endMsg);
  }
};
```

For any 2xx streaming response, success was recorded as true the moment the upstream returned a clean `done:true` from the reader — even when the SSE body was truncated mid-content. Bun's fetch surfaces a premature TCP close as a clean `done:true` (no error event), so the proxy had no signal that anything went wrong.

## Reproduction

Two independent failure signatures observed in production:

**ccmax / minimax (anthropic-compatible provider)** — paired A/B showed 1/5 runs `IncompleteRead` at 43.8s, recording 5757 of ~26190 expected chars before the stream died. Usage frames were seen before death (`stop_reason` + message_delta's output_tokens parsed, then `message_stop` never arrived).

**ccproxy2 / native anthropic** — 2 of 7450 `/v1/messages` requests = **0.027%**. Symptom: 200 OK with 0 output_tokens AND NULL input_tokens. `input_tokens` arrives in `message_start`, so the upstream died before `message_start` was ever parsed, or no usage frames flushed at all.

The existing narrow recovery wrapper (`createAnthropicTerminalRecoveryStream`) handles the first signature well — it synthesizes a `message_stop` when `stop_reason` was seen but `message_stop` never arrived, and Claude Code's watchdog doesn't hang. The second signature (no terminal event ever seen) was not caught at all.

## Why the fix is provider-agnostic

The old gate was:

```ts
const isNativeAnthropicMessagesStream =
  method === "POST" &&
  path === "/v1/messages" &&
  ctx.provider.name === "anthropic" &&
  requestHeaders.has("anthropic-version") &&
  response.ok &&
  response.headers.get("content-type")?.toLowerCase().includes("text/event-stream");
```

That gate excluded every anthropic-compatible provider that speaks the same wire format on `/v1/messages` — including minimax, which is exactly where the ccmax reproduction came from. The wire format is identical; the gate now uses the protocol shape only:

```ts
const isAnthropicMessagesSseResponse =
  method === "POST" &&
  path === "/v1/messages" &&
  response.ok &&
  (response.headers.get("content-type")?.toLowerCase().includes("text/event-stream") ?? false);
```

`provider.name` and `anthropic-version` are deliberately no longer part of the gate. The recovery wrapper now applies to any 2xx SSE on `/v1/messages`.

## Changes

1. **Generalize the gate** — see above. anthropic-compatible providers now get the same protection.

2. **Track real SSE termination.** Added an `AnthropicTerminalState` type (`"complete" | "recovered" | "error" | "truncated" | "client_cancelled"`) and an `onTerminalState` callback on the recovery wrapper fired exactly once per stream. `determineTerminalState()`:
   - `client_cancelled` if downstream cancelled before upstream finished
   - `error` if an in-band SSE error event or upstream throw was observed
   - `complete` if `message_stop` was observed (natural endpoint)
   - `recovered` if `stop_reason` was seen but `message_stop` was missing AND the wrapper synthesized the terminator
   - `truncated` otherwise (no terminal event, no explicit error)

   `response-handler.ts:onClose` derives success from this state instead of the header-only check. Bias toward the recorded value reflecting reality.

3. **Preserve prior behavior for client-initiated cancels.** Claude Code cancels streams routinely (Esc, tool interrupts, client aborts). Those are NOT upstream failures or proxy defects. Recording them as `success:false` would poison the success-rate metrics at a much higher rate than the 0.027% upstream TCP-close rate this fix addresses. `client_cancelled` preserves the prior header-based success bit (`true` for 2xx) and surfaces the specific outcome via the new column.

4. **New `requests.stream_terminal_state` column** in BOTH `packages/database/src/migrations.ts` (sqlite) AND `packages/database/src/migrations-pg.ts` (Postgres — production). Initial CREATE TABLE schemas also include the column so fresh DBs have it. ON CONFLICT UPDATE uses `COALESCE` so a later re-save (e.g. `updateUsage`) cannot blank out the real SSE termination state the handleEnd path recorded. NULL for non-streaming responses or streams not wrapped by the observer.

## Why in-flight retry is out of scope

Bytes are already streaming to the client via `teeStream` before the proxy can detect a mid-content truncation, and replaying partial content would corrupt the client's view. The proxy-level retry path (`response-handler.ts:forwardToClient`) runs before `teeStream` is constructed and would not see a mid-stream truncation. A retry buffer architecture would change the streaming semantics for every other request — too invasive for this patch. Correct success-recording and broadened detection are the must-haves; both are delivered.

## Files changed

- `packages/proxy/src/anthropic-terminal-recovery.ts` — new state type, onTerminalState callback, `determineTerminalState()` with client_cancelled precedence, fireTerminalState at every close/error/cancel path
- `packages/proxy/src/response-handler.ts` — generalized gate, terminal-state → success derivation in onClose, warn logs for truncated/error states
- `packages/proxy/src/worker-messages.ts` — EndMessage.streamTerminalState
- `packages/proxy/src/usage-collector.ts` — pass through to saveRequest
- `packages/database/src/database-operations.ts` — saveRequest signature
- `packages/database/src/repositories/request.repository.ts` — column wiring (UPSERT with COALESCE on conflict)
- `packages/database/src/migrations.ts` — sqlite ALTER + CREATE TABLE
- `packages/database/src/migrations-pg.ts` — pg ALTER + CREATE TABLE
- `packages/proxy/src/__tests__/anthropic-terminal-recovery.test.ts` — unit tests for complete / recovered / truncated / client_cancelled
- `packages/proxy/src/__tests__/response-handler-anthropic-terminal-recovery.test.ts` — integration: truncated → success:false, anthropic-compatible truncated, client_cancelled → success:true preserved; updated prior test that asserted anthropic-compatible would NOT enter the wrapper (it now does, by design)

## Verification

- `bun run typecheck`: only the 2 pre-existing baseline errors in apps/server/src/server.ts (missing dashboard dist artifacts), unrelated to this change. **No new typecheck errors.**
- `bunx biome check` on changed files: clean.
- `bun test packages/proxy/src/__tests__/anthropic-terminal-recovery.test.ts`: 34 pass / 0 fail.
- `bun test packages/proxy/src/__tests__/response-handler-anthropic-terminal-recovery.test.ts`: 7 pass / 0 fail.
- `bun test ./packages/database/src/migrations.test.ts`: 31 pass / 0 fail.
- `bun test ./packages/database/src/migrations-pg-add-column.test.ts`: 5 pass / 0 fail.

One pre-existing baseline failure: `response-handler-worker-protocol.test.ts` cannot find `./inline-integrity-check-worker` (a generated worker bundle the source worktree intentionally excludes — see the comment in the test file). Not introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)