### PR TITLE
hardening: gate agent workspace auto-discovery behind opt-in flag

### DIFF
--- a/packages/proxy/src/handlers/__tests__/agent-interceptor.security.test.ts
+++ b/packages/proxy/src/handlers/__tests__/agent-interceptor.security.test.ts
@@ -1,23 +1,35 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { existsSync, unlinkSync } from "node:fs";
+import { existsSync, mkdtempSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 /**
  * Security tests for agent-interceptor.ts
  * Tests the directory traversal protection in extractAgentDirectories()
+ *
+ * The extractor is now opt-in (gated by
+ * `BETTER_CCFLARE_AGENT_WORKSPACE_AUTODISCOVER=true`); the traversal tests
+ * below set the flag in `beforeAll` so the assertions actually exercise the
+ * extractor + path validator. A separate `describe` block verifies the gate.
  */
 
+// We need to import the function we want to test
+// Since extractAgentDirectories is not exported, we'll test via the public API
+import { agentRegistry, WorkspacePersistence } from "@better-ccflare/agents";
 import {
 	DatabaseFactory,
 	type DatabaseOperations,
 } from "@better-ccflare/database";
-// We need to import the function we want to test
-// Since extractAgentDirectories is not exported, we'll test via the public API
 import { interceptAndModifyRequest } from "../agent-interceptor";
 
 const TEST_DB_PATH = "/tmp/test-agent-interceptor-security.db";
+const AUTODISCOVER_ENV = "BETTER_CCFLARE_AGENT_WORKSPACE_AUTODISCOVER";
 
 describe("Agent Interceptor - Directory Traversal Security", () => {
 	let dbOps: DatabaseOperations;
+	let originalAutoDiscoverEnv: string | undefined;
+	let tmpWorkspacesDir: string;
+	let tmpWorkspacesFile: string;
 
 	// Helper function to create a mock request body with a system prompt
 	function createMockRequestBody(systemPrompt: string) {
@@ -55,6 +67,22 @@ describe("Agent Interceptor - Directory Traversal Security", () => {
 		}
 		DatabaseFactory.initialize(TEST_DB_PATH);
 		dbOps = DatabaseFactory.getInstance();
+
+		// Redirect the agent registry singleton at a tmp workspaces file so
+		// `registerWorkspace()` side effects from extraction never touch the
+		// real `~/.better-ccflare/workspaces.json`.
+		tmpWorkspacesDir = mkdtempSync(join(tmpdir(), "ccflare-sec-ws-"));
+		tmpWorkspacesFile = join(tmpWorkspacesDir, "workspaces.json");
+		agentRegistry.setWorkspacePersistenceForTests(
+			new WorkspacePersistence({ workspacesFile: tmpWorkspacesFile }),
+		);
+
+		// Enable workspace auto-discovery for this suite so the existing
+		// traversal assertions actually exercise the extractor + path
+		// validator. The default is OFF; the separate "gate" describe block
+		// below flips the flag explicitly per-test.
+		originalAutoDiscoverEnv = process.env[AUTODISCOVER_ENV];
+		process.env[AUTODISCOVER_ENV] = "true";
 	});
 
 	afterAll(() => {
@@ -67,6 +95,13 @@ describe("Agent Interceptor - Directory Traversal Security", () => {
 			console.warn("Failed to clean up test database:", error);
 		}
 		DatabaseFactory.reset();
+
+		// Restore env
+		if (originalAutoDiscoverEnv === undefined) {
+			delete process.env[AUTODISCOVER_ENV];
+		} else {
+			process.env[AUTODISCOVER_ENV] = originalAutoDiscoverEnv;
+		}
 	});
 
 	describe("Directory Traversal Protection - Pattern 1 (/.claude/agents paths)", () => {
@@ -319,6 +354,62 @@ Check /home/tom/git_repos/better-ccflare/.claude/agents for custom agents.
 					interceptAndModifyRequest(buffer, dbOps),
 				).resolves.toBeDefined();
 			}
+		});
+	});
+
+	describe(`BETTER_CCFLARE_AGENT_WORKSPACE_AUTODISCOVER gate`, () => {
+		// A path that passes the default allowlist (it is `process.cwd()`)
+		// and that exists on disk, so a successful extraction would call
+		// `agentRegistry.registerWorkspace()` and add it to the registry.
+		const existingWorkspace = process.cwd();
+
+		function workspacesCount(): number {
+			return agentRegistry.getWorkspaces().length;
+		}
+
+		test("does NOT extract agent directories when flag is unset", async () => {
+			// Force the default (off) state — independent of the outer
+			// beforeAll, which set the flag to exercise the other suites.
+			delete process.env[AUTODISCOVER_ENV];
+
+			const prompt = `Contents of ${existingWorkspace}/CLAUDE.md`;
+			const before = workspacesCount();
+
+			const result = await interceptAndModifyRequest(
+				toArrayBuffer(createMockRequestBody(prompt)),
+				dbOps,
+			);
+
+			expect(result).toBeDefined();
+			expect(result.agentUsed).toBeNull();
+			// The gate prevented extraction entirely, so no new workspace
+			// should have been registered.
+			expect(workspacesCount()).toBe(before);
+		});
+
+		test("DOES extract agent directories when flag is set", async () => {
+			process.env[AUTODISCOVER_ENV] = "true";
+
+			const prompt = `Contents of ${existingWorkspace}/CLAUDE.md`;
+			const before = workspacesCount();
+
+			const result = await interceptAndModifyRequest(
+				toArrayBuffer(createMockRequestBody(prompt)),
+				dbOps,
+			);
+
+			expect(result).toBeDefined();
+			// With the flag on, the extractor runs and the resulting
+			// workspace (cwd) is registered.
+			expect(workspacesCount()).toBeGreaterThan(before);
+			expect(
+				agentRegistry
+					.getWorkspaces()
+					.some((w: { path: string }) => w.path === existingWorkspace),
+			).toBe(true);
+
+			// Restore the off state for any later tests that depend on it.
+			delete process.env[AUTODISCOVER_ENV];
 		});
 	});
 });

