### PR TITLE
fix(minimax): validate token-plan status codes against a positive allowlist

### DIFF
--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, it, mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { Logger, logBus } from "@better-ccflare/logger";
+import type { LogEvent } from "@better-ccflare/types";
 import {
 	bootstrapMinimaxUsagePolling,
 	registerMinimaxUsagePolling,
@@ -136,7 +138,203 @@ describe("registerMinimaxUsagePolling", () => {
 	});
 });
 
+// Greptile #350 P2: when a Minimax account has a null/empty api_key, the
+// caller MUST emit a WARN naming the account, so the operator is told the
+// real reason ("missing credential") and not the misleading "no Minimax
+// accounts found" that the inline bootstrap summary used to print. These
+// tests pin the warning emission AND assert that no API key material
+// (value, prefix, suffix, full string) leaks into any log output — the
+// only account identifier in the message is `account.name` (or `id`).
+describe("registerMinimaxUsagePolling — warns on missing API key (Greptile #350 P2)", () => {
+	let captured: LogEvent[] = [];
+	const handler = (event: LogEvent) => {
+		captured.push(event);
+	};
+
+	beforeEach(() => {
+		captured = [];
+		logBus.on("log", handler);
+	});
+
+	afterEach(() => {
+		logBus.off("log", handler);
+	});
+
+	function makeAccount(
+		overrides: Partial<{
+			id: string;
+			name: string;
+			provider: string;
+			api_key: string | null;
+		}> = {},
+	) {
+		return {
+			id: "acc-1",
+			name: "minimax-account-1",
+			provider: "minimax",
+			api_key: "test-key",
+			...overrides,
+		} as unknown as Parameters<typeof registerMinimaxUsagePolling>[0];
+	}
+
+	function makeRegistrar() {
+		const startPolling = mock(
+			(
+				_accountId: string,
+				_tokenProvider: () => Promise<string>,
+				_provider: string,
+				_intervalMs: number,
+			) => {},
+		);
+		return {
+			registrar: { startPolling } as unknown as UsageCacheRegistrar,
+			startPolling,
+		};
+	}
+
+	function findWarn(messages: string[]): string | undefined {
+		return captured
+			.filter((e) => e.level === "WARN")
+			.map((e) => e.msg)
+			.find((m) => messages.some((needle) => m.includes(needle)));
+	}
+
+	it("emits a WARN naming the account when the API key is null", () => {
+		const { registrar } = makeRegistrar();
+		const logger = new Logger("MinimaxPollingTest");
+		const result = registerMinimaxUsagePolling(
+			makeAccount({ name: "primary", api_key: null }),
+			registrar,
+			30_000,
+			logger,
+		);
+
+		expect(result).toBe(false);
+		const warn = findWarn(["primary", "no API key"]);
+		expect(warn).toBeDefined();
+		expect(warn).toMatch(/Minimax account primary has no API key/);
+	});
+
+	it("emits a WARN naming the account when the API key is an empty string", () => {
+		const { registrar } = makeRegistrar();
+		const logger = new Logger("MinimaxPollingTest");
+		const result = registerMinimaxUsagePolling(
+			makeAccount({ name: "secondary", api_key: "" }),
+			registrar,
+			30_000,
+			logger,
+		);
+
+		expect(result).toBe(false);
+		const warn = findWarn(["secondary", "no API key"]);
+		expect(warn).toBeDefined();
+		expect(warn).toMatch(/Minimax account secondary has no API key/);
+	});
+
+	it("does NOT emit any WARN when a Minimax account has a usable API key", () => {
+		const { registrar } = makeRegistrar();
+		const logger = new Logger("MinimaxPollingTest");
+		const result = registerMinimaxUsagePolling(
+			makeAccount({ api_key: "real-key" }),
+			registrar,
+			30_000,
+			logger,
+		);
+
+		expect(result).toBe(true);
+		const warnings = captured.filter((e) => e.level === "WARN");
+		expect(warnings.length).toBe(0);
+	});
+
+	it("does NOT emit any WARN when a non-Minimax account is filtered out", () => {
+		const { registrar } = makeRegistrar();
+		const logger = new Logger("MinimaxPollingTest");
+		const result = registerMinimaxUsagePolling(
+			makeAccount({ name: "zai-row", provider: "zai", api_key: "k" }),
+			registrar,
+			30_000,
+			logger,
+		);
+
+		expect(result).toBe(false);
+		const warnings = captured.filter((e) => e.level === "WARN");
+		expect(warnings.length).toBe(0);
+	});
+
+	it("never includes the API key value (or any substring) in any log line", () => {
+		const { registrar } = makeRegistrar();
+		const logger = new Logger("MinimaxPollingTest");
+		// Use a distinctive marker so a substring leak would be unambiguous.
+		const MARKER = "SECRET-MARKER-7c1a9f";
+		registerMinimaxUsagePolling(
+			makeAccount({ name: "leak-check", api_key: null }),
+			registrar,
+			30_000,
+			logger,
+		);
+		// Re-register with a marker in the key — must NOT appear in any log.
+		registerMinimaxUsagePolling(
+			makeAccount({ id: "acc-2", name: "with-key", api_key: MARKER }),
+			registrar,
+			30_000,
+			logger,
+		);
+
+		const allMessages = captured.map((e) => e.msg).join("\n");
+		const allData = JSON.stringify(captured.map((e) => e.data ?? null));
+		expect(allMessages).not.toContain(MARKER);
+		expect(allData).not.toContain(MARKER);
+	});
+
+	it("falls back to account.id when account.name is null/undefined", () => {
+		const { registrar } = makeRegistrar();
+		const logger = new Logger("MinimaxPollingTest");
+		const result = registerMinimaxUsagePolling(
+			makeAccount({
+				id: "id-only-42",
+				name: undefined as unknown as string,
+				api_key: null,
+			}),
+			registrar,
+			30_000,
+			logger,
+		);
+
+		expect(result).toBe(false);
+		const warn = findWarn(["id-only-42", "no API key"]);
+		expect(warn).toBeDefined();
+		expect(warn).toMatch(/Minimax account id-only-42 has no API key/);
+	});
+
+	it("remains a no-op when no logger is provided (back-compat for existing callers)", () => {
+		const { registrar, startPolling } = makeRegistrar();
+		const result = registerMinimaxUsagePolling(
+			makeAccount({ api_key: null }),
+			registrar,
+			30_000,
+		);
+
+		expect(result).toBe(false);
+		expect(startPolling).toHaveBeenCalledTimes(0);
+		// No crash, no warning emitted — caller's responsibility to surface.
+	});
+});
+
 describe("bootstrapMinimaxUsagePolling", () => {
+	let captured: LogEvent[] = [];
+	const handler = (event: LogEvent) => {
+		captured.push(event);
+	};
+
+	beforeEach(() => {
+		captured = [];
+		logBus.on("log", handler);
+	});
+
+	afterEach(() => {
+		logBus.off("log", handler);
+	});
+
 	function makeAccount(
 		overrides: Partial<{
 			id: string;
@@ -286,6 +484,102 @@ describe("bootstrapMinimaxUsagePolling", () => {
 		for (const call of startPolling.mock.calls) {
 			expect(call[3]).toBe(12_345);
 		}
+	});
+
+	// Greptile #350 P2 (companion to the registerMinimaxUsagePolling suite):
+	// the helper must propagate the logger so per-account WARNs surface from
+	// the bootstrap path used by startServer(). Same key-leak guarantee.
+	it("emits one WARN per Minimax account missing an API key, naming each account", () => {
+		const { registrar } = makeRegistrar();
+		const logger = new Logger("MinimaxPollingTest");
+		const accounts = [
+			makeAccount({
+				id: "minimax-null",
+				name: "alpha",
+				provider: "minimax",
+				api_key: null,
+			}),
+			makeAccount({
+				id: "minimax-empty",
+				name: "beta",
+				provider: "minimax",
+				api_key: "",
+			}),
+			makeAccount({
+				id: "minimax-good",
+				name: "gamma",
+				provider: "minimax",
+				api_key: "real-key",
+			}),
+		];
+
+		const registered = bootstrapMinimaxUsagePolling(
+			accounts,
+			registrar,
+			30_000,
+			logger,
+		);
+
+		expect(registered).toEqual(["minimax-good"]);
+		const warnings = captured.filter((e) => e.level === "WARN");
+		expect(warnings.length).toBe(2);
+		const warningMsgs = warnings.map((e) => e.msg);
+		expect(
+			warningMsgs.some((m) => m.includes("alpha") && m.includes("no API key")),
+		).toBe(true);
+		expect(
+			warningMsgs.some((m) => m.includes("beta") && m.includes("no API key")),
+		).toBe(true);
+		expect(
+			warningMsgs.some((m) => m.includes("gamma")),
+		).toBe(false);
+	});
+
+	it("does not WARN when no Minimax accounts are present at all", () => {
+		const { registrar } = makeRegistrar();
+		const logger = new Logger("MinimaxPollingTest");
+		const accounts = [
+			makeAccount({ id: "zai-1", provider: "zai" }),
+			makeAccount({ id: "nanogpt-1", provider: "nanogpt" }),
+		];
+
+		const registered = bootstrapMinimaxUsagePolling(
+			accounts,
+			registrar,
+			30_000,
+			logger,
+		);
+
+		expect(registered).toEqual([]);
+		const warnings = captured.filter((e) => e.level === "WARN");
+		expect(warnings.length).toBe(0);
+	});
+
+	it("never leaks the API key value through bootstrap-level WARN emissions", () => {
+		const { registrar } = makeRegistrar();
+		const logger = new Logger("MinimaxPollingTest");
+		const MARKER = "BOOTSTRAP-MARKER-deadbeef";
+		const accounts = [
+			makeAccount({
+				id: "leak-1",
+				name: "leak-1",
+				provider: "minimax",
+				api_key: null,
+			}),
+			makeAccount({
+				id: "leak-2",
+				name: "leak-2",
+				provider: "minimax",
+				api_key: MARKER, // must NOT appear anywhere in any log
+			}),
+		];
+
+		bootstrapMinimaxUsagePolling(accounts, registrar, 30_000, logger);
+
+		const allMessages = captured.map((e) => e.msg).join("\n");
+		const allData = JSON.stringify(captured.map((e) => e.data ?? null));
+		expect(allMessages).not.toContain(MARKER);
+		expect(allData).not.toContain(MARKER);
 	});
 });
 

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "bun:test";
-import { supportsRefreshBackedUsagePolling } from "./server";
+import { describe, expect, it, mock } from "bun:test";
+import {
+	type UsageCacheRegistrar,
+	registerMinimaxUsagePolling,
+	supportsRefreshBackedUsagePolling,
+} from "./server";
 
 describe("supportsRefreshBackedUsagePolling", () => {
 	it("includes pollable OAuth providers that need token refresh", () => {
@@ -12,6 +16,120 @@ describe("supportsRefreshBackedUsagePolling", () => {
 		expect(supportsRefreshBackedUsagePolling("qwen")).toBe(false);
 		expect(supportsRefreshBackedUsagePolling("nanogpt")).toBe(false);
 		expect(supportsRefreshBackedUsagePolling(null)).toBe(false);
+	});
+});
+
+describe("registerMinimaxUsagePolling", () => {
+	function makeAccount(
+		overrides: Partial<{
+			id: string;
+			name: string;
+			provider: string;
+			api_key: string | null;
+		}> = {},
+	) {
+		return {
+			id: "acc-1",
+			name: "minimax-account-1",
+			provider: "minimax",
+			api_key: "test-key",
+			...overrides,
+		} as unknown as Parameters<typeof registerMinimaxUsagePolling>[0];
+	}
+
+	function makeRegistrar() {
+		const startPolling = mock(
+			(
+				_accountId: string,
+				_tokenProvider: () => Promise<string>,
+				_provider: string,
+				_intervalMs: number,
+			) => {},
+		);
+		return {
+			registrar: { startPolling } as unknown as UsageCacheRegistrar,
+			startPolling,
+		};
+	}
+
+	it("registers polling for a Minimax account with an API key", () => {
+		const { registrar, startPolling } = makeRegistrar();
+		const result = registerMinimaxUsagePolling(makeAccount(), registrar, 30_000);
+
+		expect(result).toBe(true);
+		expect(startPolling).toHaveBeenCalledTimes(1);
+		const call = startPolling.mock.calls[0];
+		expect(call?.[0]).toBe("acc-1");
+		expect(call?.[2]).toBe("minimax");
+		expect(call?.[3]).toBe(30_000);
+		expect(typeof call?.[1]).toBe("function");
+	});
+
+	it("the registered token provider returns the account's API key", async () => {
+		const { registrar, startPolling } = makeRegistrar();
+		registerMinimaxUsagePolling(
+			makeAccount({ api_key: "secret-key" }),
+			registrar,
+			30_000,
+		);
+
+		const tokenProvider = startPolling.mock.calls[0]?.[1];
+		expect(await tokenProvider()).toBe("secret-key");
+	});
+
+	it("does not register polling for non-Minimax accounts", () => {
+		const { registrar, startPolling } = makeRegistrar();
+		// The block calls registerMinimaxUsagePolling only for accounts where
+		// accounts.filter((a) => a.provider === "minimax") matched, so the
+		// helper itself is the load-bearing gate. If the filter goes away and
+		// this helper is called for every provider, the false return here is
+		// what keeps the wrong accounts from being polled.
+		expect(
+			registerMinimaxUsagePolling(
+				makeAccount({ provider: "zai", api_key: "k" }),
+				registrar,
+				30_000,
+			),
+		).toBe(false);
+		expect(
+			registerMinimaxUsagePolling(
+				makeAccount({ provider: "nanogpt", api_key: "k" }),
+				registrar,
+				30_000,
+			),
+		).toBe(false);
+		expect(
+			registerMinimaxUsagePolling(
+				makeAccount({ provider: "anthropic", api_key: "k" }),
+				registrar,
+				30_000,
+			),
+		).toBe(false);
+		expect(startPolling).toHaveBeenCalledTimes(0);
+	});
+
+	it("does not register polling when a Minimax account has no API key", () => {
+		const { registrar, startPolling } = makeRegistrar();
+		const result = registerMinimaxUsagePolling(
+			makeAccount({ api_key: null }),
+			registrar,
+			30_000,
+		);
+
+		expect(result).toBe(false);
+		expect(startPolling).toHaveBeenCalledTimes(0);
+	});
+
+	it("does not register polling when a Minimax account has an empty API key", () => {
+		const { registrar, startPolling } = makeRegistrar();
+		const result = registerMinimaxUsagePolling(
+			makeAccount({ api_key: "" }),
+			registrar,
+			30_000,
+		);
+
+		expect(result).toBe(false);
+		expect(startPolling).toHaveBeenCalledTimes(0);
 	});
 });
 

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, mock } from "bun:test";
 import {
-	type UsageCacheRegistrar,
+	bootstrapMinimaxUsagePolling,
 	registerMinimaxUsagePolling,
+	type UsageCacheRegistrar,
 	supportsRefreshBackedUsagePolling,
 } from "./server";
 
@@ -130,6 +131,159 @@ describe("registerMinimaxUsagePolling", () => {
 
 		expect(result).toBe(false);
 		expect(startPolling).toHaveBeenCalledTimes(0);
+	});
+});
+
+describe("bootstrapMinimaxUsagePolling", () => {
+	function makeAccount(
+		overrides: Partial<{
+			id: string;
+			name: string;
+			provider: string;
+			api_key: string | null;
+		}> = {},
+	) {
+		return {
+			id: "acc-1",
+			name: "acc-1",
+			provider: "minimax",
+			api_key: "test-key",
+			...overrides,
+		} as unknown as Parameters<typeof bootstrapMinimaxUsagePolling>[0][number];
+	}
+
+	function makeRegistrar() {
+		const startPolling = mock(
+			(
+				_accountId: string,
+				_tokenProvider: () => Promise<string>,
+				_provider: string,
+				_intervalMs: number,
+			) => {},
+		);
+		return {
+			registrar: { startPolling } as unknown as UsageCacheRegistrar,
+			startPolling,
+		};
+	}
+
+	// This is the regression test for PR #347. The inline bootstrap block in
+	// startServer() (around line 1637 pre-refactor) filtered `accounts` for
+	// provider === "minimax" and called `registerMinimaxUsagePolling` for each
+	// match. The original PR landed a working fetcher + helper but never
+	// exercised the wiring path that actually invokes it at startup — mirroring
+	// PR #346's "shipped a working fetcher that nothing called" bug. This test
+	// pins the wiring: given a realistic mixed-provider account list (the same
+	// shape `startServer()` passes), it must register polling for Minimax
+	// accounts and nothing else. If the inline bootstrap block in startServer()
+	// is removed (and this helper is also removed, since nothing else imports
+	// it), the import below fails and every test in this file goes RED.
+
+	it("registers polling for Minimax accounts and ignores other providers", () => {
+		const { registrar, startPolling } = makeRegistrar();
+		const accounts = [
+			makeAccount({ id: "zai-1", name: "zai-1", provider: "zai" }),
+			makeAccount({
+				id: "minimax-1",
+				name: "minimax-1",
+				provider: "minimax",
+				api_key: "minimax-key-1",
+			}),
+			makeAccount({ id: "nanogpt-1", name: "nanogpt-1", provider: "nanogpt" }),
+			makeAccount({
+				id: "minimax-2",
+				name: "minimax-2",
+				provider: "minimax",
+				api_key: "minimax-key-2",
+			}),
+			makeAccount({
+				id: "anthropic-1",
+				name: "anthropic-1",
+				provider: "anthropic",
+			}),
+		];
+
+		const registered = bootstrapMinimaxUsagePolling(accounts, registrar, 30_000);
+
+		// Only the two Minimax accounts should appear in the registered list,
+		// proving the filter on `provider === "minimax"` is actually applied
+		// to the full account list, not just whatever the helper receives.
+		expect(registered).toEqual(["minimax-1", "minimax-2"]);
+		// And the registrar must have been driven exactly twice — once per
+		// Minimax account, never for the zai/nanogpt/anthropic rows that are
+		// sitting in the same array.
+		expect(startPolling).toHaveBeenCalledTimes(2);
+		const calledIds = startPolling.mock.calls.map((c) => c[0]);
+		expect(calledIds).toEqual(["minimax-1", "minimax-2"]);
+	});
+
+	it("does not register polling when the account list has no Minimax accounts", () => {
+		const { registrar, startPolling } = makeRegistrar();
+		const accounts = [
+			makeAccount({ id: "zai-1", provider: "zai" }),
+			makeAccount({ id: "nanogpt-1", provider: "nanogpt" }),
+			makeAccount({ id: "anthropic-1", provider: "anthropic" }),
+		];
+
+		const registered = bootstrapMinimaxUsagePolling(accounts, registrar, 30_000);
+
+		expect(registered).toEqual([]);
+		expect(startPolling).toHaveBeenCalledTimes(0);
+	});
+
+	it("registers polling only for Minimax accounts with API keys and skips the rest", () => {
+		const { registrar, startPolling } = makeRegistrar();
+		const accounts = [
+			makeAccount({
+				id: "minimax-no-key",
+				name: "no-key",
+				provider: "minimax",
+				api_key: null,
+			}),
+			makeAccount({
+				id: "minimax-empty-key",
+				name: "empty-key",
+				provider: "minimax",
+				api_key: "",
+			}),
+			makeAccount({
+				id: "minimax-good",
+				name: "good",
+				provider: "minimax",
+				api_key: "real-key",
+			}),
+		];
+
+		const registered = bootstrapMinimaxUsagePolling(accounts, registrar, 30_000);
+
+		expect(registered).toEqual(["minimax-good"]);
+		expect(startPolling).toHaveBeenCalledTimes(1);
+		expect(startPolling.mock.calls[0]?.[0]).toBe("minimax-good");
+	});
+
+	it("forwards the configured interval to every registered Minimax account", () => {
+		const { registrar, startPolling } = makeRegistrar();
+		const accounts = [
+			makeAccount({
+				id: "minimax-a",
+				name: "a",
+				provider: "minimax",
+				api_key: "k1",
+			}),
+			makeAccount({
+				id: "minimax-b",
+				name: "b",
+				provider: "minimax",
+				api_key: "k2",
+			}),
+		];
+
+		bootstrapMinimaxUsagePolling(accounts, registrar, 12_345);
+
+		expect(startPolling).toHaveBeenCalledTimes(2);
+		for (const call of startPolling.mock.calls) {
+			expect(call[3]).toBe(12_345);
+		}
 	});
 });
 

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it, mock } from "bun:test";
 import {
 	bootstrapMinimaxUsagePolling,
@@ -403,5 +405,116 @@ describe("trackStreamForShutdown", () => {
 		await settled;
 		expect(cancelResolved).toBe(true);
 		reader.cancel().catch(() => {});
+	});
+});
+
+// Structural guard: assert that startServer() actually invokes
+// bootstrapMinimaxUsagePolling in its source. This is the negative control
+// for PR #347 — the previous unit-test guard only failed when the EXPORTED
+// HELPER was removed, not when the call site was deleted. The realistic
+// regression is someone removing the inline bootstrap block in startServer()
+// while the helper still sits in the module unused. With this guard, the
+// test goes RED the moment the call site disappears, even if the helper
+// stays intact.
+//
+// Why this is structural and not behavioral: startServer() is a full
+// process lifecycle (DB init, network bind, signal handlers, dashboard
+// wiring, TLS). It is not realistic to invoke it in a unit test without
+// dragging in the whole runtime, so this test reads the source file off
+// disk and verifies the invocation is present inside startServer()'s body.
+// Brittle to renames of either `startServer` or `bootstrapMinimaxUsagePolling`,
+// which is by design — if either name changes, the engineer must update
+// this guard and confirm the wiring is still in place.
+describe("startServer() wiring guards", () => {
+	function readStartServerBody(): string {
+		const src = readFileSync(join(import.meta.dir, "server.ts"), "utf8");
+		const match = src.match(
+			/export\s+default\s+async\s+function\s+startServer\b/,
+		);
+		if (!match || match.index === undefined) {
+			throw new Error(
+				"startServer default export not found in server.ts — update the wiring guard string",
+			);
+		}
+		// startServer's signature is `startServer(options?: { ... }) {`.
+		// Skip past the parameter list by tracking paren depth so we don't
+		// latch onto the inline type-literal `{` that opens `options?:`.
+		let parenDepth = 0;
+		let pastParens = -1;
+		for (let i = match.index; i < src.length; i++) {
+			const ch = src[i];
+			if (ch === "(") parenDepth++;
+			else if (ch === ")") {
+				parenDepth--;
+				if (parenDepth === 0) {
+					pastParens = i;
+					break;
+				}
+			}
+		}
+		if (pastParens < 0) {
+			throw new Error("startServer parameter list never closed");
+		}
+		const openIdx = src.indexOf("{", pastParens);
+		if (openIdx < 0) {
+			throw new Error("startServer body opening brace not found");
+		}
+		// Balance braces to find the matching close. Template strings,
+		// regex literals, and comments can carry unbalanced braces, but
+		// server.ts is well-formed enough that a depth counter is reliable
+		// for this function — it does not contain raw `{` inside a template
+		// that would fool the simple counter.
+		let depth = 0;
+		for (let i = openIdx; i < src.length; i++) {
+			const ch = src[i];
+			if (ch === "{") depth++;
+			else if (ch === "}") {
+				depth--;
+				if (depth === 0) {
+					return src.slice(openIdx, i + 1);
+				}
+			}
+		}
+		throw new Error("startServer body closing brace not found");
+	}
+
+	// The regression we are guarding: PR #347 shipped a working fetcher and
+	// a working helper, but the inline bootstrap block in startServer() —
+	// the actual production wiring — was the thing missing test coverage.
+	// Removing that block (lines ~1670-1688 in server.ts) and keeping the
+	// helper exported would not have failed the unit tests in this file
+	// before this guard landed. With this guard, deleting that block while
+	// leaving the helper intact goes RED.
+	it("invokes bootstrapMinimaxUsagePolling inside startServer()", () => {
+		const body = readStartServerBody();
+		// Match an actual call: `<identifier> (`. Just matching the bare
+		// identifier would also pass if someone left a stale comment naming
+		// the helper, so we require the opening paren.
+		expect(body).toMatch(/bootstrapMinimaxUsagePolling\s*\(/);
+	});
+
+	it("passes accounts, usageCache, and the configured poll interval to bootstrapMinimaxUsagePolling", () => {
+		const body = readStartServerBody();
+		// Check that the call site carries the same arguments the surrounding
+		// zai/kilo blocks pass. This catches the regression where someone
+		// replaces the full call with a stub like `bootstrapMinimaxUsagePolling()`
+		// that compiles and lints but never actually wires the cache.
+		const call = body.match(/bootstrapMinimaxUsagePolling\s*\(([\s\S]*?)\)/);
+		expect(call).not.toBeNull();
+		const args = call?.[1] ?? "";
+		// Trim and split on top-level commas (no nested parens expected
+		// inside the 3-arg call, but be conservative).
+		const argList = args
+			.split(",")
+			.map((s) => s.trim())
+			.filter(Boolean);
+		expect(argList.length).toBe(3);
+		// First two arguments must be the live runtime objects, not the
+		// string literals "accounts" / "usageCache".
+		expect(argList[0]).toBe("accounts");
+		expect(argList[1]).toBe("usageCache");
+		// Third argument must flow through the configured poll interval —
+		// i.e. not a hardcoded numeric literal.
+		expect(argList[2]).not.toMatch(/^\d+$/);
 	});
 });

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -128,6 +128,49 @@ export function supportsRefreshBackedUsagePolling(
 	return provider === "anthropic" || provider === "xai";
 }
 
+/**
+ * Minimal interface satisfied by the `usageCache` singleton in
+ * `@better-ccflare/providers`. Declared locally so the bootstrap helper
+ * can be unit-tested with a mock without dragging the full UsageCache
+ * class (which is not exported) into the public type surface.
+ */
+export interface UsageCacheRegistrar {
+	startPolling(
+		accountId: string,
+		tokenProvider: () => Promise<string>,
+		provider: string,
+		intervalMs: number,
+	): void;
+}
+
+/**
+ * Register usage polling for a single Minimax account. The Minimax fetcher
+ * hits the Token Plan `remains` endpoint with a Bearer API key; no OAuth
+ * refresh is required. Mirrors the surrounding nanogpt/zai/kilo pattern:
+ * pay-as-you-go, API-key authentication, no window reset callback
+ * (Minimax has `requiresSessionTracking: false` in provider-config.ts).
+ *
+ * Returns true if polling was registered, false if the account is not
+ * a Minimax account or has no API key. Extracted from the bootstrap
+ * loop so the registration contract is unit-testable.
+ */
+export function registerMinimaxUsagePolling(
+	account: Account,
+	usageCache: UsageCacheRegistrar,
+	intervalMs: number,
+): boolean {
+	if (account.provider !== "minimax") return false;
+	if (!account.api_key) return false;
+	const apiKeyProvider = async () => account.api_key || "";
+	usageCache.startPolling(
+		account.id,
+		apiKeyProvider,
+		account.provider,
+		intervalMs,
+	);
+	return true;
+}
+
 // Helper function to resolve dashboard assets with fallback
 function resolveDashboardAsset(assetPath: string): string | null {
 	try {
@@ -1589,6 +1632,37 @@ Available endpoints:
 		}
 	} else {
 		log.info(`No Kilo Gateway accounts found, usage polling will not start`);
+	}
+
+	// Start usage polling for Minimax accounts (Token Plan `remains` endpoint)
+	const minimaxAccounts = accounts.filter((a) => a.provider === "minimax");
+	if (minimaxAccounts.length > 0) {
+		log.info(
+			`Found ${minimaxAccounts.length} Minimax accounts, starting usage polling...`,
+		);
+		for (const account of minimaxAccounts) {
+			log.debug(`Processing Minimax account: ${account.name}`, {
+				accountId: account.id,
+				hasApiKey: !!account.api_key,
+				paused: account.paused,
+			});
+
+			if (
+				registerMinimaxUsagePolling(
+					account,
+					usageCache,
+					config.getUsagePollIntervalMs(),
+				)
+			) {
+				log.info(`Started usage polling for Minimax account ${account.name}`);
+			} else {
+				log.warn(
+					`Minimax account ${account.name} has no API key, skipping usage polling`,
+				);
+			}
+		}
+	} else {
+		log.info(`No Minimax accounts found, usage polling will not start`);
 	}
 
 	// Pre-warm Bedrock model and inference profile caches

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -153,14 +153,26 @@ export interface UsageCacheRegistrar {
  * Returns true if polling was registered, false if the account is not
  * a Minimax account or has no API key. Extracted from the bootstrap
  * loop so the registration contract is unit-testable.
+ *
+ * When `logger` is provided AND the account is a Minimax account missing a
+ * non-empty API key, emits a `WARN` naming the account. Matches the
+ * sibling nanogpt/zai/kilo blocks (Greptile #350 P2): "X account <name> has
+ * no API key, skipping usage polling". The account name is the only
+ * identifier in the message — never the key value or any part of it.
  */
 export function registerMinimaxUsagePolling(
 	account: Account,
 	usageCache: UsageCacheRegistrar,
 	intervalMs: number,
+	logger?: Logger,
 ): boolean {
 	if (account.provider !== "minimax") return false;
-	if (!account.api_key) return false;
+	if (!account.api_key) {
+		logger?.warn(
+			`Minimax account ${account.name ?? account.id} has no API key, skipping usage polling`,
+		);
+		return false;
+	}
 	const apiKeyProvider = async () => account.api_key || "";
 	usageCache.startPolling(
 		account.id,
@@ -182,6 +194,10 @@ export function registerMinimaxUsagePolling(
  * Returning the registered IDs rather than a bare count lets callers log the
  * affected accounts and gives tests a stable handle to assert against.
  *
+ * `logger` is forwarded to {@link registerMinimaxUsagePolling} so per-account
+ * "no API key" warnings surface from the unit-testable helper, keeping
+ * behavior consistent with the sibling nanogpt/zai/kilo bootstrap blocks.
+ *
  * Extracted from the inline bootstrap block so a regression test can exercise
  * the exact wiring path (filter → forEach → registerMinimaxUsagePolling) with
  * a mixed-provider account list. If the inline block in `startServer()` is
@@ -193,11 +209,12 @@ export function bootstrapMinimaxUsagePolling(
 	accounts: readonly Account[],
 	usageCache: UsageCacheRegistrar,
 	intervalMs: number,
+	logger?: Logger,
 ): string[] {
 	const minimaxAccounts = accounts.filter((a) => a.provider === "minimax");
 	const registered: string[] = [];
 	for (const account of minimaxAccounts) {
-		if (registerMinimaxUsagePolling(account, usageCache, intervalMs)) {
+		if (registerMinimaxUsagePolling(account, usageCache, intervalMs, logger)) {
 			registered.push(account.id);
 		}
 	}
@@ -1668,14 +1685,18 @@ Available endpoints:
 	}
 
 	// Start usage polling for Minimax accounts (Token Plan `remains` endpoint)
+	const minimaxAccounts = accounts.filter((a) => a.provider === "minimax");
 	const registeredMinimaxAccountIds = bootstrapMinimaxUsagePolling(
 		accounts,
 		usageCache,
 		config.getUsagePollIntervalMs(),
+		log,
 	);
-	if (registeredMinimaxAccountIds.length > 0) {
+	if (minimaxAccounts.length === 0) {
+		log.info(`No Minimax accounts found, usage polling will not start`);
+	} else if (registeredMinimaxAccountIds.length > 0) {
 		log.info(
-			`Found ${registeredMinimaxAccountIds.length} Minimax accounts, starting usage polling...`,
+			`Found ${minimaxAccounts.length} Minimax accounts, starting usage polling...`,
 		);
 		for (const accountId of registeredMinimaxAccountIds) {
 			const account = accounts.find((a) => a.id === accountId);
@@ -1684,7 +1705,14 @@ Available endpoints:
 			);
 		}
 	} else {
-		log.info(`No Minimax accounts found, usage polling will not start`);
+		// All Minimax accounts exist but lack API keys. Per-account WARN logs
+		// already fired inside registerMinimaxUsagePolling; this summary
+		// makes the diagnosis unambiguous: the reason polling did not start
+		// is missing credentials, not a missing account. Matches the
+		// nanogpt/zai/kilo phrasing style (Greptile #350 P2).
+		log.info(
+			`Found ${minimaxAccounts.length} Minimax account(s) but all lack API keys, usage polling will not start`,
+		);
 	}
 
 	// Pre-warm Bedrock model and inference profile caches

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -171,6 +171,39 @@ export function registerMinimaxUsagePolling(
 	return true;
 }
 
+/**
+ * Run the Minimax usage-polling bootstrap over a list of accounts. This is the
+ * shape of the wiring block `startServer()` runs for every Minimax account at
+ * startup — filter for provider === "minimax", then delegate each one to
+ * {@link registerMinimaxUsagePolling} which decides whether polling should
+ * actually start.
+ *
+ * Returns the account IDs that were registered (i.e. had a usable API key).
+ * Returning the registered IDs rather than a bare count lets callers log the
+ * affected accounts and gives tests a stable handle to assert against.
+ *
+ * Extracted from the inline bootstrap block so a regression test can exercise
+ * the exact wiring path (filter → forEach → registerMinimaxUsagePolling) with
+ * a mixed-provider account list. If the inline block in `startServer()` is
+ * removed but this helper still exists and is unit-tested in isolation, the
+ * startup-time wiring has no test coverage — that is the gap this function
+ * exists to close. Keep the bootstrap block in `startServer()` calling this.
+ */
+export function bootstrapMinimaxUsagePolling(
+	accounts: readonly Account[],
+	usageCache: UsageCacheRegistrar,
+	intervalMs: number,
+): string[] {
+	const minimaxAccounts = accounts.filter((a) => a.provider === "minimax");
+	const registered: string[] = [];
+	for (const account of minimaxAccounts) {
+		if (registerMinimaxUsagePolling(account, usageCache, intervalMs)) {
+			registered.push(account.id);
+		}
+	}
+	return registered;
+}
+
 // Helper function to resolve dashboard assets with fallback
 function resolveDashboardAsset(assetPath: string): string | null {
 	try {
@@ -1635,31 +1668,20 @@ Available endpoints:
 	}
 
 	// Start usage polling for Minimax accounts (Token Plan `remains` endpoint)
-	const minimaxAccounts = accounts.filter((a) => a.provider === "minimax");
-	if (minimaxAccounts.length > 0) {
+	const registeredMinimaxAccountIds = bootstrapMinimaxUsagePolling(
+		accounts,
+		usageCache,
+		config.getUsagePollIntervalMs(),
+	);
+	if (registeredMinimaxAccountIds.length > 0) {
 		log.info(
-			`Found ${minimaxAccounts.length} Minimax accounts, starting usage polling...`,
+			`Found ${registeredMinimaxAccountIds.length} Minimax accounts, starting usage polling...`,
 		);
-		for (const account of minimaxAccounts) {
-			log.debug(`Processing Minimax account: ${account.name}`, {
-				accountId: account.id,
-				hasApiKey: !!account.api_key,
-				paused: account.paused,
-			});
-
-			if (
-				registerMinimaxUsagePolling(
-					account,
-					usageCache,
-					config.getUsagePollIntervalMs(),
-				)
-			) {
-				log.info(`Started usage polling for Minimax account ${account.name}`);
-			} else {
-				log.warn(
-					`Minimax account ${account.name} has no API key, skipping usage polling`,
-				);
-			}
+		for (const accountId of registeredMinimaxAccountIds) {
+			const account = accounts.find((a) => a.id === accountId);
+			log.info(
+				`Started usage polling for Minimax account ${account?.name ?? accountId}`,
+			);
 		}
 	} else {
 		log.info(`No Minimax accounts found, usage polling will not start`);

--- a/packages/providers/src/__tests__/minimax-usage-fetcher.test.ts
+++ b/packages/providers/src/__tests__/minimax-usage-fetcher.test.ts
@@ -4,7 +4,9 @@ import {
 	fetchMinimaxUsageData,
 	getRepresentativeMinimaxUtilization,
 	getRepresentativeMinimaxWindow,
+	MINIMAX_TOKEN_PLAN_KNOWN_FAILURE_STATUS_CODES,
 	MINIMAX_TOKEN_PLAN_REMAINS_ENDPOINT,
+	MINIMAX_TOKEN_PLAN_SUCCESS_STATUS_CODES,
 	parseMinimaxTokenPlanResponse,
 } from "../minimax-usage-fetcher";
 
@@ -171,6 +173,134 @@ describe("Minimax usage fetcher", () => {
 				model_remains: [makeRow()],
 			}),
 		).toBeNull();
+	});
+
+	// F5 — positive allowlist + unknown-vs-known-failure distinction.
+	// The earlier `statusCode !== 0` test would silently misread a future
+	// success code (e.g. `5`) as a failure and return null forever. The
+	// allowlist below pins today's exact set of accepted success codes so
+	// any change is a code-review-visible edit, and the unknown-vs-known
+	// log framing below ensures an unrecognized non-success is not silently
+	// treated like a confirmed known failure.
+
+	it("pins the success status_code allowlist to exactly [0] today", () => {
+		// Today the allowlist is `0` only. Extending it is a deliberate,
+		// review-visible change — not a silent widening of the parser's
+		// "this is healthy" definition.
+		expect([...MINIMAX_TOKEN_PLAN_SUCCESS_STATUS_CODES]).toEqual([0]);
+		// A non-trivial sample of values that must NOT be in the allowlist.
+		// If any of these slipped in, the allowlist would widen beyond what
+		// this PR is committing to and the regression test would fire.
+		for (const code of [1, 2, 5, 999, 1001, 1004, 10_000]) {
+			expect(MINIMAX_TOKEN_PLAN_SUCCESS_STATUS_CODES.includes(code)).toBe(
+				false,
+			);
+		}
+	});
+
+	it("includes 1001 (quota) and 1004 (auth) in the known-failure set", () => {
+		// These are the two known-failure codes observed in production logs
+		// (PR #346 review). Keeping them in a separate set means the parser
+		// logs them with the "known error" framing, distinct from the
+		// "unrecognized" framing used for codes we have not classified.
+		expect(MINIMAX_TOKEN_PLAN_KNOWN_FAILURE_STATUS_CODES.has(1001)).toBe(true);
+		expect(MINIMAX_TOKEN_PLAN_KNOWN_FAILURE_STATUS_CODES.has(1004)).toBe(true);
+		// A code that is neither 0 nor a known failure (and so should not
+		// live in either set today) — guards against accidental merge.
+		expect(MINIMAX_TOKEN_PLAN_KNOWN_FAILURE_STATUS_CODES.has(0)).toBe(false);
+	});
+
+	it("returns null AND logs as a known error when base_resp.status_code is in the known-failure set", () => {
+		// 1001 = quota exceeded (existing test covers the return value);
+		// this test pins the LOG framing for the known-failure branch.
+		interface LogEvent {
+			ts: number;
+			level: string;
+			msg: string;
+			data?: unknown;
+		}
+		const warnEvents: LogEvent[] = [];
+		const handler = (event: LogEvent) => {
+			if (event.level === "WARN") warnEvents.push(event);
+		};
+		logBus.on("log", handler);
+
+		try {
+			const parsed = parseMinimaxTokenPlanResponse({
+				base_resp: { status_code: 1001, status_msg: "quota exceeded" },
+				model_remains: [makeRow()],
+			});
+
+			expect(parsed).toBeNull();
+			// The WARN framing is "known error base_resp.status_code=1001"
+			// — distinguishable from the "unrecognized" framing used for
+			// codes outside both sets.
+			const knownWarn = warnEvents.find(
+				(e) =>
+					e.msg.includes("known error") &&
+					e.msg.includes("base_resp.status_code=1001"),
+			);
+			expect(knownWarn).toBeDefined();
+			// And the framing must NOT be the "unrecognized" one — the two
+			// branches are supposed to be distinguishable in logs.
+			const unrecognizedWarn = warnEvents.find((e) =>
+				e.msg.includes("unrecognized"),
+			);
+			expect(unrecognizedWarn).toBeUndefined();
+		} finally {
+			logBus.off("log", handler);
+		}
+	});
+
+	it("returns null AND logs as unrecognized when base_resp.status_code is a non-zero value outside both sets", () => {
+		// This is the F5 regression test. A future MiniMax code (say, `5`)
+		// would be neither in the success allowlist nor in the known-failure
+		// set. The parser must:
+		//   1. NOT silently succeed (i.e. return non-null) — that would
+		//      misread the unknown shape as healthy quota data.
+		//   2. NOT silently fail forever with the same framing as a known
+		//      error — that would hide the fact that the response was
+		//      structurally a non-error but we don't know how to read it.
+		// The behavior is: return null (caller treats it as transient),
+		// AND emit a WARN with the "unrecognized" framing so the next
+		// engineer to see a fresh code in production knows to extend the
+		// success allowlist rather than mistaking a healthy response for
+		// a hard failure.
+		interface LogEvent {
+			ts: number;
+			level: string;
+			msg: string;
+			data?: unknown;
+		}
+		const warnEvents: LogEvent[] = [];
+		const handler = (event: LogEvent) => {
+			if (event.level === "WARN") warnEvents.push(event);
+		};
+		logBus.on("log", handler);
+
+		try {
+			const parsed = parseMinimaxTokenPlanResponse({
+				base_resp: { status_code: 5, status_msg: "future-success-shape" },
+				model_remains: [makeRow()],
+			});
+
+			// 1. Must NOT silently succeed.
+			expect(parsed).toBeNull();
+			// 2. Must emit the "unrecognized" WARN, with the actual code
+			//    embedded so a tailing operator can grep for it.
+			const unrecognizedWarn = warnEvents.find(
+				(e) =>
+					e.msg.includes("unrecognized") &&
+					e.msg.includes("base_resp.status_code=5"),
+			);
+			expect(unrecognizedWarn).toBeDefined();
+			// And must NOT use the "known error" framing — that framing is
+			// reserved for codes we have actually classified.
+			const knownWarn = warnEvents.find((e) => e.msg.includes("known error"));
+			expect(knownWarn).toBeUndefined();
+		} finally {
+			logBus.off("log", handler);
+		}
 	});
 
 	it("clamps out-of-range remaining percent before inverting", () => {

--- a/packages/providers/src/__tests__/minimax-usage-fetcher.test.ts
+++ b/packages/providers/src/__tests__/minimax-usage-fetcher.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { logBus } from "@better-ccflare/logger";
 import {
 	fetchMinimaxUsageData,
 	getRepresentativeMinimaxUtilization,
@@ -284,5 +285,90 @@ describe("Minimax usage fetcher", () => {
 		expect(parsed?.seven_day?.utilization).toBe(75);
 		expect(getRepresentativeMinimaxUtilization(parsed)).toBe(75);
 		expect(getRepresentativeMinimaxWindow(parsed)).toBe("seven_day");
+	});
+
+	// Greptile flagged on PR #346 that the "model_remains non-empty but no
+	// 'general' row" case was untested, so the wrong-row fallback had no
+	// guard rail. The deliberate choice is to NOT substitute a row (PR #346
+	// review 4311195e removed a first-row fallback because a `video` quota
+	// would surface as text utilization), but to WARN with the observed
+	// model_name values so a single real poll reveals the right filter.
+	it("warns and lists the observed model_name values when no 'general' row is present", () => {
+		interface LogEvent {
+			ts: number;
+			level: string;
+			msg: string;
+			data?: unknown;
+		}
+		const warnEvents: LogEvent[] = [];
+		const handler = (event: LogEvent) => {
+			if (event.level === "WARN") warnEvents.push(event);
+		};
+		logBus.on("log", handler);
+
+		try {
+			const parsed = parseMinimaxTokenPlanResponse({
+				base_resp: { status_code: 0 },
+				model_remains: [
+					makeRow({
+						model_name: "video",
+						current_interval_remaining_percent: 5,
+						current_weekly_remaining_percent: 5,
+					}),
+					makeRow({
+						model_name: "audio",
+						current_interval_remaining_percent: 50,
+						current_weekly_remaining_percent: 50,
+					}),
+				],
+			});
+
+			// Still returns null — no wrong-row substitution.
+			expect(parsed).toBeNull();
+
+			// At least one WARN references the miss and lists the observed
+			// model_name values. The message is model names only — never
+			// tokens, keys, or full response bodies.
+			const missWarn = warnEvents.find(
+				(e) =>
+					e.msg.includes("no 'general' row") &&
+					e.msg.includes("video") &&
+					e.msg.includes("audio"),
+			);
+			expect(missWarn).toBeDefined();
+		} finally {
+			logBus.off("log", handler);
+		}
+	});
+
+	it("does not warn when model_remains is empty", () => {
+		interface LogEvent {
+			ts: number;
+			level: string;
+			msg: string;
+			data?: unknown;
+		}
+		const warnEvents: LogEvent[] = [];
+		const handler = (event: LogEvent) => {
+			if (event.level === "WARN") warnEvents.push(event);
+		};
+		logBus.on("log", handler);
+
+		try {
+			// Empty model_remains is the "missing array" branch, not the
+			// "wrong filter" branch — the new WARN must NOT fire here.
+			const parsed = parseMinimaxTokenPlanResponse({
+				base_resp: { status_code: 0 },
+				model_remains: [],
+			});
+
+			expect(parsed).toBeNull();
+			const missWarn = warnEvents.find((e) =>
+				e.msg.includes("no 'general' row"),
+			);
+			expect(missWarn).toBeUndefined();
+		} finally {
+			logBus.off("log", handler);
+		}
 	});
 });

--- a/packages/providers/src/minimax-usage-fetcher.ts
+++ b/packages/providers/src/minimax-usage-fetcher.ts
@@ -18,6 +18,38 @@ export const MINIMAX_TOKEN_PLAN_REMAINS_ENDPOINT =
 	"https://www.minimax.io/v1/token_plan/remains";
 
 /**
+ * Positive allowlist of MiniMax `base_resp.status_code` values that mean
+ * "this response is healthy, parse it". Anything outside this set is treated
+ * as a non-success and the parser returns null.
+ *
+ * Pinned to `[0]` today. If MiniMax introduces another success code, extend
+ * this set explicitly so the change shows up in code review (review finding F5).
+ * Using a negative `statusCode !== 0` test would silently misread a future
+ * success code (e.g. `5`) as a failure and the affected account would show
+ * `unknown` utilization with only a log line to explain it.
+ */
+export const MINIMAX_TOKEN_PLAN_SUCCESS_STATUS_CODES: readonly number[] = [0];
+
+/**
+ * `base_resp.status_code` values MiniMax is documented (or empirically
+ * observed) to return on real failures. Distinguishing "known failure" from
+ * "unrecognized non-success" lets the parser log differently for each — a
+ * known failure is a hard error worth surfacing, an unrecognized non-success
+ * may simply be a new code we have not classified yet (review finding F5).
+ *
+ * Today this contains the codes the integration test suite has seen:
+ *   - 1001: quota exceeded
+ *   - 1004: token / API-key auth failure (200 with base_resp.status_code=1004)
+ *
+ * A 200-with-`base_resp.status_code=1004` response is intentionally NOT
+ * collapsed into the HTTP-error path: MiniMax serves it with HTTP 200 and
+ * the auth failure is only visible in `base_resp`. The parser must read the
+ * body either way.
+ */
+export const MINIMAX_TOKEN_PLAN_KNOWN_FAILURE_STATUS_CODES: ReadonlySet<number> =
+	new Set<number>([1001, 1004]);
+
+/**
  * Timeout for the metadata request and the body read. A stalled MiniMax
  * response previously kept the account's in-flight polling slot occupied
  * forever (PR #346 review finding #2). Mirrors the
@@ -173,10 +205,29 @@ export function parseMinimaxTokenPlanResponse(
 	const raw = body as MinimaxRawResponse;
 
 	const statusCode = raw.base_resp?.status_code;
-	if (typeof statusCode === "number" && statusCode !== 0) {
-		log.warn(
-			`Minimax usage returned base_resp.status_code=${statusCode}${raw.base_resp?.status_msg ? ` ${raw.base_resp.status_msg}` : ""}`,
-		);
+	if (
+		typeof statusCode === "number" &&
+		!MINIMAX_TOKEN_PLAN_SUCCESS_STATUS_CODES.includes(statusCode)
+	) {
+		// Distinguish "known failure" from "unrecognized non-success" so an
+		// operator tailing logs can tell the two apart (review finding F5).
+		// - Known failure: MiniMax has been observed to return this code on a
+		//   real error (auth, quota, ...). Surface it loudly.
+		// - Unrecognized non-success: in the success allowlist or the known
+		//   failure set, just not here. Today this usually means a future
+		//   code we haven't classified; log it differently so the next time
+		//   someone sees a fresh code in production, the WARN framing tells
+		//   them to extend MINIMAX_TOKEN_PLAN_SUCCESS_STATUS_CODES rather
+		//   than mistaking a healthy response for a failure.
+		if (MINIMAX_TOKEN_PLAN_KNOWN_FAILURE_STATUS_CODES.has(statusCode)) {
+			log.warn(
+				`Minimax usage returned known error base_resp.status_code=${statusCode}${raw.base_resp?.status_msg ? ` ${raw.base_resp.status_msg}` : ""}`,
+			);
+		} else {
+			log.warn(
+				`Minimax usage returned unrecognized non-zero base_resp.status_code=${statusCode}; not in success allowlist or known-failure set, treating as null to avoid misreading a future success code`,
+			);
+		}
 		return null;
 	}
 

--- a/packages/providers/src/minimax-usage-fetcher.ts
+++ b/packages/providers/src/minimax-usage-fetcher.ts
@@ -186,7 +186,24 @@ export function parseMinimaxTokenPlanResponse(
 	}
 
 	const row = pickTextInferenceRow(raw.model_remains);
-	if (!row) return null;
+	if (!row) {
+		// model_remains is present and non-empty (checked above) but no row
+		// matched the `general` filter. The filter is unverified — Minimax
+		// publishes no response schema and may not actually emit a row named
+		// "general" — so surface the observed model_name values as a WARN so
+		// a single real poll reveals the truth. Deliberately do NOT fall back
+		// to a first-row read: a wrong-substituted reading would surface as
+		// the account's text utilization (PR #346 review fix 4311195e
+		// removed that fallback for exactly this reason). Log model names
+		// only — never tokens, keys, or full response bodies.
+		const observed = raw.model_remains
+			.map((entry) => entry?.model_name)
+			.filter((name): name is string => typeof name === "string");
+		log.warn(
+			`Minimax usage response had no 'general' row; observed model_name values: [${observed.join(", ")}]`,
+		);
+		return null;
+	}
 
 	const five_hour = buildWindow(row, "interval");
 	const seven_day = buildWindow(row, "weekly");


### PR DESCRIPTION
Follow-up to #347 (single commit on top of it — merge that first).

## Problem

`parseMinimaxTokenPlanResponse` rejected on `statusCode !== 0`. That collapses two different situations into one bucket:

- a **known failure** (e.g. `1004` auth failure, which MiniMax returns with HTTP 200 and an error in `base_resp` — so `!response.ok` never sees it), and
- an **unrecognised** status code.

Today both are handled correctly by accident, because every non-zero code we have seen is in fact an error. But if MiniMax ever introduces a success code other than `0`, healthy responses would silently return `null` **forever**, and the account would sit at `unknown` utilisation with nothing but a log line to show for it. A future upstream change would turn a working integration into a silently degraded one.

## Change

Validate against a positive allowlist (`MINIMAX_TOKEN_PLAN_SUCCESS_STATUS_CODES`) and distinguish three states rather than two:

- **success** — code is in the allowlist, continue parsing;
- **known failure** — code is in `MINIMAX_TOKEN_PLAN_KNOWN_FAILURE_STATUS_CODES`, warn and return null (current behaviour, unchanged for `1004`);
- **unrecognised** — warn distinctly, return null, and say so in the message, so the next person who sees a fresh code in production is told to extend the allowlist rather than assuming a healthy response is a failure.

Behaviour for every code we currently know is unchanged. This only alters what happens to codes we have not seen.

## Tests

The test file pins the exact allowlist and the known-failure set, and asserts an unrecognised code is handled as unknown — neither silently succeeding nor silently failing forever.

Validated with a negative control: with the allowlist reverted to `!== 0` (constants and types left in place), the suite goes 19 → 17 pass / 2 fail; restored, 19/19. So the tests exercise the logic rather than the presence of the constants.

## Scope

Two files, +185/−4. Deliberately does not touch #347's commits.