### PR TITLE
fix: strip regex lookaround from tool schemas forwarded to OpenAI

### DIFF
--- a/packages/openai-formats/src/__tests__/utils.test.ts
+++ b/packages/openai-formats/src/__tests__/utils.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "bun:test";
 import {
 	convertAnthropicPathToOpenAI,
 	mapOpenAIFinishReason,
-	removeUriFormat,
 	repairTruncatedToolJson,
+	sanitizeSchemaForOpenAI,
 } from "../utils";
 
 // ── repairTruncatedToolJson ───────────────────────────────────────────────────
@@ -40,19 +40,19 @@ describe("repairTruncatedToolJson", () => {
 	});
 });
 
-// ── removeUriFormat ───────────────────────────────────────────────────────────
+// ── sanitizeSchemaForOpenAI ───────────────────────────────────────────────────
 
-describe("removeUriFormat", () => {
+describe("sanitizeSchemaForOpenAI", () => {
 	it("strips format:uri from string-type properties", () => {
 		const input = { type: "string", format: "uri" };
-		const result = removeUriFormat(input) as Record<string, unknown>;
+		const result = sanitizeSchemaForOpenAI(input) as Record<string, unknown>;
 		expect(result).not.toHaveProperty("format");
 		expect(result.type).toBe("string");
 	});
 
 	it("preserves non-uri format values", () => {
 		const input = { type: "string", format: "date-time" };
-		const result = removeUriFormat(input) as Record<string, unknown>;
+		const result = sanitizeSchemaForOpenAI(input) as Record<string, unknown>;
 		expect(result.format).toBe("date-time");
 	});
 
@@ -61,7 +61,7 @@ describe("removeUriFormat", () => {
 			$schema: "http://json-schema.org/draft-07/schema#",
 			type: "object",
 		};
-		const result = removeUriFormat(input) as Record<string, unknown>;
+		const result = sanitizeSchemaForOpenAI(input) as Record<string, unknown>;
 		expect(result).not.toHaveProperty("$schema");
 	});
 
@@ -73,7 +73,7 @@ describe("removeUriFormat", () => {
 				name: { type: "string", format: "date-time" },
 			},
 		};
-		const result = removeUriFormat(input) as Record<string, unknown>;
+		const result = sanitizeSchemaForOpenAI(input) as Record<string, unknown>;
 		const props = result.properties as Record<string, Record<string, unknown>>;
 		expect(props?.url).not.toHaveProperty("format");
 		expect(props?.name?.format).toBe("date-time");
@@ -84,26 +84,78 @@ describe("removeUriFormat", () => {
 			{ type: "string", format: "uri" },
 			{ type: "string", format: "email" },
 		];
-		const result = removeUriFormat(input) as Array<Record<string, unknown>>;
+		const result = sanitizeSchemaForOpenAI(input) as Array<
+			Record<string, unknown>
+		>;
 		expect(result[0]).not.toHaveProperty("format");
 		expect(result[1]?.format).toBe("email");
 	});
 
 	it("passes through null", () => {
-		expect(removeUriFormat(null)).toBeNull();
+		expect(sanitizeSchemaForOpenAI(null)).toBeNull();
 	});
 
 	it("passes through primitives unchanged", () => {
-		expect(removeUriFormat("string")).toBe("string");
-		expect(removeUriFormat(42)).toBe(42);
-		expect(removeUriFormat(true)).toBe(true);
+		expect(sanitizeSchemaForOpenAI("string")).toBe("string");
+		expect(sanitizeSchemaForOpenAI(42)).toBe(42);
+		expect(sanitizeSchemaForOpenAI(true)).toBe(true);
 	});
 
 	it("does not strip format from non-string types", () => {
 		const input = { type: "integer", format: "int64" };
-		const result = removeUriFormat(input) as Record<string, unknown>;
+		const result = sanitizeSchemaForOpenAI(input) as Record<string, unknown>;
 		// format:uri stripping only applies to string types
 		expect(result.format).toBe("int64");
+	});
+
+	it("strips pattern containing a negative lookahead", () => {
+		const input = {
+			type: "object",
+			properties: {
+				to: {
+					type: "array",
+					items: {
+						type: "string",
+						pattern:
+							"^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+					},
+				},
+			},
+		};
+		const result = sanitizeSchemaForOpenAI(input) as Record<string, unknown>;
+		const props = result.properties as Record<string, Record<string, unknown>>;
+		const items = props?.to?.items as Record<string, unknown>;
+		expect(items).not.toHaveProperty("pattern");
+		expect(items.type).toBe("string");
+	});
+
+	it("strips patterns with each lookaround flavor", () => {
+		for (const pattern of ["foo(?=bar)", "(?<=a)b", "(?<!a)b"]) {
+			const input = { type: "string", pattern };
+			const result = sanitizeSchemaForOpenAI(input) as Record<string, unknown>;
+			expect(result).not.toHaveProperty("pattern");
+			expect(result.type).toBe("string");
+		}
+	});
+
+	it("preserves plain patterns without lookaround", () => {
+		const simple = sanitizeSchemaForOpenAI({
+			type: "string",
+			pattern: "^[a-z]+$",
+		}) as Record<string, unknown>;
+		expect(simple.pattern).toBe("^[a-z]+$");
+
+		const grouped = sanitizeSchemaForOpenAI({
+			type: "string",
+			pattern: "^(abc|def)$",
+		}) as Record<string, unknown>;
+		expect(grouped.pattern).toBe("^(abc|def)$");
+	});
+
+	it("does not strip a non-string pattern value", () => {
+		const input = { type: "object", pattern: 123 };
+		const result = sanitizeSchemaForOpenAI(input) as Record<string, unknown>;
+		expect(result.pattern).toBe(123);
 	});
 });
 

--- a/packages/openai-formats/src/converters.ts
+++ b/packages/openai-formats/src/converters.ts
@@ -15,7 +15,7 @@ import type {
 	OpenAIRequest,
 	OpenAIResponse,
 } from "./types";
-import { mapOpenAIFinishReason, removeUriFormat } from "./utils";
+import { mapOpenAIFinishReason, sanitizeSchemaForOpenAI } from "./utils";
 
 const log = new Logger("openai-formats/converters");
 
@@ -114,7 +114,7 @@ export function convertAnthropicRequestToOpenAI(
 			function: {
 				name: tool.name,
 				description: tool.description,
-				parameters: removeUriFormat(tool.input_schema) as Record<
+				parameters: sanitizeSchemaForOpenAI(tool.input_schema) as Record<
 					string,
 					unknown
 				>,

--- a/packages/openai-formats/src/utils.ts
+++ b/packages/openai-formats/src/utils.ts
@@ -26,12 +26,16 @@ export function repairTruncatedToolJson(accumulated: string): string {
 	}
 }
 
+const LOOKAROUND_PATTERN = /\(\?(=|!|<=|<!)/;
+
 /**
- * Helper to remove format: 'uri' from JSON schemas (some providers reject it)
+ * Sanitize JSON schemas to the subset OpenAI's tool-schema validator accepts:
+ * strips $schema, format: "uri" on strings, and regex pattern values
+ * containing lookaround (which OpenAI's restricted regex dialect rejects).
  */
-export function removeUriFormat(schema: unknown): unknown {
+export function sanitizeSchemaForOpenAI(schema: unknown): unknown {
 	if (Array.isArray(schema)) {
-		return schema.map((item) => removeUriFormat(item));
+		return schema.map((item) => sanitizeSchemaForOpenAI(item));
 	}
 
 	if (schema === null || typeof schema !== "object") {
@@ -47,7 +51,14 @@ export function removeUriFormat(schema: unknown): unknown {
 		// Strip format: uri from string fields
 		if (key === "format" && obj.type === "string" && obj[key] === "uri")
 			continue;
-		result[key] = removeUriFormat(obj[key]);
+		// Strip pattern values with lookaround — OpenAI's restricted regex dialect rejects them
+		if (
+			key === "pattern" &&
+			typeof obj[key] === "string" &&
+			LOOKAROUND_PATTERN.test(obj[key] as string)
+		)
+			continue;
+		result[key] = sanitizeSchemaForOpenAI(obj[key]);
 	}
 	return result;
 }

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -2495,6 +2495,50 @@ describe("CodexProvider.transformRequestBody", () => {
 		expect(body.tool_choice).toBe("none");
 	});
 
+	it("sanitizes tool input_schema: strips lookaround pattern and $schema", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-opus-4-8",
+				max_tokens: 10,
+				messages: [{ role: "user", content: "send an email" }],
+				tools: [
+					{
+						name: "send_email",
+						description: "Send an email.",
+						input_schema: {
+							$schema: "http://json-schema.org/draft-07/schema#",
+							type: "object",
+							properties: {
+								to: {
+									type: "array",
+									items: {
+										type: "string",
+										pattern:
+											"^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+									},
+								},
+							},
+							required: ["to"],
+						},
+					},
+				],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request);
+		const body = await transformed.json();
+		const params = body.tools[0].parameters;
+		expect(params).not.toHaveProperty("$schema");
+		expect(params.type).toBe("object");
+		expect(params.required).toEqual(["to"]);
+		const items = params.properties.to.items;
+		expect(items).not.toHaveProperty("pattern");
+		expect(items.type).toBe("string");
+	});
+
 	it("rejects a named tool_choice that is absent from tools", async () => {
 		const provider = new CodexProvider();
 		const request = new Request("https://example.com/v1/messages", {

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -6,7 +6,10 @@ import {
 } from "@better-ccflare/core";
 import { sanitizeProxyHeaders } from "@better-ccflare/http-common";
 import { Logger } from "@better-ccflare/logger";
-import { resolveReasoningEffort } from "@better-ccflare/openai-formats";
+import {
+	resolveReasoningEffort,
+	sanitizeSchemaForOpenAI,
+} from "@better-ccflare/openai-formats";
 import type { Account } from "@better-ccflare/types";
 import { BaseProvider } from "../../base";
 import type { RateLimitInfo, TokenRefreshResult } from "../../types";
@@ -1204,7 +1207,9 @@ export class CodexProvider extends BaseProvider {
 				type: "function" as const,
 				name: t.name,
 				description: t.description,
-				parameters: t.input_schema,
+				parameters: sanitizeSchemaForOpenAI(t.input_schema) as
+					| Record<string, unknown>
+					| undefined,
 			}));
 		}
 


### PR DESCRIPTION
## What

Fixes #357 — requests routed to `codex` (OpenAI OAuth) accounts fail with `400 Invalid JSON schema: regex lookaround is not supported` whenever any tool's input schema contains a regex `pattern` with lookaround (`(?=`, `(?!`, `(?<=`, `(?<!`), e.g. MCP email tools validating addresses.

## Why

OpenAI's tool-schema validator accepts only a restricted regex dialect without lookaround; Anthropic's validator is permissive. ccflare already bridges this gap for `$schema` and `format: "uri"` via a sanitizer in `openai-formats`, but (a) the sanitizer had no `pattern`-aware rule, and (b) the codex provider never called it at all — tool schemas were forwarded verbatim, so one incompatible pattern poisoned every request on the session (Claude Code sends the full tool list each turn).

## How

- Renamed `removeUriFormat` → `sanitizeSchemaForOpenAI` (it now does more than its old name said) and added a rule that drops string `pattern`  values containing lookaround. Dropping a `pattern` only loosens  validation — the field remains `type: "string"` and the MCP server  still validates on execution — so it is safe at the proxy boundary.  Rewriting lookaround into the supported dialect is not generally possible, and rejecting the request is the bug being fixed.
- Applied the sanitizer in the codex provider's tool conversion (`transformRequestBody`), which also brings the existing
  `$schema`/`format: "uri"` scrubbing to the codex path.
- Tests: sanitizer unit tests covering the issue's exact repro schema, all four lookaround flavors, and false-positive guards (plain patterns and normal groups survive); plus an end-to-end codex `transformRequestBody` test asserting the outgoing tool `parameters` are scrubbed.