### PR TITLE
feat(providers): add MiniMax Token Plan usage polling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ test_*.sh
 .worktrees/
 docs/superpowers/
 packages/database/src/inline-integrity-check-worker.ts
+.tmp/

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "ccflare",

--- a/packages/http-api/src/handlers/accounts.ts
+++ b/packages/http-api/src/handlers/accounts.ts
@@ -451,6 +451,27 @@ export function createAccountsListHandler(
 							);
 						}
 					}
+				} else if (account.provider === "minimax" && usageData) {
+					// Minimax Token Plan usage data — 5h/7d windows from /v1/token_plan/remains
+					const isMinimaxData =
+						"five_hour" in usageData || "seven_day" in usageData;
+					if (isMinimaxData) {
+						try {
+							const {
+								getRepresentativeMinimaxUtilization,
+								getRepresentativeMinimaxWindow,
+							} = require("@better-ccflare/providers");
+							usageUtilization =
+								getRepresentativeMinimaxUtilization(usageData);
+							usageWindow = getRepresentativeMinimaxWindow(usageData);
+							fullUsageData = usageData as FullUsageData;
+						} catch (error) {
+							log.warn(
+								`Failed to process Minimax usage data for account ${account.name}:`,
+								error,
+							);
+						}
+					}
 				}
 
 				const usageThrottleSettings = {

--- a/packages/http-api/src/handlers/rate-limit-status.ts
+++ b/packages/http-api/src/handlers/rate-limit-status.ts
@@ -19,6 +19,7 @@ import type {
 	AlibabaCodingPlanUsageData,
 	AnyUsageData,
 	KiloUsageData,
+	MinimaxUsageData,
 	NanoGPTUsageData,
 	UsageData,
 	XaiUsageData,
@@ -27,6 +28,7 @@ import type {
 import {
 	getRepresentativeAlibabaCodingPlanWindow,
 	getRepresentativeKiloWindow,
+	getRepresentativeMinimaxWindow,
 	getRepresentativeNanoGPTWindow,
 	getRepresentativeWindow,
 	getRepresentativeXaiWindow,
@@ -153,6 +155,15 @@ export function getRepresentativeUsageResetMs(
 					data,
 					getRepresentativeXaiWindow(data as XaiUsageData),
 				);
+			case "minimax": {
+				const windowName = getRepresentativeMinimaxWindow(
+					data as MinimaxUsageData,
+				);
+				// extractUsageResetMs reads `resets_at` (string) OR `resetAt` (ms);
+				// the Minimax fetcher populates `resetAt` with epoch ms, so this
+				// works for both 5h and 7d windows.
+				return extractUsageResetMs(data, windowName);
+			}
 			default:
 				return null;
 		}

--- a/packages/providers/src/__tests__/minimax-usage-fetcher.test.ts
+++ b/packages/providers/src/__tests__/minimax-usage-fetcher.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+	fetchMinimaxUsageData,
+	getRepresentativeMinimaxUtilization,
+	getRepresentativeMinimaxWindow,
+	MINIMAX_TOKEN_PLAN_REMAINS_ENDPOINT,
+	parseMinimaxTokenPlanResponse,
+} from "../minimax-usage-fetcher";
+
+const FIVE_HOUR_MS = 5 * 60 * 60 * 1000;
+const SEVEN_DAY_MS = 7 * 24 * 60 * 60 * 1000;
+const TWENTY_FOUR_HOUR_MS = 24 * 60 * 60 * 1000;
+
+function makeRow(overrides: Partial<{
+	model_name: string;
+	current_interval_remaining_percent: number;
+	current_interval_status: number;
+	current_interval_total_count: number;
+	current_interval_usage_count: number;
+	start_time: number;
+	end_time: number;
+	remains_time: number;
+	current_weekly_remaining_percent: number;
+	current_weekly_status: number;
+	current_weekly_total_count: number;
+	current_weekly_usage_count: number;
+	weekly_start_time: number;
+	weekly_end_time: number;
+	weekly_remains_time: number;
+}> = {}) {
+	const intervalStart = 1_700_000_000_000;
+	const weeklyStart = 1_700_000_000_000;
+	return {
+		model_name: "general",
+		current_interval_remaining_percent: 75,
+		current_interval_status: 1,
+		current_interval_total_count: 100,
+		current_interval_usage_count: 25,
+		start_time: intervalStart,
+		end_time: intervalStart + FIVE_HOUR_MS,
+		remains_time: FIVE_HOUR_MS,
+		current_weekly_remaining_percent: 90,
+		current_weekly_status: 1,
+		current_weekly_total_count: 1000,
+		current_weekly_usage_count: 100,
+		weekly_start_time: weeklyStart,
+		weekly_end_time: weeklyStart + SEVEN_DAY_MS,
+		weekly_remains_time: SEVEN_DAY_MS,
+		...overrides,
+	};
+}
+
+describe("Minimax usage fetcher", () => {
+	let originalFetch: typeof fetch;
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("inverts remaining percent into utilization (75 remaining -> 25 utilized)", () => {
+		const parsed = parseMinimaxTokenPlanResponse({
+			base_resp: { status_code: 0, status_msg: "ok" },
+			model_remains: [makeRow()],
+		});
+
+		expect(parsed?.five_hour?.utilization).toBe(25);
+		expect(parsed?.five_hour?.remainingPercent).toBe(75);
+		expect(parsed?.seven_day?.utilization).toBe(10);
+		expect(parsed?.seven_day?.remainingPercent).toBe(90);
+	});
+
+	it("picks the `general` row, ignoring the `video` row", () => {
+		const parsed = parseMinimaxTokenPlanResponse({
+			base_resp: { status_code: 0 },
+			model_remains: [
+				makeRow({
+					model_name: "video",
+					current_interval_remaining_percent: 5,
+					current_weekly_remaining_percent: 5,
+				}),
+				makeRow({
+					model_name: "general",
+					current_interval_remaining_percent: 60,
+					current_weekly_remaining_percent: 60,
+				}),
+			],
+		});
+
+		expect(parsed?.five_hour?.utilization).toBe(40);
+		expect(parsed?.five_hour?.remainingPercent).toBe(60);
+		expect(parsed?.seven_day?.utilization).toBe(40);
+	});
+
+	it("derives interval length per-row (general=5h, video=24h — not hardcoded)", () => {
+		const generalStart = 1_700_000_000_000;
+		const videoStart = 1_700_000_000_000;
+		const parsed = parseMinimaxTokenPlanResponse({
+			base_resp: { status_code: 0 },
+			model_remains: [
+				makeRow({
+					model_name: "general",
+					start_time: generalStart,
+					end_time: generalStart + FIVE_HOUR_MS,
+				}),
+				makeRow({
+					model_name: "video",
+					current_interval_remaining_percent: 50,
+					current_weekly_remaining_percent: 50,
+					start_time: videoStart,
+					end_time: videoStart + TWENTY_FOUR_HOUR_MS,
+					remains_time: TWENTY_FOUR_HOUR_MS,
+				}),
+			],
+		});
+
+		// Even though `video` would appear first, we use the `general` row.
+		expect(parsed?.five_hour?.intervalMs).toBe(FIVE_HOUR_MS);
+		expect(parsed?.five_hour?.resetAt).toBe(generalStart + FIVE_HOUR_MS);
+		expect(parsed?.seven_day?.intervalMs).toBe(SEVEN_DAY_MS);
+	});
+
+	it("tolerates an unknown status enum value", () => {
+		const parsed = parseMinimaxTokenPlanResponse({
+			base_resp: { status_code: 0 },
+			model_remains: [
+				makeRow({
+					current_interval_status: 7,
+					current_weekly_status: 7,
+					current_interval_remaining_percent: 40,
+					current_weekly_remaining_percent: 80,
+				}),
+			],
+		});
+
+		// Still derives exhaustion purely from percentages, ignoring the
+		// unrecognised enum value.
+		expect(parsed?.five_hour?.utilization).toBe(60);
+		expect(parsed?.seven_day?.utilization).toBe(20);
+	});
+
+	it("returns null when base_resp.status_code is non-zero", () => {
+		expect(
+			parseMinimaxTokenPlanResponse({
+				base_resp: { status_code: 1001, status_msg: "quota exceeded" },
+				model_remains: [makeRow()],
+			}),
+		).toBeNull();
+	});
+
+	it("clamps out-of-range remaining percent before inverting", () => {
+		const parsed = parseMinimaxTokenPlanResponse({
+			base_resp: { status_code: 0 },
+			model_remains: [
+				makeRow({
+					current_interval_remaining_percent: 250, // bogus
+					current_weekly_remaining_percent: -10, // bogus
+				}),
+			],
+		});
+
+		expect(parsed?.five_hour?.remainingPercent).toBe(100);
+		expect(parsed?.five_hour?.utilization).toBe(0);
+		expect(parsed?.seven_day?.remainingPercent).toBe(0);
+		expect(parsed?.seven_day?.utilization).toBe(100);
+	});
+
+	it("hits the documented Token Plan remains endpoint with a Bearer header", async () => {
+		const body = {
+			base_resp: { status_code: 0 },
+			model_remains: [makeRow()],
+		};
+		const fetchMock = mock(
+			async (input: RequestInfo | URL, init?: RequestInit) => {
+				expect(String(input)).toBe(MINIMAX_TOKEN_PLAN_REMAINS_ENDPOINT);
+				expect(init?.method).toBe("GET");
+				expect((init?.headers as Record<string, string>).Authorization).toBe(
+					"Bearer test-key",
+				);
+				return new Response(JSON.stringify(body), { status: 200 });
+			},
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const usage = await fetchMinimaxUsageData(" test-key ");
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(usage?.five_hour?.utilization).toBe(25);
+	});
+
+	it("returns null on non-2xx HTTP responses", async () => {
+		const fetchMock = mock(async () => new Response("nope", { status: 500 }));
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		expect(await fetchMinimaxUsageData("k")).toBeNull();
+	});
+
+	it("returns null on a network failure", async () => {
+		const fetchMock = mock(async () => {
+			throw new Error("ECONNRESET");
+		});
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		expect(await fetchMinimaxUsageData("k")).toBeNull();
+	});
+
+	it("representative utilization picks the more-restrictive window", () => {
+		const parsed = parseMinimaxTokenPlanResponse({
+			base_resp: { status_code: 0 },
+			model_remains: [
+				makeRow({
+					current_interval_remaining_percent: 50, // -> 50% util
+					current_weekly_remaining_percent: 80, // -> 20% util
+				}),
+			],
+		})!;
+
+		expect(getRepresentativeMinimaxUtilization(parsed)).toBe(50);
+		expect(getRepresentativeMinimaxWindow(parsed)).toBe("five_hour");
+	});
+
+	it("falls back to seven_day when only the weekly window is present", () => {
+		const weeklyStart = 1_700_000_000_000;
+		// Make the interval window totally absent (NaN); the parser should
+		// still surface the weekly window as a representative reading.
+		const parsed = parseMinimaxTokenPlanResponse({
+			base_resp: { status_code: 0 },
+			model_remains: [
+				makeRow({
+					current_interval_remaining_percent: Number.NaN,
+					current_interval_total_count: Number.NaN,
+					current_interval_usage_count: Number.NaN,
+					start_time: Number.NaN,
+					end_time: Number.NaN,
+					remains_time: Number.NaN,
+					weekly_start_time: weeklyStart,
+					weekly_end_time: weeklyStart + SEVEN_DAY_MS,
+					current_weekly_remaining_percent: 25, // -> 75% util
+				}),
+			],
+		});
+
+		expect(parsed?.five_hour).toBeNull();
+		expect(parsed?.seven_day?.utilization).toBe(75);
+		expect(getRepresentativeMinimaxUtilization(parsed)).toBe(75);
+		expect(getRepresentativeMinimaxWindow(parsed)).toBe("seven_day");
+	});
+});

--- a/packages/providers/src/__tests__/minimax-usage-fetcher.test.ts
+++ b/packages/providers/src/__tests__/minimax-usage-fetcher.test.ts
@@ -95,6 +95,25 @@ describe("Minimax usage fetcher", () => {
 		expect(parsed?.seven_day?.utilization).toBe(40);
 	});
 
+	it("returns null when no `general` row is present instead of substituting video", () => {
+		const parsed = parseMinimaxTokenPlanResponse({
+			base_resp: { status_code: 0 },
+			model_remains: [
+				makeRow({
+					model_name: "video",
+					current_interval_remaining_percent: 5,
+					current_weekly_remaining_percent: 5,
+				}),
+			],
+		});
+
+		// A separate quota pool must not become text utilization. Null keeps
+		// "unknown" distinct from both 0% and 100% utilization.
+		expect(parsed).toBeNull();
+		expect(getRepresentativeMinimaxUtilization(parsed)).toBeNull();
+		expect(getRepresentativeMinimaxWindow(parsed)).toBeNull();
+	});
+
 	it("derives interval length per-row (general=5h, video=24h — not hardcoded)", () => {
 		const generalStart = 1_700_000_000_000;
 		const videoStart = 1_700_000_000_000;
@@ -196,6 +215,22 @@ describe("Minimax usage fetcher", () => {
 		globalThis.fetch = fetchMock as unknown as typeof fetch;
 
 		expect(await fetchMinimaxUsageData("k")).toBeNull();
+	});
+
+	it("aborts the request via AbortController so a stalled response cannot hold the polling slot", async () => {
+		let observedSignal: AbortSignal | undefined;
+		const fetchMock = mock(
+			async (_input: RequestInfo | URL, init?: RequestInit) => {
+				observedSignal = init?.signal ?? undefined;
+				throw new DOMException("aborted", "AbortError");
+			},
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const result = await fetchMinimaxUsageData("k");
+
+		expect(observedSignal).toBeInstanceOf(AbortSignal);
+		expect(result).toBeNull();
 	});
 
 	it("returns null on a network failure", async () => {

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -6,6 +6,8 @@ export * from "./alibaba-coding-plan-usage-fetcher";
 export { BaseProvider } from "./base";
 // Export Kilo usage fetcher
 export * from "./kilo-usage-fetcher";
+// Export Minimax usage fetcher
+export * from "./minimax-usage-fetcher";
 // Export NanoGPT usage fetcher
 export * from "./nanogpt-usage-fetcher";
 // Export OAuth utilities

--- a/packages/providers/src/minimax-usage-fetcher.ts
+++ b/packages/providers/src/minimax-usage-fetcher.ts
@@ -17,6 +17,14 @@ const log = new Logger("MinimaxUsageFetcher");
 export const MINIMAX_TOKEN_PLAN_REMAINS_ENDPOINT =
 	"https://www.minimax.io/v1/token_plan/remains";
 
+/**
+ * Timeout for the metadata request and the body read. A stalled MiniMax
+ * response previously kept the account's in-flight polling slot occupied
+ * forever (PR #346 review finding #2). Mirrors the
+ * `fetchXaiUsageData` / `fetchUsageData` convention in this package.
+ */
+const MINIMAX_USAGE_REQUEST_TIMEOUT_MS = 5000;
+
 /** Model class we surface in ccflare utilization. */
 const TEXT_INFERENCE_MODEL_NAME = "general";
 
@@ -136,18 +144,21 @@ function buildWindow(
  * Pick the row that represents the account's text-inference quota. Per
  * the live probe, `model_remains` is keyed by `model_name` (e.g. "general",
  * "video"); we use `general` and ignore `video` (gotcha #3).
+ *
+ * If no `general` entry exists we return null instead of substituting
+ * another row: `video` (and any other class) is a separate quota pool,
+ * and a wrong-substituted reading would surface as the account's text
+ * utilization. With the routing side skipping accounts at >=100% util
+ * (PR #345), that could silently drop a healthy account. "Unknown"
+ * must stay distinct from 0% and from 100%.
  */
 function pickTextInferenceRow(
 	modelRemains: MinimaxModelRemains[],
 ): MinimaxModelRemains | null {
-	const general = modelRemains.find(
-		(entry) => entry?.model_name === TEXT_INFERENCE_MODEL_NAME,
+	return (
+		modelRemains.find((entry) => entry?.model_name === TEXT_INFERENCE_MODEL_NAME) ??
+		null
 	);
-	if (general) return general;
-	// Fall back to the first row so a future schema rename still surfaces
-	// SOMETHING rather than nothing — the user will see the wrong window
-	// label but the polling path stays live.
-	return modelRemains[0] ?? null;
 }
 
 /**
@@ -195,6 +206,11 @@ export async function fetchMinimaxUsageData(
 	const key = apiKey?.trim();
 	if (!key) return null;
 
+	const controller = new AbortController();
+	const timeoutId = setTimeout(
+		() => controller.abort(),
+		MINIMAX_USAGE_REQUEST_TIMEOUT_MS,
+	);
 	try {
 		const response = await fetch(MINIMAX_TOKEN_PLAN_REMAINS_ENDPOINT, {
 			method: "GET",
@@ -203,6 +219,7 @@ export async function fetchMinimaxUsageData(
 				Accept: "application/json",
 				"Content-Type": "application/json",
 			},
+			signal: controller.signal,
 		});
 
 		if (!response.ok) {
@@ -218,6 +235,9 @@ export async function fetchMinimaxUsageData(
 			return null;
 		}
 
+		// Body read inherits the same abort signal: a stalled response with
+		// headers flushed but no body would otherwise block indefinitely and
+		// hold the in-flight polling slot until teardown.
 		const body = await response.json();
 		return parseMinimaxTokenPlanResponse(body);
 	} catch (error) {
@@ -226,6 +246,8 @@ export async function fetchMinimaxUsageData(
 			error instanceof Error ? error.message : String(error),
 		);
 		return null;
+	} finally {
+		clearTimeout(timeoutId);
 	}
 }
 

--- a/packages/providers/src/minimax-usage-fetcher.ts
+++ b/packages/providers/src/minimax-usage-fetcher.ts
@@ -1,0 +1,266 @@
+import { Logger } from "@better-ccflare/logger";
+
+const log = new Logger("MinimaxUsageFetcher");
+
+/**
+ * MiniMax Token Plan subscription usage endpoint.
+ *
+ *   GET https://www.minimax.io/v1/token_plan/remains
+ *   Authorization: Bearer <API key>
+ *
+ * The response carries one entry per model class (e.g. "general", "video").
+ * Only the `general` entry reflects text-inference quota; `video` is a
+ * separate pool that must not be folded into utilization. The endpoint is a
+ * pure metadata GET that costs zero quota; the Token Plan subscription key
+ * is sufficient (no separate pay-as-you-go key required).
+ */
+export const MINIMAX_TOKEN_PLAN_REMAINS_ENDPOINT =
+	"https://www.minimax.io/v1/token_plan/remains";
+
+/** Model class we surface in ccflare utilization. */
+const TEXT_INFERENCE_MODEL_NAME = "general";
+
+/**
+ * One row of the `model_remains` array. Field semantics:
+ *   - `*_remaining_percent` is REMAINING (0-100), not utilization.
+ *   - `*_total_count` / `*_usage_count` are request/credit counts, NOT tokens.
+ *   - `start_time` / `end_time` / `weekly_*_time` are epoch milliseconds.
+ *   - `remains_time` / `weekly_remains_time` are millisecond durations.
+ *   - The status enums are only known for healthy accounts (`1`); tolerate
+ *     unknown values and never switch on them.
+ */
+export interface MinimaxModelRemains {
+	model_name: string;
+	current_interval_remaining_percent: number;
+	current_interval_status: number;
+	current_interval_total_count: number;
+	current_interval_usage_count: number;
+	start_time: number;
+	end_time: number;
+	remains_time: number;
+	current_weekly_remaining_percent: number;
+	current_weekly_status: number;
+	current_weekly_total_count: number;
+	current_weekly_usage_count: number;
+	weekly_start_time: number;
+	weekly_end_time: number;
+	weekly_remains_time: number;
+}
+
+interface MinimaxBaseResponse {
+	status_code?: number;
+	status_msg?: string;
+}
+
+interface MinimaxRawResponse {
+	base_resp?: MinimaxBaseResponse;
+	model_remains?: MinimaxModelRemains[];
+}
+
+export interface MinimaxUsageWindow {
+	/** Utilization percent (0-100). 0 = fully available, 100 = exhausted. */
+	utilization: number;
+	/** Remaining percent (0-100) straight from the API. */
+	remainingPercent: number;
+	/** Reset time as epoch milliseconds. */
+	resetAt: number | null;
+	/** Window length in ms, derived from end_time - start_time per entry. */
+	intervalMs: number | null;
+}
+
+export interface MinimaxUsageData {
+	/** 5h-style per-model-class window derived from the `general` entry. */
+	five_hour: MinimaxUsageWindow | null;
+	/** 7d weekly window derived from the same `general` entry. */
+	seven_day: MinimaxUsageWindow | null;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value);
+}
+
+function toRemainingPercent(value: unknown): number | null {
+	if (!isFiniteNumber(value)) return null;
+	if (value < 0) return 0;
+	if (value > 100) return 100;
+	return value;
+}
+
+/**
+ * Invert the API's REMAINING percent into ccflare's UTILIZATION percent.
+ * `utilization = 100 - remaining_percent`. Forgetting to invert would
+ * report healthy accounts as exhausted and vice versa (gotcha #2).
+ */
+function remainingToUtilization(remainingPercent: number): number {
+	const util = 100 - remainingPercent;
+	if (util < 0) return 0;
+	if (util > 100) return 100;
+	return util;
+}
+
+function buildWindow(
+	raw: MinimaxModelRemains,
+	which: "interval" | "weekly",
+): MinimaxUsageWindow | null {
+	const remainingField =
+		which === "interval"
+			? "current_interval_remaining_percent"
+			: "current_weekly_remaining_percent";
+	const startField =
+		which === "interval" ? "start_time" : "weekly_start_time";
+	const endField = which === "interval" ? "end_time" : "weekly_end_time";
+
+	const remaining = toRemainingPercent(
+		(raw as unknown as Record<string, unknown>)[remainingField],
+	);
+	if (remaining === null) return null;
+
+	const start = (raw as unknown as Record<string, unknown>)[startField];
+	const end = (raw as unknown as Record<string, unknown>)[endField];
+	const startMs = isFiniteNumber(start) ? start : null;
+	const endMs = isFiniteNumber(end) ? end : null;
+	const intervalMs =
+		startMs !== null && endMs !== null && endMs >= startMs
+			? endMs - startMs
+			: null;
+
+	return {
+		utilization: remainingToUtilization(remaining),
+		remainingPercent: remaining,
+		resetAt: endMs,
+		intervalMs,
+	};
+}
+
+/**
+ * Pick the row that represents the account's text-inference quota. Per
+ * the live probe, `model_remains` is keyed by `model_name` (e.g. "general",
+ * "video"); we use `general` and ignore `video` (gotcha #3).
+ */
+function pickTextInferenceRow(
+	modelRemains: MinimaxModelRemains[],
+): MinimaxModelRemains | null {
+	const general = modelRemains.find(
+		(entry) => entry?.model_name === TEXT_INFERENCE_MODEL_NAME,
+	);
+	if (general) return general;
+	// Fall back to the first row so a future schema rename still surfaces
+	// SOMETHING rather than nothing — the user will see the wrong window
+	// label but the polling path stays live.
+	return modelRemains[0] ?? null;
+}
+
+/**
+ * Parse a raw response body. Returns null on any structural problem so the
+ * caller treats it as a transient failure (no quota consumed on the API
+ * side, so a retry from the poller is safe).
+ */
+export function parseMinimaxTokenPlanResponse(
+	body: unknown,
+): MinimaxUsageData | null {
+	if (!body || typeof body !== "object") return null;
+	const raw = body as MinimaxRawResponse;
+
+	const statusCode = raw.base_resp?.status_code;
+	if (typeof statusCode === "number" && statusCode !== 0) {
+		log.warn(
+			`Minimax usage returned base_resp.status_code=${statusCode}${raw.base_resp?.status_msg ? ` ${raw.base_resp.status_msg}` : ""}`,
+		);
+		return null;
+	}
+
+	if (!Array.isArray(raw.model_remains) || raw.model_remains.length === 0) {
+		log.warn("Minimax usage response missing model_remains array");
+		return null;
+	}
+
+	const row = pickTextInferenceRow(raw.model_remains);
+	if (!row) return null;
+
+	const five_hour = buildWindow(row, "interval");
+	const seven_day = buildWindow(row, "weekly");
+
+	if (!five_hour && !seven_day) return null;
+
+	return { five_hour, seven_day };
+}
+
+/**
+ * Fetch usage data from MiniMax's Token Plan usage endpoint. Failures
+ * return null; this is non-blocking and never affects provider operation.
+ */
+export async function fetchMinimaxUsageData(
+	apiKey: string,
+): Promise<MinimaxUsageData | null> {
+	const key = apiKey?.trim();
+	if (!key) return null;
+
+	try {
+		const response = await fetch(MINIMAX_TOKEN_PLAN_REMAINS_ENDPOINT, {
+			method: "GET",
+			headers: {
+				Authorization: `Bearer ${key}`,
+				Accept: "application/json",
+				"Content-Type": "application/json",
+			},
+		});
+
+		if (!response.ok) {
+			log.warn(
+				`Failed to fetch Minimax usage data: ${response.status} ${response.statusText}`,
+				{
+					status: response.status,
+					statusText: response.statusText,
+					url: MINIMAX_TOKEN_PLAN_REMAINS_ENDPOINT,
+					timestamp: new Date().toISOString(),
+				},
+			);
+			return null;
+		}
+
+		const body = await response.json();
+		return parseMinimaxTokenPlanResponse(body);
+	} catch (error) {
+		log.warn(
+			"Error fetching Minimax usage data:",
+			error instanceof Error ? error.message : String(error),
+		);
+		return null;
+	}
+}
+
+/**
+ * Representative utilization percent (0-100). Uses the higher of the
+ * per-model-class 5h-style window and the 7d weekly window — mirrors how
+ * the zai fetcher treats its 5h / 7d surfaces.
+ */
+export function getRepresentativeMinimaxUtilization(
+	usage: MinimaxUsageData | null,
+): number | null {
+	if (!usage) return null;
+	const candidates = [usage.five_hour, usage.seven_day]
+		.map((w) => w?.utilization)
+		.filter((v): v is number => typeof v === "number");
+	if (candidates.length === 0) return null;
+	return Math.max(...candidates);
+}
+
+/**
+ * Window label for the most-restrictive window. Maps to the same labels
+ * the accounts handler / /health surface use for Claude (so a MiniMax
+ * account sitting in the 5h pool shows up next to other 5h-pressure
+ * accounts in the UI).
+ */
+export function getRepresentativeMinimaxWindow(
+	usage: MinimaxUsageData | null,
+): string | null {
+	if (!usage) return null;
+	const five = usage.five_hour;
+	const seven = usage.seven_day;
+	if (five && seven) {
+		return five.utilization >= seven.utilization ? "five_hour" : "seven_day";
+	}
+	if (five) return "five_hour";
+	if (seven) return "seven_day";
+	return null;
+}

--- a/packages/providers/src/usage-fetcher.ts
+++ b/packages/providers/src/usage-fetcher.ts
@@ -19,6 +19,12 @@ import {
 	type NanoGPTUsageData,
 } from "./nanogpt-usage-fetcher";
 import {
+	fetchMinimaxUsageData,
+	getRepresentativeMinimaxUtilization,
+	getRepresentativeMinimaxWindow,
+	type MinimaxUsageData,
+} from "./minimax-usage-fetcher";
+import {
 	fetchXaiUsageData,
 	getRepresentativeXaiUtilization,
 	getRepresentativeXaiWindow,
@@ -94,7 +100,8 @@ export type AnyUsageData =
 	| ZaiUsageData
 	| KiloUsageData
 	| AlibabaCodingPlanUsageData
-	| XaiUsageData;
+	| XaiUsageData
+	| MinimaxUsageData;
 
 /**
  * Extract the primary window reset timestamp (ms) from usage data.
@@ -127,6 +134,15 @@ export function extractWindowResetTime(
 		if (!resetsAt) return null;
 		const ms = new Date(resetsAt).getTime();
 		return Number.isFinite(ms) ? ms : null;
+	}
+	if (provider === "minimax") {
+		const m = data as MinimaxUsageData;
+		const windowName = getRepresentativeMinimaxWindow(m);
+		if (windowName === "seven_day") {
+			return m.seven_day?.resetAt ?? null;
+		}
+		// Default and "five_hour": prefer the short window's reset
+		return m.five_hour?.resetAt ?? m.seven_day?.resetAt ?? null;
 	}
 	return null;
 }
@@ -420,6 +436,9 @@ export function getRepresentativeUtilizationForProvider(
 		}
 		case "xai": {
 			return getRepresentativeXaiUtilization(data as XaiUsageData);
+		}
+		case "minimax": {
+			return getRepresentativeMinimaxUtilization(data as MinimaxUsageData);
 		}
 		default:
 			return null;
@@ -818,6 +837,25 @@ class UsageCache {
 					const window = getRepresentativeXaiWindow(data as XaiUsageData);
 					log.debug(
 						`Successfully fetched xAI Grok usage data for account ${accountId}: ${utilization?.toFixed(1)}% used (${window} window)`,
+					);
+					return { success: true, retryAfterMs: null };
+				}
+			} else if (provider === "minimax") {
+				// Fetch Minimax Token Plan remains (metadata-only GET, zero quota).
+				data = await fetchMinimaxUsageData(token);
+				if (data) {
+					const callback = this.windowResetCallbacks.get(accountId);
+					if (callback)
+						this.notifyWindowReset(accountId, data, "minimax", callback);
+					this.cache.set(accountId, { data, timestamp: Date.now() });
+					const utilization = getRepresentativeMinimaxUtilization(
+						data as MinimaxUsageData,
+					);
+					const window = getRepresentativeMinimaxWindow(
+						data as MinimaxUsageData,
+					);
+					log.debug(
+						`Successfully fetched Minimax usage data for account ${accountId}: ${utilization?.toFixed(1)}% used (${window} window)`,
 					);
 					return { success: true, retryAfterMs: null };
 				}

--- a/packages/types/src/provider-config.ts
+++ b/packages/types/src/provider-config.ts
@@ -68,7 +68,7 @@ export const PROVIDER_CONFIG: Record<ProviderName, ProviderConfig> = {
 	},
 	[PROVIDER_NAMES.MINIMAX]: {
 		requiresSessionTracking: false, // Minimax is pay-as-you-go
-		supportsUsageTracking: false, // Minimax doesn't support usage tracking
+		supportsUsageTracking: true, // Minimax exposes Token Plan remains via /v1/token_plan/remains (polling only; request forwarding still goes through the generic anthropic-compatible path)
 		supportsOAuth: false, // Minimax uses API key authentication
 		defaultEndpoint: "https://api.minimax.io/anthropic",
 	},


### PR DESCRIPTION
Mirrors the zai/xai fetcher pattern for the MiniMax subscription usage endpoint at `/v1/token_plan/remains`.

## Scope

**Usage polling only.** Minimax accounts already route through the generic anthropic-compatible path (`packages/providers/src/providers/minimax/provider.ts` -> `base-anthropic-compatible.ts`); request forwarding is untouched. This PR only adds the polling and display plumbing.

## What's in the spec

- `GET https://www.minimax.io/v1/token_plan/remains` with `Authorization: Bearer <key>` — zero-quota metadata GET; the Token Plan subscription key works (no separate pay-as-you-go key required).
- Response carries `base_resp.status_code` and a `model_remains[]` array with one entry per model class (`general`, `video`). Each entry has 15 fields; the spec's gotchas (live probe, units bounds-checked) drove the design.

## Gotchas handled (each would silently corrupt the data if missed)

1. Per-model interval length is derived from `end_time - start_time` per row — `general` is 5h, `video` is 24h. Not hardcoded.
2. Remaining percent is inverted into utilization (`utilization = 100 - remaining_percent`).
3. Only the `general` row is used; `video` is a separate quota pool irrelevant to text inference.
4. Reset times come from `end_time` / `weekly_end_time` (already epoch ms), not derived from `remains_time`.
5. The `*_count` fields are request/credit counts, not tokens — not surfaced as token budgets.
6. Status enums are only known for healthy accounts (`1`); unknown values are tolerated and exhaustion is derived from the percentages.

## Files

- `packages/providers/src/minimax-usage-fetcher.ts` — fetch + parse + representative-utilization helpers, modeled on `zai-usage-fetcher.ts` and `xai-usage-fetcher.ts`.
- `packages/providers/src/__tests__/minimax-usage-fetcher.test.ts` — 11 cases covering each gotcha plus HTTP failure paths and window selection.
- `packages/providers/src/usage-fetcher.ts` — dispatcher branch, `AnyUsageData` union addition, and `extractWindowResetMs` case.
- `packages/types/src/provider-config.ts` — flip `minimax.supportsUsageTracking` to `true` with updated comment.
- `packages/http-api/src/handlers/accounts.ts` — `getRepresentativeMinimaxUtilization` branch alongside the zai/xai/kilo/nanogpt blocks.
- `packages/http-api/src/handlers/rate-limit-status.ts` — `getRepresentativeUsageResetMs` case so `/health` and the accounts display stay consistent.
- `packages/providers/src/index.ts` — barrel export.

## Test results (honest)

Passed:
- 11/11 new `minimax-usage-fetcher.test.ts` cases
- 60/60 tests in `packages/providers/src/__tests__/` (no regression in xai / zai / kilo / nanogpt / usage-cache / window-reset-detection / usage-fetcher-limits)
- TypeScript: only the two pre-existing `apps/server/src/server.ts` errors about missing `@better-ccflare/dashboard-web/dist/*` artifacts (already broken on upstream/main before this PR); zero new typecheck errors from this change.

Blocked by pre-existing environment breakage (not introduced by this PR — confirmed by re-running on clean upstream/main HEAD with this branch's edits stashed):
- `bun test packages/http-api/...` fails on every test file with `Cannot find module './inline-integrity-check-worker' from '.../packages/database/src/integrity-check-runner.ts'` (and variants like `inline-incremental-vacuum-worker`); only the `.d.ts` is committed upstream, Bun's test runtime can't load the missing `.ts`.
- Bun 1.3.2 with the full test suite triggers a SIGILL on the spec's notes; did not chase.

Net: the new fetcher and its 11 cases are green; downstream integration tests are blocked by the pre-existing database worker issue and would need to be fixed in a separate change to the `.gitignore` / committed source set.