### PR TITLE
feat: expose stream_terminal_state through /api/requests

### DIFF
--- a/packages/http-api/src/handlers/__tests__/requests-cold-import.test.ts
+++ b/packages/http-api/src/handlers/__tests__/requests-cold-import.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Guards the requests handler against the documented `types↔core` runtime
+ * cycle.
+ *
+ * `packages/types/src/agent.ts` imports core at runtime, while
+ * `packages/core/src/strategy.ts` imports types and evaluates
+ * `Object.values(StrategyName)` at module scope. Evaluating the types barrel
+ * FIRST therefore throws. In the normal server the router pulls core and
+ * database in earlier, which hides the problem — so the handler's own imports
+ * have to stay cycle-safe on their own.
+ *
+ * The handler needs runtime (not type-only) imports for the column-narrowing
+ * helpers, and takes them from the cycle-free `@better-ccflare/types/request`
+ * subpath.
+ *
+ * Scope of what these tests actually prove, measured rather than assumed: the
+ * first case passes with the barrel import too, because `jsonResponse` from
+ * `@better-ccflare/http-common` is imported one line earlier and pulls core in
+ * first. So the handler is currently safe by accident of import ORDER, not by
+ * design — the subpath is what makes it safe regardless of which import sits
+ * above it. These tests pin the outcome (the module loads cold), not the
+ * mechanism; they would catch a regression where that accidental protection
+ * disappears.
+ *
+ * Each import runs in its own process because module evaluation is cached per
+ * process — an in-process check would pass simply because some earlier test
+ * already loaded core.
+ */
+import { describe, expect, it } from "bun:test";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..", "..", "..", "..");
+
+async function coldImport(
+	specifier: string,
+): Promise<{ exitCode: number; stderr: string }> {
+	const proc = Bun.spawn(
+		["bun", "-e", `await import(${JSON.stringify(specifier)});`],
+		{ cwd: REPO_ROOT, stdout: "pipe", stderr: "pipe" },
+	);
+	const [exitCode, stderr] = await Promise.all([
+		proc.exited,
+		new Response(proc.stderr).text(),
+	]);
+	return { exitCode, stderr };
+}
+
+describe("requests handler — cold import", () => {
+	it("loads as the first module in a fresh process", async () => {
+		const { exitCode, stderr } = await coldImport(
+			"./packages/http-api/src/handlers/requests.ts",
+		);
+		expect(stderr).not.toContain("StrategyName");
+		expect(exitCode).toBe(0);
+	});
+
+	it("resolves the narrowing helpers without evaluating the types barrel", async () => {
+		const { exitCode, stderr } = await coldImport(
+			"@better-ccflare/types/request",
+		);
+		expect(stderr).not.toContain("StrategyName");
+		expect(exitCode).toBe(0);
+	});
+});

--- a/packages/http-api/src/handlers/__tests__/requests-cold-import.test.ts
+++ b/packages/http-api/src/handlers/__tests__/requests-cold-import.test.ts
@@ -1,63 +1,80 @@
 /**
- * Guards the requests handler against the documented `types↔core` runtime
+ * Keeps the requests handler clear of the documented `types↔core` runtime
  * cycle.
  *
  * `packages/types/src/agent.ts` imports core at runtime, while
  * `packages/core/src/strategy.ts` imports types and evaluates
  * `Object.values(StrategyName)` at module scope. Evaluating the types barrel
- * FIRST therefore throws. In the normal server the router pulls core and
- * database in earlier, which hides the problem — so the handler's own imports
- * have to stay cycle-safe on their own.
+ * FIRST therefore throws — `query-filters.test.ts` documents the same thing and
+ * works around it with a side-effect import.
  *
  * The handler needs runtime (not type-only) imports for the column-narrowing
- * helpers, and takes them from the cycle-free `@better-ccflare/types/request`
+ * helpers and takes them from the cycle-free `@better-ccflare/types/request`
  * subpath.
  *
- * Scope of what these tests actually prove, measured rather than assumed: the
- * first case passes with the barrel import too, because `jsonResponse` from
- * `@better-ccflare/http-common` is imported one line earlier and pulls core in
- * first. So the handler is currently safe by accident of import ORDER, not by
- * design — the subpath is what makes it safe regardless of which import sits
- * above it. These tests pin the outcome (the module loads cold), not the
- * mechanism; they would catch a regression where that accidental protection
- * disappears.
- *
- * Each import runs in its own process because module evaluation is cached per
- * process — an in-process check would pass simply because some earlier test
- * already loaded core.
+ * Why the first test is a SOURCE check and not just a cold import: measured,
+ * the handler loads fine with the barrel import too, because `jsonResponse`
+ * from `@better-ccflare/http-common` sits one line above and pulls core in
+ * first. A cold import alone therefore passes either way and would guard
+ * nothing — it only proves the module loads today, by accident of import
+ * ORDER. Asserting the import specifier is what actually catches a revert; the
+ * cold import is kept as the outcome check for the case where that accidental
+ * protection disappears.
  */
 import { describe, expect, it } from "bun:test";
 import { join } from "node:path";
 
 const REPO_ROOT = join(import.meta.dir, "..", "..", "..", "..", "..");
+const HANDLER_SOURCE = join(import.meta.dir, "..", "requests.ts");
+const COLD_IMPORT_TIMEOUT_MS = 30_000;
 
