### PR TITLE
fix: skip usage-exhausted accounts during selection instead of cycling their models

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "ccflare",

--- a/packages/core/src/strategy-requires-reauth.test.ts
+++ b/packages/core/src/strategy-requires-reauth.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { Account } from "@better-ccflare/types";
-import { isAccountAvailable } from "./strategy";
+import { isAccountAvailable, isUsageExhausted } from "./strategy";
 
 function account(requiresReauth: boolean): Account {
 	return {
@@ -17,5 +17,31 @@ describe("isAccountAvailable requires_reauth", () => {
 
 	it("keeps an otherwise healthy account available", () => {
 		expect(isAccountAvailable(account(false))).toBe(true);
+	});
+});
+
+describe("isAccountAvailable usage exhaustion", () => {
+	const now = Date.UTC(2026, 6, 27, 12);
+
+	it("excludes an account capped until a future reset", () => {
+		expect(
+			isAccountAvailable(account(false), now, {
+				utilization: 100,
+				resetMs: now + 60_000,
+			}),
+		).toBe(false);
+	});
+
+	it("makes a capped account eligible again after its reset", () => {
+		expect(
+			isAccountAvailable(account(false), now, {
+				utilization: 100,
+				resetMs: now - 1,
+			}),
+		).toBe(true);
+	});
+
+	it("does not claim exhaustion from a stale snapshot with a past reset", () => {
+		expect(isUsageExhausted(100, now - 1, now)).toBe(false);
 	});
 });

--- a/packages/core/src/strategy.ts
+++ b/packages/core/src/strategy.ts
@@ -10,16 +10,67 @@ export function isValidStrategy(strategy: string): strategy is StrategyName {
 // Default load balancing strategy
 export const DEFAULT_STRATEGY = StrategyName.Session;
 
-// Helper to check if an account is available (not rate-limited or paused)
-export function isAccountAvailable(
-	account: Account,
-	now = Date.now(),
+/**
+ * Optional usage snapshot fed into {@link isAccountAvailable}. Passed through
+ * by callers that already have a `usageCache.get(account.id)` payload handy;
+ * when omitted the predicate falls back to the cheap "not paused / not rate
+ * limited / not requires_reauth" check used at every other call site.
+ */
+export interface AccountUsageSnapshot {
+	/** Representative utilization in percent (0-100); null means unknown. */
+	utilization: number | null;
+	/**
+	 * Reset time (ms epoch) of the representative usage window, if known.
+	 * A known reset in the past means the snapshot predates the window
+	 * reset and must NOT count as exhausted (PR #299 review finding).
+	 */
+	resetMs: number | null;
+}
+
+/**
+ * Shared exhaustion predicate for both the rateLimitStatus display and the
+ * /health `usage_exhausted` counter — keeping the two surfaces from
+ * contradicting each other. A known reset in the past means the snapshot
+ * predates the window reset: do not claim exhaustion from stale data. An
+ * unknown reset trusts the (max 10-minute-old) usage cache.
+ *
+ * Lives in `@better-ccflare/core` so the dependency runs the right way
+ * (http-api -> core, not the reverse). Kept byte-identical with the
+ * previous in-http-api definition so existing display logic is unaffected.
+ */
+export function isUsageExhausted(
+	utilization: number | null,
+	resetMs: number | null | undefined,
+	now: number,
 ): boolean {
 	return (
-		!account.requires_reauth &&
-		!account.paused &&
-		(!account.rate_limited_until || account.rate_limited_until < now)
+		utilization !== null &&
+		utilization >= 100 &&
+		(resetMs == null || resetMs > now)
 	);
+}
+
+// Helper to check if an account is available (not rate-limited, paused, or
+// usage-capped). Callers without usage telemetry can omit the third arg and
+// get the original cheap predicate; callers with a usage snapshot pass it so
+// an account whose representative window is at 100% with a future reset is
+// skipped instead of being cycled through until it 429s.
+export function isAccountAvailable(
+	account: Account,
+	now: number = Date.now(),
+	usage?: AccountUsageSnapshot,
+): boolean {
+	if (
+		account.requires_reauth ||
+		account.paused ||
+		(account.rate_limited_until && account.rate_limited_until >= now)
+	) {
+		return false;
+	}
+	if (usage && isUsageExhausted(usage.utilization, usage.resetMs, now)) {
+		return false;
+	}
+	return true;
 }
 
 // Re-export from types package for backwards compatibility

--- a/packages/http-api/src/handlers/rate-limit-status.ts
+++ b/packages/http-api/src/handlers/rate-limit-status.ts
@@ -15,21 +15,10 @@
  *   4. "OK".
  */
 
-import type {
-	AlibabaCodingPlanUsageData,
-	AnyUsageData,
-	KiloUsageData,
-	NanoGPTUsageData,
-	UsageData,
-	XaiUsageData,
-	ZaiUsageData,
-} from "@better-ccflare/providers";
+import { isUsageExhausted } from "@better-ccflare/core";
 import {
-	getRepresentativeAlibabaCodingPlanWindow,
-	getRepresentativeKiloWindow,
-	getRepresentativeNanoGPTWindow,
-	getRepresentativeWindow,
-	getRepresentativeXaiWindow,
+	extractUsageResetMs,
+	getRepresentativeUsageResetMs,
 } from "@better-ccflare/providers";
 
 export interface RateLimitStatusInput {
@@ -49,24 +38,7 @@ function minutesLeft(untilMs: number, now: number): number {
 	return Math.ceil((untilMs - now) / 60000);
 }
 
-/**
- * Shared exhaustion predicate for BOTH the rateLimitStatus display and the
- * /health `usage_exhausted` counter — keeping the two surfaces from
- * contradicting each other. A known reset in the past means the snapshot
- * predates the window reset: do not claim exhaustion from stale data. An
- * unknown reset trusts the (max 10-minute-old) usage cache.
- */
-export function isUsageExhausted(
-	utilization: number | null,
-	resetMs: number | null | undefined,
-	now: number,
-): boolean {
-	return (
-		utilization !== null &&
-		utilization >= 100 &&
-		(resetMs == null || resetMs > now)
-	);
-}
+export { isUsageExhausted } from "@better-ccflare/core";
 
 export function computeRateLimitStatusDisplay(
 	input: RateLimitStatusInput,
@@ -95,122 +67,7 @@ export function computeRateLimitStatusDisplay(
 	return "OK";
 }
 
-/**
- * Reset time (ms epoch) of the representative usage window, derived the same
- * way for every provider — the single source BOTH the /health usage_exhausted
- * counter and the accounts rateLimitStatus display use, so their staleness
- * guards cannot diverge (PR #299 review finding). Note zai: the display
- * window is labeled "five_hour" (Claude terminology), but the payload key
- * carrying the reset is `tokens_limit` — extraction must use the payload key,
- * not the display label.
- */
-export function getRepresentativeUsageResetMs(
-	usageData: unknown,
-	provider: string,
-): number | null {
-	if (!usageData || typeof usageData !== "object") return null;
-	try {
-		const data = usageData as AnyUsageData;
-		switch (provider) {
-			case "anthropic":
-			case "codex": {
-				const windowName = getRepresentativeWindow(data as UsageData);
-				// Flat legacy shape: the window name is an actual property
-				// (five_hour/seven_day/...) carrying its own resets_at.
-				const flatReset = extractUsageResetMs(data, windowName);
-				if (flatReset !== null) return flatReset;
-				// limits[]-only payloads (2026 API): five_hour/seven_day are
-				// absent as properties — getRepresentativeWindow derives those
-				// same names synthetically from limits[] kind "session" /
-				// "weekly_all". Fall back to the matching limits[] entry's own
-				// resets_at so the staleness guard still has a real reset time.
-				return getRepresentativeLimitResetMs(data as UsageData, windowName);
-			}
-			case "zai":
-				return extractUsageResetMs(
-					data,
-					(data as ZaiUsageData).tokens_limit ? "tokens_limit" : null,
-				);
-			case "nanogpt":
-				return extractUsageResetMs(
-					data,
-					getRepresentativeNanoGPTWindow(data as NanoGPTUsageData),
-				);
-			case "kilo":
-				return extractUsageResetMs(
-					data,
-					getRepresentativeKiloWindow(data as KiloUsageData),
-				);
-			case "alibaba-coding-plan":
-				return extractUsageResetMs(
-					data,
-					getRepresentativeAlibabaCodingPlanWindow(
-						data as AlibabaCodingPlanUsageData,
-					),
-				);
-			case "xai":
-				return extractUsageResetMs(
-					data,
-					getRepresentativeXaiWindow(data as XaiUsageData),
-				);
-			default:
-				return null;
-		}
-	} catch {
-		return null;
-	}
-}
-
-/**
- * limits[] `kind` that maps to each synthetic window name produced by
- * getRepresentativeWindow's accountLevelLimitWindows fold (session ->
- * five_hour, weekly_all -> seven_day). Kept in lockstep with that mapping in
- * packages/providers/src/usage-fetcher.ts.
- */
-const WINDOW_NAME_TO_LIMIT_KIND: Record<string, string> = {
-	five_hour: "session",
-	seven_day: "weekly_all",
-};
-
-/**
- * Reset time (ms epoch) for a limits[]-only Anthropic/Codex payload: finds
- * the limits[] entry whose `kind` corresponds to the given synthetic window
- * name and returns its own `resets_at`.
- */
-function getRepresentativeLimitResetMs(
-	usage: UsageData,
-	windowName: string | null,
-): number | null {
-	if (!windowName || !Array.isArray(usage.limits)) return null;
-	const kind = WINDOW_NAME_TO_LIMIT_KIND[windowName];
-	if (!kind) return null;
-	const limit = usage.limits.find((l) => l?.kind === kind);
-	const resetsAt = limit?.resets_at;
-	if (typeof resetsAt !== "string") return null;
-	const ms = new Date(resetsAt).getTime();
-	return Number.isFinite(ms) ? ms : null;
-}
-
-/**
- * Pull the reset timestamp (ms epoch) of a named usage window out of raw
- * provider usage data. Handles both timestamp shapes in use:
- * anthropic-style `resets_at` (ISO string) and zai/nanogpt-style `resetAt`
- * (ms number).
- */
-export function extractUsageResetMs(
-	usageData: unknown,
-	windowName: string | null,
-): number | null {
-	if (!usageData || typeof usageData !== "object" || !windowName) return null;
-	const window = (usageData as Record<string, unknown>)[windowName];
-	if (!window || typeof window !== "object") return null;
-	const w = window as { resets_at?: unknown; resetAt?: unknown };
-	if (typeof w.resets_at === "string") {
-		const ms = new Date(w.resets_at).getTime();
-		return Number.isFinite(ms) ? ms : null;
-	}
-	if (typeof w.resetAt === "number" && Number.isFinite(w.resetAt)) {
-		return w.resetAt;
-	}
-	return null;
-}
+export {
+	extractUsageResetMs,
+	getRepresentativeUsageResetMs,
+} from "@better-ccflare/providers";

--- a/packages/providers/src/usage-fetcher.ts
+++ b/packages/providers/src/usage-fetcher.ts
@@ -426,6 +426,105 @@ export function getRepresentativeUtilizationForProvider(
 	}
 }
 
+const REPRESENTATIVE_WINDOW_LIMIT_KIND: Record<string, string> = {
+	five_hour: "session",
+	seven_day: "weekly_all",
+};
+
+/**
+ * Pull the reset timestamp (ms epoch) of a named usage window out of raw
+ * provider usage data. Handles both timestamp shapes in use:
+ * anthropic-style `resets_at` and zai/nanogpt-style `resetAt`.
+ */
+export function extractUsageResetMs(
+	usageData: unknown,
+	windowName: string | null,
+): number | null {
+	if (!usageData || typeof usageData !== "object" || !windowName) return null;
+	const window = (usageData as Record<string, unknown>)[windowName];
+	if (!window || typeof window !== "object") return null;
+	const value = window as { resets_at?: unknown; resetAt?: unknown };
+	if (typeof value.resets_at === "string") {
+		const ms = new Date(value.resets_at).getTime();
+		return Number.isFinite(ms) ? ms : null;
+	}
+	return typeof value.resetAt === "number" && Number.isFinite(value.resetAt)
+		? value.resetAt
+		: null;
+}
+
+function getRepresentativeLimitResetMs(
+	usage: UsageData,
+	windowName: string | null,
+): number | null {
+	if (!windowName || !Array.isArray(usage.limits)) return null;
+	const kind = REPRESENTATIVE_WINDOW_LIMIT_KIND[windowName];
+	if (!kind) return null;
+	const resetsAt = usage.limits.find((limit) => limit?.kind === kind)?.resets_at;
+	if (typeof resetsAt !== "string") return null;
+	const ms = new Date(resetsAt).getTime();
+	return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * Reset time of the representative usage window, derived with the same
+ * provider-aware window selection as representative utilization.
+ */
+export function getRepresentativeUsageResetMs(
+	usageData: unknown,
+	provider: string,
+): number | null {
+	if (!usageData || typeof usageData !== "object") return null;
+	try {
+		const data = usageData as AnyUsageData;
+		switch (provider) {
+			case "anthropic":
+			case "codex": {
+				const usage = data as UsageData;
+				const windowName = getRepresentativeWindow(usage);
+				return (
+					extractUsageResetMs(usage, windowName) ??
+					getRepresentativeLimitResetMs(usage, windowName)
+				);
+			}
+			case "zai":
+				return extractUsageResetMs(
+					data,
+					(data as ZaiUsageData).tokens_limit ? "tokens_limit" : null,
+				);
+			case "nanogpt": {
+				const usage = data as NanoGPTUsageData;
+				const windowName =
+					usage.daily.percentUsed >= usage.monthly.percentUsed
+						? "daily"
+						: "monthly";
+				return extractUsageResetMs(usage, windowName);
+			}
+			case "kilo":
+				return extractUsageResetMs(
+					data,
+					getRepresentativeKiloWindow(data as KiloUsageData),
+				);
+			case "alibaba-coding-plan":
+				return extractUsageResetMs(
+					data,
+					getRepresentativeAlibabaCodingPlanWindow(
+						data as AlibabaCodingPlanUsageData,
+					),
+				);
+			case "xai":
+				return extractUsageResetMs(
+					data,
+					getRepresentativeXaiWindow(data as XaiUsageData),
+				);
+			default:
+				return null;
+		}
+	} catch {
+		return null;
+	}
+}
+
 /**
  * Type for a function that retrieves a fresh access token or API key
  */

--- a/packages/proxy/src/handlers/__tests__/account-selector.test.ts
+++ b/packages/proxy/src/handlers/__tests__/account-selector.test.ts
@@ -7,6 +7,7 @@ import type {
 } from "@better-ccflare/types";
 import {
 	getComboSlotInfo,
+	getOrderedAccounts,
 	resolveEffectiveModel,
 	selectAccountsForRequest,
 	setComboSlotInfo,
@@ -76,7 +77,11 @@ function makeCtx(
 	const accounts = opts.accounts ?? [makeAccount()];
 	return {
 		strategy: {
-			select: mock((_all: Account[], _meta: RequestMeta) => accounts),
+			// Return what we were HANDED, not the full fixture list. A real strategy
+			// can only pick from the candidates it receives, so a mock that ignores
+			// its input silently defeats any upstream filtering — which is exactly how
+			// a disconnected usage-exhaustion filter previously looked like it worked.
+			select: mock((all: Account[], _meta: RequestMeta) => all),
 		},
 		dbOps: {
 			getAllAccounts: mock(async () => accounts),
@@ -759,5 +764,94 @@ describe("selectAccountsForRequest — routes on effective model, not the client
 		const slotInfo = getComboSlotInfo(meta);
 		expect(slotInfo?.comboName).toBe("Test Combo");
 		expect(slotInfo?.slots[0]?.modelOverride).toBe("claude-opus-4-5");
+	});
+});
+
+// ── getOrderedAccounts: usage-capped accounts never reach the strategy ────────
+//
+// These assert on what the STRATEGY RECEIVES, not on what selection returns.
+// That distinction is the whole point: every load-balancing strategy filters
+// with `isAccountAvailable(account, now)` and cannot see the usage cache, so a
+// capped account that is still handed to the strategy gets selected, retried,
+// and model-cycled until every model 429s. Asserting on the return value would
+// pass even with the filter removed, because the strategy mock decides the
+// return.
+describe("getOrderedAccounts usage-exhaustion filtering", () => {
+	it("does not hand a usage-capped account to the strategy", async () => {
+		const now = Date.now();
+		const cappedAcc = makeAccount({ id: "acc-capped", name: "capped" });
+		const healthyAcc = makeAccount({ id: "acc-healthy", name: "healthy" });
+		usageCache.set(cappedAcc.id, {
+			seven_day: {
+				utilization: 100,
+				resets_at: new Date(now + 40 * 3600_000).toISOString(),
+			},
+			five_hour: {
+				utilization: 20,
+				resets_at: new Date(now + 3600_000).toISOString(),
+			},
+		});
+
+		const ctx = makeCtx({ accounts: [cappedAcc, healthyAcc] });
+		await getOrderedAccounts(makeRequestMeta(), ctx);
+
+		const passed = (
+			ctx.strategy.select as unknown as {
+				mock: { calls: Array<[Account[], RequestMeta]> };
+			}
+		).mock.calls[0][0];
+		expect(passed.map((a) => a.id)).toEqual(["acc-healthy"]);
+	});
+
+	it("keeps an account whose capped window already reset (stale snapshot)", async () => {
+		const pastReset = new Date(Date.now() - 5 * 60_000).toISOString();
+		const acc = makeAccount({ id: "acc-stale", name: "stale" });
+		// 100% utilization but the reset is in the PAST: the snapshot predates
+		// the window reset, so exhaustion must not be claimed from it.
+		usageCache.set(acc.id, {
+			seven_day: { utilization: 100, resets_at: pastReset },
+			five_hour: { utilization: 100, resets_at: pastReset },
+		});
+
+		const ctx = makeCtx({ accounts: [acc] });
+		await getOrderedAccounts(makeRequestMeta(), ctx);
+
+		const passed = (
+			ctx.strategy.select as unknown as {
+				mock: { calls: Array<[Account[], RequestMeta]> };
+			}
+		).mock.calls[0][0];
+		expect(passed.map((a) => a.id)).toEqual(["acc-stale"]);
+	});
+
+	it("still hands a capped account to the strategy for auto-refresh probes", async () => {
+		// The scheduler probes capped accounts to detect their window reset. A
+		// capped account is neither paused nor rate_limited_until, so if the
+		// bypass did not cover it nothing else would let it back in.
+		const now = Date.now();
+		const cappedAcc = makeAccount({ id: "acc-capped", name: "capped" });
+		usageCache.set(cappedAcc.id, {
+			seven_day: {
+				utilization: 100,
+				resets_at: new Date(now + 40 * 3600_000).toISOString(),
+			},
+			five_hour: {
+				utilization: 20,
+				resets_at: new Date(now + 3600_000).toISOString(),
+			},
+		});
+
+		const ctx = makeCtx({ accounts: [cappedAcc] });
+		const meta = makeRequestMeta({
+			headers: new Headers({ "x-better-ccflare-bypass-session": "true" }),
+		});
+		await getOrderedAccounts(meta, ctx);
+
+		const passed = (
+			ctx.strategy.select as unknown as {
+				mock: { calls: Array<[Account[], RequestMeta]> };
+			}
+		).mock.calls[0][0];
+		expect(passed.map((a) => a.id)).toEqual(["acc-capped"]);
 	});
 });

--- a/packages/proxy/src/handlers/__tests__/account-selector.test.ts
+++ b/packages/proxy/src/handlers/__tests__/account-selector.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, mock } from "bun:test";
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { usageCache } from "@better-ccflare/providers";
 import type {
 	Account,
 	ComboWithSlots,
@@ -85,6 +86,10 @@ function makeCtx(
 		asyncWriter: { enqueue: mock(() => {}) },
 	} as unknown as ProxyContext;
 }
+
+afterEach(() => {
+	usageCache.clear();
+});
 
 // ── setComboSlotInfo / getComboSlotInfo ───────────────────────────────────────
 
@@ -198,6 +203,46 @@ describe("selectAccountsForRequest — x-better-ccflare-account-id header", () =
 		// Rate-limited forced account is skipped; falls back to strategy.select which returns activeAcc
 		expect(result).toHaveLength(1);
 		expect(result[0]?.id).toBe("acc-active");
+	});
+
+	it("skips a forced account whose representative usage window is capped with a future reset", async () => {
+		const cappedAcc = makeAccount({ id: "acc-capped", name: "capped" });
+		const healthyAcc = makeAccount({ id: "acc-healthy", name: "healthy" });
+		const now = Date.now();
+		// Anthropic 7-day window fully exhausted, reset 40h in the future
+		// (matches the production incident: ann at 100% seven_day with ~40h
+		// to reset, sibling accounts at 43% / 53%).
+		usageCache.set(cappedAcc.id, {
+			seven_day: { utilization: 100, resets_at: new Date(now + 40 * 3600_000).toISOString() },
+			five_hour: { utilization: 53, resets_at: new Date(now + 3600_000).toISOString() },
+		});
+		const ctx = makeCtx({ accounts: [cappedAcc, healthyAcc] });
+		const meta = makeRequestMeta({
+			headers: new Headers({ "x-better-ccflare-account-id": "acc-capped" }),
+		});
+
+		const result = await selectAccountsForRequest(meta, ctx);
+		// Forced capped account is skipped; strategy mock returns healthyAcc.
+		expect(result.map((a) => a.id)).toEqual(["acc-healthy"]);
+	});
+
+	it("re-admits a forced account whose capped window has already reset", async () => {
+		const acc = makeAccount({ id: "acc-capped", name: "capped" });
+		// Snapshot from BEFORE the reset — the past resetMs signals that the
+		// window already cycled and the cached utilization is stale; must
+		// NOT count as exhausted.
+		const pastReset = new Date(Date.now() - 5 * 60_000).toISOString();
+		usageCache.set(acc.id, {
+			seven_day: { utilization: 100, resets_at: pastReset },
+			five_hour: { utilization: 25, resets_at: pastReset },
+		});
+		const ctx = makeCtx({ accounts: [acc] });
+		const meta = makeRequestMeta({
+			headers: new Headers({ "x-better-ccflare-account-id": "acc-capped" }),
+		});
+
+		const result = await selectAccountsForRequest(meta, ctx);
+		expect(result.map((a) => a.id)).toEqual(["acc-capped"]);
 	});
 });
 

--- a/packages/proxy/src/handlers/account-selector.ts
+++ b/packages/proxy/src/handlers/account-selector.ts
@@ -1,6 +1,11 @@
 import { getModelFamily, isAccountAvailable } from "@better-ccflare/core";
 import { Logger } from "@better-ccflare/logger";
-import { usageCache } from "@better-ccflare/providers";
+import {
+	getRepresentativeUsageResetMs,
+	getRepresentativeUtilizationForProvider,
+	usageCache,
+} from "@better-ccflare/providers";
+import type { AccountUsageSnapshot } from "@better-ccflare/core";
 import type {
 	Account,
 	ComboFamily,
@@ -34,6 +39,31 @@ export function getComboSlotInfo(meta: RequestMeta): ComboSlotInfo | null {
 // Canonical definition lives in model-capacity.ts (single source of truth —
 // a structurally-identical local copy could silently drift).
 export type { ModelFamilyExhaustionInfo } from "./model-capacity";
+
+/**
+ * Snapshot of an account's representative usage window: returns null when
+ * no cached telemetry exists or the provider has no utilization surface
+ * (so the caller can fall back to the cheap `isAccountAvailable` check
+ * without a usage argument).
+ *
+ * The shared `isUsageExhausted` predicate lives in `@better-ccflare/core`
+ * and encodes both the "utilization >= 100" gate and the staleness guard
+ * (a known resetMs in the past means the snapshot predates the window
+ * reset and MUST NOT count as exhausted) — same predicate the
+ * rateLimitStatus display and /health usage_exhausted counter share, so
+ * the surfaces cannot diverge.
+ */
+function usageSnapshot(account: Account): AccountUsageSnapshot | null {
+	const data = usageCache.get(account.id);
+	if (!data) return null;
+	const provider = account.provider ?? "anthropic";
+	const utilization = getRepresentativeUtilizationForProvider(data, provider);
+	if (utilization === null) return null;
+	return {
+		utilization,
+		resetMs: getRepresentativeUsageResetMs(data, provider),
+	};
+}
 
 // Module-level WeakMap to store model-family exhaustion info per RequestMeta,
 // set when the capacity filter below removes every candidate account for a

--- a/packages/proxy/src/handlers/account-selector.ts
+++ b/packages/proxy/src/handlers/account-selector.ts
@@ -1,4 +1,8 @@
-import { getModelFamily, isAccountAvailable } from "@better-ccflare/core";
+import {
+	getModelFamily,
+	isAccountAvailable,
+	isUsageExhausted,
+} from "@better-ccflare/core";
 import { Logger } from "@better-ccflare/logger";
 import {
 	getRepresentativeUsageResetMs,
@@ -175,8 +179,40 @@ export async function getOrderedAccounts(
 ): Promise<Account[]> {
 	try {
 		const allAccounts = await ctx.dbOps.getAllAccounts();
-		// Return all accounts - the provider will be determined dynamically per account
-		return ctx.strategy.select(allAccounts, meta);
+		// Drop usage-capped accounts before the strategy ever sees them.
+		//
+		// This is the choke point that matters: every load-balancing strategy
+		// filters with `isAccountAvailable(account, now)` and has no access to
+		// the usage cache (it lives in this package, not @better-ccflare/
+		// load-balancer), so gating inside the strategies would mean plumbing
+		// usage through every one of them. Filtering here covers all strategies
+		// at once and keeps a capped account from being picked, retried, and
+		// model-cycled until every model 429s.
+		//
+		// The auto-refresh scheduler's probes must still get through: that is
+		// how a capped account's window-reset is detected, and a capped account
+		// is neither `paused` nor `rate_limited_until`, so nothing else would
+		// let it back in.
+		const isAutoRefreshBypass =
+			meta.headers?.get("x-better-ccflare-bypass-session") === "true";
+		// Deliberately narrow: this removes ONLY usage-capped accounts. The
+		// paused / requires_reauth / rate_limited_until checks stay where they
+		// already are, inside the strategies, because some of them rely on
+		// seeing the full account list (session affinity has to find its sticky
+		// account before deciding anything). Filtering those here too would
+		// silently change strategy behaviour, which is not what this fix is for.
+		const now = Date.now();
+		const candidates = isAutoRefreshBypass
+			? allAccounts
+			: allAccounts.filter((account) => {
+					const usage = usageSnapshot(account);
+					return (
+						usage === null ||
+						!isUsageExhausted(usage.utilization, usage.resetMs, now)
+					);
+				});
+		// Provider is still determined dynamically per account downstream.
+		return ctx.strategy.select(candidates, meta);
 	} catch (error) {
 		log.error("Failed to get accounts from database:", error);
 		console.error("\n❌ DATABASE ERROR DETECTED");
@@ -240,7 +276,12 @@ export async function selectAccountsForRequest(
 					// (auto_pause_on_overage_enabled=1 AND pause_reason IN (NULL,'overage')).
 					const isAutoRefreshBypass =
 						meta.headers.get("x-better-ccflare-bypass-session") === "true";
-					const available = isAccountAvailable(forcedAccount);
+					const forcedUsage = usageSnapshot(forcedAccount);
+					const available = isAccountAvailable(
+						forcedAccount,
+						Date.now(),
+						forcedUsage ?? undefined,
+					);
 					const isOveragePaused =
 						forcedAccount.paused &&
 						forcedAccount.auto_pause_on_overage_enabled &&
@@ -250,11 +291,21 @@ export async function selectAccountsForRequest(
 						!available &&
 						!forcedAccount.paused &&
 						!!forcedAccount.rate_limited_until;
+					// A usage-capped account is neither paused nor
+					// rate_limited_until, so without this it would fail
+					// `available` and then match none of the bypass conditions —
+					// leaving the scheduler unable to probe it and detect its
+					// window reset, the one thing the bypass exists to do.
+					const isUsageCapped =
+						!available &&
+						!forcedAccount.paused &&
+						!forcedAccount.rate_limited_until &&
+						forcedUsage !== null;
 					const allowThrough =
 						available ||
 						(isAutoRefreshBypass &&
 							!forcedAccount.requires_reauth &&
-							(isOveragePaused || isRateLimited));
+							(isOveragePaused || isRateLimited || isUsageCapped));
 					if (allowThrough) {
 						return [forcedAccount];
 					}
@@ -362,7 +413,13 @@ export async function selectAccountsForRequest(
 							continue;
 						}
 
-						if (!isAccountAvailable(account)) {
+						if (
+							!isAccountAvailable(
+								account,
+								Date.now(),
+								usageSnapshot(account) ?? undefined,
+							)
+						) {
 							continue;
 						}
 


### PR DESCRIPTION
## Problem

`isAccountAvailable()` (`packages/core/src/strategy.ts`) gated only on `requires_reauth`, `paused` and `rate_limited_until`. It had no notion of **usage-window** exhaustion.

So an account at 100% of its weekly window stayed "available", kept being selected by `account-selector.ts`, and had its models cycled until they all 429'd — churn instead of clean failover to a healthy account.

Measured on a production instance over 24h, against an account sitting at 100% of its weekly window with ~40h remaining until reset, while two sibling accounts were at 43% and 53% utilisation:

| Error | Count |
|---|---|
| `model_fallback_429` | 227 |
| `503 pool_exhausted` | 27 |
| `all_models_exhausted_429` | 10 |

The exhausted account served zero successful `/v1/messages` in that window while continuing to absorb selection attempts.

## Fix

Teach the selection path about usage exhaustion, reusing the predicate that already exists rather than adding a second one.

`isUsageExhausted()` previously lived in `packages/http-api/src/handlers/rate-limit-status.ts`, where its docblock notes it is deliberately the single source for **both** the `rateLimitStatus` display and the `/health` `usage_exhausted` counter, so the two surfaces cannot contradict each other (per the PR #299 review). Selection needs the same predicate, but `packages/core` cannot import from `packages/http-api` — the dependency runs the other way.

So it is **relocated** into `@better-ccflare/core` and **re-exported** from `rate-limit-status.ts`. Existing importers are unaffected, and the three surfaces still share one definition.

`isAccountAvailable()` takes usage as an **optional** parameter, so every existing call site keeps its current behaviour unchanged.

Its staleness guard is preserved verbatim: a `resetMs` in the **past** means the snapshot predates the window reset, so exhaustion is *not* claimed from stale data. Capped accounts become eligible again automatically at window reset — nothing is permanently sidelined.

## Scope

This stops **capped** accounts from being selected. It deliberately does **not** rebalance traffic among *healthy* accounts — session affinity and primary-account preference are a separate, independent distribution concern and are out of scope here.

## Tests

- `packages/core/src/strategy-requires-reauth.test.ts` — exhaustion, non-exhaustion, and explicitly the stale-snapshot case (`isUsageExhausted(100, now - 1, now) === false`). **5/5 pass locally.**
- `packages/proxy/src/handlers/__tests__/account-selector.test.ts` — capped account skipped, and a past `resets_at` snapshot that must *not* be treated as exhausted.

**Local test caveat, stated plainly:** I could not execute the `account-selector` suite locally. It fails at import with `Cannot find module './inline-integrity-check-worker'` from `packages/database/src/integrity-check-runner.ts`. This reproduces identically on a pristine `upstream/main` checkout in the same environment, so it is **pre-existing and unrelated to this change** — only `inline-integrity-check-worker.d.ts` is committed to the repo; the implementation module is not present and I found no script that generates it. Anything transitively importing `integrity-check-runner` is affected. Flagging it in case it is an unintended gap. Similarly, `bun run typecheck` reports two pre-existing errors about missing `@better-ccflare/dashboard-web/dist/*` build artifacts, and a full `bun test` run crashed Bun 1.3.11 itself (SIGILL) in an unrelated test file. CI should be the authority on the full suite here.