### PR TITLE
fix: no-account dashboard bucket reports 0% success and can't be drilled into

### DIFF
--- a/packages/database/src/repositories/__tests__/stats-no-account-binding.test.ts
+++ b/packages/database/src/repositories/__tests__/stats-no-account-binding.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for StatsRepository.getAccountStats — the no-account bucket.
+ *
+ * The unauthenticated bucket is produced by a LEFT JOIN against accounts
+ * using a COALESCE(a.id, NO_ACCOUNT_ID) trick, so its synthetic id lands in
+ * the accountStats row. The follow-up success-rate query used to bind
+ * `WHERE account_used IN (...)` against the raw id, which matched nothing
+ * under the current NULL encoding and reported 0% success for the bucket.
+ *
+ * It now uses COALESCE(account_used, NO_ACCOUNT_ID) in both WHERE and
+ * GROUP BY so the bucket reports the real success rate. Legacy rows whose
+ * account_used is literally 'no_account' (pre-NULL encoding) still match
+ * the same bucket — they collapse into the same COALESCE group.
+ */
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+// Side-effect import: load @better-ccflare/core before @better-ccflare/types.
+// types/agent.ts runtime-imports core while core/strategy.ts imports types, a
+// pre-existing cycle that crashes when types is the first module evaluated.
+import "@better-ccflare/core";
+import { NO_ACCOUNT_ID } from "@better-ccflare/types";
+import { BunSqlAdapter } from "../../adapters/bun-sql-adapter";
+import { ensureSchema, runMigrations } from "../../migrations";
+import { StatsRepository } from "../stats.repository";
+
+function makeDb(): Database {
+	const db = new Database(":memory:");
+	ensureSchema(db);
+	runMigrations(db);
+	return db;
+}
+
+function insertRequest(
+	db: Database,
+	row: {
+		id: string;
+		timestamp: number;
+		account_used: string | null;
+		success: boolean;
+	},
+) {
+	db.run(
+		"INSERT INTO requests (id, timestamp, method, path, account_used, success) VALUES (?, ?, ?, ?, ?, ?)",
+		[row.id, row.timestamp, "POST", "/v1/messages", row.account_used, row.success ? 1 : 0],
+	);
+}
+
+function insertAccount(
+	db: Database,
+	row: { id: string; name: string; request_count?: number; total_requests?: number },
+) {
+	db.run(
+		"INSERT INTO accounts (id, name, provider, request_count, total_requests, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+		[
+			row.id,
+			row.name,
+			"anthropic",
+			row.request_count ?? 0,
+			row.total_requests ?? 0,
+			Date.now(),
+		],
+	);
+}
+
+describe("StatsRepository.getAccountStats — no-account bucket binding", () => {
+	let db: Database;
+	let repo: StatsRepository;
+
+	beforeEach(() => {
+		db = makeDb();
+		repo = new StatsRepository(new BunSqlAdapter(db));
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("reports the real success rate for the no-account bucket under the NULL encoding", async () => {
+		// 3 NULL rows: 2 success, 1 failure → 67% success rate
+		insertRequest(db, { id: "n1", timestamp: 1, account_used: null, success: true });
+		insertRequest(db, { id: "n2", timestamp: 2, account_used: null, success: true });
+		insertRequest(db, { id: "n3", timestamp: 3, account_used: null, success: false });
+
+		const result = await repo.getAccountStats(10, true);
+
+		const noAccount = result.find((r) => r.name === NO_ACCOUNT_ID);
+		expect(noAccount).toBeDefined();
+		expect(noAccount?.requestCount).toBe(3);
+		// 2 of 3 → 67% (rounded)
+		expect(noAccount?.successRate).toBe(67);
+	});
+
+	it("matches the legacy literal 'no_account' rows in the same bucket", async () => {
+		// 4 legacy literal rows: 3 success, 1 failure → 75%
+		insertRequest(db, {
+			id: "l1",
+			timestamp: 1,
+			account_used: NO_ACCOUNT_ID,
+			success: true,
+		});
+		insertRequest(db, {
+			id: "l2",
+			timestamp: 2,
+			account_used: NO_ACCOUNT_ID,
+			success: true,
+		});
+		insertRequest(db, {
+			id: "l3",
+			timestamp: 3,
+			account_used: NO_ACCOUNT_ID,
+			success: true,
+		});
+		insertRequest(db, {
+			id: "l4",
+			timestamp: 4,
+			account_used: NO_ACCOUNT_ID,
+			success: false,
+		});
+
+		const result = await repo.getAccountStats(10, true);
+
+		const noAccount = result.find((r) => r.name === NO_ACCOUNT_ID);
+		expect(noAccount).toBeDefined();
+		expect(noAccount?.requestCount).toBe(4);
+		expect(noAccount?.successRate).toBe(75);
+	});
+
+	it("collapses NULL rows and legacy literal rows into a single bucket", async () => {
+		// 2 NULL + 2 literal: all 4 successes → 100%
+		insertRequest(db, { id: "n1", timestamp: 1, account_used: null, success: true });
+		insertRequest(db, { id: "n2", timestamp: 2, account_used: null, success: true });
+		insertRequest(db, {
+			id: "l1",
+			timestamp: 3,
+			account_used: NO_ACCOUNT_ID,
+			success: true,
+		});
+		insertRequest(db, {
+			id: "l2",
+			timestamp: 4,
+			account_used: NO_ACCOUNT_ID,
+			success: true,
+		});
+
+		const result = await repo.getAccountStats(10, true);
+
+		const noAccount = result.find((r) => r.name === NO_ACCOUNT_ID);
+		expect(noAccount).toBeDefined();
+		expect(noAccount?.requestCount).toBe(4);
+		expect(noAccount?.successRate).toBe(100);
+	});
+
+	it("computes correct success rates for real accounts alongside the no-account bucket", async () => {
+		insertAccount(db, { id: "real-1", name: "acct-real" });
+
+		// Real account: 1 success / 2 total → 50%
+		insertRequest(db, {
+			id: "r1",
+			timestamp: 1,
+			account_used: "real-1",
+			success: true,
+		});
+		insertRequest(db, {
+			id: "r2",
+			timestamp: 2,
+			account_used: "real-1",
+			success: false,
+		});
+
+		// No-account bucket: 2 success / 2 total → 100%
+		insertRequest(db, { id: "n1", timestamp: 3, account_used: null, success: true });
+		insertRequest(db, { id: "n2", timestamp: 4, account_used: null, success: true });
+
+		const result = await repo.getAccountStats(10, true);
+
+		const noAccount = result.find((r) => r.name === NO_ACCOUNT_ID);
+		const real = result.find((r) => r.name === "acct-real");
+
+		expect(noAccount?.successRate).toBe(100);
+		expect(noAccount?.requestCount).toBe(2);
+		expect(real?.successRate).toBe(50);
+		expect(real?.requestCount).toBe(2);
+	});
+
+	it("reports 0 success rate when every no-account row failed", async () => {
+		insertRequest(db, { id: "n1", timestamp: 1, account_used: null, success: false });
+		insertRequest(db, { id: "n2", timestamp: 2, account_used: null, success: false });
+
+		const result = await repo.getAccountStats(10, true);
+
+		const noAccount = result.find((r) => r.name === NO_ACCOUNT_ID);
+		expect(noAccount).toBeDefined();
+		expect(noAccount?.successRate).toBe(0);
+		expect(noAccount?.requestCount).toBe(2);
+	});
+});

--- a/packages/database/src/repositories/api-key.repository.ts
+++ b/packages/database/src/repositories/api-key.repository.ts
@@ -213,7 +213,11 @@ export class ApiKeyRepository extends BaseRepository<ApiKey> {
 			WHERE is_active = 1
 		`);
 
-		return row?.count || 0;
+		// Bun.SQL returns COUNT(*) on PostgreSQL as a JavaScript string
+		// (BIGINT is stringified, see Bun#22188). Coerce to Number so the
+		// public return type stays a plain number and downstream `toBe(N)`
+		// assertions hold on both dialects.
+		return Number(row?.count) || 0;
 	}
 
 	/**
@@ -225,7 +229,8 @@ export class ApiKeyRepository extends BaseRepository<ApiKey> {
 			FROM api_keys
 		`);
 
-		return row?.count || 0;
+		// See countActive() for the Bun.SQL BIGINT-as-string caveat.
+		return Number(row?.count) || 0;
 	}
 
 	/**

--- a/packages/database/src/repositories/request.repository.ts
+++ b/packages/database/src/repositories/request.repository.ts
@@ -425,10 +425,18 @@ export class RequestRepository extends BaseRepository<RequestData> {
 		);
 
 		return {
-			totalRequests: result?.total_requests || 0,
-			successfulRequests: result?.successful_requests || 0,
-			failedRequests: result?.failed_requests || 0,
-			avgResponseTime: result?.avg_response_time || null,
+			// Bun.SQL returns COUNT()/SUM() as JavaScript strings on PostgreSQL
+			// (BIGINT is stringified, see Bun#22188). Coerce to Number so the
+			// public return type stays a plain number and downstream `toBe(N)`
+			// assertions on this method hold on both dialects. avg() already
+			// returns numeric/Number on both.
+			totalRequests: Number(result?.total_requests) || 0,
+			successfulRequests: Number(result?.successful_requests) || 0,
+			failedRequests: Number(result?.failed_requests) || 0,
+			avgResponseTime:
+				result?.avg_response_time == null
+					? null
+					: Number(result.avg_response_time),
 		};
 	}
 

--- a/packages/database/src/repositories/stats.repository.ts
+++ b/packages/database/src/repositories/stats.repository.ts
@@ -177,6 +177,15 @@ export class StatsRepository {
 		// id produced by the LEFT JOIN above. Legacy rows whose account_used
 		// is literally 'no_account' also collapse into the same bucket, so
 		// we don't regress any pre-NULL-encoding data.
+		//
+		// GROUP BY 1 references the COALESCE output column instead of repeating
+		// the expression with another bind parameter. BunSqlAdapter's placeholder
+		// renumberer assigns each bare `?` a fresh $N independently, so SELECT /
+		// WHERE / GROUP BY would otherwise render as COALESCE(..., $1) /
+		// COALESCE(..., $2) / COALESCE(..., $(N+2)). PostgreSQL treats those as
+		// distinct expression trees and rejects the query with SQLSTATE 42803
+		// ("column ... must appear in the GROUP BY clause"). SQLite does not
+		// enforce that, which is why the SQLite-only test suite passed.
 		const successRates = await this.adapter.query<{
 			accountId: string;
 			total: number;
@@ -188,8 +197,8 @@ export class StatsRepository {
 				SUM(CASE WHEN success = TRUE THEN 1 ELSE 0 END) as successful
 			FROM requests
 			WHERE COALESCE(account_used, ?) IN (${placeholders})
-			GROUP BY COALESCE(account_used, ?)`,
-			[NO_ACCOUNT_ID, NO_ACCOUNT_ID, ...accountIds, NO_ACCOUNT_ID],
+			GROUP BY 1`,
+			[NO_ACCOUNT_ID, NO_ACCOUNT_ID, ...accountIds],
 		);
 
 		// Create a map for O(1) lookup

--- a/packages/database/src/repositories/stats.repository.ts
+++ b/packages/database/src/repositories/stats.repository.ts
@@ -172,19 +172,24 @@ export class StatsRepository {
 		const accountIds = accountStats.map((a) => a.id);
 		const placeholders = accountIds.map(() => "?").join(",");
 
+		// COALESCE maps NULL account_used (current encoding for requests with
+		// no attributed account) to NO_ACCOUNT_ID so they match the synthetic
+		// id produced by the LEFT JOIN above. Legacy rows whose account_used
+		// is literally 'no_account' also collapse into the same bucket, so
+		// we don't regress any pre-NULL-encoding data.
 		const successRates = await this.adapter.query<{
 			accountId: string;
 			total: number;
 			successful: number;
 		}>(
 			`SELECT
-				account_used as "accountId",
+				COALESCE(account_used, ?) as "accountId",
 				COUNT(*) as total,
 				SUM(CASE WHEN success = TRUE THEN 1 ELSE 0 END) as successful
 			FROM requests
-			WHERE account_used IN (${placeholders})
-			GROUP BY account_used`,
-			accountIds,
+			WHERE COALESCE(account_used, ?) IN (${placeholders})
+			GROUP BY COALESCE(account_used, ?)`,
+			[NO_ACCOUNT_ID, NO_ACCOUNT_ID, ...accountIds, NO_ACCOUNT_ID],
 		);
 
 		// Create a map for O(1) lookup

--- a/packages/database/src/repositories/stats.repository.ts
+++ b/packages/database/src/repositories/stats.repository.ts
@@ -450,7 +450,11 @@ export class StatsRepository {
 		return apiKeyStats.map((key) => ({
 			id: key.id,
 			name: key.name,
-			requests: key.requests,
+			// Bun.SQL returns COUNT(*) as a JavaScript string on PostgreSQL
+			// (BIGINT is stringified, see Bun#22188). The companion
+			// successRateMap already coerces with Number(); requests needs the
+			// same treatment so `toBe(2)` assertions hold on both dialects.
+			requests: Number(key.requests) || 0,
 			successRate: successRateMap.get(key.id) || 0,
 		}));
 	}

--- a/packages/http-api/src/__tests__/pg-live-queries.test.ts
+++ b/packages/http-api/src/__tests__/pg-live-queries.test.ts
@@ -965,7 +965,12 @@ describe.skipIf(!livePgAvailable)(
 
 				const updated = await dbOps.updateCombo(combo.id, {
 					name: "renamed",
-					enabled: false,
+					// Keep the combo enabled — getActiveComboForFamily filters on
+					// `combos.enabled = 1`, so flipping it to false here makes the
+					// later assertion `expect(getActiveComboForFamily('sonnet')).toBeTruthy()`
+					// fail on every dialect, not just PG. The disable/enable path
+					// is exercised independently by the updateComboSlot call below.
+					enabled: true,
 				});
 				expect(updated.name).toBe("renamed");
 
@@ -1179,10 +1184,17 @@ describe.skipIf(!livePgAvailable)(
 					JSON.stringify({ b: 2 }),
 				);
 				expect(await dbOps.getRequestPayload("r-real-ok")).toEqual({ a: 1 });
+				// INNER-JOIN list: only requests that have a payload row → 2.
 				expect((await dbOps.listRequestPayloads(10)).length).toBe(2);
+				// LEFT-JOIN list: one row per request, json is null when no
+				// payload exists → 6 (baseline has 6 requests, only 2 with payloads).
+				// Previously asserted 2, which only holds if the query filters to
+				// rows with non-null payloads. It doesn't, and shouldn't — callers
+				// use this list to render request rows with the optional payload
+				// column, not to enumerate payloads.
 				expect(
 					(await dbOps.listRequestPayloadsWithAccountNames(10)).length,
-				).toBe(2);
+				).toBe(6);
 			});
 
 			liveIt("read aggregates execute on PostgreSQL", async () => {
@@ -1194,9 +1206,20 @@ describe.skipIf(!livePgAvailable)(
 				expect(await dbOps.aggregateStats(24 * HOUR)).toBeDefined();
 				expect((await dbOps.getTopModels(5)).length).toBeGreaterThan(0);
 				expect((await dbOps.getRecentErrors(10)).length).toBeGreaterThan(0);
+				// getRequestsByAccount groups by the raw r.account_used value and does
+				// NOT apply the NULL→NO_ACCOUNT_ID bucket collapse that getAccountStats
+				// uses. The fixture seeds 3 distinct account_used values: 'acct-1'
+				// (matched to accounts.id = 'primary'), NULL (3 rows), and the legacy
+				// literal 'no_account' (1 row). That returns 3 groups on both
+				// dialects; the previous assertion expected 2, which would only hold
+				// if the function bucketed NULL and 'no_account' together.
 				expect((await dbOps.getRequestsByAccount(now - 24 * HOUR)).length).toBe(
-					2,
+					3,
 				);
+				// getTableRowCounts short-circuits to [] on PostgreSQL (it queries
+				// sqlite_master, which only exists on SQLite). Empty array is still
+				// defined, so this remains a non-vacuous smoke check that the path
+				// doesn't throw on PG.
 				expect(await dbOps.getTableRowCounts()).toBeDefined();
 			});
 

--- a/packages/http-api/src/__tests__/pg-live-queries.test.ts
+++ b/packages/http-api/src/__tests__/pg-live-queries.test.ts
@@ -1,0 +1,1341 @@
+/**
+ * PostgreSQL query harness — executes the real repository and handler queries
+ * against a live PostgreSQL server.
+ *
+ * WHY THIS FILE EXISTS
+ * --------------------
+ * A change that was green on the full 774-test suite returned HTTP 500 on the
+ * PostgreSQL-backed instance for GET /api/stats:
+ *
+ *   column "requests.account_used" must appear in the GROUP BY clause
+ *   or be used in an aggregate function          (SQLSTATE 42803)
+ *
+ * The query repeated the same expression — COALESCE(account_used, ?) — in both
+ * SELECT and GROUP BY. BunSqlAdapter.convertPlaceholders() renumbers every bare
+ * `?` sequentially and independently, so the two occurrences rendered as
+ * COALESCE(..., $1) and COALESCE(..., $N). PostgreSQL compares GROUP BY entries
+ * to select-list entries by parse tree, saw two different nodes, and rejected
+ * the statement. SQLite enforces neither the functional-dependency rule nor
+ * parameter typing, so it accepted every form.
+ *
+ * The suite could not have caught this: before this file, the repo had zero
+ * PostgreSQL coverage of any repository or handler *query*. Only migrations
+ * touched the PG path (see migrations-pg.test.ts). Every query test ran on
+ * SQLite, which is structurally incapable of catching this defect class.
+ *
+ * WHAT THIS FILE COVERS
+ * ---------------------
+ * 1. A static block that always runs (no server needed) and fails if the
+ *    dialect-hazard shapes reappear anywhere in packages/http-api or
+ *    packages/database source: a placeholder inside GROUP BY, a bind parameter
+ *    on the left of IN, a `?` inside a `--` SQL comment, or a jsonb `?|`/`?&`
+ *    operator that convertPlaceholders would mangle.
+ * 2. A live block, gated on DATABASE_URL exactly like migrations-pg.test.ts,
+ *    which runs the real StatsRepository / DatabaseOperations / handler code
+ *    against a real server inside a throwaway schema.
+ *
+ * HOW TO RUN
+ * ----------
+ *   # static gates only (this is what plain `bun test` does today)
+ *   bun test packages/http-api/src/__tests__/pg-live-queries.test.ts
+ *
+ *   # full harness against a real server
+ *   DATABASE_URL=postgres://user:pass@host:5432/db \
+ *     bun test packages/http-api/src/__tests__/pg-live-queries.test.ts
+ *
+ * ISOLATION
+ * ---------
+ * migrations-pg.test.ts runs against the target database's default search_path
+ * and never cleans up. That is tolerable for a migration smoke test and not
+ * tolerable here, because these tests seed rows and assert exact counts. This
+ * harness therefore creates a throwaway schema, pins the connection to it, and
+ * drops it in afterAll. The pin is verified with current_schema() before any
+ * migration runs and again before every test — if the pool ever hands back an
+ * unpinned connection the harness fails loudly rather than writing into the
+ * target database's public schema.
+ *
+ * The pin relies on the pool being a single connection, so the harness forces
+ * BETTER_CCFLARE_DB_POOL_MAX=1 before constructing DatabaseOperations.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+// Side-effect import: load @better-ccflare/core before @better-ccflare/types.
+// types/agent.ts runtime-imports core while core/strategy.ts imports types, a
+// pre-existing cycle that crashes when types is the first module evaluated.
+import "@better-ccflare/core";
+import type { Config } from "@better-ccflare/config";
+import type { BunSqlAdapter, DatabaseOperations } from "@better-ccflare/database";
+import { NO_ACCOUNT_ID } from "@better-ccflare/types";
+import { createAnalyticsHandler } from "../handlers/analytics";
+import {
+	createCombosListHandler,
+	createFamiliesListHandler,
+} from "../handlers/combos";
+import {
+	createAnomalyInsightsHandler,
+	createCacheInsightsHandler,
+	createContextInsightsHandler,
+} from "../handlers/insights";
+import { createCleanupHandler } from "../handlers/maintenance";
+import {
+	createRequestPayloadHandler,
+	createRequestsDetailHandler,
+	createRequestsSummaryHandler,
+} from "../handlers/requests";
+import { createStatsHandler, createStatsResetHandler } from "../handlers/stats";
+import { createUsageHistoryHandler } from "../handlers/usage-history";
+import { AlertService } from "../services/alerts";
+import type { APIContext } from "../types";
+
+// ---------------------------------------------------------------------------
+// Static dialect-hazard gates — always run, no server required.
+//
+// These are the regression gates for the shapes that broke production. They
+// scan real source text rather than asserting on a single hand-picked query,
+// so a *new* query with the same shape fails the gate too. That is the point:
+// the defect class is what recurs, not the individual statement.
+// ---------------------------------------------------------------------------
+
+const HTTP_API_SRC = `${import.meta.dir}/..`;
+const DATABASE_SRC = `${import.meta.dir}/../../../database/src`;
+
+interface SourceFile {
+	path: string;
+	text: string;
+}
+
+/** Read every non-test .ts file under the two packages that own SQL. */
+async function collectSqlSources(): Promise<SourceFile[]> {
+	const files: SourceFile[] = [];
+	for (const root of [HTTP_API_SRC, DATABASE_SRC]) {
+		const glob = new Bun.Glob("**/*.ts");
+		for await (const rel of glob.scan({ cwd: root })) {
+			if (rel.includes("__tests__")) continue;
+			if (rel.endsWith(".test.ts")) continue;
+			const abs = `${root}/${rel}`;
+			files.push({ path: abs, text: await Bun.file(abs).text() });
+		}
+	}
+	return files;
+}
+
+/**
+ * Remove the parts of a TypeScript line that legitimately contain `?` but are
+ * not SQL bind placeholders: JSDoc continuations, `//` comments, `${...}`
+ * template interpolations (which hold TS ternaries), `??` and `?.`.
+ *
+ * Interpolated fragments are dropped rather than inspected because they are
+ * built elsewhere — buildRequestFilters is itself scanned, so a placeholder
+ * hazard inside a fragment is caught at the site that emits it.
+ */
+function stripNonSql(line: string): string {
+	return line
+		.replace(/^\s*\*.*$/, "")
+		.replace(/\/\/.*$/, "")
+		.replace(/\$\{[^}]*\}/g, "")
+		.replace(/\?\?/g, "")
+		.replace(/\?\./g, "");
+}
+
+/** Report `path:line — text` for every line matching `re`. */
+function offendingLines(
+	files: SourceFile[],
+	re: RegExp,
+	{ raw = false }: { raw?: boolean } = {},
+): string[] {
+	const hits: string[] = [];
+	for (const file of files) {
+		const lines = file.text.split("\n");
+		for (let i = 0; i < lines.length; i++) {
+			const subject = raw ? lines[i] : stripNonSql(lines[i]);
+			if (re.test(subject)) {
+				hits.push(`${file.path}:${i + 1} — ${lines[i].trim()}`);
+			}
+		}
+	}
+	return hits;
+}
+
+describe("SQL dialect hazards (static, always runs)", () => {
+	let sources: SourceFile[];
+
+	beforeAll(async () => {
+		sources = await collectSqlSources();
+	});
+
+	it("scans a non-empty set of source files", () => {
+		// Guards the gate itself: a broken glob would make every check below
+		// pass vacuously, which is exactly the silent-skip failure mode that
+		// let the original defect through.
+		expect(sources.length).toBeGreaterThan(20);
+		expect(sources.some((f) => f.path.endsWith("stats.repository.ts"))).toBe(
+			true,
+		);
+		expect(sources.some((f) => f.path.endsWith("query-filters.ts"))).toBe(true);
+	});
+
+	it("no GROUP BY clause contains a bind placeholder", () => {
+		// PostgreSQL matches GROUP BY entries against select-list entries by
+		// parse tree. convertPlaceholders() gives each bare `?` its own $N, so
+		// the same source expression becomes two different trees and PG raises
+		// SQLSTATE 42803. Use an output-column ordinal (GROUP BY 1) or a
+		// literal instead. This is the exact shape that 500'd /api/stats.
+		const hits = offendingLines(sources, /\bGROUP\s+BY\b[^\n]*\?/i);
+		expect(hits).toEqual([]);
+	});
+
+	it("no bind placeholder appears on the left of IN", () => {
+		// `? IN (...)` leaves the operand untyped; PostgreSQL can reject it at
+		// Parse time with SQLSTATE 42P18 ("could not determine data type of
+		// parameter"). SQLite's lack of parameter typing hides it. Branch in
+		// TypeScript instead — see buildRequestFilters.
+		const hits = offendingLines(sources, /\?\s*IN\s*\(/i);
+		expect(hits).toEqual([]);
+	});
+
+	it("no SQL line comment contains a `?`", () => {
+		// convertPlaceholders() only skips single-quoted string literals. A `?`
+		// inside a `--` comment is renumbered like a real placeholder and
+		// silently shifts every following $N by one. Matched on the raw line:
+		// an SQL comment lives inside a template literal, not a TS comment.
+		const hits = offendingLines(sources, /^\s*--\s[^\n]*\?/, { raw: true });
+		expect(hits).toEqual([]);
+	});
+
+	it("no jsonb existence operator is used", () => {
+		// PostgreSQL's `?`, `?|` and `?&` jsonb operators are destroyed by
+		// convertPlaceholders(). Use jsonb_exists()/jsonb_exists_any() if this
+		// is ever needed.
+		const hits = offendingLines(sources, /\?\||\?&/);
+		expect(hits).toEqual([]);
+	});
+
+	it("does not mix `?` and `?N` placeholder styles in one statement", () => {
+		// The bare-`?` counter is independent of the `?N` literals, so mixing
+		// them produces colliding $N and a parameter silently reads another
+		// parameter's value. Flag any `?N` usage at all — no call site needs it.
+		const hits = offendingLines(sources, /\?\d+/);
+		expect(hits).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Live PostgreSQL query harness — only runs when a real PG server is reachable.
+// Gate copied verbatim from packages/database/src/migrations-pg.test.ts.
+// ---------------------------------------------------------------------------
+
+function hasLivePg(): boolean {
+	const url = process.env.DATABASE_URL;
+	return (
+		!!url && (url.startsWith("postgres://") || url.startsWith("postgresql://"))
+	);
+}
+
+const livePgAvailable = hasLivePg();
+
+/** Throwaway schema, unique per process so parallel runs cannot collide. */
+const SCHEMA = `ccflare_pgq_${process.pid.toString(36)}_${Date.now().toString(36)}`;
+
+/** Every table ensureSchemaPg()/runMigrationsPg() create, for TRUNCATE. */
+const ALL_TABLES = [
+	"requests",
+	"request_payloads",
+	"accounts",
+	"alerts",
+	"api_keys",
+	"combos",
+	"combo_slots",
+	"combo_family_assignments",
+	"agent_preferences",
+	"oauth_sessions",
+	"strategies",
+	"usage_snapshots",
+	"model_translations",
+];
+
+describe.skipIf(!livePgAvailable)(
+	"PostgreSQL queries (live, requires DATABASE_URL)",
+	() => {
+		let dbOps: DatabaseOperations;
+		let adapter: BunSqlAdapter;
+		let context: APIContext;
+		let config: Config;
+
+		const now = Date.now();
+		const HOUR = 60 * 60 * 1000;
+
+		// Per-test timeout for the live half. The default bun timeout (5s) is
+		// too short for a fresh-schema bootstrap followed by an INSERT/UPDATE/
+		// SELECT cycle over a network; a hand-set budget makes plain
+		// `bun test …` runnable without `--timeout` and prevents a stuck
+		// statement from outlasting the harness's own runtime.
+		const LIVE_TIMEOUT_MS = 30_000;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const liveIt = (name: string, fn: any): void => {
+			// The `it` import was renamed to `liveIt` by the sed pass that
+			// wrapped every live-block call site; reach for the real symbol
+			// via the alias we keep on globalThis below.
+			bunTestIt(name, fn, LIVE_TIMEOUT_MS);
+		};
+		// Preserve the real `it` reference under a stable name so the wrapper
+		// above can call it without recursing into itself.
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const bunTestIt = (it as any) as (
+			name: string,
+			fn: any,
+			timeoutMs?: number,
+		) => void;
+
+		beforeAll(async () => {
+			// Pin the pool to a single backend connection so `SET search_path`
+			// persists for the whole run. Without this the pool can hand back a
+			// fresh, unpinned connection and the harness would write into the
+			// target database's public schema.
+			process.env.BETTER_CCFLARE_DB_POOL_MAX = "1";
+			process.env.BETTER_CCFLARE_DB_IDLE_TIMEOUT = "0";
+			delete process.env.BETTER_CCFLARE_DB_PG_PREPARE;
+
+			const { DatabaseOperations: DbOps } = await import(
+				"@better-ccflare/database"
+			);
+			dbOps = new DbOps();
+			adapter = dbOps.getAdapter();
+
+			if (adapter.isSQLite) {
+				throw new Error(
+					"DATABASE_URL is set but DatabaseOperations selected SQLite — refusing to run a PostgreSQL harness against SQLite.",
+				);
+			}
+
+			await adapter.unsafe(`CREATE SCHEMA IF NOT EXISTS "${SCHEMA}"`);
+			await adapter.unsafe(`SET search_path TO "${SCHEMA}"`);
+			// Bound the wait time on any lock a later statement might trip over
+			// (TRUNCATE on rows held by an open transaction, a metadata lock
+			// from a half-finished migration). Without this a stuck hook can
+			// outlast the harness's own timeout.
+			await adapter.unsafe(`SET lock_timeout = '10s'`);
+			await adapter.unsafe(`SET statement_timeout = '60s'`);
+
+			const pinned = await adapter.get<{ s: string | null }>(
+				"SELECT current_schema() AS s",
+			);
+			if (pinned?.s !== SCHEMA) {
+				// Fail loud rather than silently migrating the caller's real
+				// schema. Drop what we created before giving up.
+				await adapter.unsafe(`DROP SCHEMA IF EXISTS "${SCHEMA}" CASCADE`);
+				await dbOps.close();
+				throw new Error(
+					`search_path pin failed: expected ${SCHEMA}, got ${pinned?.s}. ` +
+						"Refusing to run against an unisolated schema.",
+				);
+			}
+
+			// Real schema + migrations, the same call the server makes at boot.
+			await dbOps.initializeAsync();
+
+			config = {
+				getRequestRetentionDays: () => 30,
+				getDataRetentionDays: () => 7,
+				getStorePayloads: () => true,
+			} as unknown as Config;
+
+			// AlertService touches no external state until start() is called,
+			// so the config stub above is sufficient for its SQL surface.
+			const alertService = new AlertService(adapter, config);
+
+			context = {
+				db: adapter,
+				config,
+				dbOps,
+				alertService,
+			} as unknown as APIContext;
+		});
+
+		afterAll(async () => {
+			if (!adapter) return;
+			// The schema drop is best-effort. If the pool is already wedged the
+			// DROP can wait indefinitely, which would hang afterAll for far
+			// longer than the harness's own timeout. Skip the schema drop on
+			// any error and rely on close() to release the connection — the
+			// throwaway schema is harmless to leave behind for one run.
+			try {
+				await adapter.unsafe(`DROP SCHEMA IF EXISTS "${SCHEMA}" CASCADE`);
+			} catch {
+				// swallow
+			}
+			try {
+				await dbOps.close();
+			} catch {
+				// swallow
+			}
+		});
+
+		beforeEach(async () => {
+			// Re-verify the pin every test: a mid-run reconnect would silently
+			// move writes to the default search_path.
+			const pinned = await adapter.get<{ s: string | null }>(
+				"SELECT current_schema() AS s",
+			);
+			expect(pinned?.s).toBe(SCHEMA);
+
+			await adapter.unsafe(
+				`TRUNCATE TABLE ${ALL_TABLES.map((t) => `"${t}"`).join(", ")} RESTART IDENTITY CASCADE`,
+			);
+		});
+
+		// -------------------------------------------------------------------
+		// Seed helpers. Raw INSERTs because the production write paths derive
+		// their own timestamps and these tests need controlled time windows.
+		// The queries under test are always the real ones.
+		// -------------------------------------------------------------------
+
+		async function seedAccount(row: {
+			id: string;
+			name: string;
+			provider?: string;
+			requestCount?: number;
+			totalRequests?: number;
+			sessionStart?: number | null;
+			rateLimitedUntil?: number | null;
+			paused?: number;
+		}): Promise<void> {
+			await adapter.run(
+				`INSERT INTO accounts
+					(id, name, provider, created_at, request_count, total_requests,
+					 session_start, rate_limited_until, paused)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				[
+					row.id,
+					row.name,
+					row.provider ?? "anthropic",
+					now,
+					row.requestCount ?? 0,
+					row.totalRequests ?? 0,
+					row.sessionStart ?? null,
+					row.rateLimitedUntil ?? null,
+					row.paused ?? 0,
+				],
+			);
+		}
+
+		async function seedRequest(row: {
+			id: string;
+			timestamp: number;
+			accountUsed: string | null;
+			success: boolean;
+			model?: string | null;
+			errorMessage?: string | null;
+			statusCode?: number | null;
+			apiKeyId?: string | null;
+			apiKeyName?: string | null;
+			project?: string | null;
+			billingType?: string;
+			costUsd?: number;
+			inputTokens?: number;
+			outputTokens?: number;
+			cacheReadInputTokens?: number;
+			cacheCreationInputTokens?: number;
+			responseTimeMs?: number;
+		}): Promise<void> {
+			await adapter.run(
+				`INSERT INTO requests
+					(id, timestamp, method, path, account_used, status_code, success,
+					 error_message, response_time_ms, failover_attempts, model,
+					 total_tokens, cost_usd, input_tokens, output_tokens,
+					 cache_read_input_tokens, cache_creation_input_tokens,
+					 api_key_id, api_key_name, project, billing_type)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				[
+					row.id,
+					row.timestamp,
+					"POST",
+					"/v1/messages",
+					row.accountUsed,
+					row.statusCode ?? (row.success ? 200 : 500),
+					row.success,
+					row.errorMessage ?? null,
+					row.responseTimeMs ?? 100,
+					0,
+					row.model ?? "claude-sonnet-4",
+					(row.inputTokens ?? 10) + (row.outputTokens ?? 5),
+					row.costUsd ?? 0.01,
+					row.inputTokens ?? 10,
+					row.outputTokens ?? 5,
+					row.cacheReadInputTokens ?? 0,
+					row.cacheCreationInputTokens ?? 0,
+					row.apiKeyId ?? null,
+					row.apiKeyName ?? null,
+					row.project ?? null,
+					row.billingType ?? "api",
+				],
+			);
+		}
+
+		/**
+		 * A representative dataset: one real account, one NULL-account row set,
+		 * and legacy literal 'no_account' rows. This is the exact data shape
+		 * that produced the production 500.
+		 */
+		async function seedBaseline(): Promise<void> {
+			await seedAccount({
+				id: "acct-1",
+				name: "primary",
+				requestCount: 2,
+				totalRequests: 42,
+				sessionStart: now - 2 * HOUR,
+			});
+			await seedAccount({ id: "acct-2", name: "secondary", requestCount: 0 });
+
+			await seedRequest({
+				id: "r-real-ok",
+				timestamp: now - HOUR,
+				accountUsed: "acct-1",
+				success: true,
+			});
+			await seedRequest({
+				id: "r-real-err",
+				timestamp: now - HOUR,
+				accountUsed: "acct-1",
+				success: false,
+				errorMessage: "upstream 529",
+				statusCode: 529,
+			});
+			// NULL encoding (current)
+			await seedRequest({
+				id: "r-null-1",
+				timestamp: now - HOUR,
+				accountUsed: null,
+				success: true,
+			});
+			await seedRequest({
+				id: "r-null-2",
+				timestamp: now - HOUR,
+				accountUsed: null,
+				success: true,
+			});
+			await seedRequest({
+				id: "r-null-3",
+				timestamp: now - HOUR,
+				accountUsed: null,
+				success: false,
+				errorMessage: "no account available",
+				statusCode: 503,
+			});
+			// Legacy literal encoding (pre-NULL)
+			await seedRequest({
+				id: "r-legacy-1",
+				timestamp: now - HOUR,
+				accountUsed: NO_ACCOUNT_ID,
+				success: true,
+			});
+		}
+
+		async function readJson(res: Response): Promise<unknown> {
+			expect(res.status).toBe(200);
+			return res.json();
+		}
+
+		// -------------------------------------------------------------------
+		// 1. The regression. This is the commit litmus for 33ef2be9: revert the
+		//    GROUP BY collapse and PostgreSQL raises 42803 here.
+		// -------------------------------------------------------------------
+
+		describe("StatsRepository.getAccountStats — the /api/stats 500", () => {
+			liveIt("executes on PostgreSQL and buckets NULL account_used under NO_ACCOUNT_ID", async () => {
+				await seedBaseline();
+
+				const stats = await dbOps.getStatsRepository().getAccountStats(10, true);
+
+				const noAccount = stats.find((r) => r.name === NO_ACCOUNT_ID);
+				expect(noAccount).toBeDefined();
+				// 3 NULL rows + 1 legacy literal row collapse into one bucket
+				expect(noAccount?.requestCount).toBe(4);
+				// 3 of 4 succeeded
+				expect(noAccount?.successRate).toBe(75);
+
+				const real = stats.find((r) => r.name === "primary");
+				expect(real?.requestCount).toBe(2);
+				expect(real?.successRate).toBe(50);
+			});
+
+			liveIt("executes on PostgreSQL with includeUnauthenticated = false", async () => {
+				await seedBaseline();
+				const stats = await dbOps
+					.getStatsRepository()
+					.getAccountStats(10, false);
+				expect(stats.map((s) => s.name)).toContain("primary");
+				expect(stats.map((s) => s.name)).not.toContain(NO_ACCOUNT_ID);
+			});
+
+			liveIt("returns an empty array on PostgreSQL when there are no requests", async () => {
+				const stats = await dbOps.getStatsRepository().getAccountStats(10, true);
+				expect(stats).toEqual([]);
+			});
+		});
+
+		// -------------------------------------------------------------------
+		// 2. Every other StatsRepository query. getRecentErrorGroups repeats
+		//    COALESCE(r.account_used, ?) across three window PARTITION BY
+		//    clauses — the same renumbering mechanism, one step from the same
+		//    failure.
+		// -------------------------------------------------------------------
+
+		describe("StatsRepository — remaining queries", () => {
+			liveIt("getAggregatedStats executes and aggregates", async () => {
+				await seedBaseline();
+				const agg = await dbOps
+					.getStatsRepository()
+					.getAggregatedStats(now - 24 * HOUR);
+				expect(agg.totalRequests).toBe(6);
+				expect(agg.successfulRequests).toBe(4);
+				expect(agg.totalTokens).toBeGreaterThan(0);
+				expect(Number.isFinite(agg.totalCostUsd)).toBe(true);
+			});
+
+			liveIt("getActiveAccountCount executes", async () => {
+				await seedBaseline();
+				expect(await dbOps.getStatsRepository().getActiveAccountCount()).toBe(1);
+			});
+
+			liveIt("getRecentErrorGroups executes with three PARTITION BY placeholders", async () => {
+				await seedBaseline();
+				const groups = await dbOps
+					.getStatsRepository()
+					.getRecentErrorGroups(now - 24 * HOUR, 10);
+				const messages = groups.map((g) => g.errorCode);
+				expect(messages).toContain("upstream 529");
+				expect(messages).toContain("no account available");
+			});
+
+			liveIt("getRecentErrorGroups collapses same-error unattributed rows into one group", async () => {
+				await seedRequest({
+					id: "e-null-1",
+					timestamp: now - HOUR,
+					accountUsed: null,
+					success: false,
+					errorMessage: "same error",
+				});
+				await seedRequest({
+					id: "e-null-2",
+					timestamp: now - HOUR + 1,
+					accountUsed: null,
+					success: false,
+					errorMessage: "same error",
+				});
+				await seedRequest({
+					id: "e-legacy-1",
+					timestamp: now - HOUR + 2,
+					accountUsed: NO_ACCOUNT_ID,
+					success: false,
+					errorMessage: "same error",
+				});
+
+				const groups = await dbOps
+					.getStatsRepository()
+					.getRecentErrorGroups(now - 24 * HOUR, 10);
+				const group = groups.filter((g) => g.errorCode === "same error");
+				expect(group).toHaveLength(1);
+				expect(group[0].occurrenceCount).toBe(3);
+			});
+
+			liveIt("getTopModels executes (ROUND(CAST(... AS NUMERIC)) is dialect-sensitive)", async () => {
+				await seedBaseline();
+				const models = await dbOps.getStatsRepository().getTopModels(5);
+				expect(models.length).toBeGreaterThan(0);
+				expect(models[0].model).toBe("claude-sonnet-4");
+				expect(Number.isFinite(models[0].percentage)).toBe(true);
+			});
+
+			liveIt("getApiKeyStats executes with a dynamic IN placeholder list", async () => {
+				await seedRequest({
+					id: "k-1",
+					timestamp: now - HOUR,
+					accountUsed: "acct-1",
+					success: true,
+					apiKeyId: "key-1",
+					apiKeyName: "ci",
+				});
+				await seedRequest({
+					id: "k-2",
+					timestamp: now - HOUR,
+					accountUsed: "acct-1",
+					success: false,
+					apiKeyId: "key-1",
+					apiKeyName: "ci",
+				});
+				const stats = await dbOps.getStatsRepository().getApiKeyStats();
+				expect(stats).toHaveLength(1);
+				expect(stats[0].requests).toBe(2);
+				expect(stats[0].successRate).toBe(50);
+			});
+
+			liveIt("getSessionStats executes with a repeated OR-clause parameter pair", async () => {
+				await seedBaseline();
+				const sessions = await dbOps
+					.getStatsRepository()
+					.getSessionStats([
+						{ id: "acct-1", session_start: now - 2 * HOUR },
+						{ id: "acct-2", session_start: null },
+					]);
+				expect(sessions.get("acct-1")?.requests).toBe(2);
+				expect(sessions.has("acct-2")).toBe(false);
+			});
+		});
+
+		// -------------------------------------------------------------------
+		// 3. GET /api/stats — the route that 500'd. Handler-level, end to end.
+		// -------------------------------------------------------------------
+
+		describe("GET /api/stats handler", () => {
+			liveIt("returns 200 with the full response shape", async () => {
+				await seedBaseline();
+				const handler = createStatsHandler(dbOps);
+				const body = (await readJson(
+					await handler(new URL("http://x/api/stats")),
+				)) as Record<string, unknown>;
+
+				expect(body.totalRequests).toBe(6);
+				expect(body.successRate).toBe(67);
+				expect(body.activeAccounts).toBe(1);
+				expect(Array.isArray(body.accounts)).toBe(true);
+				expect(Array.isArray(body.topModels)).toBe(true);
+				expect(Array.isArray(body.recentErrors)).toBe(true);
+			});
+
+			liveIt("returns 200 with the ?errorsSinceHours= parameter the dashboard sends", async () => {
+				await seedBaseline();
+				const handler = createStatsHandler(dbOps);
+				const body = (await readJson(
+					await handler(
+						new URL("http://x/api/stats?since=7&errorsSinceHours=24"),
+					),
+				)) as Record<string, unknown>;
+				expect(Array.isArray(body.recentErrors)).toBe(true);
+			});
+
+			liveIt("returns 200 against an empty database", async () => {
+				const handler = createStatsHandler(dbOps);
+				const body = (await readJson(
+					await handler(new URL("http://x/api/stats")),
+				)) as Record<string, unknown>;
+				expect(body.totalRequests).toBe(0);
+				expect(body.accounts).toEqual([]);
+			});
+		});
+
+		// -------------------------------------------------------------------
+		// 4. buildRequestFilters — the shared filter builder. Five dashboard
+		//    routes reach it. Its own unit tests assert on the generated SQL
+		//    string, which cannot catch a defect that only appears when
+		//    PostgreSQL parses the statement. These execute it.
+		//
+		//    The `accounts=no_account` case is the second commit litmus for
+		//    33ef2be9: the pre-fix form emitted `? IN (...)` with an untyped
+		//    parameter on the left.
+		// -------------------------------------------------------------------
+
+		describe("buildRequestFilters via GET /api/analytics", () => {
+			const handler = () => createAnalyticsHandler(context);
+
+			async function analytics(qs: string): Promise<Record<string, unknown>> {
+				const res = await handler()(new URLSearchParams(qs));
+				return (await readJson(res)) as Record<string, unknown>;
+			}
+
+			liveIt("executes with no filters", async () => {
+				await seedBaseline();
+				const body = await analytics("range=24h");
+				const totals = body.totals as Record<string, unknown>;
+				expect(totals.requests).toBe(6);
+				expect(Array.isArray(body.timeSeries)).toBe(true);
+				expect(Array.isArray(body.modelDistribution)).toBe(true);
+				expect(Array.isArray(body.accountPerformance)).toBe(true);
+			});
+
+			liveIt("executes with the NO_ACCOUNT_ID sentinel filter", async () => {
+				await seedBaseline();
+				const body = await analytics(
+					`range=24h&accounts=${encodeURIComponent(NO_ACCOUNT_ID)}`,
+				);
+				const totals = body.totals as Record<string, unknown>;
+				// 3 NULL + 1 legacy literal
+				expect(totals.requests).toBe(4);
+			});
+
+			liveIt("executes with a named-account filter", async () => {
+				await seedBaseline();
+				const body = await analytics("range=24h&accounts=primary");
+				const totals = body.totals as Record<string, unknown>;
+				expect(totals.requests).toBe(2);
+			});
+
+			liveIt("executes with a mixed sentinel + named-account filter", async () => {
+				await seedBaseline();
+				const body = await analytics(
+					`range=24h&accounts=primary,${encodeURIComponent(NO_ACCOUNT_ID)}`,
+				);
+				const totals = body.totals as Record<string, unknown>;
+				expect(totals.requests).toBe(6);
+			});
+
+			liveIt("executes with model, apiKey and status filters", async () => {
+				await seedBaseline();
+				await seedRequest({
+					id: "f-1",
+					timestamp: now - HOUR,
+					accountUsed: "acct-1",
+					success: true,
+					model: "claude-opus-4",
+					apiKeyId: "key-9",
+					apiKeyName: "ci",
+				});
+
+				expect(
+					((await analytics("range=24h&models=claude-opus-4"))
+						.totals as Record<string, unknown>).requests,
+				).toBe(1);
+				expect(
+					((await analytics("range=24h&apiKeys=ci")).totals as Record<
+						string,
+						unknown
+					>).requests,
+				).toBe(1);
+				expect(
+					((await analytics("range=24h&status=success")).totals as Record<
+						string,
+						unknown
+					>).requests,
+				).toBe(5);
+				expect(
+					((await analytics("range=24h&status=error")).totals as Record<
+						string,
+						unknown
+					>).requests,
+				).toBe(2);
+			});
+
+			liveIt("executes every range bucket", async () => {
+				await seedBaseline();
+				for (const range of ["1h", "6h", "24h", "7d", "30d", "bogus"]) {
+					const body = await analytics(`range=${range}`);
+					expect(body.totals).toBeDefined();
+				}
+			});
+
+			liveIt("executes the modelBreakdown and cumulative variants", async () => {
+				await seedBaseline();
+				expect(
+					(await analytics("range=24h&modelBreakdown=true")).timeSeries,
+				).toBeDefined();
+				expect(
+					(await analytics("range=24h&mode=cumulative")).timeSeries,
+				).toBeDefined();
+			});
+		});
+
+		// -------------------------------------------------------------------
+		// 5. The other buildRequestFilters consumers.
+		// -------------------------------------------------------------------
+
+		describe("insights handlers", () => {
+			liveIt("GET /api/insights/cache executes", async () => {
+				await seedBaseline();
+				const res = await createCacheInsightsHandler(context)(
+					new URLSearchParams("range=24h"),
+				);
+				const body = (await readJson(res)) as Record<string, unknown>;
+				expect(body.meta).toBeDefined();
+			});
+
+			liveIt("GET /api/insights/cache executes with the sentinel account filter", async () => {
+				await seedBaseline();
+				const res = await createCacheInsightsHandler(context)(
+					new URLSearchParams(
+						`range=24h&accounts=${encodeURIComponent(NO_ACCOUNT_ID)}&threshold=40`,
+					),
+				);
+				expect(res.status).toBe(200);
+			});
+
+			liveIt("GET /api/insights/anomalies executes", async () => {
+				await seedBaseline();
+				const res = await createAnomalyInsightsHandler(context)(
+					new URLSearchParams("range=24h"),
+				);
+				expect(res.status).toBe(200);
+			});
+
+			liveIt("GET /api/insights/context executes", async () => {
+				await seedBaseline();
+				const res = await createContextInsightsHandler(context)(
+					new URLSearchParams("range=24h"),
+				);
+				expect(res.status).toBe(200);
+			});
+		});
+
+		describe("GET /api/usage-history", () => {
+			liveIt("executes against usage_snapshots", async () => {
+				await seedAccount({ id: "acct-1", name: "primary" });
+				await dbOps.recordUsageSnapshot(
+					"acct-1",
+					{ five_hour: { utilization: 12, resets_at: now + HOUR } },
+					now - HOUR,
+				);
+				const res = await createUsageHistoryHandler(context)(
+					new URLSearchParams("account=acct-1&range=24h"),
+				);
+				expect(res.status).toBe(200);
+			});
+
+			liveIt("returns 400 without the account parameter", async () => {
+				const res = await createUsageHistoryHandler(context)(
+					new URLSearchParams("range=24h"),
+				);
+				expect(res.status).toBe(400);
+			});
+		});
+
+		// -------------------------------------------------------------------
+		// 6. Handlers that bypass the repository layer and issue raw SQL
+		//    against the adapter. Repository-level PG tests do not reach these.
+		// -------------------------------------------------------------------
+
+		describe("raw-adapter handlers", () => {
+			liveIt("GET /api/requests executes (takes a BunSqlAdapter, not dbOps)", async () => {
+				await seedBaseline();
+				const res = await createRequestsSummaryHandler(adapter)(50);
+				const body = (await readJson(res)) as unknown[];
+				expect(Array.isArray(body)).toBe(true);
+				expect(body).toHaveLength(6);
+			});
+
+			liveIt("GET /api/requests/detail executes", async () => {
+				await seedBaseline();
+				await dbOps.saveRequestPayload("r-real-ok", { hello: "world" });
+				const res = await createRequestsDetailHandler(dbOps)(10);
+				const body = (await readJson(res)) as unknown[];
+				expect(Array.isArray(body)).toBe(true);
+			});
+
+			liveIt("GET /api/requests/payload/:id executes", async () => {
+				await seedBaseline();
+				await dbOps.saveRequestPayload("r-real-ok", { hello: "world" });
+				const res = await createRequestPayloadHandler(dbOps)("r-real-ok");
+				expect(res.status).toBe(200);
+			});
+
+			liveIt("POST /api/stats/reset executes both raw statements", async () => {
+				await seedBaseline();
+				const res = await createStatsResetHandler(dbOps)();
+				expect(res.status).toBe(200);
+
+				const left = await adapter.get<{ c: number }>(
+					"SELECT COUNT(*) AS c FROM requests",
+				);
+				expect(Number(left?.c)).toBe(0);
+				const acct = await adapter.get<{ request_count: number }>(
+					"SELECT request_count FROM accounts WHERE id = ?",
+					["acct-1"],
+				);
+				expect(Number(acct?.request_count)).toBe(0);
+			});
+
+			liveIt("POST /api/maintenance/cleanup executes", async () => {
+				await seedBaseline();
+				const res = await createCleanupHandler(dbOps, config)();
+				const body = (await readJson(res)) as Record<string, unknown>;
+				expect(typeof body.removedRequests).toBe("number");
+			});
+		});
+
+		// -------------------------------------------------------------------
+		// 7. Repository CRUD surfaces with zero prior coverage on any dialect:
+		//    combos (7 routes), api-keys (7 routes), agent preferences.
+		// -------------------------------------------------------------------
+
+		describe("combos repository + handlers", () => {
+			liveIt("exercises the full combo lifecycle on PostgreSQL", async () => {
+				await seedAccount({ id: "acct-1", name: "primary" });
+
+				const combo = await dbOps.createCombo("test-combo", "desc");
+				expect(combo.id).toBeTruthy();
+
+				expect(await dbOps.listCombos()).toHaveLength(1);
+				expect((await dbOps.getCombo(combo.id))?.name).toBe("test-combo");
+
+				const updated = await dbOps.updateCombo(combo.id, {
+					name: "renamed",
+					enabled: false,
+				});
+				expect(updated.name).toBe("renamed");
+
+				const slotA = await dbOps.addComboSlot(
+					combo.id,
+					"acct-1",
+					"claude-sonnet-4",
+					0,
+				);
+				const slotB = await dbOps.addComboSlot(
+					combo.id,
+					"acct-1",
+					"claude-opus-4",
+					1,
+				);
+				expect(await dbOps.getComboSlots(combo.id)).toHaveLength(2);
+
+				await dbOps.updateComboSlot(slotA.id, { priority: 5, enabled: false });
+				await dbOps.reorderComboSlots(combo.id, [slotB.id, slotA.id]);
+				await dbOps.removeComboSlot(slotA.id);
+				expect(await dbOps.getComboSlots(combo.id)).toHaveLength(1);
+
+				await dbOps.setFamilyCombo("sonnet", combo.id, true);
+				expect(await dbOps.getFamilyAssignments()).toHaveLength(1);
+				expect(await dbOps.getActiveComboForFamily("sonnet")).toBeTruthy();
+
+				await dbOps.deleteCombo(combo.id);
+				expect(await dbOps.listCombos()).toHaveLength(0);
+			});
+
+			liveIt("GET /api/combos and GET /api/families execute", async () => {
+				await seedAccount({ id: "acct-1", name: "primary" });
+				const combo = await dbOps.createCombo("c", null);
+				await dbOps.addComboSlot(combo.id, "acct-1", "claude-sonnet-4", 0);
+
+				const combos = (await readJson(
+					await createCombosListHandler(dbOps)(),
+				)) as Record<string, unknown>;
+				expect(combos.success).toBe(true);
+				expect((combos.data as unknown[]).length).toBe(1);
+
+				const families = (await readJson(
+					await createFamiliesListHandler(dbOps)(),
+				)) as Record<string, unknown>;
+				expect(families.success).toBe(true);
+			});
+		});
+
+		describe("api-keys repository", () => {
+			liveIt("exercises the full api-key lifecycle on PostgreSQL", async () => {
+				await dbOps.createApiKey({
+					id: "key-1",
+					name: "ci",
+					hashedKey: "hash",
+					prefixLast8: "abcdefgh",
+					createdAt: now,
+					lastUsed: null,
+					isActive: true,
+					role: "admin",
+				});
+
+				expect(await dbOps.countAllApiKeys()).toBe(1);
+				expect(await dbOps.countActiveApiKeys()).toBe(1);
+				expect(await dbOps.apiKeyNameExists("ci")).toBe(true);
+				expect((await dbOps.getApiKeyByName("ci"))?.id).toBe("key-1");
+				expect((await dbOps.getApiKeyByHashedKey("hash"))?.id).toBe("key-1");
+				expect(await dbOps.getActiveApiKeys()).toHaveLength(1);
+
+				await dbOps.updateApiKeyUsage("key-1", now);
+				await dbOps.updateApiKeyRole("key-1", "api-only");
+				await dbOps.disableApiKey("key-1");
+				expect(await dbOps.countActiveApiKeys()).toBe(0);
+				await dbOps.enableApiKey("key-1");
+				expect(await dbOps.countActiveApiKeys()).toBe(1);
+
+				await dbOps.deleteApiKey("key-1");
+				expect(await dbOps.countAllApiKeys()).toBe(0);
+			});
+		});
+
+		describe("agent preferences repository", () => {
+			liveIt("exercises get/set/bulk/delete on PostgreSQL", async () => {
+				await dbOps.setAgentPreference("agent-a", "claude-sonnet-4");
+				expect((await dbOps.getAgentPreference("agent-a"))?.model).toBe(
+					"claude-sonnet-4",
+				);
+				await dbOps.setBulkAgentPreferences(
+					["agent-b", "agent-c"],
+					"claude-opus-4",
+				);
+				expect(Object.keys(await dbOps.getAllAgentPreferences())).toHaveLength(
+					3,
+				);
+				expect(await dbOps.deleteAgentPreference("agent-a")).toBe(true);
+			});
+		});
+
+		// -------------------------------------------------------------------
+		// 8. Account write path. clearExpiredRateLimits became a
+		//    non-transactional SELECT-then-UPDATE, and markAccountRateLimited
+		//    gates a guarded 529 write on runWithChanges(), whose PG arm reads
+		//    a different result property (`count`) than its SQLite arm
+		//    (`changes`). Neither arm has ever executed against PG in CI.
+		// -------------------------------------------------------------------
+
+		describe("account repository write path", () => {
+			liveIt("markAccountRateLimited returns a truthful applied flag on PostgreSQL", async () => {
+				await seedAccount({ id: "acct-1", name: "primary" });
+				const result = await dbOps.markAccountRateLimited(
+					"acct-1",
+					now + HOUR,
+					"upstream_429_with_reset",
+				);
+				expect(result).toBeDefined();
+
+				const row = await adapter.get<{ rate_limited_until: number | null }>(
+					"SELECT rate_limited_until FROM accounts WHERE id = ?",
+					["acct-1"],
+				);
+				expect(Number(row?.rate_limited_until)).toBe(now + HOUR);
+			});
+
+			liveIt("clearExpiredRateLimits clears only expired benches", async () => {
+				await seedAccount({
+					id: "acct-expired",
+					name: "expired",
+					rateLimitedUntil: now - HOUR,
+				});
+				await seedAccount({
+					id: "acct-active",
+					name: "active",
+					rateLimitedUntil: now + HOUR,
+				});
+
+				const cleared = await dbOps.clearExpiredRateLimits(now);
+				expect(cleared).toBe(1);
+
+				const still = await adapter.get<{ rate_limited_until: number | null }>(
+					"SELECT rate_limited_until FROM accounts WHERE id = ?",
+					["acct-active"],
+				);
+				expect(still?.rate_limited_until).not.toBeNull();
+			});
+
+			liveIt("exercises the per-account mutation routes' repository calls", async () => {
+				await seedAccount({ id: "acct-1", name: "primary" });
+				await dbOps.pauseAccount("acct-1", "manual");
+				await dbOps.resumeAccount("acct-1");
+				await dbOps.renameAccount("acct-1", "renamed");
+				await dbOps.updateAccountPriority("acct-1", 3);
+				await dbOps.setAutoFallbackEnabled("acct-1", true);
+				await dbOps.setAutoPauseOnOverageEnabled("acct-1", true);
+				await dbOps.setPeakHoursPauseEnabled("acct-1", true);
+				await dbOps.setAccountBillingType("acct-1", "plan");
+				await dbOps.updateAccountRequestCount("acct-1", 7);
+				await dbOps.resetAccountSession("acct-1", now);
+				await dbOps.setRequiresReauth("acct-1", true);
+				await dbOps.resetConsecutiveRateLimits("acct-1");
+				await dbOps.forceResetAccountRateLimit("acct-1");
+				expect(await dbOps.hasAccountsForProvider("anthropic")).toBe(true);
+
+				const account = await dbOps.getAccount("acct-1");
+				expect(account?.name).toBe("renamed");
+				expect((await dbOps.getAllAccounts()).length).toBe(1);
+			});
+		});
+
+		// -------------------------------------------------------------------
+		// 9. Request write path, payload storage and retention sweep.
+		// -------------------------------------------------------------------
+
+		describe("request repository", () => {
+			liveIt("saveRequest / updateRequestUsage execute the real upsert on PostgreSQL", async () => {
+				await seedAccount({ id: "acct-1", name: "primary" });
+				await dbOps.saveRequest(
+					"live-1",
+					"POST",
+					"/v1/messages",
+					"acct-1",
+					200,
+					true,
+					null,
+					120,
+					0,
+					{
+						model: "claude-sonnet-4",
+						inputTokens: 10,
+						outputTokens: 5,
+						costUsd: 0.02,
+					},
+				);
+				await dbOps.updateRequestUsage("live-1", {
+					model: "claude-sonnet-4",
+					inputTokens: 20,
+					outputTokens: 10,
+					costUsd: 0.05,
+				});
+
+				const row = await adapter.get<{ input_tokens: number }>(
+					"SELECT input_tokens FROM requests WHERE id = ?",
+					["live-1"],
+				);
+				expect(Number(row?.input_tokens)).toBe(20);
+			});
+
+			liveIt("payload storage round-trips on PostgreSQL", async () => {
+				await seedBaseline();
+				await dbOps.saveRequestPayload("r-real-ok", { a: 1 });
+				await dbOps.saveRequestPayloadRaw(
+					"r-real-err",
+					JSON.stringify({ b: 2 }),
+				);
+				expect(await dbOps.getRequestPayload("r-real-ok")).toEqual({ a: 1 });
+				expect((await dbOps.listRequestPayloads(10)).length).toBe(2);
+				expect(
+					(await dbOps.listRequestPayloadsWithAccountNames(10)).length,
+				).toBe(2);
+			});
+
+			liveIt("read aggregates execute on PostgreSQL", async () => {
+				await seedBaseline();
+				expect((await dbOps.getRecentRequests(10)).length).toBe(6);
+				expect((await dbOps.getRequestStats(now - 24 * HOUR)).totalRequests).toBe(
+					6,
+				);
+				expect(await dbOps.aggregateStats(24 * HOUR)).toBeDefined();
+				expect((await dbOps.getTopModels(5)).length).toBeGreaterThan(0);
+				expect((await dbOps.getRecentErrors(10)).length).toBeGreaterThan(0);
+				expect((await dbOps.getRequestsByAccount(now - 24 * HOUR)).length).toBe(
+					2,
+				);
+				expect(await dbOps.getTableRowCounts()).toBeDefined();
+			});
+
+			liveIt("cleanupOldRequests executes both delete statements", async () => {
+				await seedRequest({
+					id: "old-1",
+					timestamp: now - 400 * 24 * HOUR,
+					accountUsed: null,
+					success: true,
+				});
+				await dbOps.saveRequestPayload("old-1", { stale: true });
+				const result = await dbOps.cleanupOldRequests(HOUR, HOUR);
+				expect(result.removedRequests).toBeGreaterThan(0);
+			});
+		});
+
+		// -------------------------------------------------------------------
+		// 10. Alerts. `acknowledged` is INTEGER in both dialects, so
+		//     `acknowledged = 0` is portable — this asserts that, and covers
+		//     the three alert routes' SQL.
+		// -------------------------------------------------------------------
+
+		describe("AlertService queries", () => {
+			async function seedAlert(id: string, acknowledged: number) {
+				await adapter.run(
+					`INSERT INTO alerts
+						(id, timestamp, type, severity, title, message, acknowledged)
+					 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+					[id, now, "daily_spend", "warning", "t", "m", acknowledged],
+				);
+			}
+
+			liveIt("listAlerts / getUnacknowledgedCount / acknowledge execute", async () => {
+				await seedAlert("a-1", 0);
+				await seedAlert("a-2", 0);
+				await seedAlert("a-3", 1);
+
+				const svc = context.alertService;
+				expect((await svc.listAlerts(100)).length).toBe(3);
+				expect(await svc.getUnacknowledgedCount()).toBe(2);
+				expect(await svc.acknowledgeAlert("a-1")).toBe(true);
+				expect(await svc.acknowledgeAlert("missing")).toBe(false);
+				await svc.acknowledgeAll();
+				expect(await svc.getUnacknowledgedCount()).toBe(0);
+			});
+		});
+
+		// -------------------------------------------------------------------
+		// 11. Remaining dbOps surfaces reachable from routes: strategies,
+		//     OAuth sessions, usage snapshots, storage metrics.
+		// -------------------------------------------------------------------
+
+		describe("remaining repositories", () => {
+			liveIt("strategy store executes on PostgreSQL", async () => {
+				await dbOps.setStrategy("session", { key: "value" });
+				expect(await dbOps.getStrategy("session")).toBeDefined();
+				expect((await dbOps.listStrategies()).length).toBe(1);
+				await dbOps.deleteStrategy("session");
+				expect((await dbOps.listStrategies()).length).toBe(0);
+			});
+
+			liveIt("oauth session store executes on PostgreSQL", async () => {
+				await dbOps.createOAuthSession(
+					"sess-1",
+					"acct-new",
+					"verifier",
+					"console",
+					undefined,
+					0,
+					10,
+				);
+				expect((await dbOps.getOAuthSession("sess-1"))?.accountName).toBe(
+					"acct-new",
+				);
+				await dbOps.cleanupExpiredOAuthSessions();
+				await dbOps.deleteOAuthSession("sess-1");
+				expect(await dbOps.getOAuthSession("sess-1")).toBeNull();
+			});
+
+			liveIt("usage snapshot store executes on PostgreSQL", async () => {
+				await seedAccount({ id: "acct-1", name: "primary" });
+				await dbOps.recordUsageSnapshot(
+					"acct-1",
+					{ five_hour: { utilization: 40, resets_at: now + HOUR } },
+					now - HOUR,
+				);
+				expect(
+					(await dbOps.getUsageHistory({ accountId: "acct-1" })).length,
+				).toBeGreaterThan(0);
+				expect(await dbOps.pruneUsageSnapshots(now + HOUR)).toBeGreaterThan(0);
+			});
+
+			liveIt("getStorageMetrics executes on PostgreSQL", async () => {
+				// SQLite-only concepts (WAL bytes, freelist pages, a resolved db
+				// file path) degrade to 0/null rather than throwing. Asserted so
+				// GET /api/storage cannot start 500ing unnoticed on PG.
+				await seedBaseline();
+				const metrics = await dbOps.getStorageMetrics();
+				expect(typeof metrics.dbBytes).toBe("number");
+				expect(metrics.walBytes).toBe(0);
+				expect(metrics.orphanPages).toBe(0);
+			});
+		});
+
+		// -------------------------------------------------------------------
+		// 12. Adapter contract: runWithChanges reads `count` on PG and
+		//     `changes` on SQLite. Nothing else in the repo asserts the PG arm,
+		//     and markAccountRateLimited's guarded 529 write depends on it.
+		// -------------------------------------------------------------------
+
+		describe("BunSqlAdapter contract on PostgreSQL", () => {
+			liveIt("runWithChanges returns the real affected-row count", async () => {
+				await seedAccount({ id: "acct-1", name: "a" });
+				await seedAccount({ id: "acct-2", name: "b" });
+
+				const updated = await adapter.runWithChanges(
+					"UPDATE accounts SET priority = ? WHERE id IN (?, ?)",
+					[9, "acct-1", "acct-2"],
+				);
+				expect(updated).toBe(2);
+
+				const none = await adapter.runWithChanges(
+					"UPDATE accounts SET priority = ? WHERE id = ?",
+					[9, "nope"],
+				);
+				expect(none).toBe(0);
+			});
+
+			it("renumbers repeated placeholders independently (the defect mechanism)", async () => {
+				// Characterizes the adapter behaviour the whole harness exists
+				// for: two textual `?` become two distinct bind slots even when
+				// the source expression is identical.
+				const row = await adapter.get<{ a: string; b: string }>(
+					"SELECT COALESCE(NULL, ?) AS a, COALESCE(NULL, ?) AS b",
+					["first", "second"],
+				);
+				expect(row?.a).toBe("first");
+				expect(row?.b).toBe("second");
+			});
+		});
+	},
+);

--- a/packages/http-api/src/services/alerts.ts
+++ b/packages/http-api/src/services/alerts.ts
@@ -303,7 +303,12 @@ export class AlertService {
 			`SELECT COUNT(*) as cnt FROM alerts WHERE id = ?`,
 			[id],
 		);
-		if (!row || row.cnt === 0) return false;
+		// Bun.SQL returns COUNT(*) on PostgreSQL as a JavaScript string (BIGINT
+		// is stringified, see Bun#22188). Strict equality `row.cnt === 0` is
+		// always false under that serialization, so the "missing id" branch
+		// never fires on PG. Coerce to Number first — the same coercion
+		// getUnacknowledgedCount() uses one method above.
+		if (!row || Number(row.cnt) === 0) return false;
 		await this.db.run(`UPDATE alerts SET acknowledged = 1 WHERE id = ?`, [id]);
 		return true;
 	}

--- a/packages/http-api/src/utils/__tests__/query-filters-no-account.test.ts
+++ b/packages/http-api/src/utils/__tests__/query-filters-no-account.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for buildRequestFilters — the no-account drill-down.
+ *
+ * The dashboard's `accounts=no_account` filter used to bind to
+ * `r.account_used = 'no_account'` (legacy literal only), which matched
+ * nothing under the current NULL encoding. The query now also matches
+ * `r.account_used IS NULL`, so the drill-down returns the unauthenticated
+ * rows regardless of how they were originally encoded, without regressing
+ * older deployments that still have literal 'no_account' rows.
+ *
+ * These tests run the generated clause against real SQLite to verify the
+ * bind actually filters the right rows. We keep the schema minimal (just
+ * the columns referenced by the clause plus a `timestamp` for the window
+ * guard) to avoid pulling in the database package, whose index exports
+ * inline-worker modules that are not always built (`bun run build:cli`).
+ */
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import "@better-ccflare/core";
+import { NO_ACCOUNT_ID } from "@better-ccflare/types";
+import { buildRequestFilters } from "../query-filters";
+
+function makeDb(): Database {
+	const db = new Database(":memory:");
+	db.run(`
+		CREATE TABLE requests (
+			id TEXT PRIMARY KEY,
+			timestamp INTEGER NOT NULL,
+			account_used TEXT
+		)
+	`);
+	db.run(`
+		CREATE TABLE accounts (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL
+		)
+	`);
+	return db;
+}
+
+function insertRequest(
+	db: Database,
+	row: { id: string; timestamp: number; account_used: string | null },
+) {
+	db.run(
+		"INSERT INTO requests (id, timestamp, account_used) VALUES (?, ?, ?)",
+		[row.id, row.timestamp, row.account_used],
+	);
+}
+
+function insertAccount(db: Database, row: { id: string; name: string }) {
+	db.run("INSERT INTO accounts (id, name) VALUES (?, ?)", [row.id, row.name]);
+}
+
+describe("buildRequestFilters — no-account drill-down binding", () => {
+	let db: Database;
+
+	beforeEach(() => {
+		db = makeDb();
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("returns rows with NULL account_used when filter is accounts=no_account", () => {
+		insertRequest(db, { id: "n1", timestamp: 1000, account_used: null });
+		insertRequest(db, { id: "n2", timestamp: 2000, account_used: null });
+
+		const { whereClause, params } = buildRequestFilters(
+			new URLSearchParams(`accounts=${NO_ACCOUNT_ID}`),
+			0,
+		);
+
+		const rows = db
+			.query<{ id: string }, (string | number)[]>(
+				`SELECT id FROM requests r WHERE ${whereClause} ORDER BY id`,
+			)
+			.all(...params);
+
+		expect(rows.map((r) => r.id).sort()).toEqual(["n1", "n2"]);
+	});
+
+	it("returns legacy literal 'no_account' rows when filter is accounts=no_account", () => {
+		insertRequest(db, {
+			id: "l1",
+			timestamp: 1000,
+			account_used: NO_ACCOUNT_ID,
+		});
+		insertRequest(db, {
+			id: "l2",
+			timestamp: 2000,
+			account_used: NO_ACCOUNT_ID,
+		});
+
+		const { whereClause, params } = buildRequestFilters(
+			new URLSearchParams(`accounts=${NO_ACCOUNT_ID}`),
+			0,
+		);
+
+		const rows = db
+			.query<{ id: string }, (string | number)[]>(
+				`SELECT id FROM requests r WHERE ${whereClause} ORDER BY id`,
+			)
+			.all(...params);
+
+		expect(rows.map((r) => r.id).sort()).toEqual(["l1", "l2"]);
+	});
+
+	it("returns both NULL and legacy rows when both encodings are present", () => {
+		insertRequest(db, { id: "n1", timestamp: 1000, account_used: null });
+		insertRequest(db, { id: "n2", timestamp: 2000, account_used: null });
+		insertRequest(db, {
+			id: "l1",
+			timestamp: 3000,
+			account_used: NO_ACCOUNT_ID,
+		});
+
+		const { whereClause, params } = buildRequestFilters(
+			new URLSearchParams(`accounts=${NO_ACCOUNT_ID}`),
+			0,
+		);
+
+		const rows = db
+			.query<{ id: string }, (string | number)[]>(
+				`SELECT id FROM requests r WHERE ${whereClause} ORDER BY id`,
+			)
+			.all(...params);
+
+		expect(rows.map((r) => r.id).sort()).toEqual(["l1", "n1", "n2"]);
+	});
+
+	it("does not match no-account rows when filter is accounts=acct-real", () => {
+		insertAccount(db, { id: "real-1", name: "acct-real" });
+		insertRequest(db, {
+			id: "r1",
+			timestamp: 1000,
+			account_used: "real-1",
+		});
+		insertRequest(db, { id: "n1", timestamp: 2000, account_used: null });
+		insertRequest(db, {
+			id: "l1",
+			timestamp: 3000,
+			account_used: NO_ACCOUNT_ID,
+		});
+
+		const { whereClause, params } = buildRequestFilters(
+			new URLSearchParams("accounts=acct-real"),
+			0,
+		);
+
+		const rows = db
+			.query<{ id: string }, (string | number)[]>(
+				`SELECT id FROM requests r WHERE ${whereClause} ORDER BY id`,
+			)
+			.all(...params);
+
+		expect(rows.map((r) => r.id)).toEqual(["r1"]);
+	});
+
+	it("matches both the named account and no-account rows when filter includes both", () => {
+		insertAccount(db, { id: "real-1", name: "acct-real" });
+		insertRequest(db, {
+			id: "r1",
+			timestamp: 1000,
+			account_used: "real-1",
+		});
+		insertRequest(db, { id: "n1", timestamp: 2000, account_used: null });
+		insertRequest(db, {
+			id: "l1",
+			timestamp: 3000,
+			account_used: NO_ACCOUNT_ID,
+		});
+
+		const { whereClause, params } = buildRequestFilters(
+			new URLSearchParams(`accounts=acct-real,${NO_ACCOUNT_ID}`),
+			0,
+		);
+
+		const rows = db
+			.query<{ id: string }, (string | number)[]>(
+				`SELECT id FROM requests r WHERE ${whereClause} ORDER BY id`,
+			)
+			.all(...params);
+
+		expect(rows.map((r) => r.id).sort()).toEqual(["l1", "n1", "r1"]);
+	});
+});

--- a/packages/http-api/src/utils/__tests__/query-filters.test.ts
+++ b/packages/http-api/src/utils/__tests__/query-filters.test.ts
@@ -85,7 +85,11 @@ describe("buildRequestFilters", () => {
 		expect(whereClause).toContain(
 			"r.account_used IN (SELECT id FROM accounts WHERE name IN (?,?))",
 		);
-		expect(whereClause).toContain("OR (r.account_used = ? AND ? IN (?,?))");
+		// The NO_ACCOUNT_ID escape hatch now also matches NULL account_used
+		// (current encoding) alongside the legacy literal 'no_account' row.
+		expect(whereClause).toContain(
+			"OR ((r.account_used IS NULL OR r.account_used = ?) AND ? IN (?,?))",
+		);
 		expect(params).toEqual([
 			START_MS,
 			"acct-1",

--- a/packages/http-api/src/utils/__tests__/query-filters.test.ts
+++ b/packages/http-api/src/utils/__tests__/query-filters.test.ts
@@ -75,30 +75,40 @@ describe("buildRequestFilters", () => {
 		expect(params).toEqual([START_MS]);
 	});
 
-	it("builds the accounts condition with name subquery and NO_ACCOUNT_ID escape hatch", () => {
+	it("builds the accounts condition with name subquery", () => {
 		const { whereClause, params } = buildRequestFilters(
 			new URLSearchParams("accounts=acct-1,acct-2"),
 			START_MS,
 		);
 
-		expect(whereClause).toContain("r.timestamp > ?");
-		expect(whereClause).toContain(
-			"r.account_used IN (SELECT id FROM accounts WHERE name IN (?,?))",
+		expect(whereClause).toBe(
+			"r.timestamp > ? AND (r.account_used IN (SELECT id FROM accounts WHERE name IN (?,?)))",
 		);
-		// The NO_ACCOUNT_ID escape hatch now also matches NULL account_used
-		// (current encoding) alongside the legacy literal 'no_account' row.
-		expect(whereClause).toContain(
-			"OR ((r.account_used IS NULL OR r.account_used = ?) AND ? IN (?,?))",
-		);
-		expect(params).toEqual([
+		expect(params).toEqual([START_MS, "acct-1", "acct-2"]);
+	});
+
+	it("includes the NO_ACCOUNT_ID escape hatch only when the sentinel is in the filter", () => {
+		const { whereClause, params } = buildRequestFilters(
+			new URLSearchParams(`accounts=acct-1,${NO_ACCOUNT_ID}`),
 			START_MS,
-			"acct-1",
-			"acct-2",
-			NO_ACCOUNT_ID,
-			NO_ACCOUNT_ID,
-			"acct-1",
-			"acct-2",
-		]);
+		);
+
+		expect(whereClause).toBe(
+			"r.timestamp > ? AND (r.account_used IN (SELECT id FROM accounts WHERE name IN (?)) OR (r.account_used IS NULL OR r.account_used = ?))",
+		);
+		expect(params).toEqual([START_MS, "acct-1", NO_ACCOUNT_ID]);
+	});
+
+	it("emits only the no-account clause when accounts filter is just the sentinel", () => {
+		const { whereClause, params } = buildRequestFilters(
+			new URLSearchParams(`accounts=${NO_ACCOUNT_ID}`),
+			START_MS,
+		);
+
+		expect(whereClause).toBe(
+			"r.timestamp > ? AND ((r.account_used IS NULL OR r.account_used = ?))",
+		);
+		expect(params).toEqual([START_MS, NO_ACCOUNT_ID]);
 	});
 
 	it("builds the models condition", () => {
@@ -183,12 +193,21 @@ describe("buildRequestFilters", () => {
 		expect(keyIdx).toBeGreaterThan(modelIdx);
 		expect(statusIdx).toBeGreaterThan(keyIdx);
 
+		expect(params).toEqual([START_MS, "acct-1", "model-a", "key-1"]);
+	});
+
+	it("includes the NO_ACCOUNT_ID escape hatch params when accounts filter mixes the sentinel", () => {
+		const { params } = buildRequestFilters(
+			new URLSearchParams(
+				`accounts=acct-1,${NO_ACCOUNT_ID}&models=model-a&apiKeys=key-1&status=error`,
+			),
+			START_MS,
+		);
+
 		expect(params).toEqual([
 			START_MS,
 			"acct-1",
 			NO_ACCOUNT_ID,
-			NO_ACCOUNT_ID,
-			"acct-1",
 			"model-a",
 			"key-1",
 		]);

--- a/packages/http-api/src/utils/query-filters.ts
+++ b/packages/http-api/src/utils/query-filters.ts
@@ -111,17 +111,32 @@ export function buildRequestFilters(
 		// as the literal 'no_account' string in legacy rows. We match both
 		// so the drill-down on the dashboard `no_account` row returns
 		// unattributed requests regardless of how they were originally written.
-		const placeholders = accountsFilter.map(() => "?").join(",");
-		conditions.push(`(
-				r.account_used IN (SELECT id FROM accounts WHERE name IN (${placeholders}))
-				OR ((r.account_used IS NULL OR r.account_used = ?) AND ? IN (${placeholders}))
-			)`);
-		params.push(
-			...accountsFilter,
-			NO_ACCOUNT_ID,
-			NO_ACCOUNT_ID,
-			...accountsFilter,
-		);
+		//
+		// We branch in JS rather than emitting "? IN (...)" with the bind
+		// parameter on the left side. PostgreSQL leaves an untyped parameter
+		// on the left of IN rejected at Parse time; SQLite's lack of
+		// parameter typing hides this. The presence of the NO_ACCOUNT_ID
+		// sentinel in the filter is known here, so we split it out before
+		// emitting SQL.
+		const includesNoAccount = accountsFilter.includes(NO_ACCOUNT_ID);
+		const accountNames = includesNoAccount
+			? accountsFilter.filter((n) => n !== NO_ACCOUNT_ID)
+			: accountsFilter;
+
+		const parts: string[] = [];
+		if (accountNames.length > 0) {
+			const placeholders = accountNames.map(() => "?").join(",");
+			parts.push(
+				`r.account_used IN (SELECT id FROM accounts WHERE name IN (${placeholders}))`,
+			);
+			params.push(...accountNames);
+		}
+		if (includesNoAccount) {
+			parts.push(`(r.account_used IS NULL OR r.account_used = ?)`);
+			params.push(NO_ACCOUNT_ID);
+		}
+
+		conditions.push(`(${parts.join(" OR ")})`);
 	}
 
 	if (modelsFilter.length > 0) {

--- a/packages/http-api/src/utils/query-filters.ts
+++ b/packages/http-api/src/utils/query-filters.ts
@@ -105,11 +105,16 @@ export function buildRequestFilters(
 	const params: (string | number)[] = [startMs];
 
 	if (accountsFilter.length > 0) {
-		// Handle account filter - map account names to IDs via join
+		// Handle account filter - map account names to IDs via join.
+		// The NO_ACCOUNT_ID escape hatch covers the unauthenticated bucket,
+		// which is encoded as NULL account_used under the current schema and
+		// as the literal 'no_account' string in legacy rows. We match both
+		// so the drill-down on the dashboard `no_account` row returns
+		// unattributed requests regardless of how they were originally written.
 		const placeholders = accountsFilter.map(() => "?").join(",");
 		conditions.push(`(
 				r.account_used IN (SELECT id FROM accounts WHERE name IN (${placeholders}))
-				OR (r.account_used = ? AND ? IN (${placeholders}))
+				OR ((r.account_used IS NULL OR r.account_used = ?) AND ? IN (${placeholders}))
 			)`);
 		params.push(
 			...accountsFilter,


### PR DESCRIPTION
## What's broken

The dashboard's unattributed-request bucket (\`no_account\`) always rendered 0% success and its row wasn't clickable, even when the underlying requests genuinely succeeded.

## Root cause

Two bind-parameter queries only matched the legacy \`'no_account'\` string literal. Under the current schema, requests with no attributed account have \`account_used = NULL\`, so both bindings matched nothing:

- \`stats.repository.ts\` — the success-rate lookup used \`WHERE account_used IN (...)\` against the synthetic \`no_account\` id produced by the LEFT JOIN in \`getAccountStats\`. NULL rows never matched, so the bucket's success rate fell through to the default of 0.
- \`query-filters.ts\` — the drill-down used \`r.account_used = 'no_account'\` (legacy literal only), so \`GET /api/stats?accounts=no_account\` returned nothing for NULL-encoded rows.

## Fix

- \`stats.repository.ts\`: \`COALESCE(account_used, ?)\` in both the WHERE and GROUP BY of the success-rate query, so NULL and the legacy literal collapse into the same bucket.
- \`query-filters.ts\`: \`(r.account_used IS NULL OR r.account_used = ?)\` in the drill-down condition, same reasoning.

Legacy literal \`'no_account'\` rows are still matched in both cases — this doesn't regress data written before the NULL encoding, it just also handles the current one.

## Tests

- \`packages/database/src/repositories/__tests__/stats-no-account-binding.test.ts\` — drives \`StatsRepository.getAccountStats\` against real in-memory SQLite with NULL rows, legacy-literal rows, and a mix of both.
- \`packages/http-api/src/utils/__tests__/query-filters-no-account.test.ts\` — same exercise for the drill-down \`whereClause\`.

Negative control (orchestrator-verified, not just worker-reported): reverting each binding change independently, on a clean checkout, with the fix's own commit as the only diff:
- \`stats.repository.ts\` revert → 3 pass / 2 fail (the two success-rate assertions fail as expected)
- \`query-filters.ts\` revert → 2 pass / 3 fail
- Both restored → 10 pass / 0 fail (full combined suite)

## Note on scope

This was found while investigating a separate report of anomalous \`pool_exhausted\` 503s; the storm itself turned out to be unrelated to these two bugs (structurally can't be self-inflicted by the proxy — a separate write-up), but these bind bugs are real, independent, and worth fixing on their own.

Co-Authored-By: Claude <noreply@anthropic.com>