### PR TITLE
security: validate header-derived project names (fixes #373)

### DIFF
--- a/packages/proxy/src/__tests__/project-attribution.test.ts
+++ b/packages/proxy/src/__tests__/project-attribution.test.ts
@@ -45,8 +45,11 @@ describe("extractProjectAttributionFromRequest", () => {
 		expect(result.projectAttributionSource).toBe("header_project");
 	});
 
-	it("strips control characters and caps header-derived project length at 64", () => {
-		const raw = `\x01\x02${"x".repeat(80)}\n`;
+	it("strips control characters from a valid header-derived project name", () => {
+		// Dash-delimited so no unbroken alnum run trips LONG_TOKEN_RE (20+), and
+		// within the 64-char slug grammar bound so it passes validation.
+		const slug = `${"x".repeat(15)}-`.repeat(4);
+		const raw = `\x01\x02${slug}\n`;
 		const headers = new Headers({ "x-project": raw });
 		const result = extractProjectAttributionFromRequest(headers, null);
 		expect(result.project).not.toBeNull();
@@ -54,6 +57,66 @@ describe("extractProjectAttributionFromRequest", () => {
 		// biome-ignore lint/suspicious/noControlCharactersInRegex: asserting control chars are gone
 		expect(result.project ?? "").not.toMatch(/[\x00-\x1F\x7F]/);
 		expect(result.projectAttributionSource).toBe("header_project");
+	});
+
+	it("rejects a header value that exceeds the 64-char slug grammar bound (no silent truncate)", () => {
+		// Round-2 P1 hardening for the H1 path made >64-char values reject
+		// wholesale rather than truncate-and-keep; the header path must match.
+		const raw = "x".repeat(80);
+		const headers = new Headers({ "x-project": raw });
+		const result = extractProjectAttributionFromRequest(headers, null);
+		expect(result.project).toBeNull();
+		expect(result.projectAttributionSource).toBe("none");
+	});
+
+	describe("header-derived project names are validated like heading-derived ones (#373)", () => {
+		it("rejects a namespaced header value that fails isLowRiskProjectSlug", () => {
+			const headers = new Headers({
+				"x-better-ccflare-project": "## some system prompt fragment",
+			});
+			const result = extractProjectAttributionFromRequest(headers, null);
+			expect(result.project).toBeNull();
+			expect(result.projectAttributionSource).toBe("none");
+		});
+
+		it("rejects a legacy x-project header value that fails isLowRiskProjectSlug", () => {
+			const headers = new Headers({
+				"x-project": "Authorization: Bearer sk_live_abc123456789",
+			});
+			const result = extractProjectAttributionFromRequest(headers, null);
+			expect(result.project).toBeNull();
+			expect(result.projectAttributionSource).toBe("none");
+		});
+
+		it("rejects a header value carrying a secret past the 64-char truncation boundary", () => {
+			// Same shape as the H1 boundary-straddling test: a pre-truncation
+			// validator would slice this down to a clean 64-char prefix and let
+			// it through. Header path must validate the FULL value too.
+			const cleanPrefix = `${"x".repeat(15)}-`.repeat(4);
+			const headers = new Headers({
+				"x-project": `${cleanPrefix}${"Z".repeat(25)}`,
+			});
+			const result = extractProjectAttributionFromRequest(headers, null);
+			expect(result.project).toBeNull();
+			expect(result.projectAttributionSource).toBe("none");
+		});
+
+		it("falls through to the legacy header when the namespaced header is rejected", () => {
+			const headers = new Headers({
+				"x-better-ccflare-project": "# leaked system prompt heading",
+				"x-project": "legacy-project",
+			});
+			const result = extractProjectAttributionFromRequest(headers, null);
+			expect(result.project).toBe("legacy-project");
+			expect(result.projectAttributionSource).toBe("header_project");
+		});
+
+		it("still accepts ordinary slug-shaped header values", () => {
+			const headers = new Headers({ "x-better-ccflare-project": "my-app" });
+			const result = extractProjectAttributionFromRequest(headers, null);
+			expect(result.project).toBe("my-app");
+			expect(result.projectAttributionSource).toBe("header_project");
+		});
 	});
 
 	it("infers a sanitized repo slug from a /home workspace path in the system prompt", () => {

--- a/packages/proxy/src/project-attribution.ts
+++ b/packages/proxy/src/project-attribution.ts
@@ -249,22 +249,31 @@ export function extractProjectAttribution(
 	getHeader: (name: string) => string | null | undefined,
 	systemPrompt: string | null,
 ): ProjectExtractionResult {
-	const namespacedHeader = sanitizeProjectName(
-		getHeader("x-better-ccflare-project"),
-	);
-	if (namespacedHeader) {
-		return {
-			project: namespacedHeader,
-			projectAttributionSource: "header_project",
-		};
+	// Validate the FULL raw header value, then length-cap only after it passes
+	// — same reject-wholesale-before-truncating rule as the H1 heading path
+	// below. A client fully controls its own request headers, so this path
+	// needs the same secret/slug validation as attacker-influenced system
+	// prompt text (#373).
+	const rawNamespaced = getHeader("x-better-ccflare-project");
+	if (rawNamespaced && isLowRiskProjectSlug(rawNamespaced)) {
+		const namespacedHeader = sanitizeProjectName(rawNamespaced);
+		if (namespacedHeader) {
+			return {
+				project: namespacedHeader,
+				projectAttributionSource: "header_project",
+			};
+		}
 	}
 
-	const legacyHeader = sanitizeProjectName(getHeader("x-project"));
-	if (legacyHeader) {
-		return {
-			project: legacyHeader,
-			projectAttributionSource: "header_project",
-		};
+	const rawLegacy = getHeader("x-project");
+	if (rawLegacy && isLowRiskProjectSlug(rawLegacy)) {
+		const legacyHeader = sanitizeProjectName(rawLegacy);
+		if (legacyHeader) {
+			return {
+				project: legacyHeader,
+				projectAttributionSource: "header_project",
+			};
+		}
 	}
 
 	if (systemPrompt) {


### PR DESCRIPTION
## Summary
- `extractProjectAttribution` in `packages/proxy/src/project-attribution.ts` validated H1-heading-derived project names with `isLowRiskProjectSlug()` before truncating, but the `x-better-ccflare-project`/`x-project` header paths skipped that validator entirely and went straight to `sanitizeProjectName()` (control-char strip + 64-char truncate only).
- Since request headers are fully client-controlled, this let secret-, URL-, or prompt-shaped values land in `requests.project`, which is exposed unauthenticated via `/api/insights/*` and `/api/requests`.
- Root-caused in #373: the reporter suspected the H1 path validated after truncation, but that path was actually correct — the bug was that the header path had no validation step at all.

## Fix
Both header-derived values are now checked with `isLowRiskProjectSlug()` on the full raw value before `sanitizeProjectName()` truncates, mirroring the existing H1 heading path's reject-wholesale-before-truncating rule.

## Test plan
- [x] Added tests reproducing the reported leak end-to-end via the header path (secret-shaped header, boundary-straddling secret, fallback to legacy header on rejection)
- [x] Updated a pre-existing test that had encoded the buggy pass-through behavior
- [x] `bun test packages/proxy/src/__tests__/project-attribution.test.ts` — 69 pass
- [x] `bun test packages/proxy` — no new failures (6 pre-existing failures in `request-handler-client-abort.test.ts` are test-isolation flakiness unrelated to this change, verified passing in isolation on both base and fix branch)
- [x] `bun run lint && bun run typecheck && bun run format` — clean (pre-existing warnings in unrelated files only)
- [x] GitNexus `detect_changes()` — LOW risk, changes isolated to `extractProjectAttribution` and its test file

Fixes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)