--- a/packages/proxy/src/handlers/agent-interceptor.ts
+++ b/packages/proxy/src/handlers/agent-interceptor.ts
@@ -179,7 +179,19 @@ export async function interceptAndModifyRequest(
 			log.debug(`Total CLAUDE.md occurrences: ${matches ? matches.length : 0}`);
 		}
 
-		const extraDirs = extractAgentDirectories(systemPrompt);
+		// Workspace auto-discovery is opt-in. In containerized/server deploys the
+		// client's CLAUDE.md paths can never satisfy the local allowlist, so every
+		// request emits WARN noise from both the extractor and the path
+		// validator, and a `registerWorkspace()` side effect (writes workspaces.json
+		// and triggers a full agent-cache refresh). Off by default — the persisted
+		// workspace list still loads via AgentRegistry.initialize() so already-
+		// registered workspaces continue to work; this only stops NEW workspaces
+		// from being auto-registered from request bodies. Mirrors the pattern
+		// used by `BETTER_CCFLARE_DISCOVER_PLUGIN_AGENTS` in packages/agents.
+		const extraDirs =
+			process.env.BETTER_CCFLARE_AGENT_WORKSPACE_AUTODISCOVER === "true"
+				? extractAgentDirectories(systemPrompt)
+				: [];
 		log.debug(
 			`Validated ${extraDirs.length} agent directories from system prompt`,
 		);


### PR DESCRIPTION
## Summary

Gates the agent workspace auto-discovery in `interceptAndModifyRequest` behind `BETTER_CCFLARE_AGENT_WORKSPACE_AUTODISCOVER=true` (off by default). Mirrors the existing `BETTER_CCFLARE_DISCOVER_PLUGIN_AGENTS` precedent in `packages/agents`.

## Why

`extractAgentDirectories(systemPrompt)` runs on every request, regex-hunts filesystem roots out of the client's `CLAUDE.md` headers, and forwards each existing one to `agentRegistry.registerWorkspace()` — which writes `workspaces.json` and triggers a full agent-cache refresh.

In any containerized/server deploy the client paths can never satisfy the local allowlist, so every request emits `WARN` noise from both the extractor and the path validator (`attack_type: "whitelist_bypass"`), and burns a hot-path `existsSync` syscall whose result is always `false`.

## Behavior change

