### PR TITLE
fix: abort the upstream fetch when the client disconnects

### DIFF
--- a/packages/openai-responses-adapter/src/handler.ts
+++ b/packages/openai-responses-adapter/src/handler.ts
@@ -125,6 +125,9 @@ export async function handleResponsesRequest(
 		method: "POST",
 		headers: syntheticHeaders,
 		body: JSON.stringify(anthropicBody),
+		// Keep the client's disconnect wired to the upstream call: this request
+		// is built from a URL, which does not inherit the signal.
+		signal: req.signal,
 	});
 
 	// 6. Forward to proxy

--- a/packages/providers/src/utils/__tests__/model-mapping.test.ts
+++ b/packages/providers/src/utils/__tests__/model-mapping.test.ts
@@ -216,3 +216,62 @@ describe("transformRequestBodyModelForce", () => {
 		expect(result).toBe(request);
 	});
 });
+
+describe("model transforms preserve the abort signal", () => {
+	// Both transforms rebuild the Request from `request.url`, and a URL-based
+	// rebuild does not inherit the signal. Losing it would detach a client
+	// disconnect from the upstream fetch for every account with a model mapping.
+	function signalledRequest(controller: AbortController, model = "sonnet") {
+		return new Request("http://test.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ model, messages: [] }),
+			signal: controller.signal,
+		});
+	}
+
+	it("keeps the signal when transformRequestBodyModel rewrites the model", async () => {
+		const controller = new AbortController();
+		const request = signalledRequest(controller);
+
+		const result = await transformRequestBodyModel(
+			request,
+			undefined,
+			() => "mapped-model",
+		);
+
+		// A rewrite happened, so this must be a new Request object …
+		expect(result).not.toBe(request);
+		// … that still aborts together with the client.
+		expect(result.signal.aborted).toBe(false);
+		controller.abort();
+		expect(result.signal.aborted).toBe(true);
+	});
+
+	it("keeps the signal when transformRequestBodyModelForce rewrites the model", async () => {
+		const controller = new AbortController();
+		const request = signalledRequest(controller);
+
+		const result = await transformRequestBodyModelForce(request, "MiniMax-M2");
+
+		expect(result).not.toBe(request);
+		expect(result.signal.aborted).toBe(false);
+		controller.abort();
+		expect(result.signal.aborted).toBe(true);
+	});
+
+	it("passes the original request through when no rewrite is needed", async () => {
+		const controller = new AbortController();
+		const request = signalledRequest(controller, "same-model");
+
+		const result = await transformRequestBodyModel(
+			request,
+			undefined,
+			() => "same-model",
+		);
+
+		expect(result).toBe(request);
+		controller.abort();
+		expect(result.signal.aborted).toBe(true);
+	});
+});

--- a/packages/providers/src/utils/model-mapping.ts
+++ b/packages/providers/src/utils/model-mapping.ts
@@ -124,11 +124,16 @@ export async function transformRequestBodyModel<T extends TransformRequestBody>(
 					`Mapped model in request: ${originalModel} -> ${mappedModel}`,
 				);
 
-				// Create new request with transformed body
+				// Create new request with transformed body.
+				// Rebuilding from `request.url` (a string) does not inherit the
+				// signal, so it is carried over explicitly — otherwise a client
+				// disconnect can no longer abort the upstream fetch for every
+				// account that has a model mapping.
 				const transformedRequest = new Request(request.url, {
 					method: request.method,
 					headers: request.headers,
 					body: JSON.stringify(body),
+					signal: request.signal,
 				});
 
 				return transformedRequest;
@@ -167,11 +172,14 @@ export async function transformRequestBodyModelForce(
 			body.model = targetModel;
 			log.debug(`Forced model mapping to: ${targetModel}`);
 
-			// Create new request with mutated body
+			// Create new request with mutated body.
+			// Carry the signal over: a URL-based rebuild drops it, which would
+			// detach the client disconnect from the upstream fetch.
 			const transformedRequest = new Request(request.url, {
 				method: request.method,
 				headers: request.headers,
 				body: JSON.stringify(body),
+				signal: request.signal,
 			});
 
 			return transformedRequest;

--- a/packages/proxy/src/handlers/__tests__/proxy-operations-client-abort.test.ts
+++ b/packages/proxy/src/handlers/__tests__/proxy-operations-client-abort.test.ts
@@ -252,3 +252,94 @@ describe("proxyWithAccount: client abort signal reaches the upstream fetch", () 
 		expect(captured.calls).toBeGreaterThan(0);
 	});
 });
