### PR TITLE
fix: dispose of teed response bodies on the 529 overload path (#354)

### DIFF
--- a/packages/providers/src/__tests__/zai-rate-limit-body.test.ts
+++ b/packages/providers/src/__tests__/zai-rate-limit-body.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test";
+import { ZaiProvider } from "../providers/zai/provider";
+
+/**
+ * S5b (spec TEST-SPEC.md §4) — `ZaiProvider.parseRateLimitFromBody` in
+ * isolation. PINS pre-existing behaviour (no fix-dependent invariant here);
+ * exists to pin the body-parsing contract that S5 exercises indirectly
+ * through `processProxyResponse`.
+ */
+describe("ZaiProvider.parseRateLimitFromBody", () => {
+	function makeFixture(): { resetUtcMs: number; body: string } {
+		const resetUtcMs = Math.floor((Date.now() + 20_000) / 1000) * 1000;
+		const sg = new Date(resetUtcMs + 8 * 3600_000);
+		const pad = (n: number) => String(n).padStart(2, "0");
+		const stamp =
+			`${sg.getUTCFullYear()}-${pad(sg.getUTCMonth() + 1)}-${pad(sg.getUTCDate())} ` +
+			`${pad(sg.getUTCHours())}:${pad(sg.getUTCMinutes())}:${pad(sg.getUTCSeconds())}`;
+		const body = JSON.stringify({
+			type: "error",
+			error: {
+				type: "1308",
+				message: `Usage limit reached for 5 hour. Your limit will reset at ${stamp}`,
+			},
+		});
+		return { resetUtcMs, body };
+	}
+
+	it("(a) returns the exact parsed resetUtcMs for a 1308 usage-limit body", async () => {
+		const provider = new ZaiProvider();
+		const { resetUtcMs, body } = makeFixture();
+		const response = new Response(body, {
+			status: 429,
+			headers: { "content-type": "application/json" },
+		});
+
+		const result = await provider.parseRateLimitFromBody(response);
+
+		expect(result).toBe(resetUtcMs);
+	});
+
+	it("(b) leaves the passed response body unread (bodyUsed stays false)", async () => {
+		const provider = new ZaiProvider();
+		const { body } = makeFixture();
+		const response = new Response(body, {
+			status: 429,
+			headers: { "content-type": "application/json" },
+		});
+
+		await provider.parseRateLimitFromBody(response);
+
+		expect(response.bodyUsed).toBe(false);
+		// And the body is still fully readable afterwards.
+		await expect(response.clone().json()).resolves.toEqual(JSON.parse(body));
+	});
+
+	it("(c) returns undefined for a non-1308 error type", async () => {
+		const provider = new ZaiProvider();
+		const body = JSON.stringify({
+			type: "error",
+			error: { type: "some_other_error", message: "Something else happened" },
+		});
+		const response = new Response(body, {
+			status: 429,
+			headers: { "content-type": "application/json" },
+		});
+
+		const result = await provider.parseRateLimitFromBody(response);
+
+		expect(result).toBeUndefined();
+	});
+
+	it("(d) returns undefined without throwing for a malformed/non-JSON body", async () => {
+		const provider = new ZaiProvider();
+		const response = new Response("not json at all {{{", {
+			status: 429,
+			headers: { "content-type": "application/json" },
+		});
+
+		const result = await provider.parseRateLimitFromBody(response);
+
+		expect(result).toBeUndefined();
+	});
+});

--- a/packages/proxy/src/handlers/__tests__/clone-leak-harness.ts
+++ b/packages/proxy/src/handlers/__tests__/clone-leak-harness.ts
@@ -1,0 +1,248 @@
+import { mock } from "bun:test";
+import type { Account, RequestMeta } from "@better-ccflare/types";
+import type { ProxyContext } from "../proxy-types";
+
+/**
+ * Shared fixtures and clone-tracking utilities for the issue #354 orphaned
+ * response-clone test suite. Extracted from
+ * `proxy-operations-529-clone-leak.test.ts` so every scenario file (S1-S10)
+ * uses one definition instead of drifting copies.
+ *
+ * Filename deliberately does NOT match `*.test.ts` so bun does not try to
+ * run it as its own test file.
+ */
+
+// ── Clone-settlement predicates ──────────────────────────────────────────
+//
+// A plain `!bodyUsed` orphan check false-positives on a null-body response:
+// `new Response(null).clone().bodyUsed` stays `false` forever in Bun — there
+// is no stream to consume or cancel, so `bodyUsed` never flips. `isSettled`
+// treats a null body as settled by construction; `isOrphaned` is its
+// negation restricted to clones that actually carry a body.
+
+/** True once a clone can no longer retain buffered bytes: no body, or its body has been disturbed. */
+export function isSettled(clone: Response): boolean {
+	return clone.body === null || clone.bodyUsed;
+}
+
+/** True for a clone that still holds an open, unconsumed tee branch. */
+export function isOrphaned(clone: Response): boolean {
+	return clone.body !== null && !clone.bodyUsed;
+}
+
+/**
+ * Records every Response clone created while `body` runs.
+ *
+ * The patch is installed around the call and removed in `finally`, not in
+ * beforeEach/afterEach: Bun executes every test file in ONE process, so a
+ * patch on Response.prototype that survives a throwing assertion would leak
+ * into unrelated suites. Keeping the window to exactly this call makes that
+ * impossible.
+ */
+export async function recordClonesDuring(
+	body: () => Promise<void>,
+): Promise<Response[]> {
+	const clones: Response[] = [];
+	const original = Response.prototype.clone;
+	Response.prototype.clone = function trackedClone(this: Response) {
+		const copy = original.call(this);
+		clones.push(copy);
+		return copy;
+	};
+	try {
+		await body();
+	} finally {
+		Response.prototype.clone = original;
+	}
+	return clones;
+}
+
+/**
+ * Waits until every recorded clone has settled (see `isSettled`), or gives up.
+ *
+ * Usage extraction runs inside a fire-and-forget IIFE (updateAccountMetadata),
+ * so there is no promise the test could await. Polling beats a fixed sleep in
+ * both directions: the passing case returns as soon as the readers are done
+ * instead of always paying a fixed margin, and the failing case gets a budget
+ * generous enough that a loaded machine cannot fake a leak.
+ */
+export async function waitForCloneBodiesToSettle(
+	clones: Response[],
+): Promise<void> {
+	for (let tick = 0; tick < 200; tick++) {
+		if (clones.every(isSettled)) return;
+		await new Promise<void>((resolve) => setTimeout(resolve, 5));
+	}
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+export function makeAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "acc-1",
+		name: "clone-leak-test",
+		provider: "anthropic",
+		api_key: "test-key",
+		refresh_token: "",
+		access_token: null,
+		expires_at: null,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: Date.now(),
+		rate_limited_until: null,
+		rate_limited_reason: null,
+		rate_limited_at: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		peak_hours_pause_enabled: false,
+		custom_endpoint: null,
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		billing_type: null,
+		pause_reason: null,
+		refresh_token_issued_at: null,
+		consecutive_rate_limits: 0,
+		...overrides,
+	} as Account;
+}
+
+export function makeRequestMeta(
+	overrides: Partial<RequestMeta> = {},
+): RequestMeta {
+	return {
+		id: "req-clone-leak",
+		method: "POST",
+		path: "/v1/messages",
+		timestamp: Date.now(),
+		headers: new Headers(),
+		...overrides,
+	} as RequestMeta;
+}
+
+export function makeRequestBody(): ArrayBuffer {
+	return new TextEncoder().encode(
+		JSON.stringify({
+			model: "claude-sonnet-4-5",
+			messages: [{ role: "user", content: "hello" }],
+			max_tokens: 10,
+		}),
+	).buffer;
+}
+
+/**
+ * Context whose provider reports a reset-less 529 — the in-place retry path.
+ *
+ * NOTE: for an account with provider "anthropic" the `provider` stub below is
+ * NOT what drives the run. `proxy-operations.ts` resolves
+ * `getProvider(account.provider) || ctx.provider`, and importing
+ * `@better-ccflare/providers` populates the registry, so the REAL
+ * AnthropicProvider wins and `ctx.provider` is only a fallback. That is
+ * deliberate here: the real provider is what supplies `extractUsageInfo`,
+ * and its clone is one of the orphans this suite is about. Editing the
+ * `parseRateLimit` stub below therefore changes nothing for anthropic-account
+ * scenarios — the real implementation reads the fixture's actual status/
+ * headers, which is exactly what each scenario's fixture is built to drive.
+ */
+export function makeProxyContext(
+	overrides: Partial<ProxyContext> = {},
+): ProxyContext {
+	return {
+		strategy: { getNextAccount: () => null } as never,
+		dbOps: {
+			markAccountRateLimited: mock(() =>
+				Promise.resolve({ consecutiveRateLimits: 1, applied: true }),
+			),
+			saveRequest: mock(() => Promise.resolve()),
+			updateAccountUsage: mock(() => Promise.resolve()),
+			resetConsecutiveRateLimits: mock(() => Promise.resolve()),
+			updateAccountRateLimitMeta: mock(() => Promise.resolve()),
+			updateRequestUsage: mock(() => Promise.resolve()),
+			resetAccountSession: mock(() => Promise.resolve()),
+			getAdapter: mock(() => ({
+				run: mock(() => Promise.resolve()),
+				get: mock(() => Promise.resolve(null)),
+			})),
+		} as never,
+		runtime: { port: 8080, clientId: "test" } as never,
+		provider: {
+			name: "anthropic",
+			canHandle: () => true,
+			buildUrl: () => "https://api.anthropic.com/v1/messages",
+			prepareHeaders: () => new Headers(),
+			transformRequestBody: null,
+			processResponse: async (r: Response) => r,
+			parseRateLimit: (r: Response) => ({
+				isRateLimited: r.status === 529,
+				resetTime: undefined,
+				statusHeader: undefined,
+				remaining: undefined,
+			}),
+			isStreamingResponse: () => false,
+		} as never,
+		refreshInFlight: new Map(),
+		asyncWriter: { enqueue: mock(() => {}) } as never,
+		config: { getStorePayloads: () => false } as never,
+		internalProbeSecret: "test-secret",
+		...overrides,
+	};
+}
+
+/** Standard env keys the 529 in-place retry path reads for backoff timing. */
+export const OVERLOAD_RETRY_ENV_KEYS = [
+	"CCFLARE_OVERLOAD_RETRY_BASE_MS",
+	"CCFLARE_OVERLOAD_RETRY_MAX_MS",
+] as const;
+
+export function makeProxyRequest(bodyBuffer: ArrayBuffer): Request {
+	return new Request("https://proxy.local/v1/messages", {
+		method: "POST",
+		body: bodyBuffer,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+/**
+ * Standard fixture bodies (spec §3.4).
+ */
+export const FIXTURES = {
+	overload529:
+		'{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+	rateLimit429:
+		'{"type":"error","error":{"type":"rate_limit_error","message":"Rate limited"}}',
+	sse: 'event: message_start\ndata: {"type":"message_start","message":{"model":"claude-sonnet-4-5","usage":{"input_tokens":10,"output_tokens":1}}}\n\nevent: message_stop\ndata: {"type":"message_stop"}\n\n',
+} as const;
+
+/**
+ * Builds a Zai 1308 (usage-limit) error body whose embedded reset timestamp
+ * is self-consistent with `Date.now()` at call time (spec §3.4).
+ *
+ * `ZaiProvider.parseRateLimitFromBody` parses the "reset at <stamp>" message
+ * as Singapore time (UTC+8) and subtracts 8h to get UTC — this fixture does
+ * the same math in reverse so the expected `resetUtcMs` is exact.
+ */
+export function makeZai1308Fixture(): { resetUtcMs: number; body: string } {
+	const resetUtcMs = Math.floor((Date.now() + 20_000) / 1000) * 1000;
+	const sg = new Date(resetUtcMs + 8 * 3600_000);
+	const pad = (n: number) => String(n).padStart(2, "0");
+	const stamp =
+		`${sg.getUTCFullYear()}-${pad(sg.getUTCMonth() + 1)}-${pad(sg.getUTCDate())} ` +
+		`${pad(sg.getUTCHours())}:${pad(sg.getUTCMinutes())}:${pad(sg.getUTCSeconds())}`;
+	const body = JSON.stringify({
+		type: "error",
+		error: {
+			type: "1308",
+			message: `Usage limit reached for 5 hour. Your limit will reset at ${stamp}`,
+		},
+	});
+	return { resetUtcMs, body };
+}

--- a/packages/proxy/src/handlers/__tests__/proxy-operations-529-clone-leak.test.ts
+++ b/packages/proxy/src/handlers/__tests__/proxy-operations-529-clone-leak.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { Account, RequestMeta } from "@better-ccflare/types";
+import { proxyWithAccount } from "../proxy-operations";
+import type { ProxyContext } from "../proxy-types";
+
+/**
+ * Regression guard for the 529 overload path (incident 2026-07-29, issue #354).
+ *
+ * `Response.clone()` tees the body: it produces a second ReadableStream fed
+ * from the same source. A tee branch that is never read and never cancelled
+ * stays open and forces the tee to buffer everything the faster branch already
+ * consumed. The 529 path cloned responses purely to hand them to
+ * `provider.parseRateLimit()`, which is declared synchronous
+ * (`parseRateLimit(response: Response): RateLimitInfo` in providers/types.ts)
+ * and therefore cannot read a body at all — so every one of those clones was
+ * orphaned by construction, once per 529 and once more per in-place retry.
+ *
+ * The test asserts the invariant rather than the implementation: after the
+ * path runs, no Response clone may be left with an unconsumed body. Cancelling
+ * a body disturbs it and thus also satisfies `bodyUsed`, so a fix that keeps a
+ * clone but disposes of it passes too.
+ */
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "acc-1",
+		name: "clone-leak-test",
+		provider: "anthropic",
+		api_key: "test-key",
+		refresh_token: "",
+		access_token: null,
+		expires_at: null,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: Date.now(),
+		rate_limited_until: null,
+		rate_limited_reason: null,
+		rate_limited_at: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		peak_hours_pause_enabled: false,
+		custom_endpoint: null,
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		billing_type: null,
+		pause_reason: null,
+		refresh_token_issued_at: null,
+		consecutive_rate_limits: 0,
+		...overrides,
+	};
+}
+
+function makeRequestMeta(): RequestMeta {
+	return {
+		id: "req-clone-leak",
+		method: "POST",
+		path: "/v1/messages",
+		timestamp: Date.now(),
+		headers: new Headers(),
+	} as RequestMeta;
+}
+
+function makeRequestBody() {
+	return new TextEncoder().encode(
+		JSON.stringify({
+			model: "claude-sonnet-4-5",
+			messages: [{ role: "user", content: "hello" }],
+			max_tokens: 10,
+		}),
+	).buffer;
+}
+
+/** Context whose provider reports a reset-less 529 — the in-place retry path. */
+function makeProxyContext(): ProxyContext {
+	return {
+		strategy: { getNextAccount: () => null } as never,
+		dbOps: {
+			markAccountRateLimited: mock(() =>
+				Promise.resolve({ consecutiveRateLimits: 1, applied: true }),
+			),
+			saveRequest: mock(() => Promise.resolve()),
+			updateAccountUsage: mock(() => Promise.resolve()),
+			resetConsecutiveRateLimits: mock(() => Promise.resolve()),
+			getAdapter: mock(() => ({
+				run: mock(() => Promise.resolve()),
+				get: mock(() => Promise.resolve(null)),
+			})),
+		} as never,
+		runtime: { port: 8080, clientId: "test" } as never,
+		provider: {
+			name: "anthropic",
+			canHandle: () => true,
+			buildUrl: () => "https://api.anthropic.com/v1/messages",
+			prepareHeaders: () => new Headers(),
+			transformRequestBody: null,
+			processResponse: async (r: Response) => r,
+			// Reset-less 529: drives the in-place retry branch and the
+			// terminal-forward branch, i.e. every clone site on this path.
+			parseRateLimit: (r: Response) => ({
+				isRateLimited: r.status === 529,
+				resetTime: undefined,
+				statusHeader: undefined,
+				remaining: undefined,
+			}),
+			isStreamingResponse: () => false,
+		} as never,
+		refreshInFlight: new Map(),
+		asyncWriter: { enqueue: mock(() => {}) } as never,
+		config: { getStorePayloads: () => false } as never,
+		internalProbeSecret: "test-secret",
+	};
+}
+
+const ENV_KEYS = [
+	"CCFLARE_OVERLOAD_RETRY_BASE_MS",
+	"CCFLARE_OVERLOAD_RETRY_MAX_MS",
+] as const;
+
+describe("529 overload path — no orphaned response clones", () => {
+	let originalFetch: typeof globalThis.fetch;
+	let originalClone: typeof Response.prototype.clone;
+	let savedEnv: Record<string, string | undefined>;
+	let clones: Response[];
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+		savedEnv = {};
+		for (const k of ENV_KEYS) {
+			savedEnv[k] = process.env[k];
+		}
+		// Keep the jittered in-place retry backoff negligible.
+		process.env.CCFLARE_OVERLOAD_RETRY_BASE_MS = "1";
+		process.env.CCFLARE_OVERLOAD_RETRY_MAX_MS = "2";
+
+		clones = [];
+		originalClone = Response.prototype.clone;
+		Response.prototype.clone = function trackedClone(this: Response) {
+			const copy = originalClone.call(this);
+			clones.push(copy);
+			return copy;
+		};
+	});
+
+	afterEach(() => {
+		Response.prototype.clone = originalClone;
+		globalThis.fetch = originalFetch;
+		for (const k of ENV_KEYS) {
+			if (savedEnv[k] === undefined) delete process.env[k];
+			else process.env[k] = savedEnv[k];
+		}
+	});
+
+	it("leaves no cloned response body unconsumed while handling a reset-less 529", async () => {
+		globalThis.fetch = mock(
+			async () =>
+				new Response(
+					'{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+					{ status: 529, headers: { "content-type": "application/json" } },
+				),
+		);
+
+		const bodyBuffer = makeRequestBody();
+		const req = new Request("https://proxy.local/v1/messages", {
+			method: "POST",
+			body: bodyBuffer,
+			headers: { "Content-Type": "application/json" },
+		});
+
+		// The terminal-attempt flag routes into the "forward the final 529"
+		// branch. forwardToClient needs a UsageCollector that unit tests do not
+		// wire up; reaching it is enough for this assertion, so that specific
+		// error is tolerated (same approach as proxy-operations-failover.test.ts).
+		try {
+			await proxyWithAccount(
+				req,
+				new URL("https://proxy.local/v1/messages"),
+				makeAccount(),
+				makeRequestMeta(),
+				bodyBuffer,
+				() => undefined,
+				0,
+				makeProxyContext(),
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				true,
+			);
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : String(e);
+			if (!msg.includes("UsageCollector not initialized")) throw e;
+		}
+
+		// updateAccountMetadata reads a clone inside a fire-and-forget IIFE
+		// (response-processor.ts) for usage extraction. That consumer is
+		// legitimate but not awaited by the caller, so give the microtask queue a
+		// turn before judging — otherwise a still-running reader looks identical
+		// to a leak.
+		await new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+		const orphaned = clones.filter((c) => !c.bodyUsed);
+		expect(orphaned.length).toBe(0);
+	});
+});

