### PR TITLE
fix(dashboard): render per-window MiniMax usage from canonical seven_day key

### DIFF
--- a/packages/dashboard-web/src/components/accounts/RateLimitProgress.test.tsx
+++ b/packages/dashboard-web/src/components/accounts/RateLimitProgress.test.tsx
@@ -253,4 +253,108 @@ describe("RateLimitProgress", () => {
 		// row labels which are <span>s — pins the header markup, not just the text.
 		expect(html).toContain(">Session</div>");
 	});
+
+	// Regression: MiniMax Token Plan emits normalized `{ utilization, resetAt }`
+	// windows under `five_hour` and `seven_day` (canonical names from
+	// minimax-usage-fetcher.ts). The legacy Anthropic collector requires
+	// snake_case `resets_at`, so without the dedicated MiniMax branch the 7d
+	// row collapses to a single most-restrictive fallback (max of 5h/7d) — the
+	// bug that hid per-window usage on ccmax. See:
+	// https://github.com/zenprocess/better-ccflare for the operator-reported
+	// dashboard dead-branch class.
+	it("renders MiniMax five_hour and seven_day as separate windows from each window's own utilization (ccflare-95)", () => {
+		const fiveHourReset = Date.now() + 5 * 60 * 60 * 1000;
+		const sevenDayReset = Date.now() + 5 * 24 * 60 * 60 * 1000;
+		const html = renderToStaticMarkup(
+			<RateLimitProgress
+				resetIso={new Date(fiveHourReset).toISOString()}
+				usageUtilization={50}
+				usageWindow="seven_day"
+				usageData={{
+					five_hour: {
+						utilization: 25,
+						remainingPercent: 75,
+						resetAt: fiveHourReset,
+						intervalMs: 5 * 60 * 60 * 1000,
+					},
+					seven_day: {
+						utilization: 90,
+						remainingPercent: 10,
+						resetAt: sevenDayReset,
+						intervalMs: 7 * 24 * 60 * 60 * 1000,
+					},
+				}}
+				provider="minimax"
+				showWeekly
+			/>,
+		);
+		// Both windows render as clearly labelled rows.
+		expect(html).toContain("Usage (5-hour)");
+		expect(html).toContain("Usage (Weekly)");
+		// Each window's own utilization surfaces — 25% for 5h (free), 90% for 7d
+		// (almost exhausted). The top-level usageUtilization (50, from the
+		// max-of-windows fallback) MUST NOT leak into the rendered bars.
+		expect(html).toContain("25%");
+		expect(html).toContain("90%");
+		expect(html).not.toContain("50%");
+		// No N/A placeholder — both windows have a real utilization and resetAt.
+		expect(html).not.toContain("N/A");
+	});
+
+	it("skips the MiniMax 7-day row entirely when seven_day is null (ccflare-95)", () => {
+		const fiveHourReset = Date.now() + 5 * 60 * 60 * 1000;
+		const html = renderToStaticMarkup(
+			<RateLimitProgress
+				resetIso={new Date(fiveHourReset).toISOString()}
+				usageUtilization={25}
+				usageWindow="five_hour"
+				usageData={{
+					five_hour: {
+						utilization: 25,
+						remainingPercent: 75,
+						resetAt: fiveHourReset,
+						intervalMs: 5 * 60 * 60 * 1000,
+					},
+					seven_day: null,
+				}}
+				provider="minimax"
+				showWeekly
+			/>,
+		);
+		// 5-hour still renders.
+		expect(html).toContain("Usage (5-hour)");
+		expect(html).toContain("25%");
+		// No "Weekly" row, no N/A placeholder.
+		expect(html).not.toContain("Usage (Weekly)");
+		expect(html).not.toContain("N/A");
+	});
+
+	it("does NOT mis-dispatch an Anthropic seven_day payload to the MiniMax branch (ccflare-95)", () => {
+		// Anthropic-style inner windows use snake_case `resets_at` (ISO string),
+		// not camelCase `resetAt`. The shape probe on the inner object is what
+		// keeps the legacy Anthropic collector reachable for its payloads.
+		const fiveHourReset = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+		const sevenDayReset = new Date(
+			Date.now() + 3 * 24 * 60 * 60 * 1000,
+		).toISOString();
+		const html = renderToStaticMarkup(
+			<RateLimitProgress
+				resetIso={fiveHourReset}
+				usageUtilization={10}
+				usageWindow="five_hour"
+				usageData={{
+					five_hour: { utilization: 10, resets_at: fiveHourReset },
+					seven_day: { utilization: 20, resets_at: sevenDayReset },
+				}}
+				provider="anthropic"
+				showWeekly
+			/>,
+		);
+		// Anthropic render path emits the legacy "Usage (5-hour)" / "Usage (Weekly)"
+		// labels with the inner `resets_at` values — MiniMax branch is unreachable.
+		expect(html).toContain("Usage (5-hour)");
+		expect(html).toContain("Usage (Weekly)");
+		expect(html).toContain("10%");
+		expect(html).toContain("20%");
+	});
 });

