### PR TITLE
fix: release teed response bodies outside the 529 path (#356)

### DIFF
--- a/packages/providers/src/__tests__/response-clone-disposal.test.ts
+++ b/packages/providers/src/__tests__/response-clone-disposal.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "bun:test";
+import { isAnthropicExtraUsageExhausted } from "../providers/anthropic/provider";
+import { OpenAICompatibleProvider } from "../providers/openai/provider";
+
+/**
+ * Guards against orphaned `Response` body tee branches (issue #356, follow-up
+ * to #354).
+ *
+ * `clone()` tees the body: the copy and the original are fed from one source,
+ * and the tee retains whatever the consumed branch has read until the other
+ * branch is read or cancelled. A branch that is neither is an orphan — it
+ * keeps buffering for as long as the response object lives, and it holds the
+ * underlying socket from finishing its teardown.
+ *
+ * The invariant asserted here is deliberately about the *observable* state
+ * rather than the implementation: after the call, no body that the function
+ * created or received may be left both unread and un-cancelled. `bodyUsed`
+ * covers cancellation too, since cancelling disturbs the stream.
+ */
+
+/**
+ * Records every clone created while `body` runs and reports the ones left with
+ * an unconsumed body.
+ *
+ * The patch is installed around the call and removed in `finally` rather than
+ * in a hook: Bun runs all test files in one process, so a patch that survived a
+ * throwing assertion would leak into unrelated suites. A null-body clone is not
+ * counted — it holds nothing and can never become `bodyUsed`.
+ */
+async function orphansCreatedBy(
+	body: () => Promise<void>,
+): Promise<Response[]> {
+	const clones: Response[] = [];
+	const original = Response.prototype.clone;
+	Response.prototype.clone = function trackedClone(this: Response) {
+		const copy = original.call(this);
+		clones.push(copy);
+		return copy;
+	};
+	try {
+		await body();
+	} finally {
+		Response.prototype.clone = original;
+	}
+	return clones.filter((c) => c.body !== null && !c.bodyUsed);
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+/** A body-carrying response that is deliberately NOT application/json. */
+function textResponse(body: string, status = 400): Response {
+	return new Response(body, {
+		status,
+		headers: { "content-type": "text/plain" },
+	});
+}
+
+describe("isAnthropicExtraUsageExhausted — no orphaned clone", () => {
+	it("detects the extra-usage 400 and consumes what it read", async () => {
+		const res = jsonResponse(
+			{
+				error: {
+					type: "invalid_request_error",
+					message: "Your extra usage balance is depleted",
+				},
+			},
+			400,
+		);
+		expect(await isAnthropicExtraUsageExhausted(res)).toBe(true);
+	});
+
+	// The clone used to be taken BEFORE the content-type check, so a 400 that
+	// is not JSON returned early and left that copy unread forever. Anthropic
+	// does emit non-JSON 400s (proxy/gateway error pages), so this is reachable.
+	it("leaves no orphaned clone when a 400 is not JSON", async () => {
+		const res = textResponse("Bad Request", 400);
+		const orphans = await orphansCreatedBy(async () => {
+			expect(await isAnthropicExtraUsageExhausted(res)).toBe(false);
+		});
+		expect(orphans.length).toBe(0);
+		// The original must still be intact for the caller.
+		expect(await res.text()).toBe("Bad Request");
+	});
+
+	it("does not touch the body at all for a non-400 status", async () => {
+		const res = jsonResponse({ ok: true }, 200);
+		expect(await isAnthropicExtraUsageExhausted(res)).toBe(false);
+		expect(res.bodyUsed).toBe(false);
+		expect(await res.json()).toEqual({ ok: true });
+	});
+});
+
+describe("OpenAICompatibleProvider.processResponse — no orphaned original", () => {
+	const provider = new OpenAICompatibleProvider();
+
+	// processResponse cloned the incoming response, read the CLONE, and returned
+	// a freshly built Response. Callers therefore never consume the original,
+	// so its branch of the tee was orphaned on EVERY openai-compatible JSON
+	// response — not just on error paths.
+	it("leaves no unread body behind on a converted JSON response", async () => {
+		const upstream = jsonResponse({
+			id: "chatcmpl-1",
+			object: "chat.completion",
+			model: "gpt-x",
+			choices: [
+				{
+					index: 0,
+					message: { role: "assistant", content: "hi" },
+					finish_reason: "stop",
+				},
+			],
+			usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+		});
+
+		const converted = await provider.processResponse(upstream, null);
+
+		// The conversion result must be usable...
+		expect(converted.status).toBe(200);
+		await converted.text();
+		// ...and the upstream response must not be left holding an unread tee
+		// branch. Anything the provider cloned has to be consumed or cancelled.
+		expect(upstream.bodyUsed).toBe(true);
+	});
+
+	it("passes non-JSON responses through without stranding a body", async () => {
+		const upstream = new Response("plain text", {
+			status: 200,
+			headers: { "content-type": "text/plain" },
+		});
+		const out = await provider.processResponse(upstream, null);
+		// Pass-through: the same body must still be readable exactly once.
+		expect(await out.text()).toBe("plain text");
+	});
+});

--- a/packages/providers/src/providers/anthropic/provider.ts
+++ b/packages/providers/src/providers/anthropic/provider.ts
@@ -78,10 +78,13 @@ export async function isAnthropicExtraUsageExhausted(
 ): Promise<boolean> {
 	if (response.status !== 400) return false;
 	try {
-		const clone = response.clone();
+		// Clone only after the content-type gate. Cloning first teed the body
+		// and then returned early for every non-JSON 400 (gateway error pages,
+		// plain-text upstream errors), leaving that copy unread forever — the
+		// tee then keeps buffering for whoever consumes the original. See #356.
 		const contentType = response.headers.get("content-type");
 		if (!contentType?.includes("application/json")) return false;
-		const json = await clone.json();
+		const json = await response.clone().json();
 		return (
 			json?.error?.type === "invalid_request_error" &&
 			typeof json?.error?.message === "string" &&

--- a/packages/providers/src/providers/openai/provider.ts
+++ b/packages/providers/src/providers/openai/provider.ts
@@ -139,6 +139,16 @@ export class OpenAICompatibleProvider extends BaseProvider {
 				const data = await clone.json();
 				const anthropicData = convertOpenAIResponseToAnthropic(data);
 
+				// Success path: callers receive the converted response, so the
+				// original is discarded here. `clone()` teed the body — leaving
+				// the original branch unread keeps the tee buffering for a body
+				// nobody will ever consume, on every JSON response this provider
+				// converts. Cancelling disturbs it immediately; the promise is
+				// not awaited because nothing downstream depends on it. Only the
+				// success path may do this: the catch below falls through and
+				// returns the original, which must stay intact. See issue #356.
+				response.body?.cancel().catch(() => {});
+
 				return new Response(JSON.stringify(anthropicData), {
 					status: response.status,
 					statusText: response.statusText,

--- a/packages/proxy/src/handlers/__tests__/error-classifier-clone-disposal.test.ts
+++ b/packages/proxy/src/handlers/__tests__/error-classifier-clone-disposal.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "bun:test";
+import { isModelUnavailableError } from "../proxy-operations";
+
+/**
+ * Guards the body-inspecting error classifiers against orphaned tee branches
+ * (issue #356, follow-up to #354).
+ *
+ * These helpers clone the response to look at its JSON body. The clone used to
+ * be taken BEFORE the content-type gate, so every non-JSON body returned early
+ * and left that copy unread — and an unread tee branch keeps buffering for
+ * whoever consumes the original. Non-JSON error bodies are ordinary here
+ * (upstream gateway pages, providers such as Qwen), so the path is reachable in
+ * normal operation rather than an exotic edge case.
+ *
+ * Only `isModelUnavailableError` is exported; its two siblings in
+ * proxy-operations.ts (`isInvalidThinkingSignatureError`,
+ * `isCacheControlRejectionError`) are module-private and share the identical
+ * shape, so they are covered by the same change but not directly reachable
+ * from a test.
+ */
+
+function textResponse(body: string, status: number): Response {
+	return new Response(body, {
+		status,
+		headers: { "content-type": "text/plain" },
+	});
+}
+
+function jsonResponse(body: unknown, status: number): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+/** Records clones made during `body`, returning those left unread. */
+async function orphansCreatedBy(
+	body: () => Promise<void>,
+): Promise<Response[]> {
+	const clones: Response[] = [];
+	const original = Response.prototype.clone;
+	Response.prototype.clone = function trackedClone(this: Response) {
+		const copy = original.call(this);
+		clones.push(copy);
+		return copy;
+	};
+	try {
+		await body();
+	} finally {
+		// Restored in finally, not in a hook: Bun runs every test file in one
+		// process, so a patch surviving a failed assertion would leak.
+		Response.prototype.clone = original;
+	}
+	return clones.filter((c) => c.body !== null && !c.bodyUsed);
+}
+
+describe("isModelUnavailableError — clone disposal", () => {
+	it("leaves no orphaned clone when a 400 body is not JSON", async () => {
+		const res = textResponse("upstream error page", 400);
+		const orphans = await orphansCreatedBy(async () => {
+			expect(await isModelUnavailableError(res)).toBe(false);
+		});
+		expect(orphans.length).toBe(0);
+		// The original must remain intact for the caller.
+		expect(await res.text()).toBe("upstream error page");
+	});
+
+	// A 429 returns true above the content-type gate. Pinned so that early
+	// return is not "tidied" down into the try block, which would start
+	// cloning bodies this path never needs to read.
+	it("short-circuits a 429 without cloning at all", async () => {
+		const res = textResponse("rate limited", 429);
+		const orphans = await orphansCreatedBy(async () => {
+			expect(await isModelUnavailableError(res)).toBe(true);
+		});
+		expect(orphans.length).toBe(0);
+		expect(res.bodyUsed).toBe(false);
+	});
+
+	it("ignores statuses it does not classify, untouched", async () => {
+		const res = jsonResponse({ ok: true }, 200);
+		expect(await isModelUnavailableError(res)).toBe(false);
+		expect(res.bodyUsed).toBe(false);
+	});
+
+	it("still detects the JSON model-not-found shapes", async () => {
+		expect(
+			await isModelUnavailableError(
+				jsonResponse({ error: { type: "not_found_error" } }, 404),
+			),
+		).toBe(true);
+		expect(
+			await isModelUnavailableError(
+				jsonResponse({ error: { code: "model_not_found" } }, 400),
+			),
+		).toBe(true);
+		expect(
+			await isModelUnavailableError(
+				jsonResponse({ error: { message: "The model does not exist" } }, 404),
+			),
+		).toBe(true);
+	});
+});

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -309,12 +309,16 @@ async function isInvalidThinkingSignatureError(
 	if (response.status !== 400) return false;
 
 	try {
-		const clone = response.clone();
 		const contentType = response.headers.get("content-type");
 
 		if (!contentType?.includes("application/json")) return false;
 
-		const json = await clone.json();
+		// Cloned only here, after the content-type gate. Cloning before it teed
+		// the body and then returned early for every non-JSON body, stranding
+		// that copy unread — the tee keeps buffering for whoever consumes the
+		// original. Reachable in normal operation: providers such as Qwen do
+		// return non-JSON error bodies. See issue #356.
+		const json = await response.clone().json();
 
 		// Check for Claude's thinking-related errors
 		if (json.error?.message && typeof json.error.message === "string") {
@@ -359,11 +363,15 @@ async function isCacheControlRejectionError(
 	if (response.status !== 400) return false;
 
 	try {
-		const clone = response.clone();
 		const contentType = response.headers.get("content-type");
 		if (!contentType?.includes("application/json")) return false;
 
-		const json = await clone.json();
+		// Cloned only here, after the content-type gate. Cloning before it teed
+		// the body and then returned early for every non-JSON body, stranding
+		// that copy unread — the tee keeps buffering for whoever consumes the
+		// original. Reachable in normal operation: providers such as Qwen do
+		// return non-JSON error bodies. See issue #356.
+		const json = await response.clone().json();
 		const message: string = json.error?.message ?? json.message ?? "";
 		return (
 			typeof message === "string" &&
@@ -401,11 +409,15 @@ export async function isModelUnavailableError(
 	}
 
 	try {
-		const clone = response.clone();
 		const contentType = response.headers.get("content-type");
 		if (!contentType?.includes("application/json")) return false;
 
-		const json = await clone.json();
+		// Cloned only here, after the content-type gate. Cloning before it teed
+		// the body and then returned early for every non-JSON body, stranding
+		// that copy unread — the tee keeps buffering for whoever consumes the
+		// original. Reachable in normal operation: providers such as Qwen do
+		// return non-JSON error bodies. See issue #356.
+		const json = await response.clone().json();
 
 		// Anthropic native format
 		if (json.error?.type === "not_found_error") return true;


### PR DESCRIPTION
**Root Cause:** four sites create a body tee via `Response.clone()` and then abandon one of its branches. An abandoned branch never stops buffering for the branch that *is* consumed, and it keeps the underlying socket from completing teardown — the defect class #354 fixed on the 529 path, at the sites that PR deliberately left alone.

Three are the body-inspecting error classifiers — `isModelUnavailableError`, `isInvalidThinkingSignatureError` and `isCacheControlRejectionError` in `proxy-operations.ts`, plus `isAnthropicExtraUsageExhausted` in the Anthropic provider. All four shared one shape:

```ts
const clone = response.clone();                                    // tee created
const contentType = response.headers.get("content-type");
if (!contentType?.includes("application/json")) return false;      // clone stranded
const json = await clone.json();
```

Every non-JSON body takes the early return and leaves that copy unread. Non-JSON error bodies are ordinary here — upstream gateway pages, and providers such as Qwen, which the code's own comment already notes returns `429`s without JSON — so this fires in normal operation.

The fourth has the widest reach and is inverted. `OpenAICompatibleProvider.processResponse` reads its *clone* and returns a freshly built `Response`, so the branch nobody ever consumes is the **incoming** one. That happens on every successful `application/json` response from every openai-compatible provider (openrouter, kilo, xai, minimax, nanogpt, ollama, …) — not only on failures.

**The Fix:** the classifiers clone after the content-type gate, so no copy exists on the paths that return early. `processResponse` cancels the original once conversion has succeeded — and only then, because its `catch` falls through and returns that same response, which must stay intact; the cancel is deliberately not awaited, since nothing downstream depends on it and cancelling disturbs the stream synchronously. Detection behaviour is unchanged: every classifier still returns exactly what it returned before, including the `429` short-circuit that fires above the gate without cloning at all.

**Validation:** 9 new cases across two files, in the package each symbol belongs to (`isModelUnavailableError` is tested from `proxy`, not imported across the package boundary). They assert the observable invariant — no clone left both unread and un-cancelled — and also pin the classifications that must keep working, so a future "simplification" cannot trade detection for disposal. Red proof by swapping the three changed files back to their `main` versions (never `git stash`; the shared checkout carries foreign stash entries): **3 of 9 fail pre-fix, all 9 pass with the change**. `bunx tsc --noEmit` clean; 1371 tests green across `proxy`, `providers` and `core`, no new failures.

**Out of scope:** the retry `Request` clone at `proxy-operations.ts:686` was listed in #356 as a suspect. Request bodies tee the same way, but that clone is handed straight to `fetch`, which consumes it, so there is no orphan — no change needed, and the issue's third bullet can be closed as not-a-defect.

**References:** closes #356 · follow-up to #354 · sibling PR #355 (the 529 path, still open).