-async function coldImport(
-	specifier: string,
-): Promise<{ exitCode: number; stderr: string }> {
+async function coldImport(specifier: string): Promise<{
+	exitCode: number | null;
+	stderr: string;
+	timedOut: boolean;
+}> {
 	const proc = Bun.spawn(
 		["bun", "-e", `await import(${JSON.stringify(specifier)});`],
-		{ cwd: REPO_ROOT, stdout: "pipe", stderr: "pipe" },
+		{ cwd: REPO_ROOT, stdout: "ignore", stderr: "pipe" },
 	);
-	const [exitCode, stderr] = await Promise.all([
-		proc.exited,
-		new Response(proc.stderr).text(),
-	]);
-	return { exitCode, stderr };
+	const timer = setTimeout(() => proc.kill(), COLD_IMPORT_TIMEOUT_MS);
+	try {
+		const [exitCode, stderr] = await Promise.all([
+			proc.exited,
+			new Response(proc.stderr).text(),
+		]);
+		return { exitCode, stderr, timedOut: proc.killed && exitCode !== 0 };
+	} finally {
+		clearTimeout(timer);
+	}
 }
 
-describe("requests handler — cold import", () => {
+describe("requests handler — cycle-free imports", () => {
+	it("takes the narrowing helpers from the subpath, never the package barrel", async () => {
+		const source = await Bun.file(HANDLER_SOURCE).text();
+
+		expect(source).toContain('from "@better-ccflare/types/request"');
+		// A bare `from "@better-ccflare/types"` (barrel) would reintroduce the
+		// dependency on some earlier import happening to load core first.
+		expect(source).not.toMatch(/from ["']@better-ccflare\/types["']/);
+	});
+
 	it("loads as the first module in a fresh process", async () => {
-		const { exitCode, stderr } = await coldImport(
+		const { exitCode, stderr, timedOut } = await coldImport(
 			"./packages/http-api/src/handlers/requests.ts",
 		);
+
+		expect(timedOut).toBe(false);
 		expect(stderr).not.toContain("StrategyName");
 		expect(exitCode).toBe(0);
 	});
 
-	it("resolves the narrowing helpers without evaluating the types barrel", async () => {
-		const { exitCode, stderr } = await coldImport(
+	it("resolves the subpath without evaluating the types barrel", async () => {
+		const { exitCode, stderr, timedOut } = await coldImport(
 			"@better-ccflare/types/request",
 		);
+
+		expect(timedOut).toBe(false);
 		expect(stderr).not.toContain("StrategyName");
 		expect(exitCode).toBe(0);
 	});

--- a/packages/http-api/src/handlers/__tests__/requests-stream-terminal-state.test.ts
+++ b/packages/http-api/src/handlers/__tests__/requests-stream-terminal-state.test.ts
@@ -116,6 +116,27 @@ describe("createRequestsSummaryHandler — stream terminal state mapping", () =>
 		expect(row?.streamTerminalState).toBeUndefined();
 	});
 
+	it("drops a value the current build does not know instead of forwarding it", async () => {
+		// The column is TEXT and nothing constrains it: a row written by a newer
+		// producer build (or by hand) can hold a state outside the union. It must
+		// not reach consumers that treat StreamTerminalState as exhaustive.
+		// Own row, so this mutation cannot influence the other assertions
+		// regardless of test execution order.
+		await saveWithTerminalState(dbOps, "req-unknown-state", "truncated");
+		await dbOps
+			.getAdapter()
+			.query(`UPDATE requests SET stream_terminal_state = ? WHERE id = ?`, [
+				"some_future_state",
+				"req-unknown-state",
+			]);
+
+		const body = await fetchRows();
+		const row = body.find((r) => r.id === "req-unknown-state");
+
+		expect(row).toBeDefined();
+		expect(row?.streamTerminalState).toBeUndefined();
+	});
+
 	it("keeps a cancelled stream distinguishable from a clean 200", async () => {
 		// The whole point of the column: statusCode alone cannot tell these
 		// apart, which is exactly why the stalls of 2026-07-30 read as healthy.

--- a/packages/http-api/src/handlers/__tests__/requests-stream-terminal-state.test.ts
+++ b/packages/http-api/src/handlers/__tests__/requests-stream-terminal-state.test.ts
@@ -116,16 +116,18 @@ describe("createRequestsSummaryHandler — stream terminal state mapping", () =>
 		expect(row?.streamTerminalState).toBeUndefined();
 	});
 
-	it("drops a value the current build does not know instead of forwarding it", async () => {
+	it('reports a state the build does not know as "unknown", not as absent', async () => {
 		// The column is TEXT and nothing constrains it: a row written by a newer
 		// producer build (or by hand) can hold a state outside the union. It must
-		// not reach consumers that treat StreamTerminalState as exhaustive.
+		// not reach consumers that treat the union as exhaustive — but it must
+		// also not collapse into the same `undefined` a non-streaming request
+		// produces, or a NEW failure state would read as a clean 200.
 		// Own row, so this mutation cannot influence the other assertions
 		// regardless of test execution order.
 		await saveWithTerminalState(dbOps, "req-unknown-state", "truncated");
 		await dbOps
 			.getAdapter()
-			.query(`UPDATE requests SET stream_terminal_state = ? WHERE id = ?`, [
+			.run(`UPDATE requests SET stream_terminal_state = ? WHERE id = ?`, [
 				"some_future_state",
 				"req-unknown-state",
 			]);
@@ -134,7 +136,31 @@ describe("createRequestsSummaryHandler — stream terminal state mapping", () =>
 		const row = body.find((r) => r.id === "req-unknown-state");
 
 		expect(row).toBeDefined();
-		expect(row?.streamTerminalState).toBeUndefined();
+		expect(row?.streamTerminalState).toBe("unknown");
+		// …and still distinguishable from a request that recorded nothing.
+		expect(
+			body.find((r) => r.id === "req-no-state")?.streamTerminalState,
+		).toBeUndefined();
+	});
+
+	it("narrows the sibling attribution columns the same way", async () => {
+		// The neighbouring provenance columns are unconstrained TEXT too; leaving
+		// them on a bare cast while hardening only this field would be an
+		// asymmetry a reader cannot explain.
+		await saveWithTerminalState(dbOps, "req-bad-attribution", "complete");
+		await dbOps
+			.getAdapter()
+			.run(
+				`UPDATE requests SET project_attribution_source = ?, agent_attribution_source = ? WHERE id = ?`,
+				["not_a_source", "also_not_a_source", "req-bad-attribution"],
+			);
+
+		const body = await fetchRows();
+		const row = body.find((r) => r.id === "req-bad-attribution");
+
+		expect(row).toBeDefined();
+		expect(row?.projectAttributionSource).toBeUndefined();
+		expect(row?.agentAttributionSource).toBeUndefined();
 	});
 
 	it("keeps a cancelled stream distinguishable from a clean 200", async () => {

--- a/packages/http-api/src/handlers/__tests__/requests-stream-terminal-state.test.ts
+++ b/packages/http-api/src/handlers/__tests__/requests-stream-terminal-state.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for createRequestsSummaryHandler's stream_terminal_state mapping.
+ *
+ * The column records the REAL outcome of an Anthropic-Messages-shaped SSE
+ * stream (see packages/proxy/src/anthropic-terminal-recovery.ts). It was
+ * written and preserved by the repository but no HTTP route read it back, so
+ * an operator could not tell a client-cancelled or truncated stream from a
+ * clean one — every such request still shows statusCode 200. These tests pin
+ * the read path onto RequestResponse.streamTerminalState.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { existsSync, unlinkSync } from "node:fs";
+import type { DatabaseOperations } from "@better-ccflare/database";
+import { DatabaseFactory } from "@better-ccflare/database";
+import type { RequestResponse } from "@better-ccflare/types";
+import { createRequestsSummaryHandler } from "../requests";
+
+const TEST_DB_PATH = "/tmp/test-requests-stream-terminal-state.db";
+
+async function saveWithTerminalState(
+	dbOps: DatabaseOperations,
+	id: string,
+	streamTerminalState:
+		| "complete"
+		| "recovered"
+		| "error"
+		| "truncated"
+		| "client_cancelled"
+		| null,
+): Promise<void> {
+	await dbOps.saveRequest(
+		id,
+		"POST",
+		"/v1/messages",
+		null, // accountUsed
+		200, // statusCode
+		true, // success
+		null, // errorMessage
+		100, // responseTime
+		0, // failoverAttempts
+		undefined, // usage
+		undefined, // agentUsed
+		undefined, // apiKeyId
+		undefined, // apiKeyName
+		undefined, // project
+		undefined, // billingType
+		undefined, // comboName
+		undefined, // originalModel
+		undefined, // appliedModel
+		undefined, // projectAttributionSource
+		undefined, // agentAttributionSource
+		streamTerminalState,
+	);
+}
+
+describe("createRequestsSummaryHandler — stream terminal state mapping", () => {
+	let dbOps: DatabaseOperations;
+	let handler: (limit?: number) => Promise<Response>;
+
+	beforeAll(async () => {
+		try {
+			if (existsSync(TEST_DB_PATH)) {
+				unlinkSync(TEST_DB_PATH);
+			}
+		} catch (error) {
+			console.warn("Failed to clean up existing test database:", error);
+		}
+
+		DatabaseFactory.initialize(TEST_DB_PATH);
+		dbOps = DatabaseFactory.getInstance();
+
+		handler = createRequestsSummaryHandler(dbOps.getAdapter());
+
+		await saveWithTerminalState(dbOps, "req-cancelled", "client_cancelled");
+		await saveWithTerminalState(dbOps, "req-truncated", "truncated");
+		await saveWithTerminalState(dbOps, "req-recovered", "recovered");
+		await saveWithTerminalState(dbOps, "req-no-state", null);
+	});
+
+	afterAll(() => {
+		try {
+			if (existsSync(TEST_DB_PATH)) {
+				unlinkSync(TEST_DB_PATH);
+			}
+		} catch (error) {
+			console.warn("Failed to clean up test database:", error);
+		}
+		DatabaseFactory.reset();
+	});
+
+	async function fetchRows(): Promise<RequestResponse[]> {
+		const response = await handler(50);
+		expect(response.status).toBe(200);
+		return (await response.json()) as RequestResponse[];
+	}
+
+	it("maps stream_terminal_state onto the response", async () => {
+		const body = await fetchRows();
+
+		expect(
+			body.find((r) => r.id === "req-cancelled")?.streamTerminalState,
+		).toBe("client_cancelled");
+		expect(
+			body.find((r) => r.id === "req-truncated")?.streamTerminalState,
+		).toBe("truncated");
+		expect(
+			body.find((r) => r.id === "req-recovered")?.streamTerminalState,
+		).toBe("recovered");
+	});
+
+	it("omits the field when no terminal state was recorded", async () => {
+		const body = await fetchRows();
+		const row = body.find((r) => r.id === "req-no-state");
+
+		expect(row).toBeDefined();
+		expect(row?.streamTerminalState).toBeUndefined();
+	});
+
+	it("keeps a cancelled stream distinguishable from a clean 200", async () => {
+		// The whole point of the column: statusCode alone cannot tell these
+		// apart, which is exactly why the stalls of 2026-07-30 read as healthy.
+		const body = await fetchRows();
+		const cancelled = body.find((r) => r.id === "req-cancelled");
+		const clean = body.find((r) => r.id === "req-no-state");
+
+		expect(cancelled?.statusCode).toBe(clean?.statusCode);
+		expect(cancelled?.streamTerminalState).not.toBe(clean?.streamTerminalState);
+	});
+});

--- a/packages/http-api/src/handlers/requests.ts
+++ b/packages/http-api/src/handlers/requests.ts
@@ -3,10 +3,10 @@ import type {
 	DatabaseOperations,
 } from "@better-ccflare/database";
 import { jsonResponse } from "@better-ccflare/http-common";
-import type {
-	AgentAttributionSource,
-	ProjectAttributionSource,
-	StreamTerminalState,
+import {
+	type AgentAttributionSource,
+	type ProjectAttributionSource,
+	toStreamTerminalState,
 } from "@better-ccflare/types";
 import type { RequestResponse } from "../types";
 
@@ -122,9 +122,10 @@ export function createRequestsSummaryHandler(db: BunSqlAdapter) {
 				undefined,
 			// The real SSE outcome. A truncated or client-cancelled stream still
 			// carries statusCode 200, so this is the only field that tells an
-			// operator the response never actually completed.
-			streamTerminalState:
-				(request.stream_terminal_state as StreamTerminalState) || undefined,
+			// operator the response never actually completed. Narrowed rather
+			// than cast: the column is TEXT and may hold a state this build does
+			// not know.
+			streamTerminalState: toStreamTerminalState(request.stream_terminal_state),
 			rateLimited: request.status_code === 429,
 		}));
 

--- a/packages/http-api/src/handlers/requests.ts
+++ b/packages/http-api/src/handlers/requests.ts
@@ -6,6 +6,7 @@ import { jsonResponse } from "@better-ccflare/http-common";
 import type {
 	AgentAttributionSource,
 	ProjectAttributionSource,
+	StreamTerminalState,
 } from "@better-ccflare/types";
 import type { RequestResponse } from "../types";
 
@@ -71,6 +72,7 @@ export function createRequestsSummaryHandler(db: BunSqlAdapter) {
 			project: string | null;
 			project_attribution_source: string | null;
 			agent_attribution_source: string | null;
+			stream_terminal_state: string | null;
 		}>(
 			`
 			SELECT r.*, a.name as account_name
@@ -118,6 +120,11 @@ export function createRequestsSummaryHandler(db: BunSqlAdapter) {
 			agentAttributionSource:
 				(request.agent_attribution_source as AgentAttributionSource) ||
 				undefined,
+			// The real SSE outcome. A truncated or client-cancelled stream still
+			// carries statusCode 200, so this is the only field that tells an
+			// operator the response never actually completed.
+			streamTerminalState:
+				(request.stream_terminal_state as StreamTerminalState) || undefined,
 			rateLimited: request.status_code === 429,
 		}));
 

--- a/packages/http-api/src/handlers/requests.ts
+++ b/packages/http-api/src/handlers/requests.ts
@@ -3,11 +3,14 @@ import type {
 	DatabaseOperations,
 } from "@better-ccflare/database";
 import { jsonResponse } from "@better-ccflare/http-common";
+// Subpath, not the package barrel: these are RUNTIME imports, and evaluating
+// the barrel first trips the documented types↔core cycle (see the header of
+// packages/types/src/request.ts). `types/request` imports nothing.
 import {
-	type AgentAttributionSource,
-	type ProjectAttributionSource,
+	toAgentAttributionSource,
+	toProjectAttributionSource,
 	toStreamTerminalState,
-} from "@better-ccflare/types";
+} from "@better-ccflare/types/request";
 import type { RequestResponse } from "../types";
 
 const MAX_BODY_PREVIEW_BYTES = 256 * 1024; // 256KB - match response body cap to preserve full conversation history
@@ -114,17 +117,20 @@ export function createRequestsSummaryHandler(db: BunSqlAdapter) {
 			originalModel: request.original_model || undefined,
 			appliedModel: request.applied_model || undefined,
 			project: request.project || undefined,
-			projectAttributionSource:
-				(request.project_attribution_source as ProjectAttributionSource) ||
-				undefined,
-			agentAttributionSource:
-				(request.agent_attribution_source as AgentAttributionSource) ||
-				undefined,
+			// All three provenance columns are unconstrained TEXT, so each is
+			// narrowed rather than cast — a value the database happens to hold
+			// must not reach consumers under a type claiming it cannot exist.
+			projectAttributionSource: toProjectAttributionSource(
+				request.project_attribution_source,
+			),
+			agentAttributionSource: toAgentAttributionSource(
+				request.agent_attribution_source,
+			),
 			// The real SSE outcome. A truncated or client-cancelled stream still
 			// carries statusCode 200, so this is the only field that tells an
-			// operator the response never actually completed. Narrowed rather
-			// than cast: the column is TEXT and may hold a state this build does
-			// not know.
+			// operator the response never actually completed — which is why an
+			// unrecognized value surfaces as "unknown" here instead of vanishing
+			// into the same `undefined` a non-streaming request produces.
 			streamTerminalState: toStreamTerminalState(request.stream_terminal_state),
 			rateLimited: request.status_code === 429,
 		}));

--- a/packages/proxy/src/__tests__/stream-terminal-state-union-parity.test.ts
+++ b/packages/proxy/src/__tests__/stream-terminal-state-union-parity.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Pins the API-side `StreamTerminalState` union (@better-ccflare/types) to the
+ * producer-side `AnthropicTerminalState` (../anthropic-terminal-recovery).
+ *
+ * The two cannot share one declaration: types is the base package, so it must
+ * not depend on proxy. That leaves the set of states duplicated, and a state
+ * added on one side only would silently produce values the other side claims
+ * cannot exist.
+ *
+ * The two `Record` types below close that gap at COMPILE time — a key added to
+ * either union makes the corresponding object literal incomplete and
+ * `bun run typecheck` fails. The runtime assertions additionally pin the
+ * exported `STREAM_TERMINAL_STATES` array to the same set, so the array cannot
+ * drift away from the type it derives from.
+ */
+import { describe, expect, it } from "bun:test";
+import type { StreamTerminalState } from "@better-ccflare/types";
+import { STREAM_TERMINAL_STATES } from "@better-ccflare/types";
+import type { AnthropicTerminalState } from "../anthropic-terminal-recovery";
+
+// Every producer state must exist as an API state …
+const PRODUCER_TO_API: Record<AnthropicTerminalState, StreamTerminalState> = {
+	complete: "complete",
+	recovered: "recovered",
+	error: "error",
+	truncated: "truncated",
+	client_cancelled: "client_cancelled",
+};
+
+// … and every API state must exist as a producer state.
+const API_TO_PRODUCER: Record<StreamTerminalState, AnthropicTerminalState> = {
+	complete: "complete",
+	recovered: "recovered",
+	error: "error",
+	truncated: "truncated",
+	client_cancelled: "client_cancelled",
+};
+
+describe("stream terminal state — union parity with the producer", () => {
+	it("covers exactly the same set on both sides", () => {
+		expect(Object.keys(PRODUCER_TO_API).sort()).toEqual(
+			Object.keys(API_TO_PRODUCER).sort(),
+		);
+	});
+
+	it("keeps STREAM_TERMINAL_STATES in sync with the union", () => {
+		expect([...STREAM_TERMINAL_STATES].sort()).toEqual(
+			Object.keys(PRODUCER_TO_API).sort() as StreamTerminalState[],
+		);
+	});
+
+	it("maps each state to itself (no silent renaming across the boundary)", () => {
+		for (const state of STREAM_TERMINAL_STATES) {
+			expect(PRODUCER_TO_API[state]).toBe(state);
+			expect(API_TO_PRODUCER[state]).toBe(state);
+		}
+	});
+});

--- a/packages/proxy/src/__tests__/stream-terminal-state-union-parity.test.ts
+++ b/packages/proxy/src/__tests__/stream-terminal-state-union-parity.test.ts
@@ -1,58 +1,44 @@
 /**
- * Pins the API-side `StreamTerminalState` union (@better-ccflare/types) to the
- * producer-side `AnthropicTerminalState` (../anthropic-terminal-recovery).
+ * Pins the API-side state set (`@better-ccflare/types`) to the producer-side
+ * set (`../anthropic-terminal-recovery`).
  *
- * The two cannot share one declaration: types is the base package, so it must
- * not depend on proxy. That leaves the set of states duplicated, and a state
- * added on one side only would silently produce values the other side claims
- * cannot exist.
+ * The two cannot share one declaration: types is the base package and must not
+ * depend on proxy. That leaves the set duplicated, and a state added on one
+ * side only would produce values the other side claims cannot exist.
  *
- * The two `Record` types below close that gap at COMPILE time — a key added to
- * either union makes the corresponding object literal incomplete and
- * `bun run typecheck` fails. The runtime assertions additionally pin the
- * exported `STREAM_TERMINAL_STATES` array to the same set, so the array cannot
- * drift away from the type it derives from.
+ * This check is deliberately a RUNTIME comparison of two exported arrays, not
+ * a type-level assertion. The root tsconfig excludes every `__tests__`
+ * directory, so `tsc` never sees this file — a type-level trick here would
+ * compile-check nothing and give false assurance. Both unions are derived from
+ * their arrays via `(typeof ARRAY)[number]`, so comparing the arrays at
+ * runtime does check the types.
  */
 import { describe, expect, it } from "bun:test";
-import type { StreamTerminalState } from "@better-ccflare/types";
-import { STREAM_TERMINAL_STATES } from "@better-ccflare/types";
-import type { AnthropicTerminalState } from "../anthropic-terminal-recovery";
+import {
+	STREAM_TERMINAL_STATES,
+	toStreamTerminalState,
+} from "@better-ccflare/types/request";
+import { ANTHROPIC_TERMINAL_STATES } from "../anthropic-terminal-recovery";
 
-// Every producer state must exist as an API state …
-const PRODUCER_TO_API: Record<AnthropicTerminalState, StreamTerminalState> = {
-	complete: "complete",
-	recovered: "recovered",
-	error: "error",
-	truncated: "truncated",
-	client_cancelled: "client_cancelled",
-};
-
-// … and every API state must exist as a producer state.
-const API_TO_PRODUCER: Record<StreamTerminalState, AnthropicTerminalState> = {
-	complete: "complete",
-	recovered: "recovered",
-	error: "error",
-	truncated: "truncated",
-	client_cancelled: "client_cancelled",
-};
-
-describe("stream terminal state — union parity with the producer", () => {
+describe("stream terminal state — parity with the producer", () => {
 	it("covers exactly the same set on both sides", () => {
-		expect(Object.keys(PRODUCER_TO_API).sort()).toEqual(
-			Object.keys(API_TO_PRODUCER).sort(),
-		);
-	});
-
-	it("keeps STREAM_TERMINAL_STATES in sync with the union", () => {
 		expect([...STREAM_TERMINAL_STATES].sort()).toEqual(
-			Object.keys(PRODUCER_TO_API).sort() as StreamTerminalState[],
+			[...ANTHROPIC_TERMINAL_STATES].sort(),
 		);
 	});
 
-	it("maps each state to itself (no silent renaming across the boundary)", () => {
-		for (const state of STREAM_TERMINAL_STATES) {
-			expect(PRODUCER_TO_API[state]).toBe(state);
-			expect(API_TO_PRODUCER[state]).toBe(state);
+	it("accepts every state the producer can emit", () => {
+		for (const state of ANTHROPIC_TERMINAL_STATES) {
+			// A producer state the API cannot name would come back as "unknown".
+			expect(toStreamTerminalState(state)).toBe(state);
 		}
+	});
+
+	it('reports a state the API does not know as "unknown", not as absent', () => {
+		expect(toStreamTerminalState("some_future_state")).toBe("unknown");
+		expect(toStreamTerminalState("")).toBeUndefined();
+		expect(toStreamTerminalState(null)).toBeUndefined();
+		expect(toStreamTerminalState(undefined)).toBeUndefined();
+		expect(toStreamTerminalState(42)).toBeUndefined();
 	});
 });

--- a/packages/proxy/src/__tests__/usage-collector-stream-terminal-state.test.ts
+++ b/packages/proxy/src/__tests__/usage-collector-stream-terminal-state.test.ts
@@ -1,0 +1,155 @@
+/**
+ * End-to-end tests for propagating `EndMessage.streamTerminalState` onto the
+ * `RequestResponse` summary emitted via `onSummary`
+ * (packages/proxy/src/usage-collector.ts).
+ *
+ * The collector already persisted the value into the `stream_terminal_state`
+ * column, but dropped it when building the real-time summary. That made the
+ * live dashboard stream and a later /api/requests fetch disagree about the
+ * same request: the row gained its terminal state only after a reload. These
+ * tests pin both surfaces to the same value.
+ *
+ * The state itself is produced by the SSE observer in
+ * packages/proxy/src/anthropic-terminal-recovery.ts.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync, unlinkSync } from "node:fs";
+
+import {
+	AsyncDbWriter,
+	DatabaseFactory,
+	type DatabaseOperations,
+} from "@better-ccflare/database";
+import type { RequestResponse } from "@better-ccflare/types";
+import { UsageCollector } from "../usage-collector";
+import type { EndMessage, StartMessage } from "../worker-messages";
+
+const TEST_DB_PATH = "/tmp/test-usage-collector-stream-terminal-state.db";
+
+describe("UsageCollector - stream terminal state in the live summary", () => {
+	let dbOps: DatabaseOperations;
+	let asyncWriter: AsyncDbWriter;
+	let collector: UsageCollector;
+	let summaries: Map<string, RequestResponse>;
+
+	beforeAll(() => {
+		try {
+			if (existsSync(TEST_DB_PATH)) unlinkSync(TEST_DB_PATH);
+		} catch (error) {
+			console.warn("Failed to clean up existing test database:", error);
+		}
+		DatabaseFactory.initialize(TEST_DB_PATH);
+		dbOps = DatabaseFactory.getInstance();
+		asyncWriter = new AsyncDbWriter();
+		summaries = new Map();
+		collector = new UsageCollector(
+			dbOps,
+			asyncWriter,
+			() => false,
+			(summary) => {
+				summaries.set(summary.id, summary);
+			},
+		);
+	});
+
+	afterAll(async () => {
+		collector.dispose();
+		await collector.drain();
+		DatabaseFactory.reset();
+		try {
+			if (existsSync(TEST_DB_PATH)) unlinkSync(TEST_DB_PATH);
+		} catch (error) {
+			console.warn("Failed to clean up test database:", error);
+		}
+	});
+
+	function makeStart(requestId: string): StartMessage {
+		return {
+			type: "start",
+			messageId: `msg-${requestId}`,
+			requestId,
+			accountId: null,
+			method: "POST",
+			path: "/v1/messages",
+			timestamp: Date.now(),
+			requestHeaders: {},
+			requestBody: null,
+			project: null,
+			responseStatus: 200,
+			responseHeaders: {},
+			isStream: true,
+			providerName: "anthropic",
+			accountBillingType: null,
+			accountAutoPauseOnOverageEnabled: null,
+			accountName: null,
+			agentUsed: null,
+			comboName: null,
+			apiKeyId: null,
+			apiKeyName: null,
+			retryAttempt: 0,
+			failoverAttempts: 0,
+		};
+	}
+
+	/**
+	 * Drives a full start->end cycle through the REAL collector and returns the
+	 * captured summary. Fails loudly if onSummary never fired, so a silently
+	 * skipped request cannot produce a false pass.
+	 */
+	async function runRequestAndGetSummary(
+		requestId: string,
+		streamTerminalState: EndMessage["streamTerminalState"],
+	): Promise<RequestResponse> {
+		collector.handleStart(makeStart(requestId));
+		const endMsg: EndMessage = {
+			type: "end",
+			requestId,
+			success: true,
+			streamTerminalState,
+		};
+		await collector.handleEnd(endMsg);
+		const summary = summaries.get(requestId);
+		if (!summary) {
+			throw new Error(
+				`onSummary was not invoked for requestId=${requestId} — request may have been silently skipped`,
+			);
+		}
+		return summary;
+	}
+
+	test("a client-cancelled stream reaches the live summary", async () => {
+		const summary = await runRequestAndGetSummary(
+			"terminal-state-cancelled",
+			"client_cancelled",
+		);
+
+		expect(summary.streamTerminalState).toBe("client_cancelled");
+		// The header status stays 200 — that is precisely why the separate
+		// terminal state is needed to spot an incomplete response.
+		expect(summary.statusCode).toBe(200);
+	});
+
+	test("a truncated stream reaches the live summary", async () => {
+		const summary = await runRequestAndGetSummary(
+			"terminal-state-truncated",
+			"truncated",
+		);
+
+		expect(summary.streamTerminalState).toBe("truncated");
+	});
+
+	test("the field stays undefined when the stream reported no terminal state", async () => {
+		const summary = await runRequestAndGetSummary(
+			"terminal-state-absent",
+			undefined,
+		);
+
+		expect(summary.streamTerminalState).toBeUndefined();
+	});
+
+	test("a null terminal state is normalised to undefined, not forwarded as null", async () => {
+		const summary = await runRequestAndGetSummary("terminal-state-null", null);
+
+		expect(summary.streamTerminalState).toBeUndefined();
+	});
+});

--- a/packages/proxy/src/__tests__/usage-collector-stream-terminal-state.test.ts
+++ b/packages/proxy/src/__tests__/usage-collector-stream-terminal-state.test.ts
@@ -152,4 +152,17 @@ describe("UsageCollector - stream terminal state in the live summary", () => {
 
 		expect(summary.streamTerminalState).toBeUndefined();
 	});
+
+	test('a state outside the union is reported as "unknown", like the REST path', async () => {
+		// The producer cannot emit this today — the cast is what a future
+		// producer state (or a bug) would look like arriving here. Both write
+		// surfaces of this field must narrow identically, otherwise the live
+		// stream and a later fetch describe the same request differently.
+		const summary = await runRequestAndGetSummary(
+			"terminal-state-foreign",
+			"totally_unknown" as unknown as EndMessage["streamTerminalState"],
+		);
+
+		expect(summary.streamTerminalState).toBe("unknown");
+	});
 });

--- a/packages/proxy/src/anthropic-terminal-recovery.ts
+++ b/packages/proxy/src/anthropic-terminal-recovery.ts
@@ -23,7 +23,11 @@ export type AnthropicTerminalRecoveryReason = "timeout" | "eof";
  * (`packages/types` must not import this package, so the two sets cannot share
  * one declaration).
  *
- * - `complete` — `message_stop` (and a stop_reason delta) was observed upstream.
+ * - `complete` — `message_stop` was observed upstream. A stop_reason delta may
+ *   or may not have preceded it: `determineTerminalState()` returns `complete`
+ *   on `messageStopSeen` alone, so a stream that reaches the protocol endpoint
+ *   without a terminal delta counts as complete, not truncated. Stated
+ *   explicitly because `response-handler` maps this state to `success: true`.
  * - `recovered` — stop_reason delta was seen but message_stop was missing, so
  *   the terminator was synthesized.
  * - `error` — the stream surfaced an explicit `error` event, or upstream threw.

--- a/packages/proxy/src/anthropic-terminal-recovery.ts
+++ b/packages/proxy/src/anthropic-terminal-recovery.ts
@@ -10,28 +10,43 @@ const MAX_PENDING_EVENT_CHARS = 64 * 1024;
 export type AnthropicTerminalRecoveryReason = "timeout" | "eof";
 
 /**
- * Real outcome of an Anthropic-Messages-shaped SSE stream. The wrapper emits
- * exactly one of these via `onTerminalState` when it finalizes — distinct from
- * a header-level `response.ok` check, which only reflects the upstream's
- * opening handshake. A 200 OK with a TCP close mid-content is `truncated`,
- * not `complete`. Used by response-handler to record genuine success/failure.
+ * Real outcome of an Anthropic-Messages-shaped SSE stream, and the
+ * authoritative definition of that set. The wrapper emits exactly one of these
+ * via `onTerminalState` when it finalizes — distinct from a header-level
+ * `response.ok` check, which only reflects the upstream's opening handshake. A
+ * 200 OK with a TCP close mid-content is `truncated`, not `complete`. Used by
+ * response-handler to record genuine success/failure.
+ *
+ * Exported as a runtime array — not just a type — so the API-side copy in
+ * `@better-ccflare/types` can be compared against it in a test. A type-only
+ * declaration is erased at compile time and could drift silently
+ * (`packages/types` must not import this package, so the two sets cannot share
+ * one declaration).
+ *
+ * - `complete` — `message_stop` (and a stop_reason delta) was observed upstream.
+ * - `recovered` — stop_reason delta was seen but message_stop was missing, so
+ *   the terminator was synthesized.
+ * - `error` — the stream surfaced an explicit `error` event, or upstream threw.
+ * - `truncated` — the stream closed without ever reaching a terminal state
+ *   (mid-content TCP close).
+ * - `client_cancelled` — downstream cancelled before the upstream finished.
+ *   Claude Code cancels streams routinely (Esc, tool interrupts, client
+ *   aborts); this is neither an upstream failure nor a proxy defect, and is
+ *   recorded distinctly so it doesn't poison success-rate metrics as a
+ *   false negative.
+ *
+ * Adding a member here without adding it to `STREAM_TERMINAL_STATES` fails
+ * `stream-terminal-state-union-parity.test.ts`.
  */
-export type AnthropicTerminalState =
-	/** `message_stop` (and a stop_reason delta) was observed upstream. */
-	| "complete"
-	/** Stop_reason delta was seen but message_stop was missing — synthesized. */
-	| "recovered"
-	/** Stream surfaced an explicit `error` event or upstream threw. */
-	| "error"
-	/** Stream closed without ever reaching a terminal state (mid-content TCP close). */
-	| "truncated"
-	/**
-	 * Downstream cancelled before the upstream finished. Claude Code cancels
-	 * streams routinely (Esc, tool interrupts, client aborts). This is neither
-	 * an upstream failure nor a proxy defect — recorded as a distinct state
-	 * so it doesn't poison the success-rate metrics as a false-negative.
-	 */
-	| "client_cancelled";
+export const ANTHROPIC_TERMINAL_STATES = [
+	"complete",
+	"recovered",
+	"error",
+	"truncated",
+	"client_cancelled",
+] as const;
+
+export type AnthropicTerminalState = (typeof ANTHROPIC_TERMINAL_STATES)[number];
 
 export interface AnthropicTerminalRecoveryOptions {
 	/** @internal Override only in deterministic unit tests. */

--- a/packages/proxy/src/usage-collector.ts
+++ b/packages/proxy/src/usage-collector.ts
@@ -910,6 +910,10 @@ export class UsageCollector {
 			comboName: startMessage.comboName || undefined,
 			projectAttributionSource: state.projectAttributionSource ?? undefined,
 			agentAttributionSource: state.agentAttributionSource ?? undefined,
+			// Same value that is persisted above, so the live stream and a later
+			// /api/requests fetch describe the request identically. Without it a
+			// row would gain its terminal state only after a dashboard reload.
+			streamTerminalState: msg.streamTerminalState ?? undefined,
 		};
 
 		// Notify cacheBodyStore and emit summary for real-time updates

--- a/packages/proxy/src/usage-collector.ts
+++ b/packages/proxy/src/usage-collector.ts
@@ -910,9 +910,14 @@ export class UsageCollector {
 			comboName: startMessage.comboName || undefined,
 			projectAttributionSource: state.projectAttributionSource ?? undefined,
 			agentAttributionSource: state.agentAttributionSource ?? undefined,
-			// Same value that is persisted above, so the live stream and a later
-			// /api/requests fetch describe the request identically. Without it a
-			// row would gain its terminal state only after a dashboard reload.
+			// Same value handed to saveRequest above, so a dashboard does not have
+			// to reload before a request shows its terminal state. Note this is
+			// the value as REPORTED, not as persisted: the save is an
+			// AsyncDbWriter job that may be dropped when the metadata queue is
+			// saturated, and its own failures are logged rather than propagated —
+			// so under write pressure the live summary can show a state that no
+			// later /api/requests fetch will confirm. That gap predates this field
+			// and applies to the whole row, not just this value.
 			streamTerminalState: msg.streamTerminalState ?? undefined,
 		};
 

--- a/packages/proxy/src/usage-collector.ts
+++ b/packages/proxy/src/usage-collector.ts
@@ -11,6 +11,9 @@ import {
 	type ProjectAttributionSource,
 	type RequestResponse,
 } from "@better-ccflare/types";
+// Cycle-free subpath (see packages/types/src/request.ts header) — same guard
+// the REST handler uses, so both write surfaces narrow identically.
+import { toStreamTerminalState } from "@better-ccflare/types/request";
 import { formatCost } from "@better-ccflare/ui-common";
 import { cacheBodyStore } from "./cache-body-store";
 import {
@@ -918,7 +921,11 @@ export class UsageCollector {
 			// so under write pressure the live summary can show a state that no
 			// later /api/requests fetch will confirm. That gap predates this field
 			// and applies to the whole row, not just this value.
-			streamTerminalState: msg.streamTerminalState ?? undefined,
+			//
+			// Narrowed with the same guard as the REST path even though the
+			// producer only emits known states: both surfaces feed one field, and
+			// hardening one of them is how the two drift apart.
+			streamTerminalState: toStreamTerminalState(msg.streamTerminalState),
 		};
 
 		// Notify cacheBodyStore and emit summary for real-time updates

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -4,7 +4,8 @@
 	"type": "module",
 	"main": "./src/index.ts",
 	"exports": {
-		".": "./src/index.ts"
+		".": "./src/index.ts",
+		"./request": "./src/request.ts"
 	},
 	"scripts": {
 		"typecheck": "bunx tsc --noEmit"

--- a/packages/types/src/request.ts
+++ b/packages/types/src/request.ts
@@ -1,10 +1,57 @@
-export type ProjectAttributionSource =
-	| "header_project"
-	| "path_project"
-	| "heading_project"
-	| "none";
+/**
+ * This module is deliberately import-free and is re-exported unchanged through
+ * the package barrel. `@better-ccflare/types` has a documented runtime cycle
+ * (`types/agent.ts` → core → `core/strategy.ts` → types, which evaluates
+ * `Object.values(StrategyName)` at module scope), so evaluating the barrel
+ * first crashes. Runtime consumers of the narrowing helpers below therefore
+ * import them via the cycle-free `@better-ccflare/types/request` subpath
+ * rather than the barrel.
+ */
 
-export type AgentAttributionSource = "header_agent" | "prompt_agent" | "none";
+export const PROJECT_ATTRIBUTION_SOURCES = [
+	"header_project",
+	"path_project",
+	"heading_project",
+	"none",
+] as const;
+
+export type ProjectAttributionSource =
+	(typeof PROJECT_ATTRIBUTION_SOURCES)[number];
+
+export const AGENT_ATTRIBUTION_SOURCES = [
+	"header_agent",
+	"prompt_agent",
+	"none",
+] as const;
+
+export type AgentAttributionSource = (typeof AGENT_ATTRIBUTION_SOURCES)[number];
+
+/**
+ * Narrow a raw `project_attribution_source` column value. Like every
+ * provenance column this is TEXT with no database-side constraint, so a bare
+ * `as` cast would hand consumers a value the type says cannot exist.
+ * Unrecognized values become `undefined` — unlike the terminal state below,
+ * this union already carries an explicit `"none"`, and the field is a
+ * provenance label rather than the sole signal of an incomplete response.
+ */
+export function toProjectAttributionSource(
+	value: unknown,
+): ProjectAttributionSource | undefined {
+	return typeof value === "string" &&
+		(PROJECT_ATTRIBUTION_SOURCES as readonly string[]).includes(value)
+		? (value as ProjectAttributionSource)
+		: undefined;
+}
+
+/** Narrow a raw `agent_attribution_source` column value. See above. */
+export function toAgentAttributionSource(
+	value: unknown,
+): AgentAttributionSource | undefined {
+	return typeof value === "string" &&
+		(AGENT_ATTRIBUTION_SOURCES as readonly string[]).includes(value)
+		? (value as AgentAttributionSource)
+		: undefined;
+}
 
 /**
  * Real outcome of an Anthropic-Messages-shaped SSE stream, as recorded in the
@@ -28,20 +75,37 @@ export const STREAM_TERMINAL_STATES = [
 export type StreamTerminalState = (typeof STREAM_TERMINAL_STATES)[number];
 
 /**
- * Narrow a raw `stream_terminal_state` column value to the union. The column is
- * TEXT and the database enforces nothing, so a bare `as` cast would let a value
- * from a newer producer build — or a hand-edited row — reach consumers while
- * the type claims exhaustiveness. Unknown values become `undefined`, i.e. they
- * are reported as "no terminal state recorded" rather than as a state nobody
- * can switch on.
+ * What the API reports for a request: one of the known states, or `"unknown"`
+ * when the column holds a value this build does not recognize.
+ *
+ * The distinction matters more here than for the provenance columns above.
+ * `streamTerminalState` is the only field separating a stream that died
+ * mid-content from a clean `statusCode: 200`, so collapsing an unrecognized
+ * state into "nothing recorded" would make a NEW failure state — written by a
+ * newer producer, or surviving a rollback — read as healthy. `"unknown"` says
+ * "something terminated this stream and this build cannot name it", which is
+ * the honest answer and still keeps consumers off a union member that does not
+ * exist for them.
+ */
+export type ReportedStreamTerminalState = StreamTerminalState | "unknown";
+
+/**
+ * Narrow a raw `stream_terminal_state` column value. The column is TEXT and
+ * the database enforces nothing, so a bare `as` cast would let a value from a
+ * newer producer build — or a hand-edited row — reach consumers while the type
+ * claims exhaustiveness.
+ *
+ * Absent (`null`/`undefined`/empty) stays `undefined` — no stream was observed.
+ * A non-empty value outside the known set becomes `"unknown"` rather than
+ * `undefined`, so version skew cannot make a failed stream look clean.
  */
 export function toStreamTerminalState(
 	value: unknown,
-): StreamTerminalState | undefined {
-	return typeof value === "string" &&
-		(STREAM_TERMINAL_STATES as readonly string[]).includes(value)
+): ReportedStreamTerminalState | undefined {
+	if (typeof value !== "string" || value.length === 0) return undefined;
+	return (STREAM_TERMINAL_STATES as readonly string[]).includes(value)
 		? (value as StreamTerminalState)
-		: undefined;
+		: "unknown";
 }
 
 // Database row type
@@ -111,7 +175,7 @@ export interface Request {
 	appliedModel?: string;
 	projectAttributionSource?: ProjectAttributionSource;
 	agentAttributionSource?: AgentAttributionSource;
-	streamTerminalState?: StreamTerminalState;
+	streamTerminalState?: ReportedStreamTerminalState;
 }
 
 // API response type
@@ -149,7 +213,7 @@ export interface RequestResponse {
 	rateLimited?: boolean;
 	projectAttributionSource?: ProjectAttributionSource;
 	agentAttributionSource?: AgentAttributionSource;
-	streamTerminalState?: StreamTerminalState;
+	streamTerminalState?: ReportedStreamTerminalState;
 }
 
 // Detailed request with payload
@@ -241,10 +305,12 @@ export function toRequest(row: RequestRow): Request {
 		comboName: row.combo_name || undefined,
 		originalModel: row.original_model || undefined,
 		appliedModel: row.applied_model || undefined,
-		projectAttributionSource:
-			(row.project_attribution_source as ProjectAttributionSource) || undefined,
-		agentAttributionSource:
-			(row.agent_attribution_source as AgentAttributionSource) || undefined,
+		projectAttributionSource: toProjectAttributionSource(
+			row.project_attribution_source,
+		),
+		agentAttributionSource: toAgentAttributionSource(
+			row.agent_attribution_source,
+		),
 		streamTerminalState: toStreamTerminalState(row.stream_terminal_state),
 	};
 }

--- a/packages/types/src/request.ts
+++ b/packages/types/src/request.ts
@@ -6,6 +6,24 @@ export type ProjectAttributionSource =
 
 export type AgentAttributionSource = "header_agent" | "prompt_agent" | "none";
 
+/**
+ * Real outcome of an Anthropic-Messages-shaped SSE stream, as recorded in the
+ * `stream_terminal_state` column. Distinct from `statusCode`, which only
+ * reflects the upstream's opening handshake: a stream that dies mid-content or
+ * is cancelled by the client still carries a 200. Absent for non-streaming
+ * responses and for streams not wrapped by the terminal-recovery observer.
+ *
+ * The producer defines the same set as `AnthropicTerminalState` in
+ * packages/proxy/src/anthropic-terminal-recovery.ts (which documents what each
+ * state means); it cannot be imported here because types is the base package.
+ */
+export type StreamTerminalState =
+	| "complete"
+	| "recovered"
+	| "error"
+	| "truncated"
+	| "client_cancelled";
+
 // Database row type
 export interface RequestRow {
 	id: string;
@@ -38,6 +56,7 @@ export interface RequestRow {
 	applied_model: string | null;
 	project_attribution_source: string | null;
 	agent_attribution_source: string | null;
+	stream_terminal_state: string | null;
 }
 
 // Domain model
@@ -72,6 +91,7 @@ export interface Request {
 	appliedModel?: string;
 	projectAttributionSource?: ProjectAttributionSource;
 	agentAttributionSource?: AgentAttributionSource;
+	streamTerminalState?: StreamTerminalState;
 }
 
 // API response type
@@ -109,6 +129,7 @@ export interface RequestResponse {
 	rateLimited?: boolean;
 	projectAttributionSource?: ProjectAttributionSource;
 	agentAttributionSource?: AgentAttributionSource;
+	streamTerminalState?: StreamTerminalState;
 }
 
 // Detailed request with payload
@@ -204,6 +225,8 @@ export function toRequest(row: RequestRow): Request {
 			(row.project_attribution_source as ProjectAttributionSource) || undefined,
 		agentAttributionSource:
 			(row.agent_attribution_source as AgentAttributionSource) || undefined,
+		streamTerminalState:
+			(row.stream_terminal_state as StreamTerminalState) || undefined,
 	};
 }
 
@@ -240,6 +263,7 @@ export function toRequestResponse(request: Request): RequestResponse {
 		rateLimited: request.statusCode === 429,
 		projectAttributionSource: request.projectAttributionSource,
 		agentAttributionSource: request.agentAttributionSource,
+		streamTerminalState: request.streamTerminalState,
 	};
 }
 

--- a/packages/types/src/request.ts
+++ b/packages/types/src/request.ts
@@ -17,12 +17,32 @@ export type AgentAttributionSource = "header_agent" | "prompt_agent" | "none";
  * packages/proxy/src/anthropic-terminal-recovery.ts (which documents what each
  * state means); it cannot be imported here because types is the base package.
  */
-export type StreamTerminalState =
-	| "complete"
-	| "recovered"
-	| "error"
-	| "truncated"
-	| "client_cancelled";
+export const STREAM_TERMINAL_STATES = [
+	"complete",
+	"recovered",
+	"error",
+	"truncated",
+	"client_cancelled",
+] as const;
+
+export type StreamTerminalState = (typeof STREAM_TERMINAL_STATES)[number];
+
+/**
+ * Narrow a raw `stream_terminal_state` column value to the union. The column is
+ * TEXT and the database enforces nothing, so a bare `as` cast would let a value
+ * from a newer producer build — or a hand-edited row — reach consumers while
+ * the type claims exhaustiveness. Unknown values become `undefined`, i.e. they
+ * are reported as "no terminal state recorded" rather than as a state nobody
+ * can switch on.
+ */
+export function toStreamTerminalState(
+	value: unknown,
+): StreamTerminalState | undefined {
+	return typeof value === "string" &&
+		(STREAM_TERMINAL_STATES as readonly string[]).includes(value)
+		? (value as StreamTerminalState)
+		: undefined;
+}
 
 // Database row type
 export interface RequestRow {
@@ -225,8 +245,7 @@ export function toRequest(row: RequestRow): Request {
 			(row.project_attribution_source as ProjectAttributionSource) || undefined,
 		agentAttributionSource:
 			(row.agent_attribution_source as AgentAttributionSource) || undefined,
-		streamTerminalState:
-			(row.stream_terminal_state as StreamTerminalState) || undefined,
+		streamTerminalState: toStreamTerminalState(row.stream_terminal_state),
 	};
 }
 


### PR DESCRIPTION
**Why:** `requests.stream_terminal_state` records what actually happened to an
Anthropic-Messages-shaped SSE stream — `complete`, `recovered`, `error`,
`truncated`, `client_cancelled` — but no HTTP route ever read it back
(0 hits for the column in `packages/http-api/src` before this branch). The
summary handler already selects it via `SELECT r.*` and dropped it at the
TypeScript mapping, so an operator sees `statusCode: 200` for a stream that
died mid-content or was cancelled, with nothing to tell them apart. That is
the gap @zenprocess describes in #348 ("detect and log an abandoned request …
so it stops being invisible" — noting it alone would have saved considerable
time), and it is why four stalled requests read as a healthy deployment for a
full day of local diagnosis.

**Changes:**
- `/api/requests` returns `streamTerminalState`, and `UsageCollector` puts the
  same value on the real-time summary so a request does not gain its terminal
  state only after a dashboard reload.
- The value is *narrowed*, not cast. All three provenance columns
  (`stream_terminal_state`, `project_attribution_source`,
  `agent_attribution_source`) are unconstrained TEXT, so a bare `as` would hand
  consumers a value the type says cannot exist; each now goes through a guard.
- An unrecognized terminal state surfaces as `"unknown"` rather than
  `undefined`. Collapsing it into `undefined` would give it the same
  representation as a non-streaming request — and since this field is the only
  thing separating a dead stream from a clean 200, a state written by a newer
  producer would have read as healthy.
- Both state sets derive from exported arrays (`ANTHROPIC_TERMINAL_STATES`,
  `STREAM_TERMINAL_STATES`) and a test compares them **at runtime**.
  `packages/types` must not import `packages/proxy`, so the sets cannot share
  one declaration; a type-level check would not work here because the root
  tsconfig excludes every `__tests__` directory, so `tsc` never reads that file.
- Both write surfaces of the field (REST read path and the live SSE summary)
  narrow through the same guard; hardening only one is how they drift apart.
- The guards are imported from a new cycle-free `@better-ccflare/types/request`
  subpath. `types/agent.ts` imports core while `core/strategy.ts` evaluates
  `Object.values(StrategyName)` at module scope, so evaluating the barrel first
  throws — the handler survived that only because `jsonResponse` is imported one
  line earlier and pulls core in first.

**Accepted risk:** the live summary reports the value it was *handed*, not one
confirmed as durable. `saveRequest` runs as an `AsyncDbWriter` job that is
dropped when the metadata queue saturates (`async-writer.ts:94-104`) and whose
failures are logged rather than propagated, so under write pressure the live
stream can show a state no later fetch confirms. This predates the field and
applies to the whole row — making persistence admission-visible would touch
every writer and is deliberately out of scope. The code comment states this
rather than promising agreement it cannot keep.

**BC note:** additive only — one new optional field on the `/api/requests`
response, plus a new `./request` subpath export on `@better-ccflare/types`.
No schema or migration change: the column, both migrations and the write path
all pre-date this PR.

**Verification:** `bun run lint && bun run typecheck && bun run format` clean;
`bun test packages/http-api packages/types packages/proxy` → 1119 pass / 0 fail.
Red-first evidence for each behavioural claim: without the narrowing,
`/api/requests` returns a hand-written `some_future_state` verbatim; without
the collector change the live summary drops the state entirely. The cycle was
confirmed by cold import in a fresh process — importing the types barrel first
dies at `core/strategy.ts:4`, the subpath and the handler both load clean.

Reviewed twice by three external models (codex gpt-5.6-sol, kimi k3, gemini
3.1-pro). The first pass produced the unchecked-cast finding (unanimous) and
the unpinned-union finding (majority). The second pass reviewed the fix commit
itself and caught that its stated typecheck guarantee did not hold, that
unknown states were being conflated with absent ones, and that the sibling
attribution columns had been left behind — all addressed in 7d753e8. A third pass over that commit found the live SSE path
still unhardened, a cold-import guard that passed with the fix reverted, and a
doc block whose `complete` definition contradicted the classifier it described
— fixed in b3c69ad. `bun run build` was additionally run locally (no reviewer
sandbox could) and completes clean with the new subpath export. One
single-source claim about COALESCE-driven divergence was checked against
`request.repository.ts:192` and refuted (`EXCLUDED` wins, so the two surfaces
agree).

**Known and deliberately not addressed here:** `RequestRow`, `toRequest` and
`toRequestResponse` in `packages/types/src/request.ts` have no callers anywhere
in the repo and were extended along with everything else — removing them is a
breaking change for out-of-tree consumers and unrelated to this feature. The
two attribution columns map an unrecognized value to `undefined` rather than
`"unknown"`: both unions already carry an explicit `"none"` and neither is a
completeness signal, so only the terminal state needs the third answer. Both
choices are stated in code comments rather than left implicit.

**References:** #348