--- a/packages/dashboard-web/src/components/accounts/RateLimitProgress.tsx
+++ b/packages/dashboard-web/src/components/accounts/RateLimitProgress.tsx
@@ -234,6 +234,35 @@ export function RateLimitProgress({
 	const isAlibabaData =
 		usageData && "five_hour" in usageData && "weekly" in usageData;
 
+	// Check if this is MiniMax Token Plan usage data. The fetcher normalizes
+	// MiniMax's native `weekly_*` fields into a canonical `seven_day` window
+	// (see minimax-usage-fetcher.ts) with camelCase `resetAt` (epoch ms) on the
+	// inner object — distinct from Anthropic-style snake_case `resets_at`
+	// (ISO string). We disambiguate by inspecting the inner shape, not the
+	// provider name, so this also tolerates any future fetcher that adopts the
+	// same canonical convention. Without this guard a MiniMax payload falls
+	// into the Anthropic render branch below, `isUsageWindow` rejects both
+	// inner windows (no `resets_at`), and the 7d row collapses to "N/A".
+	const isMinimaxData = (() => {
+		if (!usageData || typeof usageData !== "object") return false;
+		if (!("five_hour" in usageData) && !("seven_day" in usageData)) {
+			return false;
+		}
+		// Anthropic-style: snake_case `resets_at` (string). MiniMax: camelCase
+		// `resetAt` (number, epoch ms). Require every present inner window
+		// to match the MiniMax shape — rejects payloads where one window
+		// looks like MiniMax and another looks like Anthropic, and rejects
+		// empty-object inner windows that would otherwise render "undefined%".
+		for (const key of ["five_hour", "seven_day"] as const) {
+			const obj = (usageData as Record<string, unknown>)[key];
+			if (obj === undefined || obj === null) continue;
+			if (typeof obj !== "object") return false;
+			const o = obj as Record<string, unknown>;
+			if (!("resetAt" in o) || "resets_at" in o) return false;
+		}
+		return true;
+	})();
+
 	// Anthropic-style quota data is shared by Anthropic and Codex; detect by shape, not provider name.
 	const hasAnthropicStyleData =
 		usageData != null &&
@@ -242,6 +271,7 @@ export function RateLimitProgress({
 		(("five_hour" in usageData && "seven_day" in usageData) ||
 			Array.isArray((usageData as { limits?: unknown }).limits)) &&
 		!isAlibabaData &&
+		!isMinimaxData &&
 		!isZaiData &&
 		!isNanoGPTData;
 
@@ -272,6 +302,46 @@ export function RateLimitProgress({
 				? new Date(alibabaData.monthly.resetAt).toISOString()
 				: null,
 		});
+	} else if (isMinimaxData && showWeekly) {
+		// MiniMax Token Plan usage data — show 5-hour and 7-day windows from
+		// each window's own `utilization` and `resetAt` (camelCase, epoch ms).
+		// Do NOT collapse to a single `usageUtilization` row: that fallback
+		// takes the most-restrictive window across all accounts and hides
+		// the second window entirely.
+		const minimaxData = usageData as {
+			five_hour?: {
+				utilization: number | null;
+				resetAt: number | null;
+			} | null;
+			seven_day?: {
+				utilization: number | null;
+				resetAt: number | null;
+			} | null;
+		};
+		const fiveHourUtil = minimaxData.five_hour?.utilization;
+		if (typeof fiveHourUtil === "number") {
+			usages.push({
+				utilization: fiveHourUtil,
+				window: "five_hour",
+				resetTime:
+					minimaxData.five_hour &&
+					typeof minimaxData.five_hour.resetAt === "number"
+						? new Date(minimaxData.five_hour.resetAt).toISOString()
+						: null,
+			});
+		}
+		const sevenDayUtil = minimaxData.seven_day?.utilization;
+		if (typeof sevenDayUtil === "number") {
+			usages.push({
+				utilization: sevenDayUtil,
+				window: "seven_day",
+				resetTime:
+					minimaxData.seven_day &&
+					typeof minimaxData.seven_day.resetAt === "number"
+						? new Date(minimaxData.seven_day.resetAt).toISOString()
+						: null,
+			});
+		}
 	} else if (isXaiData && showWeekly) {
 		// xAI/Grok usage data - show Grok Build credits utilization.
 		const xaiData = usageData as {

--- a/packages/dashboard-web/src/components/accounts/provider-utils.test.ts
+++ b/packages/dashboard-web/src/components/accounts/provider-utils.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Regression tests for provider-utils. These lock in the two-gate
+ * contract that AccountListItem and RateLimitProgress depend on:
+ *
+ *   1. providerShowsWeeklyUsage MUST return true for any provider whose
+ *      usage payload is shaped such that RateLimitProgress can render
+ *      per-window rows. Otherwise AccountListItem passes showWeekly=false
+ *      and the component falls back to a single max-of-windows bar.
+ *   2. A future revert of any allow-list entry MUST be caught here —
+ *      otherwise the Gate B render branch becomes unreachable in
+ *      production and the bug returns silently.
+ *
+ * Provider strings are asserted as literals (not via PROVIDER_NAMES) so
+ * this test file has no @better-ccflare/types dependency — adding one
+ * pulls in a circular import that breaks PROVIDER_NAMES initialization
+ * across the whole dashboard-web test process.
+ */
+import { describe, expect, it } from "bun:test";
+import { providerShowsWeeklyUsage } from "../../utils/provider-utils";
+
+describe("providerShowsWeeklyUsage", () => {
+	it("returns true for minimax so AccountListItem passes showWeekly=true (ccflare-100)", () => {
+		// Gate A for the MiniMax per-window fix. Without this entry the
+		// component renders a single collapsed bar instead of separate
+		// 5-hour and 7-day windows — the dashboard dead-branch bug this
+		// branch is meant to fix.
+		expect(providerShowsWeeklyUsage("minimax")).toBe(true);
+	});
+
+	it("returns true for alibaba-coding-plan so its five_hour/weekly/monthly branch is reachable (ccflare-100)", () => {
+		// Gate A for the Alibaba per-window fix. Without this entry the
+		// isAlibabaData branch in RateLimitProgress is unreachable and
+		// the pool-usage eligibility set never sees Alibaba accounts.
+		expect(providerShowsWeeklyUsage("alibaba-coding-plan")).toBe(true);
+	});
+
+	it("returns true for the pre-existing allow-listed providers (regression guard)", () => {
+		// These were already allow-listed before this branch. Pins them
+		// so a future cleanup pass doesn't quietly remove an entry the
+		// dashboard still depends on.
+		expect(providerShowsWeeklyUsage("anthropic")).toBe(true);
+		expect(providerShowsWeeklyUsage("codex")).toBe(true);
+		expect(providerShowsWeeklyUsage("nanogpt")).toBe(true);
+		expect(providerShowsWeeklyUsage("zai")).toBe(true);
+		expect(providerShowsWeeklyUsage("xai")).toBe(true);
+	});
+
+	it("returns false for providers without a per-window usage shape (negative coverage)", () => {
+		// These providers either render a single bar (kilo credits) or no
+		// usage surface at all. If any of these flip to true the dashboard
+		// would dispatch an unhandled payload into the showWeekly gate.
+		expect(providerShowsWeeklyUsage("kilo")).toBe(false);
+		expect(providerShowsWeeklyUsage("unknown-provider")).toBe(false);
+		expect(providerShowsWeeklyUsage("")).toBe(false);
+	});
+});

--- a/packages/dashboard-web/src/utils/provider-utils.ts
+++ b/packages/dashboard-web/src/utils/provider-utils.ts
@@ -50,7 +50,18 @@ export function providerShowsWeeklyUsage(provider: string): boolean {
 		provider === PROVIDER_NAMES.CODEX ||
 		provider === PROVIDER_NAMES.NANOGPT ||
 		provider === PROVIDER_NAMES.ZAI ||
-		provider === PROVIDER_NAMES.XAI
+		provider === PROVIDER_NAMES.XAI ||
+		// Alibaba Coding Plan emits its own five_hour/weekly/monthly shape
+		// (see AlibabaCodingPlanUsageData + alibaba-coding-plan-usage-fetcher).
+		// Without this entry the isAlibabaData branch in RateLimitProgress and
+		// the pool-usage eligibility set both silently never render.
+		provider === PROVIDER_NAMES.ALIBABA_CODING_PLAN ||
+		// MiniMax Token Plan normalizes its native weekly window to the
+		// canonical `seven_day` key (see minimax-usage-fetcher.ts). Without
+		// this entry AccountListItem passes showWeekly=false and both 5h
+		// and 7d windows collapse to a single fallback bar — the bug
+		// fixed in this branch.
+		provider === PROVIDER_NAMES.MINIMAX
 	);
 }
 


### PR DESCRIPTION
## Symptom

For accounts on the MiniMax Token Plan provider, the dashboard showed a single collapsed usage bar instead of the separate 5-hour and 7-day windows. The top-level bar is a `Math.max` across windows, so an account with a free 5-hour window and a saturated 7-day window displayed only the saturated value — the 5-hour headroom was invisible.

Live example: `five_hour.utilization = 0`, `seven_day.utilization = 100` → dashboard rendered 100%.

## Root cause

Two independent gates, both required and both broken:

1. **`providerShowsWeeklyUsage` allow-list missing the provider.** `packages/dashboard-web/src/utils/provider-utils.ts:47` returns `true` only for `ANTHROPIC | CODEX | NANOGPT | ZAI | XAI`. `MINIMAX` (and `ALIBABA_CODING_PLAN`) are absent. Without this entry, `AccountListItem` (`packages/dashboard-web/src/components/accounts/AccountListItem.tsx:492`) passes `showWeekly={false}`, and the dedicated MiniMax render branch is never reached regardless of payload shape.

2. **Component shape check tests for a key that no normalized payload carries.** `packages/dashboard-web/src/components/accounts/RateLimitProgress.tsx` (pre-fix) had no `isMinimaxData` probe and fell through to the Anthropic-style collector, which requires snake_case `resets_at`. The MiniMax fetcher emits camelCase `resetAt` (epoch ms), so `isUsageWindow` rejected both inner windows and the 7-day row collapsed to "N/A".

## Normalization rename mechanism

The bug is at a **rename boundary**, not a missing field. `minimax-usage-fetcher.ts` calls `GET https://www.minimax.io/v1/token_plan/remains` and normalizes the response's native `weekly_*` fields into the canonical `seven_day` window name and `resetAt` (epoch ms). Anthropic-style collectors assume snake_case `resets_at` (ISO string). The component must therefore disambiguate by inner shape (`resetAt` present, `resets_at` absent) rather than by provider name. The PR adds exactly that probe and a dedicated render branch.

This is what lets the same provider name (`minimax`) coexist with the Anthropic legacy collector without colliding on `seven_day` semantics — and what makes a future fetcher that adopts the same canonical convention work without further component changes.

## Scope

Display-only.

- Touched files (4): `provider-utils.ts`, `RateLimitProgress.tsx`, `RateLimitProgress.test.tsx`, new `provider-utils.test.ts`.
- **Untouched:** `usageUtilization` / `usageWindow` / `isUsageExhausted` semantics. The top-level fallback (`providerShowsWeeklyUsage(provider) && usageUtilization && usageWindow`) is unchanged. `strategy.ts`, `account-selector.ts`, `rate-limit-status.ts`, `health.ts`, `accounts.ts` not modified.
- **Routing unaffected.** The 5h/7d windows render as rows; the router does not see them.
- **Provider registry untouched.** `packages/types/src/constants.ts` and `provider-config.ts` already define `MINIMAX` and `ALIBABA_CODING_PLAN` — the gap was the dashboard's allow-list, not the type system.

## Tested

- `bun run build` ✅
- `bun run typecheck` ✅ (root tsconfig; pre-existing package-level test-file errors at `RateLimitProgress.test.tsx:19` and `:154` are baseline and out of scope)
- `bun run lint` ✅ (9 warnings, all pre-existing on upstream/main; none in our diff)
- `bun test packages/dashboard-web` ✅ **171 pass / 0 fail** (was 164 on upstream/main; +7 new tests = +3 MiniMax render cases + 4 allow-list regression pins)
- The new `provider-utils.test.ts` locks in Gate A: a revert of the `MINIMAX` or `ALIBABA_CODING_PLAN` allow-list entry now fails the dashboard test suite. This was the central failure mode the two-gate design was meant to prevent.
- The MiniMax probe is now asymmetric-safe: a payload with one Anthropic-shaped inner window and one MiniMax-shaped inner window is rejected (falls through to the Anthropic collector), so future fetcher transitions cannot partial-render garbage.

## Not tested

- No live MiniMax account against the running dashboard. The component is a pure render with no new hooks; verified via static markup against representative payloads (free-5h + saturated-7d, null-7d, Anthropic-mis-dispatch).
- No fetcher-side changes. `utilization: null` and `resetAt: null` edge cases inside an inner window are tolerated by the render branch (row skipped if `utilization` isn't a number) but not exercised by a test — pre-existing pattern, matches Anthropic legacy behavior.
- No merge-base inspection of the 43 commits on `upstream/main` against this branch's two touched files (verified clean rebase, no conflicts; no per-commit blast radius walk beyond what GitNexus impact surfaces).
- The `[skip-version]` convention from the repo's release workflow is preserved (no `package.json` edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)