### PR TITLE
fix: wire minimax usage polling into server bootstrap and instrument unknown model_name

### DIFF
--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "bun:test";
-import { supportsRefreshBackedUsagePolling } from "./server";
+import { describe, expect, it, mock } from "bun:test";
+import {
+	type UsageCacheRegistrar,
+	registerMinimaxUsagePolling,
+	supportsRefreshBackedUsagePolling,
+} from "./server";
 
 describe("supportsRefreshBackedUsagePolling", () => {
 	it("includes pollable OAuth providers that need token refresh", () => {
@@ -12,6 +16,120 @@ describe("supportsRefreshBackedUsagePolling", () => {
 		expect(supportsRefreshBackedUsagePolling("qwen")).toBe(false);
 		expect(supportsRefreshBackedUsagePolling("nanogpt")).toBe(false);
 		expect(supportsRefreshBackedUsagePolling(null)).toBe(false);
+	});
+});
+
+describe("registerMinimaxUsagePolling", () => {
+	function makeAccount(
+		overrides: Partial<{
+			id: string;
+			name: string;
+			provider: string;
+			api_key: string | null;
+		}> = {},
+	) {
+		return {
+			id: "acc-1",
+			name: "minimax-account-1",
+			provider: "minimax",
+			api_key: "test-key",
+			...overrides,
+		} as unknown as Parameters<typeof registerMinimaxUsagePolling>[0];
+	}
+
+	function makeRegistrar() {
+		const startPolling = mock(
+			(
+				_accountId: string,
+				_tokenProvider: () => Promise<string>,
+				_provider: string,
+				_intervalMs: number,
+			) => {},
+		);
+		return {
+			registrar: { startPolling } as unknown as UsageCacheRegistrar,
+			startPolling,
+		};
+	}
+
+	it("registers polling for a Minimax account with an API key", () => {
+		const { registrar, startPolling } = makeRegistrar();
+		const result = registerMinimaxUsagePolling(makeAccount(), registrar, 30_000);
+
+		expect(result).toBe(true);
+		expect(startPolling).toHaveBeenCalledTimes(1);
+		const call = startPolling.mock.calls[0];
+		expect(call?.[0]).toBe("acc-1");
+		expect(call?.[2]).toBe("minimax");
+		expect(call?.[3]).toBe(30_000);
+		expect(typeof call?.[1]).toBe("function");
+	});
+
+	it("the registered token provider returns the account's API key", async () => {
+		const { registrar, startPolling } = makeRegistrar();
+		registerMinimaxUsagePolling(
+			makeAccount({ api_key: "secret-key" }),
+			registrar,
+			30_000,
+		);
+
+		const tokenProvider = startPolling.mock.calls[0]?.[1];
+		expect(await tokenProvider()).toBe("secret-key");
+	});
+
+	it("does not register polling for non-Minimax accounts", () => {
+		const { registrar, startPolling } = makeRegistrar();
+		// The block calls registerMinimaxUsagePolling only for accounts where
+		// accounts.filter((a) => a.provider === "minimax") matched, so the
+		// helper itself is the load-bearing gate. If the filter goes away and
+		// this helper is called for every provider, the false return here is
+		// what keeps the wrong accounts from being polled.
+		expect(
+			registerMinimaxUsagePolling(
+				makeAccount({ provider: "zai", api_key: "k" }),
+				registrar,
+				30_000,
+			),
+		).toBe(false);
+		expect(
+			registerMinimaxUsagePolling(
+				makeAccount({ provider: "nanogpt", api_key: "k" }),
+				registrar,
+				30_000,
+			),
+		).toBe(false);
+		expect(
+			registerMinimaxUsagePolling(
+				makeAccount({ provider: "anthropic", api_key: "k" }),
+				registrar,
+				30_000,
+			),
+		).toBe(false);
+		expect(startPolling).toHaveBeenCalledTimes(0);
+	});
+
+	it("does not register polling when a Minimax account has no API key", () => {
+		const { registrar, startPolling } = makeRegistrar();
+		const result = registerMinimaxUsagePolling(
+			makeAccount({ api_key: null }),
+			registrar,
+			30_000,
+		);
+
+		expect(result).toBe(false);
+		expect(startPolling).toHaveBeenCalledTimes(0);
+	});
+
+	it("does not register polling when a Minimax account has an empty API key", () => {
+		const { registrar, startPolling } = makeRegistrar();
+		const result = registerMinimaxUsagePolling(
+			makeAccount({ api_key: "" }),
+			registrar,
+			30_000,
+		);
+
+		expect(result).toBe(false);
+		expect(startPolling).toHaveBeenCalledTimes(0);
 	});
 });
 

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, mock } from "bun:test";
 import {
-	type UsageCacheRegistrar,
+	bootstrapMinimaxUsagePolling,
 	registerMinimaxUsagePolling,
+	type UsageCacheRegistrar,
 	supportsRefreshBackedUsagePolling,
 } from "./server";
 
@@ -130,6 +131,159 @@ describe("registerMinimaxUsagePolling", () => {
 
 		expect(result).toBe(false);
 		expect(startPolling).toHaveBeenCalledTimes(0);
+	});
+});
+
+describe("bootstrapMinimaxUsagePolling", () => {
+	function makeAccount(
+		overrides: Partial<{
+			id: string;
+			name: string;
+			provider: string;
+			api_key: string | null;
+		}> = {},
+	) {
+		return {
+			id: "acc-1",
+			name: "acc-1",
+			provider: "minimax",
+			api_key: "test-key",
+			...overrides,
+		} as unknown as Parameters<typeof bootstrapMinimaxUsagePolling>[0][number];
+	}
+
+	function makeRegistrar() {
+		const startPolling = mock(
+			(
+				_accountId: string,
+				_tokenProvider: () => Promise<string>,
+				_provider: string,
+				_intervalMs: number,
+			) => {},
+		);
+		return {
+			registrar: { startPolling } as unknown as UsageCacheRegistrar,
+			startPolling,
+		};
+	}
+
+	// This is the regression test for PR #347. The inline bootstrap block in
+	// startServer() (around line 1637 pre-refactor) filtered `accounts` for
+	// provider === "minimax" and called `registerMinimaxUsagePolling` for each
+	// match. The original PR landed a working fetcher + helper but never
+	// exercised the wiring path that actually invokes it at startup — mirroring
+	// PR #346's "shipped a working fetcher that nothing called" bug. This test
+	// pins the wiring: given a realistic mixed-provider account list (the same
+	// shape `startServer()` passes), it must register polling for Minimax
+	// accounts and nothing else. If the inline bootstrap block in startServer()
+	// is removed (and this helper is also removed, since nothing else imports
+	// it), the import below fails and every test in this file goes RED.
+
+	it("registers polling for Minimax accounts and ignores other providers", () => {
+		const { registrar, startPolling } = makeRegistrar();
+		const accounts = [
+			makeAccount({ id: "zai-1", name: "zai-1", provider: "zai" }),
+			makeAccount({
+				id: "minimax-1",
+				name: "minimax-1",
+				provider: "minimax",
+				api_key: "minimax-key-1",
+			}),
+			makeAccount({ id: "nanogpt-1", name: "nanogpt-1", provider: "nanogpt" }),
+			makeAccount({
+				id: "minimax-2",
+				name: "minimax-2",
+				provider: "minimax",
+				api_key: "minimax-key-2",
+			}),
+			makeAccount({
+				id: "anthropic-1",
+				name: "anthropic-1",
+				provider: "anthropic",
+			}),
+		];
+
+		const registered = bootstrapMinimaxUsagePolling(accounts, registrar, 30_000);
+
+		// Only the two Minimax accounts should appear in the registered list,
+		// proving the filter on `provider === "minimax"` is actually applied
+		// to the full account list, not just whatever the helper receives.
+		expect(registered).toEqual(["minimax-1", "minimax-2"]);
+		// And the registrar must have been driven exactly twice — once per
+		// Minimax account, never for the zai/nanogpt/anthropic rows that are
+		// sitting in the same array.
+		expect(startPolling).toHaveBeenCalledTimes(2);
+		const calledIds = startPolling.mock.calls.map((c) => c[0]);
+		expect(calledIds).toEqual(["minimax-1", "minimax-2"]);
+	});
+
+	it("does not register polling when the account list has no Minimax accounts", () => {
+		const { registrar, startPolling } = makeRegistrar();
+		const accounts = [
+			makeAccount({ id: "zai-1", provider: "zai" }),
+			makeAccount({ id: "nanogpt-1", provider: "nanogpt" }),
+			makeAccount({ id: "anthropic-1", provider: "anthropic" }),
+		];
+
+		const registered = bootstrapMinimaxUsagePolling(accounts, registrar, 30_000);
+
+		expect(registered).toEqual([]);
+		expect(startPolling).toHaveBeenCalledTimes(0);
+	});
+
+	it("registers polling only for Minimax accounts with API keys and skips the rest", () => {
+		const { registrar, startPolling } = makeRegistrar();
+		const accounts = [
+			makeAccount({
+				id: "minimax-no-key",
+				name: "no-key",
+				provider: "minimax",
+				api_key: null,
+			}),
+			makeAccount({
+				id: "minimax-empty-key",
+				name: "empty-key",
+				provider: "minimax",
+				api_key: "",
+			}),
+			makeAccount({
+				id: "minimax-good",
+				name: "good",
+				provider: "minimax",
+				api_key: "real-key",
+			}),
+		];
+
+		const registered = bootstrapMinimaxUsagePolling(accounts, registrar, 30_000);
+
+		expect(registered).toEqual(["minimax-good"]);
+		expect(startPolling).toHaveBeenCalledTimes(1);
+		expect(startPolling.mock.calls[0]?.[0]).toBe("minimax-good");
+	});
+
+	it("forwards the configured interval to every registered Minimax account", () => {
+		const { registrar, startPolling } = makeRegistrar();
+		const accounts = [
+			makeAccount({
+				id: "minimax-a",
+				name: "a",
+				provider: "minimax",
+				api_key: "k1",
+			}),
+			makeAccount({
+				id: "minimax-b",
+				name: "b",
+				provider: "minimax",
+				api_key: "k2",
+			}),
+		];
+
+		bootstrapMinimaxUsagePolling(accounts, registrar, 12_345);
+
+		expect(startPolling).toHaveBeenCalledTimes(2);
+		for (const call of startPolling.mock.calls) {
+			expect(call[3]).toBe(12_345);
+		}
 	});
 });
 

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it, mock } from "bun:test";
 import {
 	bootstrapMinimaxUsagePolling,
@@ -403,5 +405,116 @@ describe("trackStreamForShutdown", () => {
 		await settled;
 		expect(cancelResolved).toBe(true);
 		reader.cancel().catch(() => {});
+	});
+});
+
+// Structural guard: assert that startServer() actually invokes
+// bootstrapMinimaxUsagePolling in its source. This is the negative control
+// for PR #347 — the previous unit-test guard only failed when the EXPORTED
+// HELPER was removed, not when the call site was deleted. The realistic
+// regression is someone removing the inline bootstrap block in startServer()
+// while the helper still sits in the module unused. With this guard, the
+// test goes RED the moment the call site disappears, even if the helper
+// stays intact.
+//
+// Why this is structural and not behavioral: startServer() is a full
+// process lifecycle (DB init, network bind, signal handlers, dashboard
+// wiring, TLS). It is not realistic to invoke it in a unit test without
+// dragging in the whole runtime, so this test reads the source file off
+// disk and verifies the invocation is present inside startServer()'s body.
+// Brittle to renames of either `startServer` or `bootstrapMinimaxUsagePolling`,
+// which is by design — if either name changes, the engineer must update
+// this guard and confirm the wiring is still in place.
+describe("startServer() wiring guards", () => {
+	function readStartServerBody(): string {
+		const src = readFileSync(join(import.meta.dir, "server.ts"), "utf8");
+		const match = src.match(
+			/export\s+default\s+async\s+function\s+startServer\b/,
+		);
+		if (!match || match.index === undefined) {
+			throw new Error(
+				"startServer default export not found in server.ts — update the wiring guard string",
+			);
+		}
+		// startServer's signature is `startServer(options?: { ... }) {`.
+		// Skip past the parameter list by tracking paren depth so we don't
+		// latch onto the inline type-literal `{` that opens `options?:`.
+		let parenDepth = 0;
+		let pastParens = -1;
+		for (let i = match.index; i < src.length; i++) {
+			const ch = src[i];
+			if (ch === "(") parenDepth++;
+			else if (ch === ")") {
+				parenDepth--;
+				if (parenDepth === 0) {
+					pastParens = i;
+					break;
+				}
+			}
+		}
+		if (pastParens < 0) {
+			throw new Error("startServer parameter list never closed");
+		}
+		const openIdx = src.indexOf("{", pastParens);
+		if (openIdx < 0) {
+			throw new Error("startServer body opening brace not found");
+		}
+		// Balance braces to find the matching close. Template strings,
+		// regex literals, and comments can carry unbalanced braces, but
+		// server.ts is well-formed enough that a depth counter is reliable
+		// for this function — it does not contain raw `{` inside a template
+		// that would fool the simple counter.
+		let depth = 0;
+		for (let i = openIdx; i < src.length; i++) {
+			const ch = src[i];
+			if (ch === "{") depth++;
+			else if (ch === "}") {
+				depth--;
+				if (depth === 0) {
+					return src.slice(openIdx, i + 1);
+				}
+			}
+		}
+		throw new Error("startServer body closing brace not found");
+	}
+
+	// The regression we are guarding: PR #347 shipped a working fetcher and
+	// a working helper, but the inline bootstrap block in startServer() —
+	// the actual production wiring — was the thing missing test coverage.
+	// Removing that block (lines ~1670-1688 in server.ts) and keeping the
+	// helper exported would not have failed the unit tests in this file
+	// before this guard landed. With this guard, deleting that block while
+	// leaving the helper intact goes RED.
+	it("invokes bootstrapMinimaxUsagePolling inside startServer()", () => {
+		const body = readStartServerBody();
+		// Match an actual call: `<identifier> (`. Just matching the bare
+		// identifier would also pass if someone left a stale comment naming
+		// the helper, so we require the opening paren.
+		expect(body).toMatch(/bootstrapMinimaxUsagePolling\s*\(/);
+	});
+
+	it("passes accounts, usageCache, and the configured poll interval to bootstrapMinimaxUsagePolling", () => {
+		const body = readStartServerBody();
+		// Check that the call site carries the same arguments the surrounding
+		// zai/kilo blocks pass. This catches the regression where someone
+		// replaces the full call with a stub like `bootstrapMinimaxUsagePolling()`
+		// that compiles and lints but never actually wires the cache.
+		const call = body.match(/bootstrapMinimaxUsagePolling\s*\(([\s\S]*?)\)/);
+		expect(call).not.toBeNull();
+		const args = call?.[1] ?? "";
+		// Trim and split on top-level commas (no nested parens expected
+		// inside the 3-arg call, but be conservative).
+		const argList = args
+			.split(",")
+			.map((s) => s.trim())
+			.filter(Boolean);
+		expect(argList.length).toBe(3);
+		// First two arguments must be the live runtime objects, not the
+		// string literals "accounts" / "usageCache".
+		expect(argList[0]).toBe("accounts");
+		expect(argList[1]).toBe("usageCache");
+		// Third argument must flow through the configured poll interval —
+		// i.e. not a hardcoded numeric literal.
+		expect(argList[2]).not.toMatch(/^\d+$/);
 	});
 });

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -128,6 +128,49 @@ export function supportsRefreshBackedUsagePolling(
 	return provider === "anthropic" || provider === "xai";
 }
 
+/**
+ * Minimal interface satisfied by the `usageCache` singleton in
+ * `@better-ccflare/providers`. Declared locally so the bootstrap helper
+ * can be unit-tested with a mock without dragging the full UsageCache
+ * class (which is not exported) into the public type surface.
+ */
+export interface UsageCacheRegistrar {
+	startPolling(
+		accountId: string,
+		tokenProvider: () => Promise<string>,
+		provider: string,
+		intervalMs: number,
+	): void;
+}
+
+/**
+ * Register usage polling for a single Minimax account. The Minimax fetcher
+ * hits the Token Plan `remains` endpoint with a Bearer API key; no OAuth
+ * refresh is required. Mirrors the surrounding nanogpt/zai/kilo pattern:
+ * pay-as-you-go, API-key authentication, no window reset callback
+ * (Minimax has `requiresSessionTracking: false` in provider-config.ts).
+ *
+ * Returns true if polling was registered, false if the account is not
+ * a Minimax account or has no API key. Extracted from the bootstrap
+ * loop so the registration contract is unit-testable.
+ */
+export function registerMinimaxUsagePolling(
+	account: Account,
+	usageCache: UsageCacheRegistrar,
+	intervalMs: number,
+): boolean {
+	if (account.provider !== "minimax") return false;
+	if (!account.api_key) return false;
+	const apiKeyProvider = async () => account.api_key || "";
+	usageCache.startPolling(
+		account.id,
+		apiKeyProvider,
+		account.provider,
+		intervalMs,
+	);
+	return true;
+}
+
 // Helper function to resolve dashboard assets with fallback
 function resolveDashboardAsset(assetPath: string): string | null {
 	try {
@@ -1589,6 +1632,37 @@ Available endpoints:
 		}
 	} else {
 		log.info(`No Kilo Gateway accounts found, usage polling will not start`);
+	}
+
+	// Start usage polling for Minimax accounts (Token Plan `remains` endpoint)
+	const minimaxAccounts = accounts.filter((a) => a.provider === "minimax");
+	if (minimaxAccounts.length > 0) {
+		log.info(
+			`Found ${minimaxAccounts.length} Minimax accounts, starting usage polling...`,
+		);
+		for (const account of minimaxAccounts) {
+			log.debug(`Processing Minimax account: ${account.name}`, {
+				accountId: account.id,
+				hasApiKey: !!account.api_key,
+				paused: account.paused,
+			});
+
+			if (
+				registerMinimaxUsagePolling(
+					account,
+					usageCache,
+					config.getUsagePollIntervalMs(),
+				)
+			) {
+				log.info(`Started usage polling for Minimax account ${account.name}`);
+			} else {
+				log.warn(
+					`Minimax account ${account.name} has no API key, skipping usage polling`,
+				);
+			}
+		}
+	} else {
+		log.info(`No Minimax accounts found, usage polling will not start`);
 	}
 
 	// Pre-warm Bedrock model and inference profile caches

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -171,6 +171,39 @@ export function registerMinimaxUsagePolling(
 	return true;
 }
 
+/**
+ * Run the Minimax usage-polling bootstrap over a list of accounts. This is the
+ * shape of the wiring block `startServer()` runs for every Minimax account at
+ * startup — filter for provider === "minimax", then delegate each one to
+ * {@link registerMinimaxUsagePolling} which decides whether polling should
+ * actually start.
+ *
+ * Returns the account IDs that were registered (i.e. had a usable API key).
+ * Returning the registered IDs rather than a bare count lets callers log the
+ * affected accounts and gives tests a stable handle to assert against.
+ *
+ * Extracted from the inline bootstrap block so a regression test can exercise
+ * the exact wiring path (filter → forEach → registerMinimaxUsagePolling) with
+ * a mixed-provider account list. If the inline block in `startServer()` is
+ * removed but this helper still exists and is unit-tested in isolation, the
+ * startup-time wiring has no test coverage — that is the gap this function
+ * exists to close. Keep the bootstrap block in `startServer()` calling this.
+ */
+export function bootstrapMinimaxUsagePolling(
+	accounts: readonly Account[],
+	usageCache: UsageCacheRegistrar,
+	intervalMs: number,
+): string[] {
+	const minimaxAccounts = accounts.filter((a) => a.provider === "minimax");
+	const registered: string[] = [];
+	for (const account of minimaxAccounts) {
+		if (registerMinimaxUsagePolling(account, usageCache, intervalMs)) {
+			registered.push(account.id);
+		}
+	}
+	return registered;
+}
+
 // Helper function to resolve dashboard assets with fallback
 function resolveDashboardAsset(assetPath: string): string | null {
 	try {
@@ -1635,31 +1668,20 @@ Available endpoints:
 	}
 
 	// Start usage polling for Minimax accounts (Token Plan `remains` endpoint)
-	const minimaxAccounts = accounts.filter((a) => a.provider === "minimax");
-	if (minimaxAccounts.length > 0) {
+	const registeredMinimaxAccountIds = bootstrapMinimaxUsagePolling(
+		accounts,
+		usageCache,
+		config.getUsagePollIntervalMs(),
+	);
+	if (registeredMinimaxAccountIds.length > 0) {
 		log.info(
-			`Found ${minimaxAccounts.length} Minimax accounts, starting usage polling...`,
+			`Found ${registeredMinimaxAccountIds.length} Minimax accounts, starting usage polling...`,
 		);
-		for (const account of minimaxAccounts) {
-			log.debug(`Processing Minimax account: ${account.name}`, {
-				accountId: account.id,
-				hasApiKey: !!account.api_key,
-				paused: account.paused,
-			});
-
-			if (
-				registerMinimaxUsagePolling(
-					account,
-					usageCache,
-					config.getUsagePollIntervalMs(),
-				)
-			) {
-				log.info(`Started usage polling for Minimax account ${account.name}`);
-			} else {
-				log.warn(
-					`Minimax account ${account.name} has no API key, skipping usage polling`,
-				);
-			}
+		for (const accountId of registeredMinimaxAccountIds) {
+			const account = accounts.find((a) => a.id === accountId);
+			log.info(
+				`Started usage polling for Minimax account ${account?.name ?? accountId}`,
+			);
 		}
 	} else {
 		log.info(`No Minimax accounts found, usage polling will not start`);

--- a/packages/providers/src/__tests__/minimax-usage-fetcher.test.ts
+++ b/packages/providers/src/__tests__/minimax-usage-fetcher.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { logBus } from "@better-ccflare/logger";
 import {
 	fetchMinimaxUsageData,
 	getRepresentativeMinimaxUtilization,
@@ -284,5 +285,90 @@ describe("Minimax usage fetcher", () => {
 		expect(parsed?.seven_day?.utilization).toBe(75);
 		expect(getRepresentativeMinimaxUtilization(parsed)).toBe(75);
 		expect(getRepresentativeMinimaxWindow(parsed)).toBe("seven_day");
+	});
+
+	// Greptile flagged on PR #346 that the "model_remains non-empty but no
+	// 'general' row" case was untested, so the wrong-row fallback had no
+	// guard rail. The deliberate choice is to NOT substitute a row (PR #346
+	// review 4311195e removed a first-row fallback because a `video` quota
+	// would surface as text utilization), but to WARN with the observed
+	// model_name values so a single real poll reveals the right filter.
+	it("warns and lists the observed model_name values when no 'general' row is present", () => {
+		interface LogEvent {
+			ts: number;
+			level: string;
+			msg: string;
+			data?: unknown;
+		}
+		const warnEvents: LogEvent[] = [];
+		const handler = (event: LogEvent) => {
+			if (event.level === "WARN") warnEvents.push(event);
+		};
+		logBus.on("log", handler);
+
+		try {
+			const parsed = parseMinimaxTokenPlanResponse({
+				base_resp: { status_code: 0 },
+				model_remains: [
+					makeRow({
+						model_name: "video",
+						current_interval_remaining_percent: 5,
+						current_weekly_remaining_percent: 5,
+					}),
+					makeRow({
+						model_name: "audio",
+						current_interval_remaining_percent: 50,
+						current_weekly_remaining_percent: 50,
+					}),
+				],
+			});
+
+			// Still returns null — no wrong-row substitution.
+			expect(parsed).toBeNull();
+
+			// At least one WARN references the miss and lists the observed
+			// model_name values. The message is model names only — never
+			// tokens, keys, or full response bodies.
+			const missWarn = warnEvents.find(
+				(e) =>
+					e.msg.includes("no 'general' row") &&
+					e.msg.includes("video") &&
+					e.msg.includes("audio"),
+			);
+			expect(missWarn).toBeDefined();
+		} finally {
+			logBus.off("log", handler);
+		}
+	});
+
+	it("does not warn when model_remains is empty", () => {
+		interface LogEvent {
+			ts: number;
+			level: string;
+			msg: string;
+			data?: unknown;
+		}
+		const warnEvents: LogEvent[] = [];
+		const handler = (event: LogEvent) => {
+			if (event.level === "WARN") warnEvents.push(event);
+		};
+		logBus.on("log", handler);
+
+		try {
+			// Empty model_remains is the "missing array" branch, not the
+			// "wrong filter" branch — the new WARN must NOT fire here.
+			const parsed = parseMinimaxTokenPlanResponse({
+				base_resp: { status_code: 0 },
+				model_remains: [],
+			});
+
+			expect(parsed).toBeNull();
+			const missWarn = warnEvents.find((e) =>
+				e.msg.includes("no 'general' row"),
+			);
+			expect(missWarn).toBeUndefined();
+		} finally {
+			logBus.off("log", handler);
+		}
 	});
 });

--- a/packages/providers/src/minimax-usage-fetcher.ts
+++ b/packages/providers/src/minimax-usage-fetcher.ts
@@ -186,7 +186,24 @@ export function parseMinimaxTokenPlanResponse(
 	}
 
 	const row = pickTextInferenceRow(raw.model_remains);
-	if (!row) return null;
+	if (!row) {
+		// model_remains is present and non-empty (checked above) but no row
+		// matched the `general` filter. The filter is unverified — Minimax
+		// publishes no response schema and may not actually emit a row named
+		// "general" — so surface the observed model_name values as a WARN so
+		// a single real poll reveals the truth. Deliberately do NOT fall back
+		// to a first-row read: a wrong-substituted reading would surface as
+		// the account's text utilization (PR #346 review fix 4311195e
+		// removed that fallback for exactly this reason). Log model names
+		// only — never tokens, keys, or full response bodies.
+		const observed = raw.model_remains
+			.map((entry) => entry?.model_name)
+			.filter((name): name is string => typeof name === "string");
+		log.warn(
+			`Minimax usage response had no 'general' row; observed model_name values: [${observed.join(", ")}]`,
+		);
+		return null;
+	}
 
 	const five_hour = buildWindow(row, "interval");
 	const seven_day = buildWindow(row, "weekly");


### PR DESCRIPTION
Closes #346

## Summary

PR #346 added the MiniMax Token Plan `remains` fetcher and the read-side in the accounts handler, but never wired the server bootstrap. `apps/server/src/server.ts` was not in the PR's changeset, so `usageCache.startPolling` was never called for a minimax account, so `cache.set` never happened, so `usageCache.get()` returned `null`, so every `&& usageData` gate in the accounts handler skipped, so the dashboard showed no usage for any deployment.

This was found from a live v3.5.44 deployment (ccmax) showing 3 healthy MiniMax accounts with 80k+ proxied requests, but `usageUtilization`, `usageWindow`, and `usageData` all `null`. The fetcher and parser were correct; the wiring was simply missing.

### Fix A — wire the bootstrap

Adds a Minimax polling block in `apps/server/src/server.ts` mirroring the existing `nanogpt` / `zai` / `kilo` pattern: filter `accounts` by `provider === "minimax"`, gate on a non-empty `api_key`, build a `() => account.api_key` token provider, call `usageCache.startPolling` with `config.getUsagePollIntervalMs()`. The per-account work is extracted into a small exported helper `registerMinimaxUsagePolling` so the registration contract is unit-testable without spinning up the full bootstrap.

The shape mirrors the `kilo` block (pay-as-you-go, API-key auth, no OAuth refresh, no session-tracking reset callback — Minimax has `requiresSessionTracking: false` in `provider-config.ts`). The inline boot block keeps the surrounding `info` / `debug` / `warn` log envelope.

### Fix B — instrument the unknown, deliberately do not guess

The fetcher's `pickTextInferenceRow` filter keeps only the row where `model_name === "general"`. **This filter is unverified.** MiniMax publishes no response schema; its documented models are M-series (`MiniMax-M3`, `MiniMax-M2.7`) and Token Plan is described as a unified quota, so a row literally named `"general"` may not exist.

PR #346's own review (commit `4311195e`) deliberately removed a first-row fallback because a wrong-substituted reading would surface the `video` quota pool as text-inference utilization. **This PR does NOT reintroduce that fallback.**

Instead, when `model_remains` is present and non-empty but no row matches, the fetcher emits a single WARN that lists the `model_name` values actually received:

```
Minimax usage response had no 'general' row; observed model_name values: [video, audio]
```

The WARN is model names only — never tokens, keys, or full response bodies. One real poll against a real account reveals the truth, and the filter correction lands in a follow-up PR based on evidence rather than guesswork.

### Tests

- `registerMinimaxUsagePolling` (in `apps/server/src/server.test.ts`): covers minimax-with-key, non-minimax-providers (zai, nanogpt, anthropic), minimax-with-null-key, and minimax-with-empty-key. The token provider is invoked and returns the account's API key.
- `parseMinimaxTokenPlanResponse` (in `minimax-usage-fetcher.test.ts`): added a test that asserts the new WARN fires with the observed `model_name` values when no `general` row is present, and a guard test that it does NOT fire on the empty `model_remains` branch (the "missing array" branch has a different warning).
- No existing tests were deleted or weakened.

### Negative control — verified

The polling-registration test references the exported `registerMinimaxUsagePolling` helper. Verified manually:

1. Removed the helper from `server.ts` → re-ran tests → **RED** with `SyntaxError: Export named 'registerMinimaxUsagePolling' not found in module 'apps/server/src/server.ts'`. 0 passed, 1 failed.
2. Restored the helper → re-ran tests → **GREEN**: 28 passed, 0 failed across both files.

A test that passes without the fix would prove nothing; this one does not.

### Scope

- 2 production files touched: `apps/server/src/server.ts`, `packages/providers/src/minimax-usage-fetcher.ts`.
- 2 test files touched: `apps/server/src/server.test.ts`, `packages/providers/src/__tests__/minimax-usage-fetcher.test.ts`.
- No other code refactored. The load-balancing strategy is untouched.

### What we are NOT claiming

We are not claiming the usage numbers are now confirmed correct. We have not yet seen a real MiniMax payload. The fix lands the wiring so a production deployment can produce a real poll, the WARN can surface the actual `model_name` values, and a follow-up PR can correct the filter (or keep it) based on evidence.