### PR TITLE
fix(proxy): make the pool-exhausted 503 usage-aware (Retry-After, reason, /health routable)

### DIFF
--- a/packages/http-api/src/handlers/__tests__/health-usage-exhausted.test.ts
+++ b/packages/http-api/src/handlers/__tests__/health-usage-exhausted.test.ts
@@ -7,9 +7,15 @@ import { computePoolStatus, createHealthHandler } from "../health";
  * Incident 2026-07-09: /health reported `routable: 2` and the dashboard showed
  * `rateLimitStatus: OK` for MAX_200_ALT_2 while the account's weekly usage
  * window sat at 100% (every request 429'd upstream) and /v1/messages returned
- * 503 pool_exhausted. `routable` must keep its meaning (unpaused + no active
- * cooldown), but the pool status has to EXPOSE usage-exhausted accounts so the
- * two readings stop contradicting each other.
+ * 503 pool_exhausted. The follow-up incident on 2026-07-30T20:24-22:20Z
+ * showed the same split-brain: a 116-minute total outage where every 503
+ * carried `Retry-After: 60`, which (combined with CLAUDE_CODE_MAX_RETRIES=5)
+ * killed clients in 300s — measured 300.4-300.6s across seven agents. To stop
+ * the outage from being invisible, `routable` now honors usage telemetry:
+ * accounts whose 100% utilization is visible to ccflare are no longer
+ * counted as routable. `usage_exhausted` keeps its diagnostic-overlay role
+ * (pre-usage-aware isAccountAvailable gate), so dashboards and alerting can
+ * still isolate "why is this pool empty?".
  */
 
 function makeAccount(overrides: Partial<Account> = {}): Account {
@@ -36,7 +42,7 @@ describe("computePoolStatus — usage_exhausted counter", () => {
 		];
 		const utilization: Record<string, number> = {
 			main: 76,
-			alt: 100, // paused — already visible as paused, must not double-count
+			alt: 100, // paused — already visible as paused, must not double-count in usage_exhausted
 			alt2: 100,
 			alt3: 41,
 		};
@@ -47,11 +53,14 @@ describe("computePoolStatus — usage_exhausted counter", () => {
 				: null,
 		);
 
+		// New contract: routable honors usage telemetry, so ALT_2 (100% util,
+		// future reset) is no longer counted as routable. ALT_3 is the only
+		// genuinely-routable account now.
+		expect(status.routable).toBe(1);
+		// usage_exhausted stays at 1: ALT_2 hits the diagnostic predicate
+		// (isAccountAvailable(old) && exhausted). ALT is excluded because
+		// it's paused (would otherwise be double-counted against `paused`).
 		expect(status.usage_exhausted).toBe(1);
-		// routable keeps its existing meaning — ALT_2 has no active cooldown,
-		// so it still counts. The contradiction becomes visible instead of
-		// hidden: routable 2, of which 1 is usage-exhausted.
-		expect(status.routable).toBe(2);
 		expect(status.paused).toBe(2);
 		expect(status.rate_limited).toBe(0);
 	});
@@ -108,6 +117,9 @@ describe("createHealthHandler — pool.usage_exhausted in the response", () => {
 		usageCache.delete("health-test-stale");
 		usageCache.delete("health-test-zai-stale");
 		usageCache.delete("health-test-zai-fresh");
+		usageCache.delete("health-test-outage-a");
+		usageCache.delete("health-test-outage-b");
+		usageCache.delete("health-test-outage-c");
 	});
 
 	it("exposes usage_exhausted via an injected utilization source", async () => {
@@ -131,7 +143,10 @@ describe("createHealthHandler — pool.usage_exhausted in the response", () => {
 			pool: { routable: number; usage_exhausted: number };
 		};
 
-		expect(body.pool.routable).toBe(2);
+		// a2 has 100% utilization (resetMs=null, which isUsageExhausted treats
+		// as exhausted because of "trust the cache" semantics) so it is no
+		// longer counted as routable under the new contract.
+		expect(body.pool.routable).toBe(1);
 		expect(body.pool.usage_exhausted).toBe(1);
 	});
 
@@ -161,7 +176,11 @@ describe("createHealthHandler — pool.usage_exhausted in the response", () => {
 			pool: { routable: number; usage_exhausted: number };
 		};
 
-		expect(body.pool.routable).toBe(1);
+		// The single account is usage-exhausted (100% seven_day with future
+		// reset), so under the new routable contract it is not routable and
+		// the pool-level totals are zero. This is exactly the situation that
+		// was hidden before the fix.
+		expect(body.pool.routable).toBe(0);
 		expect(body.pool.usage_exhausted).toBe(1);
 	});
 
@@ -261,5 +280,76 @@ describe("createHealthHandler — pool.usage_exhausted in the response", () => {
 		};
 
 		expect(body.pool.usage_exhausted).toBe(1);
+	});
+
+	it("reports routable:0 during a total usage-capped outage (incident 2026-07-30 scenario)", async () => {
+		// Production trace: ccproxy2 was down 116 minutes because every account
+		// was usage-capped. Pre-fix /health reported `routable: 3` because
+		// computePoolStatus called isAccountAvailable(a, now) without the
+		// usage argument. This test guards against that regression directly.
+		usageCache.set("health-test-outage-a", {
+			five_hour: { utilization: 12, resets_at: null },
+			seven_day: {
+				utilization: 100,
+				resets_at: new Date(Date.now() + 6_960_000).toISOString(),
+			},
+		});
+		usageCache.set("health-test-outage-b", {
+			five_hour: { utilization: 18, resets_at: null },
+			seven_day: {
+				utilization: 100,
+				resets_at: new Date(Date.now() + 6_960_000).toISOString(),
+			},
+		});
+		usageCache.set("health-test-outage-c", {
+			five_hour: { utilization: 25, resets_at: null },
+			seven_day: {
+				utilization: 100,
+				resets_at: new Date(Date.now() + 6_960_000).toISOString(),
+			},
+		});
+
+		const handler = createHealthHandler(
+			dbWith([
+				{
+					id: "health-test-outage-a",
+					name: "outage-a",
+					provider: "anthropic",
+					paused: false,
+				},
+				{
+					id: "health-test-outage-b",
+					name: "outage-b",
+					provider: "anthropic",
+					paused: false,
+				},
+				{
+					id: "health-test-outage-c",
+					name: "outage-c",
+					provider: "anthropic",
+					paused: false,
+				},
+			]),
+			config,
+		);
+
+		const response = await handler(new URL("http://localhost/health"));
+		const body = (await response.json()) as {
+			pool: {
+				configured: number;
+				routable: number;
+				usage_exhausted: number;
+				rate_limited: number;
+				paused: number;
+			};
+		};
+
+		// Outage visibility: routable must drop to 0 even though the
+		// accounts have no `paused` flag or `rate_limited_until`.
+		expect(body.pool.configured).toBe(3);
+		expect(body.pool.routable).toBe(0);
+		expect(body.pool.usage_exhausted).toBe(3);
+		expect(body.pool.paused).toBe(0);
+		expect(body.pool.rate_limited).toBe(0);
 	});
 });

