### PR TITLE
fix: stop reporting a missing payload as a missing request

### DIFF
--- a/packages/http-api/src/handlers/__tests__/requests-payload.test.ts
+++ b/packages/http-api/src/handlers/__tests__/requests-payload.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+import { createRequestPayloadHandler } from "../requests";
+
+/**
+ * A stored payload is optional by design: capture can be switched off, and the
+ * usage collector releases payloads of requests that are still active after
+ * REQUEST_PAYLOAD_RETENTION_MS to bound memory. The endpoint must therefore not
+ * report a missing payload as a missing request — that reading cost real
+ * debugging time when a 340 s request came back as "Request not found".
+ */
+
+function dbWithPayload(payload: unknown) {
+	return { getRequestPayload: async () => payload } as never;
+}
+
+describe("createRequestPayloadHandler", () => {
+	it("returns the payload when one is stored", async () => {
+		const handler = createRequestPayloadHandler(
+			dbWithPayload({ requestBody: "e30=" }),
+		);
+
+		const response = await handler("req-1");
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ requestBody: "e30=" });
+	});
+
+	it("does not claim the request is missing when only the payload is absent", async () => {
+		const handler = createRequestPayloadHandler(dbWithPayload(null));
+
+		const response = await handler("req-2");
+		const body = (await response.json()) as {
+			error: string;
+			detail?: string;
+		};
+
+		expect(response.status).toBe(404);
+		// The old wording asserted something the endpoint cannot know.
+		expect(body.error).not.toBe("Request not found");
+		expect(body.error.toLowerCase()).toContain("payload");
+		// And it explains why a payload can legitimately be absent.
+		expect(body.detail).toBeDefined();
+	});
+
+	it("answers with JSON content type in the absent case", async () => {
+		const handler = createRequestPayloadHandler(dbWithPayload(null));
+
+		const response = await handler("req-3");
+
+		expect(response.headers.get("Content-Type")).toBe("application/json");
+	});
+});

--- a/packages/http-api/src/handlers/requests.ts
+++ b/packages/http-api/src/handlers/requests.ts
@@ -204,10 +204,23 @@ export function createRequestPayloadHandler(dbOps: DatabaseOperations) {
 		const payload = await dbOps.getRequestPayload(requestId);
 
 		if (!payload) {
-			return new Response(JSON.stringify({ error: "Request not found" }), {
-				status: 404,
-				headers: { "Content-Type": "application/json" },
-			});
+			// A missing payload does not mean the request is unknown. Capture is
+			// optional, and payloads of requests still active after
+			// REQUEST_PAYLOAD_RETENTION_MS are deliberately released to bound
+			// memory — so long-running requests routinely have none while their
+			// row exists. "Request not found" sends people hunting for a request
+			// that is right there.
+			return new Response(
+				JSON.stringify({
+					error: "No payload stored for this request",
+					detail:
+						"The request itself may exist. Payload capture can be disabled, and payloads of long-running requests are released while the request is still active to bound memory.",
+				}),
+				{
+					status: 404,
+					headers: { "Content-Type": "application/json" },
+				},
+			);
 		}
 
 		return jsonResponse(payload);


### PR DESCRIPTION
**Cause:** `/api/requests/payload/:id` answers `404 {"error":"Request not found"}` whenever `getRequestPayload()` returns nothing — but the handler never checks whether the request exists, only whether a payload was stored. A payload is absent for ordinary reasons: capture can be disabled, and the usage collector deliberately releases payloads of requests that are still active after `REQUEST_PAYLOAD_RETENTION_MS` (2 min) to bound memory (`usage-collector.ts`, intentional since `3a524cbd`, pinned by a test). Long-running requests therefore routinely have a row but no body.

**Impact:** The message now says no payload is stored and explains why one can legitimately be missing; status stays 404 and the JSON shape is unchanged, with an added `detail` field. No consumer matched on the old string (checked repo-wide; the dashboard catches the failure generically), so nothing downstream changes.

This came out of a stream-stall investigation where a 340-second request reported "Request not found" while its row was in the table the whole time — the wording cost real debugging time. Retention behaviour itself is deliberate and is **not** touched here.

**Validation:** new test file, 3 cases. On `main` the case `does not claim the request is missing when only the payload is absent` fails with `Expected: not "Request not found"`; with the fix all three pass. `tsc --noEmit`, lint and format clean.