+
+describe("proxyWithAccount: a client disconnect must not look like an account failure", () => {
+	let originalFetch: typeof globalThis.fetch;
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	function abortError(): Error {
+		// Shape of what fetch rejects with once its signal fires.
+		const err = new Error("The operation was aborted.");
+		err.name = "AbortError";
+		return err;
+	}
+
+	async function run(req: Request): Promise<Response | null> {
+		const bodyBuffer = makeRequestBody();
+		return await proxyWithAccount(
+			req,
+			new URL("https://proxy.local/v1/messages"),
+			makeAccount(),
+			makeRequestMeta(),
+			bodyBuffer,
+			() => undefined,
+			0,
+			makeProxyContext(),
+		);
+	}
+
+	it("returns 499 instead of null when the client disconnected", async () => {
+		const controller = new AbortController();
+		globalThis.fetch = mock(async () => {
+			// The client goes away while the upstream call is in flight.
+			controller.abort();
+			throw abortError();
+		}) as unknown as typeof globalThis.fetch;
+
+		const result = await run(
+			new Request("https://proxy.local/v1/messages", {
+				method: "POST",
+				body: makeRequestBody(),
+				headers: { "Content-Type": "application/json" },
+				signal: controller.signal,
+			}),
+		);
+
+		// null would send the caller through every remaining account and
+		// fallback route for a request nobody is listening to.
+		expect(result).not.toBeNull();
+		expect(result?.status).toBe(499);
+	});
+
+	it("still fails over when an abort did NOT come from the client", async () => {
+		// The header-phase timeout aborts only the internal controller, so
+		// req.signal stays untouched. Such a failure must keep failing over —
+		// this is the discriminator the fix relies on.
+		globalThis.fetch = mock(async () => {
+			throw abortError();
+		}) as unknown as typeof globalThis.fetch;
+
+		const result = await run(
+			new Request("https://proxy.local/v1/messages", {
+				method: "POST",
+				body: makeRequestBody(),
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+
+		expect(result).toBeNull();
+	});
+
+	it("still fails over on ordinary upstream errors", async () => {
+		globalThis.fetch = mock(async () => {
+			throw new TypeError("fetch failed");
+		}) as unknown as typeof globalThis.fetch;
+
+		const result = await run(
+			new Request("https://proxy.local/v1/messages", {
+				method: "POST",
+				body: makeRequestBody(),
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+
+		expect(result).toBeNull();
+	});
+});

--- a/packages/proxy/src/handlers/__tests__/proxy-operations-client-abort.test.ts
+++ b/packages/proxy/src/handlers/__tests__/proxy-operations-client-abort.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { Account, RequestMeta } from "@better-ccflare/types";
+import { proxyWithAccount } from "../proxy-operations";
+import type { ProxyContext } from "../proxy-types";
+
+/**
+ * The client's abort signal must reach the upstream fetch through the whole
+ * proxy path — including provider body transforms that rebuild the Request from
+ * its URL and thereby drop the signal. That rebuild is why the signal is passed
+ * explicitly at the call site instead of riding along on the Request object.
+ */
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "acc-abort",
+		name: "abort-test",
+		provider: "openai-compatible",
+		api_key: "test-key",
+		refresh_token: "",
+		access_token: null,
+		expires_at: null,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: Date.now(),
+		rate_limited_until: null,
+		rate_limited_reason: null,
+		rate_limited_at: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		peak_hours_pause_enabled: false,
+		custom_endpoint: "https://openrouter.ai/api/v1",
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		billing_type: null,
+		pause_reason: null,
+		refresh_token_issued_at: null,
+		consecutive_rate_limits: 0,
+		...overrides,
+	};
+}
+
+function makeRequestMeta(): RequestMeta {
+	return {
+		id: "req-abort",
+		method: "POST",
+		path: "/v1/messages",
+		timestamp: Date.now(),
+		headers: new Headers(),
+	};
+}
+
+function makeRequestBody(model = "claude-sonnet-4-5") {
+	return new TextEncoder().encode(
+		JSON.stringify({
+			model,
+			messages: [{ role: "user", content: "hello" }],
+			max_tokens: 10,
+		}),
+	).buffer as ArrayBuffer;
+}
+
+/**
+ * @param transformRequestBody - lets a test inject a signal-dropping transform,
+ *   mirroring what the real providers do (`new Request(request.url, …)`).
+ */
+function makeProxyContext(
+	transformRequestBody:
+		| ((req: Request, account: Account) => Promise<Request>)
+		| null = null,
+): ProxyContext {
+	return {
+		strategy: { getNextAccount: () => null } as never,
+		dbOps: {
+			markAccountRateLimited: mock(() =>
+				Promise.resolve({ consecutiveRateLimits: 1, applied: true }),
+			),
+			saveRequest: mock(() => Promise.resolve()),
+			updateAccountUsage: mock(() => Promise.resolve()),
+			getAdapter: mock(() => ({
+				run: mock(() => Promise.resolve()),
+				get: mock(() => Promise.resolve(null)),
+			})),
+		} as never,
+		runtime: { port: 8080, clientId: "test" } as never,
+		provider: {
+			name: "openai-compatible",
+			canHandle: () => true,
+			buildUrl: () => "https://openrouter.ai/api/v1/messages",
+			prepareHeaders: () => new Headers(),
+			transformRequestBody,
+			processResponse: async (r: Response) => r,
+			parseRateLimit: () => ({
+				isRateLimited: false,
+				resetTime: undefined,
+				statusHeader: "allowed",
+				remaining: undefined,
+			}),
+			isStreamingResponse: () => false,
+		} as never,
+		refreshInFlight: new Map(),
+		asyncWriter: { enqueue: mock(() => {}) } as never,
+		config: { getStorePayloads: () => false } as never,
+		internalProbeSecret: "test-secret",
+	};
+}
+
+/** A transform that rebuilds from the URL — the real signal-dropping shape. */
+async function signalDroppingTransform(request: Request): Promise<Request> {
+	const body = await request.clone().text();
+	return new Request(request.url, {
+		method: request.method,
+		headers: request.headers,
+		body,
+	});
+}
+
+interface CapturedFetch {
+	signal: AbortSignal | undefined;
+	calls: number;
+}
+
+/**
+ * Replaces global fetch, records the signal the upstream call was armed with,
+ * and answers 429 so proxyWithAccount short-circuits into failover instead of
+ * reaching forwardToClient (which needs an initialised UsageCollector).
+ */
+function captureUpstreamFetch(): CapturedFetch {
+	const captured: CapturedFetch = { signal: undefined, calls: 0 };
+	globalThis.fetch = mock(async (input: unknown, init?: RequestInit) => {
+		captured.calls++;
+		captured.signal ??=
+			input instanceof Request ? input.signal : (init?.signal ?? undefined);
+		return new Response(
+			JSON.stringify({ error: { type: "api_error", message: "rate limited" } }),
+			{ status: 429, headers: { "Content-Type": "application/json" } },
+		);
+	}) as unknown as typeof globalThis.fetch;
+	return captured;
+}
+
+async function runProxy(
+	req: Request,
+	ctx: ProxyContext,
+	account = makeAccount(),
+): Promise<void> {
+	const bodyBuffer = makeRequestBody();
+	try {
+		await proxyWithAccount(
+			req,
+			new URL("https://proxy.local/v1/messages"),
+			account,
+			makeRequestMeta(),
+			bodyBuffer,
+			() => undefined,
+			0,
+			ctx,
+		);
+	} catch {
+		// Downstream forwarding is out of scope here; the assertion is about the
+		// signal that armed the upstream fetch.
+	}
+}
+
+describe("proxyWithAccount: client abort signal reaches the upstream fetch", () => {
+	let originalFetch: typeof globalThis.fetch;
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("arms the upstream fetch with a signal that follows the client request", async () => {
+		const captured = captureUpstreamFetch();
+		const controller = new AbortController();
+		const req = new Request("https://proxy.local/v1/messages", {
+			method: "POST",
+			body: makeRequestBody(),
+			headers: { "Content-Type": "application/json" },
+			signal: controller.signal,
+		});
+
+		await runProxy(req, makeProxyContext());
+
+		expect(captured.calls).toBeGreaterThan(0);
+		expect(captured.signal).toBeDefined();
+		expect(captured.signal?.aborted).toBe(false);
+
+		// The decisive assertion: aborting the CLIENT must abort what the upstream
+		// fetch was armed with. Without the wiring these are unrelated objects.
+		controller.abort();
+		expect(captured.signal?.aborted).toBe(true);
+	});
+
+	it("keeps the wiring even when the provider transform rebuilds the Request and drops the signal", async () => {
+		const captured = captureUpstreamFetch();
+		const controller = new AbortController();
+		const req = new Request("https://proxy.local/v1/messages", {
+			method: "POST",
+			body: makeRequestBody(),
+			headers: { "Content-Type": "application/json" },
+			signal: controller.signal,
+		});
+
+		await runProxy(req, makeProxyContext(signalDroppingTransform));
+
+		expect(captured.signal).toBeDefined();
+		expect(captured.signal?.aborted).toBe(false);
+
+		controller.abort();
+		expect(captured.signal?.aborted).toBe(true);
+	});
+
+	it("does not abort the upstream fetch while the client stays connected", async () => {
+		const captured = captureUpstreamFetch();
+		const req = new Request("https://proxy.local/v1/messages", {
+			method: "POST",
+			body: makeRequestBody(),
+			headers: { "Content-Type": "application/json" },
+		});
+
+		await runProxy(req, makeProxyContext());
+
+		expect(captured.calls).toBeGreaterThan(0);
+		expect(captured.signal?.aborted).toBe(false);
+	});
+
+	it("still forwards requests whose client signal is absent", async () => {
+		// A Request built without an explicit signal exposes a non-aborted signal;
+		// the upstream call must proceed normally rather than being skipped.
+		const captured = captureUpstreamFetch();
+		const req = new Request("https://proxy.local/v1/messages", {
+			method: "POST",
+			body: makeRequestBody(),
+			headers: { "Content-Type": "application/json" },
+		});
+
+		await runProxy(req, makeProxyContext(signalDroppingTransform));
+
+		expect(captured.calls).toBeGreaterThan(0);
+	});
+});

--- a/packages/proxy/src/handlers/__tests__/request-handler-client-abort.test.ts
+++ b/packages/proxy/src/handlers/__tests__/request-handler-client-abort.test.ts
@@ -1,0 +1,261 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { makeProxyRequest } from "../request-handler";
+
+/**
+ * Client-disconnect propagation for the upstream fetch.
+ *
+ * Background: a client that goes away mid-stream (Claude Code's 300 s idle
+ * watchdog, Ctrl-C, network drop) left the upstream connection running,
+ * because makeProxyRequest overwrote any caller signal with its own
+ * timeout-only controller — and that controller is unreachable once the
+ * headers arrive (its timer is cleared in `finally`).
+ *
+ * These tests drive a real local upstream so the assertions measure actual
+ * socket behaviour rather than a mock's promise. The upstream records how many
+ * requests it saw and whether its response stream was cancelled.
+ */
+
+interface Upstream {
+	url: string;
+	requests: number;
+	cancelled: string[];
+	pulls: number;
+	stop: () => void;
+}
+
+function startUpstream(opts: { chunkDelayMs?: number } = {}): Upstream {
+	const state = {
+		requests: 0,
+		cancelled: [] as string[],
+		pulls: 0,
+	};
+	const delay = opts.chunkDelayMs ?? 100;
+	const server = Bun.serve({
+		port: 0,
+		idleTimeout: 0,
+		fetch() {
+			state.requests++;
+			return new Response(
+				new ReadableStream<Uint8Array>({
+					async pull(controller) {
+						state.pulls++;
+						await Bun.sleep(delay);
+						controller.enqueue(
+							new TextEncoder().encode(`: chunk ${state.pulls}\n\n`),
+						);
+					},
+					cancel(reason) {
+						state.cancelled.push(String(reason ?? "no-reason"));
+					},
+				}),
+				{ headers: { "content-type": "text/event-stream" } },
+			);
+		},
+	});
+	return {
+		url: `http://127.0.0.1:${server.port}/v1/messages`,
+		get requests() {
+			return state.requests;
+		},
+		get cancelled() {
+			return state.cancelled;
+		},
+		get pulls() {
+			return state.pulls;
+		},
+		stop: () => server.stop(true),
+	};
+}
+
+/** Reads one chunk so we are provably past the header boundary. */
+async function readOneChunk(response: Response): Promise<void> {
+	const reader = response.body?.getReader();
+	if (!reader) throw new Error("response had no body");
+	await reader.read();
+	reader.releaseLock();
+}
+
+describe("makeProxyRequest: client disconnect aborts the upstream fetch", () => {
+	let upstream: Upstream;
+
+	beforeAll(() => {
+		upstream = startUpstream();
+	});
+
+	afterAll(() => {
+		upstream.stop();
+	});
+
+	it("aborts the upstream when the caller signal fires AFTER the headers arrived", async () => {
+		const controller = new AbortController();
+		const response = await makeProxyRequest(
+			upstream.url,
+			"POST",
+			new Headers({ "content-type": "application/json" }),
+			undefined,
+			false,
+			controller.signal,
+		);
+		expect(response.status).toBe(200);
+
+		await readOneChunk(response);
+		const pullsAtAbort = upstream.pulls;
+		const cancelledBefore = upstream.cancelled.length;
+
+		controller.abort();
+		await Bun.sleep(600);
+
+		// The upstream must stop producing: at most the in-flight pull completes.
+		expect(upstream.pulls).toBeLessThanOrEqual(pullsAtAbort + 1);
+		expect(upstream.cancelled.length).toBeGreaterThan(cancelledBefore);
+	});
+
+	it("aborts the upstream when the signal is inherited from a Request target", async () => {
+		const controller = new AbortController();
+		// This mirrors the production shape: the proxy hands a Request object to
+		// makeProxyRequest. A Request carries its own signal, which must not be
+		// discarded.
+		const target = new Request(upstream.url, {
+			method: "POST",
+			signal: controller.signal,
+		});
+
+		const response = await makeProxyRequest(target);
+		expect(response.status).toBe(200);
+
+		await readOneChunk(response);
+		const pullsAtAbort = upstream.pulls;
+		const cancelledBefore = upstream.cancelled.length;
+
+		controller.abort();
+		await Bun.sleep(600);
+
+		expect(upstream.pulls).toBeLessThanOrEqual(pullsAtAbort + 1);
+		expect(upstream.cancelled.length).toBeGreaterThan(cancelledBefore);
+	});
+
+	it("rejects without contacting the upstream when the signal is already aborted", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		const before = upstream.requests;
+
+		await expect(
+			makeProxyRequest(
+				upstream.url,
+				"POST",
+				new Headers(),
+				undefined,
+				false,
+				controller.signal,
+			),
+		).rejects.toThrow();
+
+		expect(upstream.requests).toBe(before);
+	});
+
+	it("surfaces an AbortError (not a timeout error) when the client goes away", async () => {
+		const controller = new AbortController();
+		const response = await makeProxyRequest(
+			upstream.url,
+			"POST",
+			new Headers(),
+			undefined,
+			false,
+			controller.signal,
+		);
+		const reader = response.body?.getReader();
+		if (!reader) throw new Error("no body");
+
+		controller.abort();
+
+		let caught: unknown;
+		try {
+			// Draining after the abort must fail, and it must fail as an abort.
+			for (;;) {
+				const { done } = await reader.read();
+				if (done) break;
+			}
+		} catch (err) {
+			caught = err;
+		}
+		expect(caught).toBeDefined();
+		expect((caught as Error).name).toBe("AbortError");
+	});
+});
+
+describe("makeProxyRequest: existing contracts stay intact", () => {
+	let upstream: Upstream;
+
+	beforeAll(() => {
+		upstream = startUpstream();
+	});
+
+	afterAll(() => {
+		upstream.stop();
+	});
+
+	it("still performs the request when no signal is supplied", async () => {
+		const response = await makeProxyRequest(
+			upstream.url,
+			"POST",
+			new Headers({ "content-type": "application/json" }),
+			undefined,
+			false,
+		);
+		expect(response.status).toBe(200);
+		expect(upstream.requests).toBeGreaterThan(0);
+		await response.body?.cancel();
+	});
+
+	it("does not abort a healthy in-flight stream while the caller signal stays quiet", async () => {
+		const controller = new AbortController();
+		const response = await makeProxyRequest(
+			upstream.url,
+			"POST",
+			new Headers(),
+			undefined,
+			false,
+			controller.signal,
+		);
+		const reader = response.body?.getReader();
+		if (!reader) throw new Error("no body");
+
+		// Drain several chunks across a span that dwarfs a chunk delay. The
+		// header timeout must already be disarmed at this point, so nothing may
+		// tear the stream down.
+		const decoder = new TextDecoder();
+		let seen = 0;
+		for (let i = 0; i < 4; i++) {
+			const { value, done } = await reader.read();
+			if (done) break;
+			if (decoder.decode(value).includes("chunk")) seen++;
+		}
+		expect(seen).toBeGreaterThanOrEqual(3);
+		expect(controller.signal.aborted).toBe(false);
+
+		await reader.cancel();
+	});
+
+	it("keeps the caller signal usable as the abort source for the whole stream lifetime", async () => {
+		// Guards the combination: a caller signal must remain effective after the
+		// header-phase timeout has been cleared. If the implementation returned a
+		// signal that is detached once headers land, this abort would be a no-op.
+		const controller = new AbortController();
+		const response = await makeProxyRequest(
+			upstream.url,
+			"POST",
+			new Headers(),
+			undefined,
+			false,
+			controller.signal,
+		);
+		await readOneChunk(response);
+		await Bun.sleep(300); // well past the header boundary
+
+		const cancelledBefore = upstream.cancelled.length;
+		controller.abort();
+		await Bun.sleep(600);
+
+		expect(upstream.cancelled.length).toBeGreaterThan(cancelledBefore);
+	});
+});

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -475,6 +475,9 @@ export async function proxyUnauthenticated(
 			headers,
 			createBodyStream,
 			!!req.body,
+			// Abort upstream when the client disconnects; this path builds no
+			// Request object, so the signal has to be passed explicitly.
+			req.signal,
 		);
 
 		return forwardToClient(
@@ -543,6 +546,22 @@ export async function proxyWithAccount(
 	returnRateLimitedResponseOnExhaustion = false,
 ): Promise<Response | null> {
 	try {
+		// Every upstream call stays tied to the client connection: when the client
+		// disconnects, the upstream fetch must be aborted instead of running on.
+		// The signal is passed explicitly instead of relying on the Request object
+		// to carry it, because provider body transforms rebuild the Request from
+		// its URL and drop the signal (see providers/src/utils/model-mapping.ts and
+		// the openai/codex providers). One guarantee at the call site beats an
+		// invariant that every provider has to remember.
+		const forwardUpstream = (target: Request) =>
+			makeProxyRequest(
+				target,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				req.signal,
+			);
 		if (
 			process.env.DEBUG?.includes("proxy") ||
 			process.env.DEBUG === "true" ||
@@ -638,6 +657,11 @@ export async function proxyWithAccount(
 		const requestInit: RequestInit & { duplex?: "half" } = {
 			method: req.method,
 			headers,
+			// Tie the upstream fetch to the client connection. When the client goes
+			// away mid-stream (idle-watchdog abort, Ctrl-C, network drop) the
+			// upstream request must be aborted too, instead of streaming on
+			// unattended and holding the connection open.
+			signal: req.signal,
 		};
 		if (effectiveBodyBuffer) {
 			requestInit.body = new Uint8Array(effectiveBodyBuffer);
@@ -676,6 +700,8 @@ export async function proxyWithAccount(
 				method: transformedRequest.method,
 				headers: transformedRequest.headers,
 				body: JSON.stringify(transformedBodyJson),
+				// A URL-based rebuild drops the signal — carry it over.
+				signal: req.signal,
 			});
 			log.debug(
 				`Pre-stripped cache_control for known rejector: account=${account.name} model=${transformedModel}`,
@@ -688,7 +714,7 @@ export async function proxyWithAccount(
 		// Make the request (or unwrap a synthetic provider response)
 		let rawResponse = isSyntheticProviderResponse(transformedRequest)
 			? materializeSyntheticResponse(transformedRequest)
-			: await makeProxyRequest(transformedRequest);
+			: await forwardUpstream(transformedRequest);
 
 		// Check if this is a Claude provider and we got an invalid thinking signature error
 		const isClaudeProvider =
@@ -711,6 +737,7 @@ export async function proxyWithAccount(
 					headers,
 					body: new Uint8Array(filteredBodyBuffer),
 					duplex: "half",
+					signal: req.signal,
 				};
 
 				const retryProviderRequest = new Request(targetUrl, retryRequestInit);
@@ -722,7 +749,7 @@ export async function proxyWithAccount(
 				// Make the retry request (or unwrap a synthetic provider response)
 				rawResponse = isSyntheticProviderResponse(retryTransformedRequest)
 					? materializeSyntheticResponse(retryTransformedRequest)
-					: await makeProxyRequest(retryTransformedRequest);
+					: await forwardUpstream(retryTransformedRequest);
 			} else {
 				log.warn(
 					"Failed to filter thinking blocks or no changes made, proceeding with original error response",
@@ -751,10 +778,12 @@ export async function proxyWithAccount(
 					method: transformedRequest.method,
 					headers: transformedRequest.headers,
 					body: JSON.stringify(retryBodyJson),
+					// A URL-based rebuild drops the signal — carry it over.
+					signal: req.signal,
 				});
 				rawResponse = isSyntheticProviderResponse(retryRequest)
 					? materializeSyntheticResponse(retryRequest)
-					: await makeProxyRequest(retryRequest);
+					: await forwardUpstream(retryRequest);
 			} catch (err) {
 				log.warn("Failed to retry without cache_control:", err);
 			}
@@ -1033,6 +1062,7 @@ export async function proxyWithAccount(
 						headers,
 						body: new Uint8Array(patchedBody),
 						duplex: "half",
+						signal: req.signal,
 					};
 
 					const retryProviderRequest = new Request(targetUrl, retryRequestInit);
@@ -1060,6 +1090,8 @@ export async function proxyWithAccount(
 									method: retryTransformedRequest.method,
 									headers: repatchedHeaders,
 									body: JSON.stringify(transformedBody),
+									// A URL-based rebuild drops the signal — carry it over.
+									signal: req.signal,
 								},
 							);
 						}
@@ -1069,7 +1101,7 @@ export async function proxyWithAccount(
 
 					rawResponse = isSyntheticProviderResponse(retryTransformedRequest)
 						? materializeSyntheticResponse(retryTransformedRequest)
-						: await makeProxyRequest(retryTransformedRequest);
+						: await forwardUpstream(retryTransformedRequest);
 
 					if (!(await isModelUnavailableError(rawResponse.clone()))) {
 						break; // Success — stop cycling
@@ -1206,7 +1238,7 @@ export async function proxyWithAccount(
 							transformedRequestForRetry,
 						)
 							? materializeSyntheticResponse(transformedRequestForRetry.clone())
-							: await makeProxyRequest(transformedRequestForRetry.clone());
+							: await forwardUpstream(transformedRequestForRetry.clone());
 
 						const retryTaggedHeaders = new Headers(retryRaw.headers);
 						retryTaggedHeaders.set(

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -1374,6 +1374,20 @@ export async function proxyWithAccount(
 			{ ...ctx, provider },
 		);
 	} catch (err) {
+		// A client disconnect now aborts the upstream fetch by design. That is
+		// not an account failure: returning null would send the proxy through
+		// every remaining account and every fallback route for a request nobody
+		// is listening to, and report "all accounts failed" at the end.
+		// `req.signal` is the discriminator — the header-phase timeout aborts
+		// only the internal controller and never touches it, so genuine timeouts
+		// still fail over. 499 mirrors nginx's "Client Closed Request"; the
+		// socket is gone, so the status matters only for the log and the record.
+		if (req.signal.aborted) {
+			log.info(
+				`Client disconnected during request to ${account.name} — ending instead of failing over`,
+			);
+			return new Response(null, { status: 499 });
+		}
 		handleProxyError(err, account, log);
 		return null;
 	}

--- a/packages/proxy/src/handlers/request-handler.ts
+++ b/packages/proxy/src/handlers/request-handler.ts
@@ -93,19 +93,28 @@ export async function makeProxyRequest(
 	hasBody?: boolean,
 	signal?: AbortSignal,
 ): Promise<Response> {
-	let timeoutId: ReturnType<typeof setTimeout> | null = null;
-	let internalController: AbortController | null = null;
+	// The caller's abort source: either passed explicitly, or already carried by
+	// a Request target (Request derivation preserves the signal object). It must
+	// survive the header phase — a client that disconnects mid-stream is the
+	// primary reason this exists, and that happens long after the headers.
+	const callerSignal =
+		signal ?? (target instanceof Request ? target.signal : undefined);
 
-	const effectiveSignal =
-		signal ??
-		(() => {
-			internalController = new AbortController();
-			timeoutId = setTimeout(
-				() => internalController?.abort(),
-				TIME_CONSTANTS.PROXY_REQUEST_TIMEOUT_MS,
-			);
-			return internalController.signal;
-		})();
+	// The header-phase timeout is always armed, independent of the caller
+	// signal, and disarmed in `finally` once the headers are in.
+	const timeoutController = new AbortController();
+	const timeoutId: ReturnType<typeof setTimeout> | null = setTimeout(
+		() => timeoutController.abort(),
+		TIME_CONSTANTS.PROXY_REQUEST_TIMEOUT_MS,
+	);
+
+	// Both reasons must be able to abort the same fetch. Combining them keeps
+	// the caller signal live for the whole stream lifetime, whereas replacing
+	// one with the other silently drops a client disconnect (upstream leak) or
+	// the header timeout.
+	const effectiveSignal = callerSignal
+		? AbortSignal.any([callerSignal, timeoutController.signal])
+		: timeoutController.signal;
 
 	try {
 		if (target instanceof Request) {


### PR DESCRIPTION
**Root Cause:** `makeProxyRequest()` replaced any caller-supplied abort signal with its own timeout-only controller, and that controller becomes unreachable the moment `fetch()` resolves with the response headers — its timer is cleared in the `finally` block, and the controller itself leaves scope. From that point the upstream request has no abort path at all. Two things compounded it: no production caller ever passed a signal, and the `target instanceof Request` branch actively overwrote a signal the Request already carried (`new Request(target, { signal: effectiveSignal })`). Client connection and upstream fetch were therefore never linked.

Minimal trigger: start any streaming request through the proxy and drop the client — Ctrl-C, a closed terminal, or Claude Code's 300 s idle watchdog firing on a silent stream. The upstream keeps streaming into a reader nobody consumes. `reader.cancel()` does not close the socket in Bun (measured: only `abort()` does, in 8 ms), so every disconnect leaks one upstream connection for as long as the provider holds it open — and that connection keeps generating tokens against the account's quota for a response nobody will read.

**The Fix:** The caller signal — the explicit parameter, or the one a `Request` target already carries — is combined with the header-phase timeout through `AbortSignal.any`, so either reason can abort the same fetch and the client signal stays live for the whole stream lifetime. `proxyWithAccount` routes all five Request-based upstream calls through one `forwardUpstream` helper that passes the signal explicitly; the URL-based path in `proxyUnauthenticated` takes it as an argument.

Passing it explicitly rather than letting the Request carry it is deliberate: provider body transforms rebuild the Request from its URL and drop the signal (`utils/model-mapping.ts`, and the openai/codex providers do the same), and that rebuild is conditional — it only happens when a model mapping applies. One guarantee at the call site beats an invariant each of the eight providers has to remember. Both model transforms additionally preserve the signal across their rebuild as defence in depth.

Unchanged: the 30-minute `PROXY_REQUEST_TIMEOUT_MS` header timeout, and the behaviour of every request whose client stays connected.

**Out of scope:** The "Response stalled mid-stream" client abort that surfaced this defect is upstream behaviour (silence after `message_start`, no pings) and is not addressed here — it proved transient and non-reproducible. Separately found while investigating: `REQUEST_PAYLOAD_RETENTION_MS` (2 minutes) discards payloads of requests that are still active, which is why long-running requests have no stored body.

**Validation:**

Red proof — the three production files reverted to HEAD via `git show HEAD:<path>` (deliberately not `git stash`), then the new suites run:

```
(fail) arms the upstream fetch with a signal that follows the client request
        Expected: true    Received: false
(fail) keeps the wiring even when the provider transform rebuilds the Request
        Expected: true    Received: false
(fail) aborts the upstream when the signal is inherited from a Request target
        Expected: <= 5    Received: 9     ← 9 stream pulls after the abort
(fail) keeps the signal when transformRequestBodyModel rewrites the model
        Expected: true    Received: false
(fail) keeps the signal when transformRequestBodyModelForce rewrites the model
        Expected: true    Received: false
```

All five are real assertion failures, not missing-module errors. With the fix applied the same suites pass.

Green: **104 tests, 0 failures** across the 16 suites that import the changed modules. `bunx tsc --noEmit` exits 0, `bun run lint` and `bun run format` clean.

Runtime assumptions measured on both the local Bun (1.3.8) and the bundled production Bun (**1.3.11**), identical on both:

| Assumption | Measurement |
|---|---|
| `req.signal` fires on client disconnect | `ABORT_FIRED at 1496ms — AbortError: The connection was closed.` |
| `abort()` after headers stops the upstream | `pulls at abort=2 → after 1.5 s: 2`, server-side `cancel()` fires |
| `new Request(req, init)` inherits the signal, `init.signal` overrides | `INHERITS: true`, `explicit init.signal wins: true` |

Suites additionally re-run on Bun 1.3.11: **56 pass, 0 fail**.

**References:** branched from `053746c1`; commit `fd389fd2`. The new tests drive a real local upstream server, so the assertions measure socket behaviour rather than a mock's promise.