--- a/packages/http-api/src/handlers/health.ts
+++ b/packages/http-api/src/handlers/health.ts
@@ -69,14 +69,25 @@ export function computePoolStatus(
 		(a) => !a.paused && a.rate_limited_until && a.rate_limited_until >= now,
 	);
 	const rate_limited = rateLimitedAccounts.length;
-	const routable = accounts.filter((a) => isAccountAvailable(a, now)).length;
-	// Subset of `routable`: accounts with no pause and no active cooldown
-	// whose usage window sits at 100% — they look available locally, yet
-	// upstream rejects their requests, so `routable > 0` alone can mask an
-	// effectively exhausted pool (incident 2026-07-09). Benched accounts are
-	// excluded — they are already visible via `rate_limited`, and counting
-	// them here would let usage_exhausted exceed routable (PR #299 review
-	// finding).
+	// `routable` reflects what ccflare will actually attempt to route, i.e.
+	// unpaused + no active cooldown + NOT usage-exhausted. Passing the usage
+	// snapshot here is load-bearing: without it, an account at 100% utilization
+	// with no `rate_limited_until` was counted as routable while upstream
+	// rejected every request — masking the effective outage from the dashboard
+	// and from clients polling /health (incident 2026-07-30T20:24-22:20Z:
+	// every 503 came back with a default 60s Retry-After that compounded with
+	// CLAUDE_CODE_MAX_RETRIES=5 to kill clients in 300s). The relationship
+	// between `routable` and `usage_exhausted` changed because `routable` now
+	// honors usage telemetry — see commit message for details.
+	const routable = accounts.filter((a) =>
+		isAccountAvailable(a, now, getUsageInfo(a) ?? undefined),
+	).length;
+	// `usage_exhausted` is the diagnostic overlay: accounts whose cached
+	// telemetry shows 100% utilization with a future reset, AND that have no
+	// other reason to be unavailable (no pause, no active cooldown). The
+	// pre-usage-aware isAccountAvailable gate is preserved on purpose so this
+	// counter keeps its PR #299 semantics (no double-counting with paused or
+	// rate_limited accounts).
 	const usage_exhausted = accounts.filter((a) => {
 		if (!isAccountAvailable(a, now)) return false;
 		const usage = getUsageInfo(a);

--- a/packages/providers/src/usage-fetcher.ts
+++ b/packages/providers/src/usage-fetcher.ts
@@ -576,6 +576,40 @@ export function getRepresentativeUsageResetMs(
 }
 
 /**
+ * Representative utilization paired with the reset that belongs to the same
+ * winning window. Zai needs special handling because its utilization is the
+ * max of time_limit and tokens_limit while getRepresentativeUsageResetMs is
+ * intentionally tokens_limit-only for display surfaces. Other providers keep
+ * their existing representative-reset behavior unchanged.
+ */
+export function getRepresentativeUsageSnapshotForProvider(
+	data: AnyUsageData,
+	provider: string,
+): { utilization: number; resetMs: number | null } | null {
+	if (provider === "zai") {
+		const zai = data as ZaiUsageData;
+		const candidates = [zai.time_limit, zai.tokens_limit].filter(
+			(window): window is NonNullable<typeof window> => window !== null,
+		);
+		if (candidates.length === 0) return null;
+		const winning = candidates.reduce((prev, current) =>
+			current.percentage > prev.percentage ? current : prev,
+		);
+		return {
+			utilization: winning.percentage,
+			resetMs: winning.resetAt,
+		};
+	}
+
+	const utilization = getRepresentativeUtilizationForProvider(data, provider);
+	if (utilization === null) return null;
+	return {
+		utilization,
+		resetMs: getRepresentativeUsageResetMs(data, provider),
+	};
+}
+
+/**
  * Type for a function that retrieves a fresh access token or API key
  */
 export type AccessTokenProvider = () => Promise<string>;

--- a/packages/proxy/src/__tests__/pool-exhausted.test.ts
+++ b/packages/proxy/src/__tests__/pool-exhausted.test.ts
@@ -263,7 +263,14 @@ describe("pool exhausted — 503 response", () => {
 		}
 	});
 
-	it("sets Retry-After to 60 when no cooldown info (only paused accounts)", async () => {
+	it("clamps Retry-After to the 600s unknown-reset floor when no cooldown info (only paused accounts)", async () => {
+		// Pre-fix this asserted Retry-After: 60, which combined with
+		// CLAUDE_CODE_MAX_RETRIES=5 to kill clients in 300s during a 116-minute
+		// total outage (production trace 2026-07-30). The new contract returns
+		// the unknown-reset floor (600s = UsageCache TTL, see
+		// POOL_EXHAUSTED_UNKNOWN_RESET_RETRY_AFTER_SECONDS in proxy-operations.ts)
+		// so a client retry is guaranteed to see fresh telemetry rather than
+		// retrying blindly against a stale snapshot.
 		const pausedAccount = makeAccount({
 			id: "acc-paused",
 			name: "paused-account",
@@ -278,7 +285,7 @@ describe("pool exhausted — 503 response", () => {
 		);
 
 		expect(response.status).toBe(503);
-		expect(response.headers.get("Retry-After")).toBe("60");
+		expect(response.headers.get("Retry-After")).toBe("600");
 	});
 
 	it("filters accounts by provider in multi-provider setup", async () => {

--- a/packages/proxy/src/handlers/__tests__/pool-exhausted-usage-aware.test.ts
+++ b/packages/proxy/src/handlers/__tests__/pool-exhausted-usage-aware.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import type { AccountUsageSnapshot } from "@better-ccflare/core";
+import {
+	getRepresentativeUsageSnapshotForProvider,
+	type ZaiUsageData,
+} from "@better-ccflare/providers";
 import type { Account } from "@better-ccflare/types";
 import {
 	createPoolExhaustedResponse,
@@ -224,5 +228,82 @@ describe("createPoolExhaustedResponse — usage-aware", () => {
 			error: { accounts: Array<{ reason: string }> };
 		};
 		expect(body.error.accounts[0]?.reason).toBe("requires_reauth");
+	});
+});
+
+describe("Zai pool-exhausted snapshot pairing", () => {
+	it("uses the reset from the window with the winning utilization", async () => {
+		const timeLimitResetMs = Date.now() + 120_000;
+		const tokensLimitResetMs = Date.now() + 3_600_000;
+		const zaiUsage: ZaiUsageData = {
+			time_limit: {
+				used: 100,
+				remaining: 0,
+				percentage: 100,
+				resetAt: timeLimitResetMs,
+				type: "time_limit",
+			},
+			tokens_limit: {
+				used: 50,
+				remaining: 50,
+				percentage: 50,
+				resetAt: tokensLimitResetMs,
+				type: "tokens_limit",
+			},
+		};
+		const account = makeAccount({ provider: "zai" });
+		const snapshot = getRepresentativeUsageSnapshotForProvider(zaiUsage, "zai");
+		expect(snapshot).not.toBeNull();
+		if (!snapshot) return;
+
+		const response = createPoolExhaustedResponse(
+			[account],
+			new Map([[account.id, snapshot]]),
+		);
+		const body = (await response.json()) as {
+			error: {
+				next_available_at: string | null;
+				accounts: Array<{
+					reason: string;
+					available_at: string | null;
+				}>;
+			};
+		};
+		const winningReset = new Date(timeLimitResetMs).toISOString();
+
+		expect(snapshot.utilization).toBe(100);
+		expect(snapshot.resetMs).toBe(timeLimitResetMs);
+		expect(body.error.accounts[0]?.reason).toBe("usage_exhausted");
+		expect(body.error.accounts[0]?.available_at).toBe(winningReset);
+		expect(body.error.next_available_at).toBe(winningReset);
+		expect(body.error.next_available_at).not.toBe(
+			new Date(tokensLimitResetMs).toISOString(),
+		);
+		const retryAfter = Number(response.headers.get("Retry-After"));
+		expect(retryAfter).toBeGreaterThan(110);
+		expect(retryAfter).toBeLessThanOrEqual(120);
+	});
+
+	it("keeps the reset unknown when the winning window has no reset", () => {
+		const zaiUsage: ZaiUsageData = {
+			time_limit: {
+				used: 100,
+				remaining: 0,
+				percentage: 100,
+				resetAt: null,
+				type: "time_limit",
+			},
+			tokens_limit: {
+				used: 10,
+				remaining: 90,
+				percentage: 10,
+				resetAt: Date.now() + 3_600_000,
+				type: "tokens_limit",
+			},
+		};
+		const snapshot = getRepresentativeUsageSnapshotForProvider(zaiUsage, "zai");
+
+		expect(snapshot).not.toBeNull();
+		if (snapshot) expect(snapshot.resetMs).toBeNull();
 	});
 });

--- a/packages/proxy/src/handlers/__tests__/pool-exhausted-usage-aware.test.ts
+++ b/packages/proxy/src/handlers/__tests__/pool-exhausted-usage-aware.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "bun:test";
+import type { AccountUsageSnapshot } from "@better-ccflare/core";
+import type { Account } from "@better-ccflare/types";
+import {
+	createPoolExhaustedResponse,
+	POOL_EXHAUSTED_MAX_RETRY_AFTER_SECONDS,
+	POOL_EXHAUSTED_UNKNOWN_RESET_RETRY_AFTER_SECONDS,
+} from "../proxy-operations";
+
+/**
+ * Pools exhausted by usage caps (not by `rate_limited_until` cooldowns) must
+ * surface a `usage_exhausted` reason and a Retry-After that matches the
+ * upstream reset window. The 2026-07-30T20:24-22:20Z production trace
+ * exposed this gap: every 503 carried Retry-After: 60 against
+ * CLAUDE_CODE_MAX_RETRIES=5, killing clients in ~300s of a 116-minute outage.
+ *
+ * `now` is sourced from `Date.now()` rather than a hardcoded timestamp so the
+ * tests remain stable as wall-clock time advances during a long-lived CI run
+ * — the function under test calls `Date.now()` internally too.
+ */
+
+const FUTURE_OFFSET_MS = 3_600_000; // +1 hour from "now"
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "acc-1",
+		name: "acc-1",
+		provider: "anthropic",
+		api_key: null,
+		refresh_token: "refresh-token",
+		access_token: null,
+		expires_at: null,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: 1,
+		rate_limited_until: null,
+		rate_limited_reason: null,
+		rate_limited_at: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		requires_reauth: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		peak_hours_pause_enabled: false,
+		custom_endpoint: null,
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		billing_type: null,
+		pause_reason: null,
+		refresh_token_issued_at: null,
+		consecutive_rate_limits: 0,
+		...overrides,
+	};
+}
+
+describe("createPoolExhaustedResponse — usage-aware", () => {
+	it("reports usage_exhausted for a 100%-utilization account with rate_limited_until=null", async () => {
+		const usageCapped = makeAccount({
+			id: "usage-only",
+			name: "usage-only",
+			// rate_limited_until intentionally null — this is the production
+			// case the pre-fix code misclassified as "unavailable".
+		});
+		const resetMs = Date.now() + FUTURE_OFFSET_MS;
+		const snapshot: AccountUsageSnapshot = {
+			utilization: 100,
+			resetMs,
+		};
+		const snapshots = new Map<string, AccountUsageSnapshot>([
+			[usageCapped.id, snapshot],
+		]);
+
+		const response = createPoolExhaustedResponse([usageCapped], snapshots);
+		expect(response.status).toBe(503);
+
+		const body = (await response.json()) as {
+			error: {
+				type: string;
+				next_available_at: string | null;
+				accounts: Array<{
+					name: string;
+					reason: string;
+					available_at: string | null;
+				}>;
+			};
+		};
+
+		expect(body.error.type).toBe("pool_exhausted");
+		expect(body.error.accounts[0]?.reason).toBe("usage_exhausted");
+		expect(body.error.accounts[0]?.available_at).toBe(
+			new Date(resetMs).toISOString(),
+		);
+		expect(body.error.next_available_at).toBe(new Date(resetMs).toISOString());
+
+		const retryAfter = Number(response.headers.get("Retry-After"));
+		expect(retryAfter).toBeGreaterThan(3500);
+		expect(retryAfter).toBeLessThanOrEqual(FUTURE_OFFSET_MS / 1000);
+		expect(response.headers.get("Retry-After")).not.toBe("60");
+	});
+
+	it("falls back to the 600s unknown-reset floor when usage is exhausted but resetMs is null (matches UsageCache TTL)", async () => {
+		const usageCapped = makeAccount({
+			id: "usage-no-reset",
+			name: "usage-no-reset",
+		});
+		const snapshots = new Map<string, AccountUsageSnapshot>([
+			[usageCapped.id, { utilization: 100, resetMs: null }],
+		]);
+
+		const response = createPoolExhaustedResponse([usageCapped], snapshots);
+		expect(response.headers.get("Retry-After")).toBe(
+			String(POOL_EXHAUSTED_UNKNOWN_RESET_RETRY_AFTER_SECONDS),
+		);
+		expect(Number(response.headers.get("Retry-After"))).not.toBe(60);
+
+		const body = (await response.json()) as {
+			error: {
+				accounts: Array<{ reason: string; available_at: string | null }>;
+				next_available_at: string | null;
+			};
+		};
+		expect(body.error.accounts[0]?.reason).toBe("usage_exhausted");
+		expect(body.error.accounts[0]?.available_at).toBeNull();
+		expect(body.error.next_available_at).toBeNull();
+	});
+
+	it("takes the EARLIEST known recovery across usage reset and rate_limited_until", async () => {
+		const usageCapped = makeAccount({ id: "early-usage", name: "early-usage" });
+		const cooldownOnly = makeAccount({
+			id: "later-cooldown",
+			name: "later-cooldown",
+			rate_limited_until: Date.now() + 3_600_000, // 1h
+		});
+		const snapshots = new Map<string, AccountUsageSnapshot>([
+			[
+				usageCapped.id,
+				{ utilization: 100, resetMs: Date.now() + 90_000 }, // 90s
+			],
+		]);
+
+		const response = createPoolExhaustedResponse(
+			[usageCapped, cooldownOnly],
+			snapshots,
+		);
+		// tolerance: a few hundred ms of slack for Date.now() advancing
+		// between when we set the snapshot and when the function reads it.
+		const retryAfter = Number(response.headers.get("Retry-After"));
+		expect(retryAfter).toBeGreaterThan(80);
+		expect(retryAfter).toBeLessThan(91);
+	});
+
+	it("clamps Retry-After to POOL_EXHAUSTED_MAX_RETRY_AFTER_SECONDS for outages longer than the cap", async () => {
+		// Mirrors the incident: 116-minute outage, every account usage-capped.
+		// Pre-fix Retry-After: 60 → 5x60=300s and clients die. With the fix
+		// the Retry-After honors the actual reset horizon but is clamped to
+		// the 1h cap so clients cannot sleep through an unannounced recovery.
+		const allCapped = [
+			makeAccount({ id: "a", name: "a" }),
+			makeAccount({ id: "b", name: "b" }),
+			makeAccount({ id: "c", name: "c" }),
+		];
+		const snapshots = new Map<string, AccountUsageSnapshot>();
+		const resetMs = Date.now() + 6_960_000; // 116 minutes
+		for (const acc of allCapped) {
+			snapshots.set(acc.id, { utilization: 100, resetMs });
+		}
+
+		const response = createPoolExhaustedResponse(allCapped, snapshots);
+		const retryAfter = Number(response.headers.get("Retry-After"));
+		// Clamped to MAX (3600s) — i.e. NOT 6960s, NOT 60s.
+		expect(retryAfter).toBe(POOL_EXHAUSTED_MAX_RETRY_AFTER_SECONDS);
+		expect(retryAfter).not.toBe(60);
+	});
+
+	it("falls back to the unknown-reset floor when no usage info AND no cooldown (only paused accounts)", async () => {
+		// Pre-fix returned Retry-After: 60 here. The new contract applies the
+		// 600s floor so client retries cannot outpace the cache refresh.
+		const onlyPaused = makeAccount({ id: "p", name: "p", paused: true });
+		const response = createPoolExhaustedResponse([onlyPaused]);
+		expect(response.headers.get("Retry-After")).toBe(
+			String(POOL_EXHAUSTED_UNKNOWN_RESET_RETRY_AFTER_SECONDS),
+		);
+	});
+
+	it("ignores stale usage resets (resetMs in the past) when computing next_available_at", async () => {
+		// Same staleness guard isUsageExhausted uses everywhere else — a
+		// snapshot predating the window reset MUST NOT claim recovery.
+		const usageCapped = makeAccount({ id: "stale", name: "stale" });
+		const snapshots = new Map<string, AccountUsageSnapshot>([
+			[usageCapped.id, { utilization: 100, resetMs: Date.now() - 1_000 }],
+		]);
+
+		const response = createPoolExhaustedResponse([usageCapped], snapshots);
+		const body = (await response.json()) as {
+			error: { accounts: Array<{ reason: string }> };
+		};
+		expect(body.error.accounts[0]?.reason).toBe("unavailable");
+		expect(response.headers.get("Retry-After")).toBe(
+			String(POOL_EXHAUSTED_UNKNOWN_RESET_RETRY_AFTER_SECONDS),
+		);
+	});
+
+	it("keeps requires_reauth / paused reasons ahead of usage_exhausted", async () => {
+		// Precedence is unchanged for reasons that aren't reset-driven.
+		const stuck = makeAccount({
+			id: "stuck",
+			name: "stuck",
+			requires_reauth: true,
+		});
+		const snapshots = new Map<string, AccountUsageSnapshot>([
+			[stuck.id, { utilization: 100, resetMs: Date.now() + FUTURE_OFFSET_MS }],
+		]);
+
+		const response = createPoolExhaustedResponse([stuck], snapshots);
+		const body = (await response.json()) as {
+			error: { accounts: Array<{ reason: string }> };
+		};
+		expect(body.error.accounts[0]?.reason).toBe("requires_reauth");
+	});
+});

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -1,7 +1,9 @@
 import {
+	type AccountUsageSnapshot,
 	getModelFamily,
 	getModelList,
 	getOverloadRetryConfig,
+	isUsageExhausted,
 	logError,
 	ProviderError,
 	TIME_CONSTANTS,
@@ -1348,28 +1350,67 @@ export async function proxyWithAccount(
 }
 
 /**
+ * Floor for `Retry-After` when no recovery time is known (cooldown cleared and
+ * usage reset unknown). Tuned to the UsageCache TTL (10 minutes — see
+ * providers/src/usage-fetcher.ts:1065) so a client that respects this header
+ * is guaranteed to see fresh usage telemetry on retry. Pre-fix this was the
+ * optimistic 60s that triggered CLAUDE_CODE_MAX_RETRIES=5 clients to die in
+ * 300s during a 116-minute ccproxy2 outage (production trace 2026-07-30).
+ */
+export const POOL_EXHAUSTED_UNKNOWN_RESET_RETRY_AFTER_SECONDS = 600;
+
+/** Upper bound on Retry-After so clients don't sleep through a recovery. */
+export const POOL_EXHAUSTED_MAX_RETRY_AFTER_SECONDS = 3600;
+
+/**
  * Create a 503 Service Unavailable response when the account pool is exhausted.
- * All accounts are paused, rate-limited, or filtered out.
+ * All accounts are paused, rate-limited, usage-exhausted, or filtered out.
+ *
+ * Usage-aware: `usageSnapshots` (keyed by account.id) lets the function surface
+ * a `usage_exhausted` reason for accounts with no `rate_limited_until` cooldown
+ * — otherwise those would fall through to the `unavailable` bucket and the
+ * client would receive an optimistic `Retry-After: 60`, never reaching the
+ * upstream reset. The caller is responsible for sourcing snapshots from
+ * `usageCache` (or its own snapshot provider); the function itself stays pure
+ * and testable without touching I/O.
+ *
  * @param accounts - All accounts that were considered but are unavailable
+ * @param usageSnapshots - Per-account usage telemetry (id → snapshot), used
+ *   to identify usage_exhausted accounts and to derive `next_available_at` /
+ *   `Retry-After` when an upstream reset time is known.
  * @returns 503 response with pool_exhausted error and Retry-After header
  */
-export function createPoolExhaustedResponse(accounts: Account[]): Response {
+export function createPoolExhaustedResponse(
+	accounts: Account[],
+	usageSnapshots?: ReadonlyMap<string, AccountUsageSnapshot>,
+): Response {
 	const now = Date.now();
 
-	// Build account info list
+	// Build account info list — usage-exhausted outranks cooldown because the
+	// client needs the longer reset horizon (weekly vs minutes-long cooldowns)
+	// to avoid retrying an account upstream will reject immediately.
 	const accountInfos = accounts.map((account) => {
+		const usage = usageSnapshots?.get(account.id);
+		const usageExhausted =
+			usage !== undefined &&
+			isUsageExhausted(usage.utilization, usage.resetMs, now);
+
 		const reason = account.requires_reauth
 			? "requires_reauth"
 			: account.paused
 				? "paused"
-				: account.rate_limited_until && account.rate_limited_until > now
-					? "rate_limited"
-					: "unavailable";
+				: usageExhausted
+					? "usage_exhausted"
+					: account.rate_limited_until && account.rate_limited_until > now
+						? "rate_limited"
+						: "unavailable";
 
-		const availableAt =
-			account.rate_limited_until && account.rate_limited_until > now
-				? new Date(account.rate_limited_until).toISOString()
-				: null;
+		let availableAt: string | null = null;
+		if (usageExhausted && usage?.resetMs && usage.resetMs > now) {
+			availableAt = new Date(usage.resetMs).toISOString();
+		} else if (account.rate_limited_until && account.rate_limited_until > now) {
+			availableAt = new Date(account.rate_limited_until).toISOString();
+		}
 
 		return {
 			name: account.name,
@@ -1378,27 +1419,47 @@ export function createPoolExhaustedResponse(accounts: Account[]): Response {
 		};
 	});
 
-	// Calculate next_available_at from earliest rate_limited_until
-	const rateLimitedAccounts = accounts.filter(
-		(account): account is Account & { rate_limited_until: number } =>
-			!!account.rate_limited_until && account.rate_limited_until > now,
-	);
-	const earliestRateLimitedUntil =
-		rateLimitedAccounts.length > 0
-			? Math.min(
-					...rateLimitedAccounts.map((account) => account.rate_limited_until),
-				)
-			: null;
+	// next_available_at = earliest of (active cooldown) and (future usage
+	// reset). Both signals have to be considered — a usage-capped account with
+	// `rate_limited_until = null` would otherwise be ignored by the original
+	// code and leak Retry-After: 60 to the client.
+	const recoveryCandidates: number[] = [];
+	for (const account of accounts) {
+		if (account.rate_limited_until && account.rate_limited_until > now) {
+			recoveryCandidates.push(account.rate_limited_until);
+		}
+		const usage = usageSnapshots?.get(account.id);
+		if (
+			usage &&
+			isUsageExhausted(usage.utilization, usage.resetMs, now) &&
+			usage.resetMs &&
+			usage.resetMs > now
+		) {
+			recoveryCandidates.push(usage.resetMs);
+		}
+	}
+	const earliestRecoveryMs =
+		recoveryCandidates.length > 0 ? Math.min(...recoveryCandidates) : null;
+
 	const nextAvailableAt =
-		earliestRateLimitedUntil !== null
-			? new Date(earliestRateLimitedUntil).toISOString()
+		earliestRecoveryMs !== null
+			? new Date(earliestRecoveryMs).toISOString()
 			: null;
 
-	// Calculate Retry-After header (seconds) directly from numeric min
+	// Retry-After: clamped to [1, MAX], with a defensible floor when no
+	// recovery time is known. Mirrors model-capacity.ts's clamp semantics; the
+	// floor (600s = UsageCache TTL) ensures a client retry can observe fresh
+	// telemetry rather than retrying blindly against a stale snapshot.
 	const retryAfterSeconds =
-		earliestRateLimitedUntil !== null
-			? Math.max(1, Math.round((earliestRateLimitedUntil - now) / 1000))
-			: 60; // Default 60s if no cooldown info
+		earliestRecoveryMs !== null
+			? Math.max(
+					1,
+					Math.min(
+						POOL_EXHAUSTED_MAX_RETRY_AFTER_SECONDS,
+						Math.ceil((earliestRecoveryMs - now) / 1000),
+					),
+				)
+			: POOL_EXHAUSTED_UNKNOWN_RESET_RETRY_AFTER_SECONDS;
 
 	return new Response(
 		JSON.stringify({

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -1,11 +1,16 @@
 import {
+	type AccountUsageSnapshot,
 	requestEvents,
 	ServiceUnavailableError,
 	trackClientVersion,
 } from "@better-ccflare/core";
 import { DatabaseFactory } from "@better-ccflare/database";
 import { Logger } from "@better-ccflare/logger";
-import { usageCache } from "@better-ccflare/providers";
+import {
+	getRepresentativeUsageResetMs,
+	getRepresentativeUtilizationForProvider,
+	usageCache,
+} from "@better-ccflare/providers";
 import type { Account } from "@better-ccflare/types";
 import { cacheBodyStore } from "./cache-body-store";
 import {
@@ -434,7 +439,32 @@ export async function handleProxy(
 			(a) => a.provider === ctx.provider.name,
 		);
 
-		const poolExhaustedResponse = createPoolExhaustedResponse(allAccounts);
+		// Build a usage snapshot map (id → snapshot) so createPoolExhaustedResponse
+		// can surface `usage_exhausted` reasons and derive next_available_at /
+		// Retry-After from the same telemetry the strategy just consulted.
+		// Without this, accounts at 100% utilization with no rate_limited_until
+		// fall through to the catch-all `unavailable` branch with a default
+		// Retry-After of 60s — see incident 2026-07-30T20:24-22:20Z.
+		const usageSnapshots = new Map<string, AccountUsageSnapshot>();
+		for (const account of allAccounts) {
+			const cached = usageCache.get(account.id);
+			if (!cached) continue;
+			const provider = account.provider ?? "anthropic";
+			const utilization = getRepresentativeUtilizationForProvider(
+				cached,
+				provider,
+			);
+			if (utilization === null) continue;
+			usageSnapshots.set(account.id, {
+				utilization,
+				resetMs: getRepresentativeUsageResetMs(cached, provider),
+			});
+		}
+
+		const poolExhaustedResponse = createPoolExhaustedResponse(
+			allAccounts,
+			usageSnapshots,
+		);
 
 		// Skip request-log staging for synthetic auto-refresh probes that
 		// 503 because their target account is on a known cooldown. Logging

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -7,8 +7,7 @@ import {
 import { DatabaseFactory } from "@better-ccflare/database";
 import { Logger } from "@better-ccflare/logger";
 import {
-	getRepresentativeUsageResetMs,
-	getRepresentativeUtilizationForProvider,
+	getRepresentativeUsageSnapshotForProvider,
 	usageCache,
 } from "@better-ccflare/providers";
 import type { Account } from "@better-ccflare/types";
@@ -445,20 +444,23 @@ export async function handleProxy(
 		// Without this, accounts at 100% utilization with no rate_limited_until
 		// fall through to the catch-all `unavailable` branch with a default
 		// Retry-After of 60s — see incident 2026-07-30T20:24-22:20Z.
+		//
+		// The snapshot MUST pair utilization with the reset belonging to the SAME
+		// window that produced the max — picking them independently (as the
+		// pre-fix code did) pairs e.g. Zai's time_limit.max with tokens_limit's
+		// reset and lies to clients about when capacity returns (Greptile review
+		// on PR #365). The paired helper returns null when no telemetry exists.
 		const usageSnapshots = new Map<string, AccountUsageSnapshot>();
 		for (const account of allAccounts) {
 			const cached = usageCache.get(account.id);
 			if (!cached) continue;
 			const provider = account.provider ?? "anthropic";
-			const utilization = getRepresentativeUtilizationForProvider(
+			const snapshot = getRepresentativeUsageSnapshotForProvider(
 				cached,
 				provider,
 			);
-			if (utilization === null) continue;
-			usageSnapshots.set(account.id, {
-				utilization,
-				resetMs: getRepresentativeUsageResetMs(cached, provider),
-			});
+			if (snapshot === null) continue;
+			usageSnapshots.set(account.id, snapshot);
 		}
 
 		const poolExhaustedResponse = createPoolExhaustedResponse(


### PR DESCRIPTION
## Problem

A usage-capped account has `rate_limited_until = null`. `createPoolExhaustedResponse` derives both `next_available_at` and `Retry-After` **only** from `rate_limited_until`:

```ts
const retryAfterSeconds =
    earliestRateLimitedUntil !== null
        ? Math.max(1, Math.round((earliestRateLimitedUntil - now) / 1000))
        : 60; // Default 60s if no cooldown info
```

So when every account is usage-capped rather than rate-limited, the pool is empty for hours or days and the client is told to retry in 60 seconds. The per-account reason ladder (`requires_reauth` → `paused` → `rate_limited` → `unavailable`) has no usage branch either, so the response gives no hint that quota, not cooldown, is the blocker.

Separately, `packages/http-api/src/handlers/health.ts` computed `routable` via `isAccountAvailable(a, now)` with no usage argument, so `/health` reported a healthy routable count while the data plane served nothing.

## Production incident

A PostgreSQL-backed deployment, 3 Anthropic accounts, all usage-capped simultaneously (two at 100% on the seven-day window):

```
2026-07-30T20:24:03Z – 22:20:45Z   116 minutes, 100% pool_exhausted, zero successes
```

Throughout, `/health` reported `status: "ok"` with `routable: 3` against a data plane serving nothing. Nothing alerted for the entire window. The pool recovered on its own with no intervention.

Every 503 carried `Retry-After: 60`. Clients running `CLAUDE_CODE_MAX_RETRIES=5` therefore exhausted their retries in five minutes and gave up permanently. Measured time-to-death across seven independent agent processes:

```
300.555  300.501  300.464  300.396  300.518  300.546  300.448   seconds
```

Seven processes agreeing to within 0.6 s is the signature of a fixed server-supplied 60, not jittered client backoff. 19 agent runs were lost across two batches.

## Changes

**`packages/proxy/src/handlers/proxy-operations.ts`**

`createPoolExhaustedResponse` takes an optional `usageSnapshots` map (account id → snapshot). The function stays pure; the caller sources snapshots from `usageCache`. With it:

- `usage_exhausted` is added to the per-account reason ladder, ahead of `rate_limited`, so a quota-blocked account is no longer reported as generic `unavailable`.
- `next_available_at` and `Retry-After` derive from `earliestRecoveryMs` — the earliest of any cooldown expiry *and* any known upstream usage reset — instead of cooldown alone.
- When usage is capped and no reset time is known, the fallback is floored at the `UsageCache` TTL (600 s) rather than 60 s, so a client retry observes fresh telemetry instead of retrying blindly against a stale snapshot. An optimistic 60 in that state is actively harmful; it converts a recoverable wait into client death.

**`packages/http-api/src/handlers/health.ts`**

`routable` now passes the usage snapshot to `isAccountAvailable`, so it reflects what ccflare will actually attempt to route.

Note this changes the relationship between `routable` and `usage_exhausted`. The `usage_exhausted` counter deliberately keeps its existing PR #299 semantics — it still gates on the pre-usage-aware `isAccountAvailable` so it does not double-count paused or rate-limited accounts, and cannot exceed `routable`. That was a review finding on #299 and I did not want to silently reverse it.

## Tests

New: `pool-exhausted-usage-aware.test.ts`, `health-usage-exhausted.test.ts`. 18 pass / 0 fail, including a case reproducing the incident shape — all accounts usage-capped with `rate_limited_until = null`, asserting `routable: 0` and a `Retry-After` that is not 60.

Existing `pool-exhausted.test.ts`: 10 pass / 0 fail, no regression.

Verified on Bun 1.2.23.

## Notes for review

- The `usageSnapshots` parameter is optional, so existing callers compile unchanged and behaviour is identical when it is absent. Only `proxy.ts` passes it today.
- I have deliberately not touched the `isUsageExhausted` predicate in `packages/core/src/strategy.ts` — this PR surfaces what that predicate already decides, it does not change eligibility.
- 600 s is chosen because it matches the `UsageCache` TTL. If you would rather it track the poll interval or a configurable value, say so and I will change it — the number matters less than not defaulting to 60 in a state where 60 is known to be wrong.
- Related, not required by this PR: #348 covers a different way abandoned requests become invisible. This one is specifically about the pool-exhausted path lying about when capacity returns.