The extractor at `agent-interceptor.ts:182` is now opt-in. With the flag unset, no extraction runs at all; the for-loop over `extraDirs` gets `[]` and is a no-op.

**Important: this is not "workspaces stop working".** Already-persisted workspaces still load via `AgentRegistry.initialize()` (`packages/agents/src/discovery.ts:90-99`). The only regression is: **no new workspace auto-registers from request bodies.** To get the previous behavior, set `BETTER_CCFLARE_AGENT_WORKSPACE_AUTODISCOVER=true`.

This also means `:195` (`agentRegistry.registerWorkspace(workspacePath)`) is the **only** production caller of `registerWorkspace` (every other call site in the codebase is in a test file). With the flag off, that line is dead code. The agent cache is unaffected — it's repopulated from the persisted workspaces file.

## Security test is no longer vacuous

`packages/proxy/src/handlers/__tests__/agent-interceptor.security.test.ts` asserted outcome-based invariants (`agentUsed === null`, `modifiedBody === buffer`) that pass identically when the extractor is never invoked. The suite now sets the flag in `beforeAll` so the traversal assertions actually exercise `extractAgentDirectories` + `validatePath`, plus a new `describe` block verifies the gate in both directions.

## Reachable hardening case (the reason this isn't cosmetic)

A hostile system prompt containing:

```
Contents of /app/packages/proxy/CLAUDE.md
```

constructs `/app/packages/proxy/.claude/agents`, which **passes** the path validator because `/app` (the cwd) is in the default allowlist. The for-loop then strips `.claude/agents` → `/app/packages/proxy`, `existsSync` returns true (the directory exists in the deployed image), and `registerWorkspace` writes `workspaces.json` and triggers a full agent-cache refresh that re-`readdir`s every registered workspace.

The ccflare image is built from a public repo, so directory names are enumerable. Low severity (no RCE, no exfil, just a hot-path cache refresh and a JSON write), non-zero — and it disappears entirely with the flag off.

## Acceptance

```
$ bun run typecheck
apps/server/src/server.ts(105,32): error TS2307: ...
apps/server/src/server.ts(112,4):   error TS2307: ...
```

Pre-existing errors in `apps/server/src/server.ts` about `@better-ccflare/dashboard-web/dist/*` (build artifacts not generated in this worktree). My changes introduce zero new typecheck errors.

```
$ bunx @biomejs/biome check \
    packages/proxy/src/handlers/agent-interceptor.ts \
    packages/proxy/src/handlers/__tests__/agent-interceptor.security.test.ts
Checked 2 files in 15ms. No fixes applied.
```

Clean.

```
$ bun test packages/proxy/src/handlers/__tests__/
 300 pass
   0 fail
   4 errors
 858 expect() calls
Ran 300 tests across 22 files.
```

Baseline (pre-change) was 297 pass / 1 fail (pre-existing flaky `rate-limit-cooldown-reentry` timeout) / 4 errors (pre-existing `SQLiteError: disk I/O error` in `DatabaseFactory.reset()` `afterAll`). My change adds 2 passing tests, breaks nothing, and the 4 errors are unchanged.

## Negative control

Reverted only the `:182` gate (kept every other line intact), ran the new gate tests, observed they go red, restored the gate, re-ran, observed green.

```
$ bun test packages/proxy/src/handlers/__tests__/agent-interceptor.security.test.ts \
    -t "BETTER_CCFLARE_AGENT_WORKSPACE_AUTODISCOVER gate"
# gate REVERTED
  0 pass
 20 filtered out
  2 fail
  1 error
  5 expect() calls
Ran 2 tests across 1 file. [335.00ms]

# gate RESTORED
  2 pass
 20 filtered out
  0 fail
  1 error
  6 expect() calls
Ran 2 tests across 1 file. [714.00ms]
```

(The "1 error" both times is the pre-existing `SQLiteError` in the shared `afterAll`, unrelated to these tests.)

## Diff

```
 packages/proxy/src/handlers/__tests__/agent-interceptor.security.test.ts | 97 +++++++++++++++++++++-
 packages/proxy/src/handlers/agent-interceptor.ts                       | 14 +++-
 2 files changed, 107 insertions(+), 4 deletions(-)
```