--- a/packages/proxy/src/handlers/__tests__/proxy-operations-529-clone-leak.test.ts
+++ b/packages/proxy/src/handlers/__tests__/proxy-operations-529-clone-leak.test.ts
@@ -97,6 +97,16 @@ function makeProxyContext(): ProxyContext {
 			})),
 		} as never,
 		runtime: { port: 8080, clientId: "test" } as never,
+		// NOTE: for an account with provider "anthropic" this stub is NOT what
+		// drives the run. proxy-operations.ts resolves
+		// `getProvider(account.provider) || ctx.provider`, and importing
+		// @better-ccflare/providers populates the registry, so the REAL
+		// AnthropicProvider wins and ctx.provider is only a fallback. That is
+		// deliberate here: the real provider is what supplies extractUsageInfo,
+		// and its clone is one of the orphans this test is about. Editing the
+		// parseRateLimit below therefore changes nothing — the real
+		// implementation returns isRateLimited/no resetTime for a 529 that
+		// carries no reset headers, which is exactly the path we want.
 		provider: {
 			name: "anthropic",
 			canHandle: () => true,
@@ -104,8 +114,6 @@ function makeProxyContext(): ProxyContext {
 			prepareHeaders: () => new Headers(),
 			transformRequestBody: null,
 			processResponse: async (r: Response) => r,
-			// Reset-less 529: drives the in-place retry branch and the
-			// terminal-forward branch, i.e. every clone site on this path.
 			parseRateLimit: (r: Response) => ({
 				isRateLimited: r.status === 529,
 				resetTime: undefined,
@@ -126,11 +134,52 @@ const ENV_KEYS = [
 	"CCFLARE_OVERLOAD_RETRY_MAX_MS",
 ] as const;
 
+/**
+ * Records every Response clone created while `body` runs.
+ *
+ * The patch is installed around the call and removed in `finally`, not in
+ * beforeEach/afterEach: Bun executes every test file in ONE process, so a patch
+ * on Response.prototype that survives a throwing assertion would leak into
+ * unrelated suites. Keeping the window to exactly this call makes that
+ * impossible.
+ */
+async function recordClonesDuring(
+	body: () => Promise<void>,
+): Promise<Response[]> {
+	const clones: Response[] = [];
+	const original = Response.prototype.clone;
+	Response.prototype.clone = function trackedClone(this: Response) {
+		const copy = original.call(this);
+		clones.push(copy);
+		return copy;
+	};
+	try {
+		await body();
+	} finally {
+		Response.prototype.clone = original;
+	}
+	return clones;
+}
+
+/**
+ * Waits until every recorded clone has had its body consumed, or gives up.
+ *
+ * The usage extraction in updateAccountMetadata reads its clone inside a
+ * fire-and-forget IIFE, so there is no promise the test could await. Polling
+ * beats a fixed sleep in both directions: the passing case returns as soon as
+ * the readers are done instead of always paying a fixed margin, and the failing
+ * case gets a budget generous enough that a loaded machine cannot fake a leak.
+ */
+async function waitForCloneBodiesToSettle(clones: Response[]): Promise<void> {
+	for (let tick = 0; tick < 200; tick++) {
+		if (clones.every((c) => c.bodyUsed)) return;
+		await new Promise<void>((resolve) => setTimeout(resolve, 5));
+	}
+}
+
 describe("529 overload path — no orphaned response clones", () => {
 	let originalFetch: typeof globalThis.fetch;
-	let originalClone: typeof Response.prototype.clone;
 	let savedEnv: Record<string, string | undefined>;
-	let clones: Response[];
 
 	beforeEach(() => {
 		originalFetch = globalThis.fetch;
@@ -141,18 +190,9 @@ describe("529 overload path — no orphaned response clones", () => {
 		// Keep the jittered in-place retry backoff negligible.
 		process.env.CCFLARE_OVERLOAD_RETRY_BASE_MS = "1";
 		process.env.CCFLARE_OVERLOAD_RETRY_MAX_MS = "2";
-
-		clones = [];
-		originalClone = Response.prototype.clone;
-		Response.prototype.clone = function trackedClone(this: Response) {
-			const copy = originalClone.call(this);
-			clones.push(copy);
-			return copy;
-		};
 	});
 
 	afterEach(() => {
-		Response.prototype.clone = originalClone;
 		globalThis.fetch = originalFetch;
 		for (const k of ENV_KEYS) {
 			if (savedEnv[k] === undefined) delete process.env[k];
@@ -176,38 +216,40 @@ describe("529 overload path — no orphaned response clones", () => {
 			headers: { "Content-Type": "application/json" },
 		});
 
-		// The terminal-attempt flag routes into the "forward the final 529"
-		// branch. forwardToClient needs a UsageCollector that unit tests do not
-		// wire up; reaching it is enough for this assertion, so that specific
-		// error is tolerated (same approach as proxy-operations-failover.test.ts).
-		try {
-			await proxyWithAccount(
-				req,
-				new URL("https://proxy.local/v1/messages"),
-				makeAccount(),
-				makeRequestMeta(),
-				bodyBuffer,
-				() => undefined,
-				0,
-				makeProxyContext(),
-				undefined,
-				undefined,
-				undefined,
-				undefined,
-				true,
-			);
-		} catch (e) {
-			const msg = e instanceof Error ? e.message : String(e);
-			if (!msg.includes("UsageCollector not initialized")) throw e;
-		}
+		const clones = await recordClonesDuring(async () => {
+			// The terminal-attempt flag routes into the "forward the final 529"
+			// branch. forwardToClient needs a UsageCollector that unit tests do
+			// not wire up; reaching it is enough for this assertion, so that
+			// specific error is tolerated (same workaround as
+			// proxy-operations-failover.test.ts — the shared limitation is the
+			// test harness, not the path under test).
+			try {
+				await proxyWithAccount(
+					req,
+					new URL("https://proxy.local/v1/messages"),
+					makeAccount(),
+					makeRequestMeta(),
+					bodyBuffer,
+					() => undefined,
+					0,
+					makeProxyContext(),
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					true,
+				);
+			} catch (e) {
+				const msg = e instanceof Error ? e.message : String(e);
+				if (!msg.includes("UsageCollector not initialized")) throw e;
+			}
+		});
 
-		// updateAccountMetadata reads a clone inside a fire-and-forget IIFE
-		// (response-processor.ts) for usage extraction. That consumer is
-		// legitimate but not awaited by the caller, so give the microtask queue a
-		// turn before judging — otherwise a still-running reader looks identical
-		// to a leak.
-		await new Promise<void>((resolve) => setTimeout(resolve, 50));
+		await waitForCloneBodiesToSettle(clones);
 
+		// Guard against the assertion passing for the wrong reason: if nothing
+		// was cloned at all, the path never ran and "no orphans" is vacuous.
+		expect(clones.length).toBeGreaterThan(0);
 		const orphaned = clones.filter((c) => !c.bodyUsed);
 		expect(orphaned.length).toBe(0);
 	});

--- a/packages/proxy/src/handlers/__tests__/proxy-operations-529-clone-leak.test.ts
+++ b/packages/proxy/src/handlers/__tests__/proxy-operations-529-clone-leak.test.ts
@@ -1,7 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
-import type { Account, RequestMeta } from "@better-ccflare/types";
-import { proxyWithAccount } from "../proxy-operations";
-import type { ProxyContext } from "../proxy-types";
+import { isModelUnavailableError, proxyWithAccount } from "../proxy-operations";
+import {
+	FIXTURES,
+	isOrphaned,
+	makeAccount,
+	makeProxyContext,
+	makeProxyRequest,
+	makeRequestBody,
+	makeRequestMeta,
+	OVERLOAD_RETRY_ENV_KEYS,
+	recordClonesDuring,
+	waitForCloneBodiesToSettle,
+} from "./clone-leak-harness";
 
 /**
  * Regression guard for the 529 overload path (incident 2026-07-29, issue #354).
@@ -15,167 +25,16 @@ import type { ProxyContext } from "../proxy-types";
  * and therefore cannot read a body at all — so every one of those clones was
  * orphaned by construction, once per 529 and once more per in-place retry.
  *
- * The test asserts the invariant rather than the implementation: after the
- * path runs, no Response clone may be left with an unconsumed body. Cancelling
- * a body disturbs it and thus also satisfies `bodyUsed`, so a fix that keeps a
- * clone but disposes of it passes too.
+ * The tests assert the invariant rather than the implementation: after the
+ * path runs, no Response clone may be left with an unconsumed, non-null body
+ * (see `isOrphaned` — a null-body clone holds nothing to retain and can never
+ * become `bodyUsed`, so it must not count as a leak; see S7 below).
  */
-
-function makeAccount(overrides: Partial<Account> = {}): Account {
-	return {
-		id: "acc-1",
-		name: "clone-leak-test",
-		provider: "anthropic",
-		api_key: "test-key",
-		refresh_token: "",
-		access_token: null,
-		expires_at: null,
-		request_count: 0,
-		total_requests: 0,
-		last_used: null,
-		created_at: Date.now(),
-		rate_limited_until: null,
-		rate_limited_reason: null,
-		rate_limited_at: null,
-		session_start: null,
-		session_request_count: 0,
-		paused: false,
-		rate_limit_reset: null,
-		rate_limit_status: null,
-		rate_limit_remaining: null,
-		priority: 0,
-		auto_fallback_enabled: false,
-		auto_refresh_enabled: false,
-		auto_pause_on_overage_enabled: false,
-		peak_hours_pause_enabled: false,
-		custom_endpoint: null,
-		model_mappings: null,
-		cross_region_mode: null,
-		model_fallbacks: null,
-		billing_type: null,
-		pause_reason: null,
-		refresh_token_issued_at: null,
-		consecutive_rate_limits: 0,
-		...overrides,
-	};
-}
-
-function makeRequestMeta(): RequestMeta {
-	return {
-		id: "req-clone-leak",
-		method: "POST",
-		path: "/v1/messages",
-		timestamp: Date.now(),
-		headers: new Headers(),
-	} as RequestMeta;
-}
-
-function makeRequestBody() {
-	return new TextEncoder().encode(
-		JSON.stringify({
-			model: "claude-sonnet-4-5",
-			messages: [{ role: "user", content: "hello" }],
-			max_tokens: 10,
-		}),
-	).buffer;
-}
-
-/** Context whose provider reports a reset-less 529 — the in-place retry path. */
-function makeProxyContext(): ProxyContext {
-	return {
-		strategy: { getNextAccount: () => null } as never,
-		dbOps: {
-			markAccountRateLimited: mock(() =>
-				Promise.resolve({ consecutiveRateLimits: 1, applied: true }),
-			),
-			saveRequest: mock(() => Promise.resolve()),
-			updateAccountUsage: mock(() => Promise.resolve()),
-			resetConsecutiveRateLimits: mock(() => Promise.resolve()),
-			getAdapter: mock(() => ({
-				run: mock(() => Promise.resolve()),
-				get: mock(() => Promise.resolve(null)),
-			})),
-		} as never,
-		runtime: { port: 8080, clientId: "test" } as never,
-		// NOTE: for an account with provider "anthropic" this stub is NOT what
-		// drives the run. proxy-operations.ts resolves
-		// `getProvider(account.provider) || ctx.provider`, and importing
-		// @better-ccflare/providers populates the registry, so the REAL
-		// AnthropicProvider wins and ctx.provider is only a fallback. That is
-		// deliberate here: the real provider is what supplies extractUsageInfo,
-		// and its clone is one of the orphans this test is about. Editing the
-		// parseRateLimit below therefore changes nothing — the real
-		// implementation returns isRateLimited/no resetTime for a 529 that
-		// carries no reset headers, which is exactly the path we want.
-		provider: {
-			name: "anthropic",
-			canHandle: () => true,
-			buildUrl: () => "https://api.anthropic.com/v1/messages",
-			prepareHeaders: () => new Headers(),
-			transformRequestBody: null,
-			processResponse: async (r: Response) => r,
-			parseRateLimit: (r: Response) => ({
-				isRateLimited: r.status === 529,
-				resetTime: undefined,
-				statusHeader: undefined,
-				remaining: undefined,
-			}),
-			isStreamingResponse: () => false,
-		} as never,
-		refreshInFlight: new Map(),
-		asyncWriter: { enqueue: mock(() => {}) } as never,
-		config: { getStorePayloads: () => false } as never,
-		internalProbeSecret: "test-secret",
-	};
-}
 
 const ENV_KEYS = [
-	"CCFLARE_OVERLOAD_RETRY_BASE_MS",
-	"CCFLARE_OVERLOAD_RETRY_MAX_MS",
+	...OVERLOAD_RETRY_ENV_KEYS,
+	"CCFLARE_OVERLOAD_RETRY_MAX_ATTEMPTS",
 ] as const;
-
-/**
- * Records every Response clone created while `body` runs.
- *
- * The patch is installed around the call and removed in `finally`, not in
- * beforeEach/afterEach: Bun executes every test file in ONE process, so a patch
- * on Response.prototype that survives a throwing assertion would leak into
- * unrelated suites. Keeping the window to exactly this call makes that
- * impossible.
- */
-async function recordClonesDuring(
-	body: () => Promise<void>,
-): Promise<Response[]> {
-	const clones: Response[] = [];
-	const original = Response.prototype.clone;
-	Response.prototype.clone = function trackedClone(this: Response) {
-		const copy = original.call(this);
-		clones.push(copy);
-		return copy;
-	};
-	try {
-		await body();
-	} finally {
-		Response.prototype.clone = original;
-	}
-	return clones;
-}
-
-/**
- * Waits until every recorded clone has had its body consumed, or gives up.
- *
- * The usage extraction in updateAccountMetadata reads its clone inside a
- * fire-and-forget IIFE, so there is no promise the test could await. Polling
- * beats a fixed sleep in both directions: the passing case returns as soon as
- * the readers are done instead of always paying a fixed margin, and the failing
- * case gets a budget generous enough that a loaded machine cannot fake a leak.
- */
-async function waitForCloneBodiesToSettle(clones: Response[]): Promise<void> {
-	for (let tick = 0; tick < 200; tick++) {
-		if (clones.every((c) => c.bodyUsed)) return;
-		await new Promise<void>((resolve) => setTimeout(resolve, 5));
-	}
-}
 
 describe("529 overload path — no orphaned response clones", () => {
 	let originalFetch: typeof globalThis.fetch;
@@ -190,6 +49,7 @@ describe("529 overload path — no orphaned response clones", () => {
 		// Keep the jittered in-place retry backoff negligible.
 		process.env.CCFLARE_OVERLOAD_RETRY_BASE_MS = "1";
 		process.env.CCFLARE_OVERLOAD_RETRY_MAX_MS = "2";
+		delete process.env.CCFLARE_OVERLOAD_RETRY_MAX_ATTEMPTS;
 	});
 
 	afterEach(() => {
@@ -200,21 +60,17 @@ describe("529 overload path — no orphaned response clones", () => {
 		}
 	});
 
-	it("leaves no cloned response body unconsumed while handling a reset-less 529", async () => {
+	it("leaves no cloned response body unconsumed while handling a reset-less 529 (terminal)", async () => {
 		globalThis.fetch = mock(
 			async () =>
-				new Response(
-					'{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
-					{ status: 529, headers: { "content-type": "application/json" } },
-				),
+				new Response(FIXTURES.overload529, {
+					status: 529,
+					headers: { "content-type": "application/json" },
+				}),
 		);
 
 		const bodyBuffer = makeRequestBody();
-		const req = new Request("https://proxy.local/v1/messages", {
-			method: "POST",
-			body: bodyBuffer,
-			headers: { "Content-Type": "application/json" },
-		});
+		const req = makeProxyRequest(bodyBuffer);
 
 		const clones = await recordClonesDuring(async () => {
 			// The terminal-attempt flag routes into the "forward the final 529"
@@ -250,7 +106,291 @@ describe("529 overload path — no orphaned response clones", () => {
 		// Guard against the assertion passing for the wrong reason: if nothing
 		// was cloned at all, the path never ran and "no orphans" is vacuous.
 		expect(clones.length).toBeGreaterThan(0);
-		const orphaned = clones.filter((c) => !c.bodyUsed);
-		expect(orphaned.length).toBe(0);
+		expect(clones.filter(isOrphaned).length).toBe(0);
+	});
+
+	// S1 — Reset-less 529, NON-terminal (failover), one in-place retry.
+	it("S1: reset-less 529 failover — retries once, exhausts, fails over with no orphaned clones", async () => {
+		let callCount = 0;
+		globalThis.fetch = mock(async () => {
+			callCount++;
+			return new Response(FIXTURES.overload529, {
+				status: 529,
+				headers: { "content-type": "application/json" },
+			});
+		});
+
+		const bodyBuffer = makeRequestBody();
+		const req = makeProxyRequest(bodyBuffer);
+		const account = makeAccount();
+
+		const clones = await recordClonesDuring(async () => {
+			const result = await proxyWithAccount(
+				req,
+				new URL("https://proxy.local/v1/messages"),
+				account,
+				makeRequestMeta(),
+				bodyBuffer,
+				() => undefined,
+				0,
+				makeProxyContext(),
+				// returnRateLimitedResponseOnExhaustion omitted -> false/failover
+			);
+			expect(result).toBeNull();
+		});
+
+		await waitForCloneBodiesToSettle(clones);
+
+		expect(callCount).toBe(2); // initial + 1 in-place retry (default maxAttempts=2)
+		expect(account.rate_limited_reason).toBe(
+			"upstream_529_overloaded_no_reset",
+		);
+		expect(clones.length).toBeGreaterThanOrEqual(1);
+		expect(clones.filter(isOrphaned).length).toBe(0);
+	});
+
+	// S2 — 529 WITH a reset header (terminal flag true) — no in-place retry.
+	it("S2: 529 with a reset header skips the retry loop and leaves no orphaned clones", async () => {
+		let callCount = 0;
+		globalThis.fetch = mock(async () => {
+			callCount++;
+			return new Response(FIXTURES.overload529, {
+				status: 529,
+				headers: {
+					"content-type": "application/json",
+					"retry-after": "30",
+				},
+			});
+		});
+
+		const bodyBuffer = makeRequestBody();
+		const req = makeProxyRequest(bodyBuffer);
+		const account = makeAccount();
+
+		const clones = await recordClonesDuring(async () => {
+			try {
+				await proxyWithAccount(
+					req,
+					new URL("https://proxy.local/v1/messages"),
+					account,
+					makeRequestMeta(),
+					bodyBuffer,
+					() => undefined,
+					0,
+					makeProxyContext(),
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					true,
+				);
+			} catch (e) {
+				const msg = e instanceof Error ? e.message : String(e);
+				if (!msg.includes("UsageCollector not initialized")) throw e;
+			}
+		});
+
+		await waitForCloneBodiesToSettle(clones);
+
+		expect(callCount).toBe(1); // no in-place retry — resetTime was present
+		expect(account.rate_limited_reason).toBe(
+			"upstream_529_overloaded_with_reset",
+		);
+		expect(clones.length).toBeGreaterThanOrEqual(2);
+		expect(clones.filter(isOrphaned).length).toBe(0);
+	});
+
+	// S3 — Plain 429 (anthropic), no model fallbacks configured. PINS: this
+	// route creates no Response clones at all, before or after the fix — the
+	// 429 short-circuits isModelUnavailableError before any clone, and
+	// processProxyResponse is never reached (proxyWithAccount returns inside
+	// the 429 branch). Included to document that fact and to prove
+	// processProxyResponse never sees a 429 originating from proxyWithAccount.
+	it("S3 (pins): plain 429 with no model fallbacks creates zero Response clones", async () => {
+		let callCount = 0;
+		globalThis.fetch = mock(async () => {
+			callCount++;
+			return new Response(FIXTURES.rateLimit429, {
+				status: 429,
+				headers: { "content-type": "application/json" },
+			});
+		});
+
+		const bodyBuffer = makeRequestBody();
+		const req = makeProxyRequest(bodyBuffer);
+		const account = makeAccount(); // no model_fallbacks / model_mappings
+
+		const clones = await recordClonesDuring(async () => {
+			const result = await proxyWithAccount(
+				req,
+				new URL("https://proxy.local/v1/messages"),
+				account,
+				makeRequestMeta(),
+				bodyBuffer,
+				() => undefined,
+				0,
+				makeProxyContext(),
+			);
+			expect(result).toBeNull();
+		});
+
+		expect(callCount).toBe(1);
+		expect(account.rate_limited_reason).toBe("model_fallback_429");
+		// Exact, not a lower bound: this path is fully synchronous and clone-free.
+		expect(clones.length).toBe(0);
+	});
+
+	// S4 — SSE/streaming 200 response (anthropic). RED-without-fix: the bare
+	// `extractUsageInfo(response.clone())` call-site clone was orphaned pre-fix.
+	it("S4: streaming 200 response leaves no orphaned usage-extraction clone", async () => {
+		globalThis.fetch = mock(
+			async () =>
+				new Response(FIXTURES.sse, {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				}),
+		);
+
+		const bodyBuffer = makeRequestBody();
+		const req = makeProxyRequest(bodyBuffer);
+
+		const clones = await recordClonesDuring(async () => {
+			try {
+				await proxyWithAccount(
+					req,
+					new URL("https://proxy.local/v1/messages"),
+					makeAccount(),
+					makeRequestMeta(),
+					bodyBuffer,
+					() => undefined,
+					0,
+					makeProxyContext(),
+				);
+			} catch (e) {
+				const msg = e instanceof Error ? e.message : String(e);
+				if (!msg.includes("UsageCollector not initialized")) throw e;
+			}
+		});
+
+		await waitForCloneBodiesToSettle(clones);
+
+		expect(clones.length).toBeGreaterThanOrEqual(1);
+		expect(clones.filter(isOrphaned).length).toBe(0);
+	});
+
+	// S6 — Two or more in-place retries. RED-without-fix: pre-fix orphan count
+	// scales with retry count (one `parseRateLimit(*.clone())` orphan per
+	// attempt, plus the terminal clone and the usage call-site clone).
+	it("S6: exhausting 3 attempts (2 retries) leaves no orphaned clones", async () => {
+		let callCount = 0;
+		globalThis.fetch = mock(async () => {
+			callCount++;
+			return new Response(FIXTURES.overload529, {
+				status: 529,
+				headers: { "content-type": "application/json" },
+			});
+		});
+
+		process.env.CCFLARE_OVERLOAD_RETRY_MAX_ATTEMPTS = "3";
+		const bodyBuffer = makeRequestBody();
+		const req = makeProxyRequest(bodyBuffer);
+		const account = makeAccount();
+
+		const clones = await recordClonesDuring(async () => {
+			try {
+				await proxyWithAccount(
+					req,
+					new URL("https://proxy.local/v1/messages"),
+					account,
+					makeRequestMeta(),
+					bodyBuffer,
+					() => undefined,
+					0,
+					makeProxyContext(),
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					true,
+				);
+			} catch (e) {
+				const msg = e instanceof Error ? e.message : String(e);
+				if (!msg.includes("UsageCollector not initialized")) throw e;
+			}
+		});
+
+		await waitForCloneBodiesToSettle(clones);
+
+		expect(callCount).toBe(3); // initial + 2 in-place retries
+		expect(account.rate_limited_reason).toBe(
+			"upstream_529_overloaded_no_reset",
+		);
+		expect(clones.length).toBeGreaterThanOrEqual(2);
+		expect(clones.filter(isOrphaned).length).toBe(0);
+	});
+
+	// S7 — Null-body 529 (terminal flag true). PINS: a null-body clone holds no
+	// stream to retain, so this is green on both trees — it exists to prove
+	// the cancel guards are crash-safe against a null body and that the
+	// refined `isOrphaned` predicate doesn't false-positive on one (a bare
+	// `!bodyUsed` check would flag every clone here forever, per Bun's
+	// behaviour that cloning a null body never flips `bodyUsed`).
+	it("S7 (pins): null-body 529 resolves cleanly with no false-positive orphans", async () => {
+		globalThis.fetch = mock(
+			async () =>
+				new Response(null, {
+					status: 529,
+					headers: { "content-type": "application/json" },
+				}),
+		);
+
+		const bodyBuffer = makeRequestBody();
+		const req = makeProxyRequest(bodyBuffer);
+
+		let threw: unknown;
+		const clones = await recordClonesDuring(async () => {
+			try {
+				await proxyWithAccount(
+					req,
+					new URL("https://proxy.local/v1/messages"),
+					makeAccount(),
+					makeRequestMeta(),
+					bodyBuffer,
+					() => undefined,
+					0,
+					makeProxyContext(),
+					undefined,
+					undefined,
+					undefined,
+					undefined,
+					true,
+				);
+			} catch (e) {
+				const msg = e instanceof Error ? e.message : String(e);
+				if (!msg.includes("UsageCollector not initialized")) {
+					threw = e;
+				}
+			}
+		});
+
+		expect(threw).toBeUndefined();
+
+		await waitForCloneBodiesToSettle(clones);
+
+		expect(clones.length).toBeGreaterThanOrEqual(2);
+		for (const c of clones) {
+			expect(c.body).toBeNull();
+		}
+		expect(clones.filter(isOrphaned).length).toBe(0);
+	});
+});
+
+describe("isModelUnavailableError — 529 exclusion (existing behaviour)", () => {
+	it("returns false for 529 overloaded responses without cloning", async () => {
+		const response = new Response(FIXTURES.overload529, {
+			status: 529,
+			headers: { "content-type": "application/json" },
+		});
+		expect(await isModelUnavailableError(response)).toBe(false);
 	});
 });

--- a/packages/proxy/src/handlers/__tests__/response-processor-usage-disposal.test.ts
+++ b/packages/proxy/src/handlers/__tests__/response-processor-usage-disposal.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { Provider } from "@better-ccflare/providers";
+import {
+	updateAccountMetadata,
+	withDisposableCopy,
+} from "../response-processor";
+import {
+	isOrphaned,
+	makeAccount,
+	makeProxyContext,
+	recordClonesDuring,
+	waitForCloneBodiesToSettle,
+} from "./clone-leak-harness";
+
+/**
+ * S8 & S9 (spec TEST-SPEC.md §4) — `updateAccountMetadata` driven directly.
+ *
+ * `updateAccountMetadata` uses `ctx.provider` directly (unlike
+ * `proxyWithAccount`, which resolves the registry-registered provider first),
+ * so a plain stub binds here and is the honest unit for exercising both
+ * `withDisposableCopy` call sites (the `parseUsage` streaming branch and the
+ * `extractUsageInfo` branch) without needing the real Bedrock/Anthropic
+ * implementations.
+ */
+describe("updateAccountMetadata — usage-extraction clone disposal", () => {
+	it("S8 (red-without-fix): a throwing extractUsageInfo reader still disposes of its clone", async () => {
+		const account = makeAccount({ provider: "openai-compatible" }); // not "codex"
+		const stubProvider = {
+			name: "stub",
+			canHandle: () => true,
+			buildUrl: () => "https://example.test",
+			prepareHeaders: () => new Headers(),
+			processResponse: async (r: Response) => r,
+			refreshToken: async () => {
+				throw new Error("not used");
+			},
+			parseRateLimit: () => ({ isRateLimited: false }),
+			isStreamingResponse: () => false,
+			extractUsageInfo: async () => {
+				throw new Error("usage boom");
+			},
+		} as unknown as Provider;
+		const ctx = makeProxyContext({ provider: stubProvider });
+
+		const response = new Response('{"id":"msg_1","usage":{}}', {
+			status: 200,
+			headers: { "content-type": "application/json" },
+		});
+
+		let unhandledRejection: unknown;
+		const onUnhandled = (reason: unknown) => {
+			unhandledRejection = reason;
+		};
+		process.on("unhandledRejection", onUnhandled);
+
+		const clones = await recordClonesDuring(async () => {
+			updateAccountMetadata(account, response, ctx, "req-1");
+			// updateAccountMetadata is synchronous; the usage extraction runs in
+			// a fire-and-forget IIFE. Give it a chance to run, throw, and settle
+			// before the prototype patch is removed.
+			await new Promise<void>((resolve) => setTimeout(resolve, 20));
+		});
+
+		process.off("unhandledRejection", onUnhandled);
+
+		expect(unhandledRejection).toBeUndefined();
+		await waitForCloneBodiesToSettle(clones);
+		expect(clones.length).toBeGreaterThanOrEqual(1);
+		expect(clones.every((c) => c.bodyUsed)).toBe(true); // disposed via the finally cancel (P2)
+		expect(clones.filter(isOrphaned).length).toBe(0);
+	});
+
+	it("S9 (red-without-fix): the streaming parseUsage branch disposes of its clone even when the reader ignores it", async () => {
+		const account = makeAccount({ provider: "openai-compatible" });
+		const parseUsage = mock(async (_copy: Response) => null);
+		const stubProvider = {
+			name: "stub-stream",
+			canHandle: () => true,
+			buildUrl: () => "https://example.test",
+			prepareHeaders: () => new Headers(),
+			processResponse: async (r: Response) => r,
+			refreshToken: async () => {
+				throw new Error("not used");
+			},
+			parseRateLimit: () => ({ isRateLimited: false }),
+			isStreamingResponse: () => true,
+			parseUsage,
+		} as unknown as Provider;
+		const ctx = makeProxyContext({ provider: stubProvider });
+
+		const response = new Response("event: message_start\ndata: {}\n\n", {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+
+		const clones = await recordClonesDuring(async () => {
+			updateAccountMetadata(account, response, ctx, "req-1");
+			await new Promise<void>((resolve) => setTimeout(resolve, 20));
+		});
+
+		await waitForCloneBodiesToSettle(clones);
+
+		expect(parseUsage).toHaveBeenCalledTimes(1);
+		expect(clones.length).toBeGreaterThanOrEqual(1);
+		expect(clones.every((c) => c.bodyUsed)).toBe(true);
+		expect(clones.filter(isOrphaned).length).toBe(0);
+	});
+});
+
+/**
+ * S10 (spec TEST-SPEC.md §4) — `withDisposableCopy` contract tests, driven
+ * directly. PINS: the helper is new code introduced by the fix; on the
+ * pre-fix tree the import itself fails to resolve (a build-red, not an
+ * invariant-red) — see IMPL-REPORT.md.
+ */
+describe("withDisposableCopy — contract", () => {
+	it("(a) reader consumes: resolves the read value, copy settles, source stays readable", async () => {
+		const response = new Response("payload-123");
+
+		const clones = await recordClonesDuring(async () => {
+			const result = await withDisposableCopy(response, (c) => c.text());
+			expect(result).toBe("payload-123");
+		});
+
+		expect(clones.length).toBe(1);
+		expect(clones[0].bodyUsed).toBe(true);
+		await expect(response.text()).resolves.toBe("payload-123");
+	});
+
+	it("(b) reader ignores the copy: helper cancels it, resolves the read value, source stays readable", async () => {
+		const response = new Response("payload-123");
+
+		const clones = await recordClonesDuring(async () => {
+			const result = await withDisposableCopy(response, async () => 42);
+			expect(result).toBe(42);
+		});
+
+		expect(clones.length).toBe(1);
+		expect(clones[0].bodyUsed).toBe(true); // cancelled by the finally block (P2)
+		await expect(response.text()).resolves.toBe("payload-123");
+	});
+
+	it("(c) reader throws: rejection propagates and the clone still settles via the finally cancel", async () => {
+		const response = new Response("payload-123");
+		const original = Response.prototype.clone;
+		let captured: Response | undefined;
+		Response.prototype.clone = function tracked(this: Response) {
+			const copy = original.call(this);
+			captured = copy;
+			return copy;
+		};
+
+		let caught: unknown;
+		try {
+			await withDisposableCopy(response, async () => {
+				throw new Error("boom");
+			});
+		} catch (e) {
+			caught = e;
+		} finally {
+			Response.prototype.clone = original;
+		}
+
+		expect(caught).toBeInstanceOf(Error);
+		expect(captured).toBeDefined();
+		expect(captured?.bodyUsed).toBe(true); // finally ran before the rejection propagated
+	});
+
+	it("(d) body already locked by the reader: helper skips the cancel, branch stays locked, no throw escapes", async () => {
+		const response = new Response("payload-123");
+
+		let captured: Response | undefined;
+		const original = Response.prototype.clone;
+		Response.prototype.clone = function tracked(this: Response) {
+			const copy = original.call(this);
+			captured = copy;
+			return copy;
+		};
+
+		let result: unknown;
+		let threw = false;
+		try {
+			result = await withDisposableCopy(response, async (c) => {
+				c.body?.getReader();
+				return "locked";
+			});
+		} catch {
+			threw = true;
+		} finally {
+			Response.prototype.clone = original;
+		}
+
+		expect(threw).toBe(false);
+		expect(result).toBe("locked");
+		// Bun marks bodyUsed=true on getReader() alone (P3), so the helper's
+		// `!copy.bodyUsed` guard is false and it skips the cancel — the branch
+		// stays locked. This pins a documented limitation of the helper: a
+		// lock-and-abandon reader defeats disposal (the inner catch in
+		// withDisposableCopy's finally is defensive and, on this Bun version,
+		// unreachable via getReader alone).
+		expect(captured?.body?.locked).toBe(true);
+	});
+
+	it("(e) null body: resolves the read value without throwing, copy has a null body", async () => {
+		const response = new Response(null);
+
+		const clones = await recordClonesDuring(async () => {
+			const result = await withDisposableCopy(response, async () => "x");
+			expect(result).toBe("x");
+		});
+
+		expect(clones.length).toBe(1);
+		expect(clones[0].body).toBeNull();
+	});
+});

--- a/packages/proxy/src/handlers/__tests__/response-processor-zai-429.test.ts
+++ b/packages/proxy/src/handlers/__tests__/response-processor-zai-429.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { getProvider } from "@better-ccflare/providers";
+import { processProxyResponse } from "../response-processor";
+import {
+	isOrphaned,
+	makeAccount,
+	makeProxyContext,
+	makeZai1308Fixture,
+	recordClonesDuring,
+	waitForCloneBodiesToSettle,
+} from "./clone-leak-harness";
+
+/**
+ * S5 (spec TEST-SPEC.md §4) — the zai-429 body-reading branch in
+ * `processProxyResponse` (response-processor.ts:272-295).
+ *
+ * This branch is integration-unreachable from `proxyWithAccount`: every
+ * final 429 exits inside the `isModelUnavailableError` block before
+ * `processProxyResponse` is ever called (F7 in the spec), and the 529→429
+ * in-place-retry route does not exist for zai because `ZaiProvider.
+ * parseRateLimit` returns `isRateLimited:false` for a 529. Testing this
+ * through `proxyWithAccount` would therefore test a dead route —
+ * `processProxyResponse` is exported and is the honest unit to drive
+ * directly.
+ *
+ * Orphan assertion is RED-without-fix (the usage call-site clone was
+ * orphaned pre-fix); assertions 1-4 below PIN pre-existing behaviour (they
+ * hold on the pre-fix tree too) — see IMPL-REPORT.md for the recorded
+ * red/green split.
+ */
+describe("processProxyResponse — zai 429 body-reading branch (S5)", () => {
+	let savedBackoffBase: string | undefined;
+	let savedBackoffMax: string | undefined;
+
+	beforeEach(() => {
+		savedBackoffBase = process.env.CCFLARE_RATE_LIMIT_BACKOFF_BASE_MS;
+		savedBackoffMax = process.env.CCFLARE_RATE_LIMIT_BACKOFF_MAX_MS;
+		// Guard against an ambient override shrinking the tier-1 429 backoff
+		// below the fixture's ~20s reset delta — the assertion relies on the
+		// default 30s tier-1 backoff being larger than that delta so
+		// `min(resetTime, now+backoff)` picks the parsed resetTime.
+		delete process.env.CCFLARE_RATE_LIMIT_BACKOFF_BASE_MS;
+		delete process.env.CCFLARE_RATE_LIMIT_BACKOFF_MAX_MS;
+	});
+
+	afterEach(() => {
+		if (savedBackoffBase === undefined) {
+			delete process.env.CCFLARE_RATE_LIMIT_BACKOFF_BASE_MS;
+		} else {
+			process.env.CCFLARE_RATE_LIMIT_BACKOFF_BASE_MS = savedBackoffBase;
+		}
+		if (savedBackoffMax === undefined) {
+			delete process.env.CCFLARE_RATE_LIMIT_BACKOFF_MAX_MS;
+		} else {
+			process.env.CCFLARE_RATE_LIMIT_BACKOFF_MAX_MS = savedBackoffMax;
+		}
+	});
+
+	it("parses the reset time from the body, applies the with-reset cooldown, and leaves the body live and no clone orphaned", async () => {
+		const zaiProvider = getProvider("zai");
+		expect(zaiProvider).toBeDefined();
+		if (!zaiProvider) throw new Error("zai provider not registered");
+
+		const { resetUtcMs, body } = makeZai1308Fixture();
+		const account = makeAccount({ provider: "zai", api_key: "test-key" });
+		const ctx = makeProxyContext({ provider: zaiProvider });
+
+		const response = new Response(body, {
+			status: 429,
+			headers: { "content-type": "application/json" },
+			// Deliberately no retry-after — ZaiProvider.parseRateLimit then
+			// yields {isRateLimited: true, resetTime: undefined}, which is what
+			// makes processProxyResponse fall into the body-parsing branch.
+		});
+
+		const clones = await recordClonesDuring(async () => {
+			const isRateLimited = await processProxyResponse(
+				response,
+				account,
+				ctx,
+				"req-1",
+				{ headers: new Headers() },
+			);
+			expect(isRateLimited).toBe(true);
+		});
+
+		expect(account.rate_limited_reason).toBe("upstream_429_with_reset");
+		expect(account.rate_limited_until).toBe(resetUtcMs);
+
+		// The internal-clone read must not disturb the live, forwardable body.
+		expect(response.bodyUsed).toBe(false);
+		const parsedBody = (await response.json()) as {
+			type: string;
+			error: { type: string; message: string };
+		};
+		expect(parsedBody).toEqual(JSON.parse(body));
+
+		await waitForCloneBodiesToSettle(clones);
+		expect(clones.length).toBeGreaterThanOrEqual(2);
+		expect(clones.filter(isOrphaned).length).toBe(0);
+	});
+});

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -1185,7 +1185,12 @@ export async function proxyWithAccount(
 		// all accounts cooling simultaneously under concurrency spikes. Skipped for
 		// synthetic (keepalive / auto-refresh) requests to avoid loop amplification.
 		if (response.status === 529 && !isSyntheticInternal) {
-			const rlInfo = provider.parseRateLimit(response.clone());
+			// No clone: `parseRateLimit` is declared synchronous
+			// (providers/types.ts) and reads only headers and status, so it
+			// cannot touch the body. Cloning here teed the body into a second
+			// stream that nothing ever read or cancelled — one orphan per 529,
+			// plus one per in-place retry below. See issue #354.
+			const rlInfo = provider.parseRateLimit(response);
 			if (rlInfo.isRateLimited && !rlInfo.resetTime) {
 				const retryCfg = getOverloadRetryConfig();
 				if (retryCfg.enabled && retryCfg.maxAttempts > 1) {
@@ -1239,7 +1244,9 @@ export async function proxyWithAccount(
 							break;
 						}
 
-						const retryRlInfo = provider.parseRateLimit(retryResponse.clone());
+						// Header-only read, see the note on the first parseRateLimit
+						// call above — the retry response must not be teed either.
+						const retryRlInfo = provider.parseRateLimit(retryResponse);
 						if (!retryRlInfo.isRateLimited || retryRlInfo.resetTime) {
 							// Got a reset hint on retry — stop; let processProxyResponse apply cooldown
 							break;
@@ -1265,11 +1272,20 @@ export async function proxyWithAccount(
 			return null;
 		}
 
-		// Check for rate limit using account-specific provider
-		const responseForRateLimitCheck =
-			returnRateLimitedResponseOnExhaustion && response.status === 529
-				? response.clone()
-				: response;
+		// Check for rate limit using account-specific provider.
+		//
+		// The clone exists only for the terminal-529 path, where `response`
+		// itself still has to reach the client afterwards. It cannot be dropped
+		// like the header-only calls above, because processProxyResponse may
+		// legitimately read the body (the zai 429 branch calls
+		// parseRateLimitFromBody). Whatever it does NOT read stays an open tee
+		// branch that keeps buffering for the client-facing twin, so the copy is
+		// disposed of immediately after the call. See issue #354.
+		const needsRateLimitCheckClone =
+			returnRateLimitedResponseOnExhaustion && response.status === 529;
+		const responseForRateLimitCheck = needsRateLimitCheckClone
+			? response.clone()
+			: response;
 		const isRateLimited = await processProxyResponse(
 			responseForRateLimitCheck,
 			account,
@@ -1280,6 +1296,13 @@ export async function proxyWithAccount(
 			requestMeta.id,
 			requestMeta,
 		);
+		if (needsRateLimitCheckClone && !responseForRateLimitCheck.bodyUsed) {
+			try {
+				await responseForRateLimitCheck.body?.cancel();
+			} catch {
+				// An already errored or locked body needs no disposal.
+			}
+		}
 		if (isRateLimited) {
 			if (returnRateLimitedResponseOnExhaustion && response.status === 529) {
 				log.warn(

--- a/packages/proxy/src/handlers/response-processor.ts
+++ b/packages/proxy/src/handlers/response-processor.ts
@@ -14,6 +14,35 @@ import {
 
 const log = new Logger("ResponseProcessor");
 
+/**
+ * Hands a private copy of `response` to `read`, then disposes of whatever the
+ * reader left behind.
+ *
+ * `clone()` tees the body: the copy is a second stream fed from the same
+ * source, and the tee keeps buffering for whichever branch lags behind. A
+ * reader that returns early — no usage field, wrong content-type, a throw —
+ * leaves its branch open, and the client-facing twin then pays for it in
+ * retained memory and a socket that cannot finish tearing down. Cancelling
+ * disturbs the body, so an already-consumed copy is left alone. See issue #354.
+ */
+async function withDisposableCopy<T>(
+	response: Response,
+	read: (copy: Response) => Promise<T>,
+): Promise<T> {
+	const copy = response.clone() as Response;
+	try {
+		return await read(copy);
+	} finally {
+		if (!copy.bodyUsed) {
+			try {
+				await copy.body?.cancel();
+			} catch {
+				// Already errored or locked elsewhere — nothing left to release.
+			}
+		}
+	}
+}
+
 function isSyntheticCountTokensRequest(
 	ctx: ProxyContext,
 	requestMeta?: { path?: string },
@@ -168,7 +197,9 @@ export function updateAccountMetadata(
 			const parseUsage = ctx.provider.parseUsage.bind(ctx.provider);
 			(async () => {
 				try {
-					const usageInfo = await parseUsage(response.clone() as Response);
+					const usageInfo = await withDisposableCopy(response, (copy) =>
+						parseUsage(copy),
+					);
 					if (usageInfo) {
 						log.debug(
 							`Extracted streaming usage for account ${account.name}: ${JSON.stringify(usageInfo)}`,
@@ -193,8 +224,8 @@ export function updateAccountMetadata(
 			const extractUsageInfo = ctx.provider.extractUsageInfo.bind(ctx.provider);
 			(async () => {
 				try {
-					const usageInfo = await extractUsageInfo(
-						response.clone() as Response,
+					const usageInfo = await withDisposableCopy(response, (copy) =>
+						extractUsageInfo(copy),
 					);
 					if (usageInfo) {
 						log.debug(

--- a/packages/proxy/src/handlers/response-processor.ts
+++ b/packages/proxy/src/handlers/response-processor.ts
@@ -24,8 +24,12 @@ const log = new Logger("ResponseProcessor");
  * leaves its branch open, and the client-facing twin then pays for it in
  * retained memory and a socket that cannot finish tearing down. Cancelling
  * disturbs the body, so an already-consumed copy is left alone. See issue #354.
+ *
+ * @internal — exported for direct unit tests only (issue #354 test suite,
+ * `withDisposableCopy` scenarios). Not part of the package's public surface:
+ * neither `handlers/index.ts` nor `packages/proxy/src/index.ts` re-export it.
  */
-async function withDisposableCopy<T>(
+export async function withDisposableCopy<T>(
 	response: Response,
 	read: (copy: Response) => Promise<T>,
 ): Promise<T> {


### PR DESCRIPTION
**Root Cause:** `Response.clone()` tees the body — the copy is a second stream fed from the same source, and the tee retains everything the faster branch already consumed. Three sites on the 529 path produced copies nothing ever read. Two handed a clone to `provider.parseRateLimit()`, which is declared synchronous (`packages/providers/src/types.ts:60`) and reads only status and headers, so it cannot consume a body at all — those clones were orphaned by construction. The third passed a clone to the usage extraction in `updateAccountMetadata`, whose Anthropic implementation clones again internally and reads only its own inner copy, leaving the outer one untouched.

Minimal trigger: one reset-less 529 with one in-place retry leaves **4** orphaned body streams. The path runs once per 529 and once more per retry, so an upstream overload leaves orphans in proportion to the burst. Each orphan holds a stream open and keeps the tee buffering for the twin being written to the client concurrently — the same socket the runtime then tears down.

**The Fix:** The two header-only calls receive the response itself. The two remaining copies are genuinely needed, because their readers may consume a body, and now go through `withDisposableCopy`, which cancels whatever the reader left behind; cancelling disturbs the body, so a fully-read copy is untouched. Byte-identical: the 429 ramp, cooldown durations, streak handling and the terminal-529 forwarding decision. `zai`'s 429 body branch keeps working — it reads through its own separate `parseRateLimitFromBody` clone, which the disposal never touches (pinned by a test).

**Accepted risk:** this is a hardening, not a root-cause fix. The production crash it came out of (issue #354, 2026-07-29) terminated inside Bun's socket teardown (`us_socket_close`, Bun 1.3.11); that defect lives in the runtime, and `oven-sh/bun#31467` is open against 1.3.14 with its fix PR unmerged, so no Bun version currently available resolves it. Fewer unread streams at teardown reduces exposure; it does not eliminate the crash. The three cloning sites also **pre-date** the version that crashed — they come from v3.5.16 and v3.5.31 and are present in the 3.5.41 build production was rolled back to — so this is a long-standing defect, not the 3.5.43/44 regression.

**Out of scope:** the same defect class survives at sites this PR deliberately does not touch, found while writing the tests. `OpenAICompatibleProvider.extractUsageInfo` orphans a body on every openai-compatible JSON response (`packages/providers/src/providers/openai/provider.ts:138-146`); the caller-side clones at `proxy-operations.ts:780` and `:1074` are orphaned by construction when their guard short-circuits; and the per-request retry `Request` clone at `:686` is never disposed. Each deserves its own change — filing follow-ups.

**Validation:** 20 test cases across four files plus a shared harness. Every case asserts the invariant (no clone survives with an unconsumed, non-null body) rather than a call shape, and each is labelled honestly. Red proof on a clean `origin/main` worktree: **4 orphans, test fails**; with only the two fix files swapped in, **green** — same worktree, same dependencies, so the fix is the only variable. Orphan counts 4, 3, 3, 1, 5 reproduce on the pre-fix tree. Four cases pin invariants that already held and are labelled regression guards, not catchers; one file needs a scratch copy for its red proof because it imports `withDisposableCopy`, which does not exist pre-fix. `bunx tsc --noEmit` clean; 1382 tests green across `proxy`, `providers` and `core`, no new failures. Red proofs use file swaps, never `git stash` — the shared checkout carries foreign stash entries.

**References:** #354 · builds on the 529/429 cooldown separation in #342.
