### PR TITLE
fix(proxy): stop benching an account for a 429 that reports no rate-limit window

### DIFF
--- a/docs/routing-architecture.md
+++ b/docs/routing-architecture.md
@@ -41,7 +41,7 @@ flowchart TD
     J -->|"Strategy itself found nothing<br/>(all paused / rate-limited)"| M["503 pool_exhausted"]
     I -->|"Yes"| N["Dispatch: try candidates in order"]
     N --> O{"Upstream 429?"}
-    O -->|"Yes"| P{"out_of_credits (model/beta-<br/>scoped) or synthetic keepalive?"}
+    O -->|"Yes"| P{"Narrower than the account?<br/>out_of_credits (model/beta-scoped),<br/>windowless 429 (request-scoped),<br/>or synthetic keepalive"}
     P -->|"Yes"| P2["No account cooldown —<br/>fail over to next candidate"]
     P -->|"No"| P3["Apply account cooldown,<br/>fail over to next candidate"]
     P2 --> N
@@ -49,7 +49,22 @@ flowchart TD
     O -->|"No"| Q["Return response to client"]
 ```
 
-*Source: `packages/proxy/src/proxy.ts` (`handleProxy`, `applyUsageThrottling`), `packages/proxy/src/handlers/account-selector.ts` (`selectAccountsForRequest`).*
+Three classes of 429 are narrower than the account and therefore fail over per
+request with the account left in rotation — no cooldown, no
+`consecutive_rate_limits` increment:
+
+- **`out_of_credits`** — credits/overage depleted for one model or beta (e.g. context-1m); the account's other models still work.
+- **`windowless_429`** — `x-should-retry: true` with no rate-limit metadata at all (no `retry-after`, no `anthropic-ratelimit-*` / `x-ratelimit-*` header). Measured on a production install as **request**-scoped: the same account served 200s two seconds before and 38 seconds after on the same model, retries spanning 11.2s returned identical bare 429s without ever clearing, and the next account rejected the same client request the same way. Benching for it drained the pool one account per failover attempt. The check is fail-closed — any header that reports window state, known name or not, is treated as a real limit and benched as before.
+- **Synthetic keepalive replays** — the keepalive scheduler's own parallel burst trips a per-IP limit; no request-history row is written either.
+
+The `windowless_429` exemption is not universal: it is evaluated only on the
+no-fallback path (the requested model has no multi-entry mapping). An account
+**with** multi-entry model mappings walks its fallback list first, and when every
+mapped model has 429ed the request ends at `all_models_exhausted_429`, which
+**does** apply an account cooldown — even if each individual 429 reported no
+window.
+
+*Source: `packages/proxy/src/proxy.ts` (`handleProxy`, `applyUsageThrottling`), `packages/proxy/src/handlers/account-selector.ts` (`selectAccountsForRequest`), `packages/proxy/src/handlers/proxy-operations.ts` + `packages/proxy/src/handlers/retryable-429.ts` (the three no-bench 429 classes).*
 
 ## The Four Load-Balancing Strategies
 

--- a/packages/dashboard-web/src/components/overview/system-status/errorCodeMeta.ts
+++ b/packages/dashboard-web/src/components/overview/system-status/errorCodeMeta.ts
@@ -69,6 +69,26 @@ const KNOWN_ERROR_META: Record<
 			"Top up the account's credits or raise its overage allowance. Meanwhile, traffic for other models continues to use this account, and the rejected model shifts to other accounts.",
 		severity: "error",
 	},
+	windowless_429: {
+		title: "Request rejected (no rate-limit window)",
+		description:
+			"Anthropic returned 429 with `x-should-retry: true` and no rate-limit " +
+			"window at all — no `retry-after` and no `anthropic-ratelimit-*` " +
+			"header. Measured behaviour is that this is scoped to the request, not " +
+			"the account: the same account keeps serving other requests in the same " +
+			"second, while every other account rejects this particular request the " +
+			"same way. The account was NOT benched and stays in rotation. The " +
+			"request itself was tried on the remaining accounts and, because they " +
+			"all reject it identically, still failed for the client.",
+		suggestion:
+			"No action needed on the accounts — they are still routable and normal " +
+			"traffic is unaffected. Upstream rejected this specific request for " +
+			"reasons narrower than the account, so neither retrying it nor adding " +
+			"accounts helps; the client typically has to start a new request. A " +
+			"steady stream of these points at the requests themselves (session " +
+			"start-up, unusually large payload) rather than at your accounts.",
+		severity: "warning",
+	},
 	extra_usage_exhausted: {
 		title: "Extra usage credits depleted",
 		description:

--- a/packages/http-api/src/handlers/accounts.ts
+++ b/packages/http-api/src/handlers/accounts.ts
@@ -64,6 +64,11 @@ const RATE_LIMIT_REASONS = new Set<RateLimitReason>([
 	"upstream_529_overloaded_no_reset",
 	"out_of_credits",
 	"extra_usage_exhausted",
+	// Never actually written to accounts.rate_limited_reason today (a
+	// windowless 429 does not bench the account), but listed so this set stays
+	// a faithful mirror of the union and cannot silently null the value if a
+	// future path ever persists it.
+	"windowless_429",
 ]);
 
 function toRateLimitReason(v: string | null): RateLimitReason | null {

--- a/packages/proxy/src/__tests__/bun-leak-273-regression.test.ts
+++ b/packages/proxy/src/__tests__/bun-leak-273-regression.test.ts
@@ -17,9 +17,9 @@
  *
  * This test imports the PRODUCTION helper
  * (`handlers/discard-body-cancel.ts:cancelDiscardedResponseBody`) directly
- * — the same function the 12 discard sites in proxy-operations.ts call.
+ * — the same function the 13 discard sites in proxy-operations.ts call.
  * The orchestrator's mandatory negative-control run removes ONLY those
- * 12 call sites (and/or the `void drainBody(...)` invocation inside the
+ * 13 call sites (and/or the `void drainBody(...)` invocation inside the
  * helper); the assertions below verify both halves:
  *
  *   Group A (helper contract) — verifies `cancelDiscardedResponseBody`
@@ -28,13 +28,13 @@
  *   `drainBody` call from inside the helper function flips these red.
  *
  *   Group B (call-site coverage) — performs static analysis of
- *   `proxy-operations.ts` to assert the 12 drain calls are present
+ *   `proxy-operations.ts` to assert the 13 drain calls are present
  *   and structurally well-formed. Removing any one of them flips this
  *   red. We don't import proxy-operations.ts (its transitive
  *   dependency chain loads @better-ccflare/database, which itself has
  *   missing modules in this worktree's `bun install`-blocked state —
  *   a pre-existing issue unrelated to this fix), but the source-level
- *   check is enough to detect the negative-control removal: 12 sites,
+ *   check is enough to detect the negative-control removal: 13 sites,
  *   each line beginning with the helper name.
  *
  * Run: bun test packages/proxy/src/__tests__/bun-leak-273-regression.test.ts
@@ -105,16 +105,16 @@ describe("issue #273 — Group A: helper contract", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Group B — call-site coverage. Static check that the 12 drain sites the
+// Group B — call-site coverage. Static check that the 13 drain sites the
 // spec calls out (429/529/401 failover return-null + retry-loop overwrite)
 // are wired into proxy-operations.ts. The negative-control run removes
 // these lines; this check fails if any are missing.
 // ---------------------------------------------------------------------------
 
-const EXPECTED_SITE_COUNT = 12;
+const EXPECTED_SITE_COUNT = 13;
 
 describe("issue #273 — Group B: call-site coverage in proxy-operations.ts", () => {
-	it("proxy-operations.ts has exactly 12 cancelDiscardedResponseBody call sites", () => {
+	it("proxy-operations.ts has exactly 13 cancelDiscardedResponseBody call sites", () => {
 		const source = readFileSync(
 			"packages/proxy/src/handlers/proxy-operations.ts",
 			"utf-8",
@@ -139,7 +139,7 @@ describe("issue #273 — Group B: call-site coverage in proxy-operations.ts", ()
 		);
 	});
 
-	it("proxy-operations.ts has drain sites at the 12 expected line ranges", () => {
+	it("proxy-operations.ts has drain sites at the 13 expected line ranges", () => {
 		const source = readFileSync(
 			"packages/proxy/src/handlers/proxy-operations.ts",
 			"utf-8",

--- a/packages/proxy/src/__tests__/bun-leak-273-safety.test.ts
+++ b/packages/proxy/src/__tests__/bun-leak-273-safety.test.ts
@@ -6,7 +6,7 @@
  * branch was created to address: draining a body stream that is still
  * being forwarded truncates the client's response silently. The
  * ccflare-side leak fix (cancelDiscardedResponseBody) intentionally
- * targets ONLY the failover/retry discard sites (see the 12 call sites
+ * targets ONLY the failover/retry discard sites (see the 13 call sites
  * listed in proxy-operations.ts). Every other path — the streaming
  * forwarder in response-handler.ts, the non-streaming forwarder, and
  * the model-not-found forward to the client (`withSanitizedProxyHeaders`) —

--- a/packages/proxy/src/circuit-breaker.ts
+++ b/packages/proxy/src/circuit-breaker.ts
@@ -203,6 +203,11 @@ interface CircuitEntry {
  * similarly scoped to a single model/surface, not account-wide, so the
  * request fails over naturally without tripping the breaker.
  *
+ * `windowless_429` (a 429 reporting no rate-limit window at all) is scoped
+ * to the individual request — no cooldown is applied and the account stays
+ * in rotation — so counting it would open the breaker on an account that is
+ * still serving traffic.
+ *
  * Every other `RateLimitReason` — account/provider-wide exhaustion,
  * 529 overload — counts as a circuit failure.
  *
@@ -229,6 +234,10 @@ export function shouldCountAsCircuitFailure(kind: FailureKind): boolean {
 		case "model_fallback_429":
 		case "out_of_credits":
 		case "extra_usage_exhausted":
+			return false;
+		// Request-scoped, and no cooldown is applied — the account keeps
+		// serving other traffic, so this must not count toward opening.
+		case "windowless_429":
 			return false;
 		case "upstream_429_with_reset":
 		case "upstream_429_no_reset_default_5h":

--- a/packages/proxy/src/handlers/__tests__/proxy-operations-windowless-429.test.ts
+++ b/packages/proxy/src/handlers/__tests__/proxy-operations-windowless-429.test.ts
@@ -1,0 +1,393 @@
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	mock,
+	spyOn,
+} from "bun:test";
+import { usageCache } from "@better-ccflare/providers";
+import type { Account, RequestMeta } from "@better-ccflare/types";
+import * as usageCollectorModule from "../../usage-collector";
+import { clearFamilyExhaustionCache } from "../model-capacity";
+import { proxyWithAccount } from "../proxy-operations";
+import type { ProxyContext } from "../proxy-types";
+
+function stubUsageCollector() {
+	return spyOn(usageCollectorModule, "getUsageCollector").mockReturnValue({
+		handleStart: mock(() => {}),
+		handleChunk: mock(() => {}),
+		handleEnd: mock(() => Promise.resolve()),
+	} as unknown as usageCollectorModule.UsageCollector);
+}
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "acc-anthropic-1",
+		name: "claude-pro",
+		provider: "anthropic",
+		api_key: null,
+		refresh_token: "refresh-token",
+		access_token: "access-token",
+		expires_at: Date.now() + 3 * 60 * 60 * 1000,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: Date.now(),
+		rate_limited_until: null,
+		rate_limited_reason: null,
+		rate_limited_at: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		peak_hours_pause_enabled: false,
+		custom_endpoint: null,
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		billing_type: null,
+		pause_reason: null,
+		refresh_token_issued_at: null,
+		consecutive_rate_limits: 0,
+		...overrides,
+	};
+}
+
+function makeRequestMeta(): RequestMeta {
+	return {
+		id: "req-1",
+		method: "POST",
+		path: "/v1/messages",
+		timestamp: Date.now(),
+		headers: new Headers(),
+	};
+}
+
+function makeRequestBody(model = "claude-sonnet-4-5") {
+	const body = JSON.stringify({
+		model,
+		messages: [{ role: "user", content: "hello" }],
+		max_tokens: 10,
+	});
+	return new TextEncoder().encode(body).buffer;
+}
+
+function makeRequest(body: ArrayBuffer, headers: Record<string, string> = {}) {
+	return new Request("https://proxy.local/v1/messages", {
+		method: "POST",
+		body,
+		headers: { "Content-Type": "application/json", ...headers },
+	});
+}
+
+/**
+ * The windowless 429, captured verbatim from Anthropic on 2026-07-31: an
+ * explicit retry instruction and no rate-limit window state at all.
+ *
+ * Live measurement showed this shape to be REQUEST-scoped, not account-wide.
+ * The same account served 200s two seconds before and 38 seconds after the
+ * rejection, on the same model, while every other account in the pool rejected
+ * the same client request with the same bare 429.
+ *
+ * Passing window headers via `extra` models a genuine limit, which also carries
+ * `x-should-retry: true` and MUST still bench.
+ */
+function burst429(extra: Record<string, string> = {}): Response {
+	return new Response(
+		JSON.stringify({
+			type: "error",
+			error: { type: "rate_limit_error", message: "rate limit exceeded" },
+		}),
+		{
+			status: 429,
+			headers: {
+				"content-type": "application/json",
+				"x-robots-tag": "none",
+				"x-should-retry": "true",
+				...extra,
+			},
+		},
+	);
+}
+
+function ok200(): Response {
+	return new Response(
+		JSON.stringify({
+			id: "msg_1",
+			type: "message",
+			role: "assistant",
+			model: "claude-sonnet-4-5",
+			content: [{ type: "text", text: "hi" }],
+			stop_reason: "end_turn",
+			usage: { input_tokens: 5, output_tokens: 2 },
+		}),
+		{ status: 200, headers: { "content-type": "application/json" } },
+	);
+}
+
+function makeCtx(): ProxyContext {
+	return {
+		strategy: { getNextAccount: () => null } as never,
+		dbOps: {
+			markAccountRateLimited: mock(
+				(_id: string, _until: number, _reason: string) =>
+					Promise.resolve({ consecutiveRateLimits: 1, applied: true }),
+			),
+			saveRequest: mock((..._args: unknown[]) => Promise.resolve()),
+			updateAccountUsage: mock(() => Promise.resolve()),
+			getAdapter: mock(() => ({
+				run: mock(() => Promise.resolve()),
+				get: mock(() => Promise.resolve(null)),
+			})),
+		} as never,
+		runtime: { port: 8080, clientId: "test" } as never,
+		// NOTE: getProvider("anthropic") from the registry wins over this, by
+		// design — the real parser and processResponse run.
+		provider: { name: "anthropic" } as never,
+		refreshInFlight: new Map(),
+		asyncWriter: {
+			enqueue: mock(async (job: () => void | Promise<void>) => {
+				await job();
+			}),
+		} as never,
+		config: { getStorePayloads: () => true } as never,
+		internalProbeSecret: "test-secret",
+	};
+}
+
+async function runProxy(
+	account: Account,
+	ctx: ProxyContext,
+	req: Request,
+	body: ArrayBuffer,
+) {
+	return proxyWithAccount(
+		req,
+		new URL("https://proxy.local/v1/messages"),
+		account,
+		makeRequestMeta(),
+		body,
+		() => undefined,
+		0,
+		ctx,
+	);
+}
+
+const marks = (ctx: ProxyContext) =>
+	(ctx.dbOps.markAccountRateLimited as ReturnType<typeof mock>).mock.calls
+		.length;
+const saveReasons = (ctx: ProxyContext) =>
+	(ctx.dbOps.saveRequest as ReturnType<typeof mock>).mock.calls.map(
+		(c) => (c as unknown[])[6],
+	);
+/** markAccountRateLimited(accountId, until, reason, incrementStreak) */
+const markCalls = (ctx: ProxyContext) =>
+	(ctx.dbOps.markAccountRateLimited as ReturnType<typeof mock>).mock
+		.calls as unknown as [string, number, string, boolean][];
+
+describe("proxyWithAccount — windowless 429 is not benched (issue #301)", () => {
+	let originalFetch: typeof globalThis.fetch;
+	let collectorSpy: ReturnType<typeof stubUsageCollector>;
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+		collectorSpy = stubUsageCollector();
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		collectorSpy.mockRestore();
+		usageCache.clear();
+		clearFamilyExhaustionCache();
+	});
+
+	// The core claim. A bare 429 is request-scoped, so it must fail over per
+	// request WITHOUT a cooldown, without touching the consecutive-429 counter,
+	// and without a second upstream attempt — three retries spanning 11.2s were
+	// measured returning three identical bare 429s, and not once did one succeed.
+	it("fails over without benching on a bare 429", async () => {
+		let calls = 0;
+		globalThis.fetch = mock(async () => {
+			calls++;
+			return burst429();
+		});
+
+		const ctx = makeCtx();
+		const account = makeAccount();
+		const body = makeRequestBody();
+
+		const result = await runProxy(account, ctx, makeRequest(body), body);
+
+		// Exactly one upstream call — no in-place retry.
+		expect(calls).toBe(1);
+		// null = fail over to the next account.
+		expect(result).toBeNull();
+		expect(marks(ctx)).toBe(0);
+		expect(account.rate_limited_until).toBeNull();
+		expect(account.rate_limited_reason).toBeNull();
+		expect(account.consecutive_rate_limits).toBe(0);
+		expect(saveReasons(ctx)).toContain("windowless_429");
+		expect(saveReasons(ctx)).not.toContain("model_fallback_429");
+	});
+
+	// The operational point of not benching: the account is immediately routable
+	// again, exactly as production showed it to be (200s two seconds either side
+	// of the rejected request).
+	it("leaves the account routable for the very next request", async () => {
+		let calls = 0;
+		globalThis.fetch = mock(async () => {
+			calls++;
+			return calls === 1 ? burst429() : ok200();
+		});
+
+		const ctx = makeCtx();
+		const account = makeAccount();
+		const body = makeRequestBody();
+
+		expect(await runProxy(account, ctx, makeRequest(body), body)).toBeNull();
+
+		const second = await runProxy(account, ctx, makeRequest(body), body);
+		expect(second?.status).toBe(200);
+		expect(marks(ctx)).toBe(0);
+		expect(account.rate_limited_until).toBeNull();
+	});
+
+	// Regression guard: a 429 that reports a reset is a REAL window limit and
+	// must bench exactly as it did before this change.
+	it("still benches a 429 carrying a reset hint", async () => {
+		let calls = 0;
+		globalThis.fetch = mock(async () => {
+			calls++;
+			return burst429({
+				"anthropic-ratelimit-unified-reset": String(
+					Math.floor(Date.now() / 1000) + 300,
+				),
+			});
+		});
+
+		const ctx = makeCtx();
+		const account = makeAccount();
+		const body = makeRequestBody();
+
+		const result = await runProxy(account, ctx, makeRequest(body), body);
+
+		expect(calls).toBe(1);
+		expect(result).toBeNull();
+		expect(markCalls(ctx)).toHaveLength(1);
+		expect(markCalls(ctx)[0][2]).toBe("model_fallback_429");
+		expect(typeof account.rate_limited_until).toBe("number");
+		expect(saveReasons(ctx)).toContain("model_fallback_429");
+		expect(saveReasons(ctx)).not.toContain("windowless_429");
+	});
+
+	// The fail-closed property, end to end. A genuinely spent window was measured
+	// carrying ONLY per-window headers — no aggregate `-unified-reset` — while
+	// still setting `x-should-retry: true`. The predicate scans header-name
+	// prefixes rather than probing known names, so this benches too.
+	it("still benches a 429 carrying only per-window headers", async () => {
+		let calls = 0;
+		globalThis.fetch = mock(async () => {
+			calls++;
+			return burst429({
+				"anthropic-ratelimit-unified-5h-status": "rejected",
+				"anthropic-ratelimit-unified-5h-reset": String(
+					Math.floor(Date.now() / 1000) + 300,
+				),
+			});
+		});
+
+		const ctx = makeCtx();
+		const account = makeAccount();
+		const body = makeRequestBody();
+
+		const result = await runProxy(account, ctx, makeRequest(body), body);
+
+		expect(calls).toBe(1);
+		expect(result).toBeNull();
+		expect(markCalls(ctx)).toHaveLength(1);
+		expect(markCalls(ctx)[0][2]).toBe("model_fallback_429");
+		expect(saveReasons(ctx)).not.toContain("windowless_429");
+	});
+
+	// Hard blocks and billing problems all carry rate-limit metadata, so they are
+	// declined by the predicate and keep the unchanged bench-and-failover path.
+	it.each([
+		"blocked",
+		"payment_required",
+		"queueing_hard",
+		"rejected",
+	])("still benches unified status %s", async (status) => {
+		let calls = 0;
+		globalThis.fetch = mock(async () => {
+			calls++;
+			return burst429({ "anthropic-ratelimit-unified-status": status });
+		});
+
+		const ctx = makeCtx();
+		const body = makeRequestBody();
+		await runProxy(makeAccount(), ctx, makeRequest(body), body);
+
+		expect(calls).toBe(1);
+		expect(marks(ctx)).toBe(1);
+		expect(saveReasons(ctx)).not.toContain("windowless_429");
+	});
+
+	// out_of_credits (issue #261) is the model-scoped sibling of this fix and is
+	// handled earlier in the path. It must keep its own audit reason.
+	it("leaves the out_of_credits path unchanged", async () => {
+		let calls = 0;
+		globalThis.fetch = mock(async () => {
+			calls++;
+			return burst429({
+				"anthropic-ratelimit-unified-overage-disabled-reason": "out_of_credits",
+			});
+		});
+
+		const ctx = makeCtx();
+		const account = makeAccount();
+		const body = makeRequestBody("claude-sonnet-4-5");
+
+		const result = await runProxy(account, ctx, makeRequest(body), body);
+
+		expect(calls).toBe(1);
+		expect(result).toBeNull();
+		expect(account.rate_limited_until).toBeNull();
+		expect(marks(ctx)).toBe(0);
+		expect(saveReasons(ctx)).toContain("out_of_credits");
+		expect(saveReasons(ctx)).not.toContain("windowless_429");
+	});
+
+	// Pre-existing behaviour: a synthetic keepalive replay's 429 is neither
+	// benched nor recorded — the burst is the scheduler's own doing.
+	it("records nothing for a keepalive probe's bare 429", async () => {
+		let calls = 0;
+		globalThis.fetch = mock(async () => {
+			calls++;
+			return burst429();
+		});
+
+		const ctx = makeCtx();
+		const account = makeAccount();
+		const body = makeRequestBody();
+		const req = makeRequest(body, {
+			"x-better-ccflare-keepalive": "true",
+			"x-better-ccflare-internal-probe-secret": "test-secret",
+		});
+
+		const result = await runProxy(account, ctx, req, body);
+
+		expect(calls).toBe(1);
+		expect(result).toBeNull();
+		expect(marks(ctx)).toBe(0);
+		expect(account.rate_limited_until).toBeNull();
+		expect(saveReasons(ctx)).toHaveLength(0);
+	});
+});

--- a/packages/proxy/src/handlers/__tests__/proxy-operations-windowless-429.test.ts
+++ b/packages/proxy/src/handlers/__tests__/proxy-operations-windowless-429.test.ts
@@ -68,8 +68,21 @@ function makeRequestMeta(): RequestMeta {
 		path: "/v1/messages",
 		timestamp: Date.now(),
 		headers: new Headers(),
+		clientSessionId: "sess-1",
 	};
 }
+
+/**
+ * The LAST positional argument of saveRequest is clientSessionId. Asserting on
+ * the tail rather than a fixed index is deliberate: this branch originally
+ * dropped the two trailing arguments because it was copied from a sibling 429
+ * path that later grew them, and a hardcoded index would not have caught that.
+ */
+const lastSaveArg = (ctx: ProxyContext) => {
+	const calls = (ctx.dbOps.saveRequest as ReturnType<typeof mock>).mock.calls;
+	const args = calls[calls.length - 1] as unknown[];
+	return args[args.length - 1];
+};
 
 function makeRequestBody(model = "claude-sonnet-4-5") {
 	const body = JSON.stringify({
@@ -236,6 +249,9 @@ describe("proxyWithAccount — windowless 429 is not benched (issue #301)", () =
 		expect(account.consecutive_rate_limits).toBe(0);
 		expect(saveReasons(ctx)).toContain("windowless_429");
 		expect(saveReasons(ctx)).not.toContain("model_fallback_429");
+		// The audit row must stay correlated with its originating client session,
+		// exactly as the out_of_credits and model_fallback_429 rows do.
+		expect(lastSaveArg(ctx)).toBe("sess-1");
 	});
 
 	// The operational point of not benching: the account is immediately routable

--- a/packages/proxy/src/handlers/__tests__/retryable-429.test.ts
+++ b/packages/proxy/src/handlers/__tests__/retryable-429.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "bun:test";
+import { hasRateLimitMetadata, isRetryable429 } from "../retryable-429";
+
+/**
+ * The real shape captured from Anthropic on 2026-07-31 for the windowless 429
+ * this fix targets: an explicit retry instruction and NO rate-limit window
+ * headers.
+ *   {"x-robots-tag":"none","x-should-retry":"true"}
+ */
+function burst429(extra: Record<string, string> = {}): Response {
+	return new Response(
+		JSON.stringify({
+			type: "error",
+			error: { type: "rate_limit_error", message: "rate limit exceeded" },
+		}),
+		{
+			status: 429,
+			headers: {
+				"content-type": "application/json",
+				"x-robots-tag": "none",
+				"x-should-retry": "true",
+				...extra,
+			},
+		},
+	);
+}
+
+describe("hasRateLimitMetadata", () => {
+	it("is false for the windowless shape, which carries no rate-limit header at all", () => {
+		expect(hasRateLimitMetadata(burst429().headers)).toBe(false);
+	});
+
+	// The last four are the fail-closed half: none of them is a reset hint, and
+	// none was on the old enumerated list, yet each one proves the response knows
+	// something about a window. The prefix scan catches them by construction, so
+	// a header name Anthropic invents tomorrow needs no change here.
+	it.each([
+		["retry-after", "60"],
+		["anthropic-ratelimit-unified-reset", "1785438225"],
+		["x-ratelimit-reset", "1785438225"],
+		["anthropic-ratelimit-unified-5h-reset", "1785518400"],
+		["anthropic-ratelimit-unified-5h-utilization", "1.01"],
+		["anthropic-ratelimit-unified-status", "allowed"],
+		["x-ratelimit-limit", "1000"],
+	])("is true for %s", (name, value) => {
+		expect(hasRateLimitMetadata(burst429({ [name]: value }).headers)).toBe(
+			true,
+		);
+	});
+});
+
+describe("isRetryable429", () => {
+	it("accepts the captured windowless-429 shape", () => {
+		expect(isRetryable429(burst429(), true)).toBe(true);
+	});
+
+	it("rejects a non-429 status", () => {
+		const res = new Response("{}", {
+			status: 529,
+			headers: { "x-should-retry": "true" },
+		});
+		expect(isRetryable429(res, true)).toBe(false);
+	});
+
+	it("rejects a non-Claude provider even for an identical response", () => {
+		// Zai's parser deliberately returns no reset so response-processor can
+		// read the real window from the JSON body. Calling that request-scoped
+		// would leave an account in rotation against a genuine window limit.
+		expect(isRetryable429(burst429(), false)).toBe(false);
+	});
+
+	it('rejects when x-should-retry is absent or not "true"', () => {
+		const missing = new Response("{}", { status: 429 });
+		expect(isRetryable429(missing, true)).toBe(false);
+		const falsey = new Response("{}", {
+			status: 429,
+			headers: { "x-should-retry": "false" },
+		});
+		expect(isRetryable429(falsey, true)).toBe(false);
+	});
+
+	it("rejects when any reset hint is present", () => {
+		expect(
+			isRetryable429(
+				burst429({ "anthropic-ratelimit-unified-reset": "1785438225" }),
+				true,
+			),
+		).toBe(false);
+		expect(isRetryable429(burst429({ "retry-after": "60" }), true)).toBe(false);
+	});
+
+	// THE fail-closed regression guard. Measured 429: `x-should-retry: true` plus
+	// ONLY the per-window headers — `anthropic-ratelimit-unified-5h-status:
+	// rejected`, `-5h-reset`, `-5h-utilization: 1.01` — and none of the aggregate
+	// ones. A genuinely spent five-hour window. The old enumerated predicate
+	// probed `anthropic-ratelimit-unified-reset` / `x-ratelimit-reset` /
+	// `retry-after`, none of which is present here, so it called this windowless
+	// and would have kept a spent account in rotation. The prefix scan declines it.
+	it("rejects a windowed-only exhausted 429 with no aggregate headers", () => {
+		expect(
+			isRetryable429(
+				burst429({
+					"anthropic-ratelimit-unified-5h-status": "rejected",
+					"anthropic-ratelimit-unified-5h-reset": "1785518400",
+					"anthropic-ratelimit-unified-5h-utilization": "1.01",
+				}),
+				true,
+			),
+		).toBe(false);
+	});
+
+	// A bare `x-ratelimit-*` header that is not a reset: it says nothing about
+	// when the limit lifts, but it proves the response carries window state, so
+	// fail-closed declines it.
+	it("rejects a bare x-ratelimit-limit header that is not a reset", () => {
+		expect(
+			isRetryable429(burst429({ "x-ratelimit-limit": "1000" }), true),
+		).toBe(false);
+	});
+
+	// These now fail the metadata scan before the status is ever inspected — the
+	// header name alone is disqualifying. The expectation is unchanged; what
+	// guards it moved, and ACCOUNT_WIDE_UNIFIED_STATUSES is defence in depth.
+	it.each([
+		"blocked",
+		"queueing_hard",
+		"payment_required",
+		"rejected",
+	])("rejects hard unified status %s", (status) => {
+		expect(
+			isRetryable429(
+				burst429({ "anthropic-ratelimit-unified-status": status }),
+				true,
+			),
+		).toBe(false);
+	});
+
+	// Deliberately flipped when the predicate became fail-closed. It previously
+	// asserted `true` here, on the reasoning that a `rate_limited` status with no
+	// reset hint is indistinguishable from the windowless shape. It is not
+	// indistinguishable: the windowless shape carries no `anthropic-ratelimit-`
+	// header whatsoever, so the presence of a unified status is itself the
+	// difference. Leaving an account in rotation for a window Anthropic has
+	// already named `rate_limited` is exactly the hole a previous review flagged
+	// as unexplained.
+	it("rejects unified status rate_limited even with no reset hint", () => {
+		expect(
+			isRetryable429(
+				burst429({ "anthropic-ratelimit-unified-status": "rate_limited" }),
+				true,
+			),
+		).toBe(false);
+	});
+
+	it("rejects out_of_credits even though it also sets x-should-retry true", () => {
+		// The repo's own #261 fixture sets x-should-retry: "true", so the retry
+		// instruction alone cannot exclude this model-scoped case. The metadata
+		// scan is what fires first now — the reason header is
+		// `anthropic-ratelimit-unified-overage-disabled-reason` — with the explicit
+		// isAnthropicOutOfCredits guard behind it stating the intent.
+		expect(
+			isRetryable429(
+				burst429({
+					"anthropic-ratelimit-unified-overage-disabled-reason":
+						"out_of_credits",
+				}),
+				true,
+			),
+		).toBe(false);
+	});
+
+	it("declines the real captured exhausted-window 429 (measured, verbatim)", () => {
+		// Captured from Anthropic on the live installation 44 minutes after the
+		// windowless 429 above, on the SAME account: a genuinely spent five-hour
+		// window (utilization 1.01, unified status `rejected`, retry-after
+		// 7835s) that STILL sets x-should-retry: true. Calling this
+		// request-scoped would keep a spent account in rotation, so this is the
+		// characterization test for the whole file. `hasRateLimitMetadata`
+		// declines it on the first `anthropic-ratelimit-` header it reaches; the
+		// `rejected` unified status and the `retry-after` would each have
+		// declined it too. Note overage-disabled-reason here is
+		// `org_level_disabled`, NOT `out_of_credits`.
+		const res = new Response(
+			JSON.stringify({
+				type: "error",
+				error: { type: "rate_limit_error", message: "rate limit exceeded" },
+			}),
+			{
+				status: 429,
+				headers: {
+					"anthropic-ratelimit-unified-5h-reset": "1785518400",
+					"anthropic-ratelimit-unified-5h-status": "rejected",
+					"anthropic-ratelimit-unified-5h-surpassed-threshold": "1.0",
+					"anthropic-ratelimit-unified-5h-utilization": "1.01",
+					"anthropic-ratelimit-unified-7d-reset": "1786006800",
+					"anthropic-ratelimit-unified-7d-status": "allowed",
+					"anthropic-ratelimit-unified-7d-utilization": "0.69",
+					"anthropic-ratelimit-unified-fallback-percentage": "0.5",
+					"anthropic-ratelimit-unified-overage-disabled-reason":
+						"org_level_disabled",
+					"anthropic-ratelimit-unified-overage-status": "rejected",
+					"anthropic-ratelimit-unified-representative-claim": "five_hour",
+					"anthropic-ratelimit-unified-reset": "1785518400",
+					"anthropic-ratelimit-unified-status": "rejected",
+					"retry-after": "7835",
+					"x-robots-tag": "none",
+					"x-should-retry": "true",
+				},
+			},
+		);
+		expect(isRetryable429(res, true)).toBe(false);
+	});
+
+	it("does not consume the response body", async () => {
+		const res = burst429();
+		isRetryable429(res, true);
+		expect(res.bodyUsed).toBe(false);
+		await expect(res.json()).resolves.toBeDefined();
+	});
+});

--- a/packages/proxy/src/handlers/discard-body-cancel.ts
+++ b/packages/proxy/src/handlers/discard-body-cancel.ts
@@ -56,7 +56,7 @@
  * directly without pulling in the proxy-operations.ts transitive
  * dependency chain (which loads cacheBodyStore → @better-ccflare/database,
  * and that module fails to initialise in worktrees where `bun install`
- * has not run). The 12 discard sites in proxy-operations.ts import this
+ * has not run). The 13 discard sites in proxy-operations.ts import this
  * helper and call it before each `return null;`.
  */
 export function cancelDiscardedResponseBody(

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -1072,6 +1072,8 @@ export async function proxyWithAccount(
 									modelRewrite ? (requestMeta.appliedModel ?? null) : null,
 									requestMeta.projectAttributionSource ?? null,
 									requestMeta.agentAttributionSource ?? null,
+									null,
+									requestMeta.clientSessionId ?? null,
 								),
 							);
 							cancelDiscardedResponseBody(rawResponse);

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -36,6 +36,7 @@ import {
 import { applyRateLimitCooldown } from "./rate-limit-cooldown";
 import { makeProxyRequest, validateProviderPath } from "./request-handler";
 import { handleProxyError, processProxyResponse } from "./response-processor";
+import { isRetryable429 } from "./retryable-429";
 import { getValidAccessToken } from "./token-manager";
 import { collectWindows } from "./usage-throttling";
 
@@ -1004,6 +1005,74 @@ export async function proxyWithAccount(
 						if (isKeepalive) {
 							log.warn(
 								`Keepalive replay for ${account.name} got 429 — skipping cooldown (synthetic burst, not a real per-account rate limit)`,
+							);
+							cancelDiscardedResponseBody(rawResponse);
+							return null;
+						}
+
+						// ── windowless 429: request-scoped, NOT account-wide (issue #301) ──
+						// Anthropic 429s some requests with `x-should-retry: true` and no
+						// rate-limit metadata whatsoever — no `retry-after`, not one
+						// `anthropic-ratelimit-*` / `x-ratelimit-*` header. Live measurement
+						// on a production install showed this to be scoped to the REQUEST,
+						// not the account: the same account served 200s two seconds before
+						// and 38 seconds after on the same model, three in-place retries
+						// spanning 11.2s returned three identical bare 429s (never once a
+						// success), and the NEXT account rejected the same client request
+						// the same way. The rejected requests are session-initialising ones
+						// with no project attribution; ordinary conversation turns on the
+						// same account succeed throughout.
+						//
+						// So benching is simply the wrong response: it drains the pool one
+						// account per attempt until the operator has to force-reset every
+						// account before ordinary traffic works again. Treat it exactly like
+						// out_of_credits above (issue #261) — fail over per request with NO
+						// cooldown and NO consecutive-429 increment, leaving the account in
+						// rotation. Placed after the keepalive check so a synthetic probe
+						// still records nothing at all.
+						//
+						// The predicate is `isRetryable429` (header-only, synchronous,
+						// fail-closed: `x-should-retry: true`, no `retry-after`, and no
+						// header under either rate-limit prefix). Its name is now a slight
+						// misnomer — nothing is retried any more — but it is exactly the
+						// right discriminator and its module is reviewed and tested, so it
+						// keeps its name.
+						if (isRetryable429(rawResponse, isClaudeProvider)) {
+							const reason: RateLimitReason = "windowless_429";
+							log.warn(
+								`Account ${account.name} returned a windowless 429 (${
+									requestedModel ? `model=${requestedModel}, ` : ""
+								}x-should-retry with no rate-limit window) — request-scoped, ` +
+									`NOT benching account; failing over to next account`,
+							);
+							const responseTime = Date.now() - requestMeta.timestamp;
+							const modelRewrite = isModelRewrite(
+								requestMeta.originalModel,
+								requestMeta.appliedModel,
+							);
+							ctx.asyncWriter.enqueue(() =>
+								ctx.dbOps.saveRequest(
+									crypto.randomUUID(),
+									req.method,
+									url.pathname,
+									account.id,
+									429,
+									false,
+									reason,
+									responseTime,
+									failoverAttempts,
+									requestedModel ? { model: requestedModel } : undefined,
+									requestMeta.agentUsed ?? undefined,
+									apiKeyId ?? undefined,
+									apiKeyName ?? undefined,
+									requestMeta.project ?? null,
+									undefined,
+									requestMeta.comboName ?? null,
+									modelRewrite ? (requestMeta.originalModel ?? null) : null,
+									modelRewrite ? (requestMeta.appliedModel ?? null) : null,
+									requestMeta.projectAttributionSource ?? null,
+									requestMeta.agentAttributionSource ?? null,
+								),
 							);
 							cancelDiscardedResponseBody(rawResponse);
 							return null;

--- a/packages/proxy/src/handlers/retryable-429.ts
+++ b/packages/proxy/src/handlers/retryable-429.ts
@@ -1,0 +1,142 @@
+import { isAnthropicOutOfCredits } from "@better-ccflare/providers";
+
+/**
+ * Identifies a 429 whose scope is narrower than the account, so the caller can
+ * fail the request over while leaving the account in rotation instead of
+ * benching it.
+ *
+ * THE NAME IS HISTORICAL. `isRetryable429` was written when this module gated
+ * an in-place retry of the same request against the same account. That retry is
+ * gone — measurement showed the rejection does not clear within a request's
+ * lifetime (three attempts spanning 11.2s returned three identical bare 429s) —
+ * but the predicate turned out to be exactly the right discriminator for "this
+ * rejection is not the account's fault", and it is pinned by 23 tests, so the
+ * exported names are left alone. Nothing in here retries anything: a `true`
+ * result means "fail over with NO account cooldown".
+ */
+
+/**
+ * Header-name prefixes under which Anthropic reports rate-limit state — window
+ * status, utilization, reset, overage, remaining, anything.
+ *
+ * The check that uses these is a PREFIX SCAN over the response's actual header
+ * names, not a probe of known names, and that is the whole point. Enumerating
+ * names is fail-open: a real exhausted-window 429 was measured carrying ONLY the
+ * per-window headers (`anthropic-ratelimit-unified-5h-status: rejected`,
+ * `-5h-reset`, `-5h-utilization: 1.01`) with none of the aggregate ones, so a
+ * predicate that probed `anthropic-ratelimit-unified-reset` classified a
+ * genuinely spent window as windowless — it would have left an account in
+ * rotation whose five-hour window was already over budget. Safety must not rest
+ * on Anthropic happening to send the aggregate headers alongside the windowed
+ * ones — they control that header set and can change it without telling us.
+ * Scanning by prefix declines every present and future window shape
+ * automatically.
+ *
+ * `retry-after` is checked separately: it carries no prefix.
+ */
+const RATE_LIMIT_HEADER_PREFIXES = [
+	"anthropic-ratelimit-",
+	"x-ratelimit-",
+] as const;
+
+/**
+ * Unified statuses that are account-wide or a billing block, and therefore the
+ * opposite of what this module looks for: a hard block or a payment problem is
+ * not narrower than the account, so the account must still be benched.
+ *
+ * NOTE ON WHAT ACTUALLY GUARDS THESE: nothing here is reachable today. Any
+ * response carrying `anthropic-ratelimit-unified-status` at all is already
+ * declined by `hasRateLimitMetadata`, which runs first and does not care what
+ * the status says. This set is kept purely as defence in depth and as
+ * self-documentation of intent — if the metadata scan is ever narrowed, these
+ * four statuses stay declined.
+ *
+ * Derivation: AnthropicProvider's HARD_LIMIT_STATUSES
+ * (providers/anthropic/provider.ts:14-19) plus `rejected`, which was measured on
+ * a real exhausted-window 429 (five-hour utilization 1.01,
+ * `anthropic-ratelimit-unified-5h-status: rejected`) that ALSO carried
+ * `x-should-retry: true` — proof that the retry instruction alone can never
+ * discriminate a request-scoped rejection from a genuinely spent window.
+ * `rejected` is absent from that provider's own set, so this is the only place
+ * it is named.
+ *
+ * `rate_limited` is not listed and does not need to be: as of the fail-closed
+ * scan, a `rate_limited` unified status is declined by the metadata check like
+ * every other unified status, reset hint or not.
+ */
+const ACCOUNT_WIDE_UNIFIED_STATUSES = new Set([
+	"blocked",
+	"queueing_hard",
+	"payment_required",
+	"rejected",
+]);
+
+/**
+ * True when the response carries ANY rate-limit metadata — a `retry-after`, or
+ * any header whose name starts with `anthropic-ratelimit-` or `x-ratelimit-`.
+ *
+ * Fail-closed by construction: it iterates the response's own header names
+ * instead of probing a fixed list, so a window shape we have never seen is
+ * declined without this file being updated. The windowless 429 this module
+ * exists to identify carries none of these headers, so it still qualifies.
+ *
+ * Detection is header-based on purpose: AnthropicProvider.parseRateLimit
+ * FABRICATES `resetTime = now + 60_000` for a bare 429
+ * (providers/anthropic/provider.ts:459-463), so a `!resetTime` test is false for
+ * precisely the responses this module exists to identify.
+ */
+export function hasRateLimitMetadata(headers: Headers): boolean {
+	if (headers.get("retry-after") !== null) return true;
+	for (const name of headers.keys()) {
+		const lower = name.toLowerCase();
+		for (const prefix of RATE_LIMIT_HEADER_PREFIXES) {
+			if (lower.startsWith(prefix)) return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * True when a 429 reports no rate-limit window at all, which measurement showed
+ * to mean the rejection is scoped to the request rather than to the account —
+ * so the account must NOT be benched.
+ *
+ * Observed 2026-07-31 (issue #301): Anthropic 429s some requests with exactly
+ * `{"x-robots-tag":"none","x-should-retry":"true"}` — an explicit retry
+ * instruction and no rate-limit metadata of any kind — while the same account
+ * keeps serving other requests on the same model seconds either side of the
+ * rejection. Header-only and synchronous, so the caller needs no clone.
+ *
+ * The condition is deliberately asymmetric: the explicit upstream instruction
+ * PLUS a total absence of rate-limit metadata. Anything that hints at a window —
+ * known header name or not — is declined, and the caller benches as before.
+ */
+export function isRetryable429(
+	response: Response,
+	isClaudeProvider: boolean,
+): boolean {
+	if (response.status !== 429) return false;
+	// Gate to Anthropic/Claude-OAuth: other providers' parsers have their own
+	// reset conventions (Zai reads the window from the body downstream).
+	if (!isClaudeProvider) return false;
+	// Require the explicit upstream instruction rather than inferring it.
+	if (response.headers.get("x-should-retry") !== "true") return false;
+	// The load-bearing guard, and the first one that fires for every window
+	// shape: any rate-limit metadata at all means the response DOES report a
+	// window, so the limit is the account's and the account must be benched.
+	if (hasRateLimitMetadata(response.headers)) return false;
+	// Unreachable while the scan above stands (an `anthropic-ratelimit-`
+	// prefixed header is exactly what it declines) — kept as defence in depth.
+	const unified = response.headers.get("anthropic-ratelimit-unified-status");
+	if (unified && ACCOUNT_WIDE_UNIFIED_STATUSES.has(unified)) return false;
+	// Model/beta-scoped credit depletion (issue #261) also sets
+	// x-should-retry: true, but it has its own handler earlier in the failover
+	// path which records `out_of_credits` as the audit reason; claiming it here
+	// would steal that reason and its family-exhaustion bookkeeping. Also
+	// unreachable today: the reason header it reads is
+	// `anthropic-ratelimit-unified-overage-disabled-reason`, which the scan above
+	// already declines. Kept because it states the intent independently of header
+	// naming, and it does not depend on ordering.
+	if (isAnthropicOutOfCredits(response)) return false;
+	return true;
+}

--- a/packages/proxy/src/handlers/retryable-429.ts
+++ b/packages/proxy/src/handlers/retryable-429.ts
@@ -81,9 +81,10 @@ const ACCOUNT_WIDE_UNIFIED_STATUSES = new Set([
  * exists to identify carries none of these headers, so it still qualifies.
  *
  * Detection is header-based on purpose: AnthropicProvider.parseRateLimit
- * FABRICATES `resetTime = now + 60_000` for a bare 429
- * (providers/anthropic/provider.ts:459-463), so a `!resetTime` test is false for
- * precisely the responses this module exists to identify.
+ * FABRICATES `resetTime = now + 60_000` for a bare 429 — see
+ * `DEFAULT_429_COOLDOWN_MS` in providers/anthropic/provider.ts — so a
+ * `!resetTime` test is false for precisely the responses this module exists to
+ * identify.
  */
 export function hasRateLimitMetadata(headers: Headers): boolean {
 	if (headers.get("retry-after") !== null) return true;

--- a/packages/types/src/account.ts
+++ b/packages/types/src/account.ts
@@ -21,7 +21,16 @@ export type RateLimitReason =
 	 *  model-scoped in the rate-limit sense — the account is not benched, and by
 	 *  the time this is detected the response has typically already been passed
 	 *  through to the client. */
-	| "extra_usage_exhausted";
+	| "extra_usage_exhausted"
+	/** Anthropic 429 that reports no rate-limit window at all — `x-should-retry:
+	 *  true` and not a single `anthropic-ratelimit-*` / `x-ratelimit-*` header or
+	 *  `retry-after`. Live measurement showed this to be request-scoped rather
+	 *  than account-wide: the same account served 200s seconds either side of the
+	 *  rejection on the same model, while every other account rejected the same
+	 *  request identically, and retries spanning 11s never once cleared it. The
+	 *  account is NOT benched — the request fails over and the account stays in
+	 *  rotation. */
+	| "windowless_429";
 
 // Usage data types for Anthropic accounts
 export interface UsageWindowData {

--- a/packages/types/src/rate-limit-reason.ts
+++ b/packages/types/src/rate-limit-reason.ts
@@ -36,6 +36,9 @@
  *   breaker.
  * - `extra_usage_exhausted` — third-party OAuth extra-usage depletion.
  *   Scoped, not account-wide. Does NOT trip the breaker.
+ * - `windowless_429` — 429 reporting no rate-limit window at all; measured
+ *   as request-scoped, so the account is never benched. Does NOT trip the
+ *   breaker.
  */
 import type { RateLimitReason } from "./account";
 
@@ -49,6 +52,7 @@ export const RATE_LIMIT_REASONS: readonly RateLimitReason[] = [
 	"upstream_529_overloaded_no_reset",
 	"out_of_credits",
 	"extra_usage_exhausted",
+	"windowless_429",
 ] as const;
 
 export function isRateLimitReason(value: string): value is RateLimitReason {


### PR DESCRIPTION
# fix(proxy): stop benching an account for a 429 that reports no rate-limit window

Closes nothing automatically — this addresses #301, but the reporter should confirm first.

## You proposed same-account retry. We built it, shipped it, and measured it — it does not work.

On #301 you suggested *"add same-account retry with backoff on a genuine 429 when no other
account is available, instead of immediately giving up"*, reading the 429 as a real, likely
transient/burst-related limit. That was the obvious reading and we implemented it fully: a
bounded in-place retry with full-jitter backoff, config knobs, tests, the lot. Then we ran it on
a production install for a day. It never once helped, and the data explains why.

### Four measurements

1. **Retrying does nothing.** Three retries spanning **11.2 s** (2477 + 2319 + 6370 ms of
   jittered sleep) returned three byte-identical bare 429s. Across every observed incident the
   retries exhausted; not once did one succeed.
2. **The account is not rate-limited.** It served HTTP 200s **two seconds before and 38 seconds
   after** the same 429 — same account, same model, including large-cache requests from a live
   session.
3. **Failover does not rescue it either.** In request history, 85 `model_fallback_429` rows have
   `failover_attempts = 1` and 5 have `2`: the *next* account returns 429 for the same client
   request. Each attempt benches another account, so a bigger pool makes it worse, not better.
4. **The rejected requests are identifiable.** They are the ones with no project attribution,
   arriving seconds after the client's `/api/hello` startup ping — session-initialising
   requests. Ordinary conversation turns on the same account succeed throughout.

Your own characterization commit `7497ecb1` describes exactly this: *"Anthropic 429'd every NEW
session on the two unpaused accounts … while the sticky main session kept getting 200s on the
same account/model/second."*

### The conclusion

**This 429 is scoped to the request, not the account.** So neither retrying it (there is nothing
to wait for) nor benching the account (there is nothing wrong with it) is correct. The only right
action is to fail over without a cooldown — which is precisely how `out_of_credits` is already
treated (#261).

The harm was never the failed request; the client copes. The harm is that each attempt benched an
account until the pool emptied, after which ordinary traffic — the traffic that works — hit
`All accounts are temporarily unavailable` for the whole cooldown, and the operator had to
force-reset every account.

## What this changes

A 429 satisfying the predicate now writes an audit row with a new `windowless_429` reason and
returns `null` for per-request failover, with **no** `applyRateLimitCooldown` and no
consecutive-429 increment. Structurally a copy of the `out_of_credits` branch immediately above
it in the same function, placed after the keepalive skip so probes still record nothing.

+68 lines of production code in `proxy-operations.ts`, plus a 142-line predicate module, a
`RateLimitReason` member, a dashboard entry and a docs paragraph. No env vars, no config surface,
no kill switch, no migration.

## `x-should-retry: true` cannot be the discriminator

This is the trap, and it is why the predicate looks the way it does. A genuinely spent five-hour
window sends `x-should-retry: true` **as well**:

```
# transient, must not bench            # genuinely exhausted, must bench
x-robots-tag: none                     anthropic-ratelimit-unified-5h-status: rejected
x-should-retry: true                   anthropic-ratelimit-unified-5h-utilization: 1.01
                                       anthropic-ratelimit-unified-reset: 1785518400
                                       anthropic-ratelimit-unified-status: rejected
                                       retry-after: 7835
                                       x-should-retry: true
```

Two further traps we hit, in case they save someone else the time:

- `AnthropicProvider.parseRateLimit` **fabricates** `resetTime = now + 60_000` for a bare 429 —
  see `DEFAULT_429_COOLDOWN_MS` in `providers/anthropic/provider.ts` — so any `!resetTime` test is
  false for exactly the responses this targets. Detection must read raw headers.
- Enumerating known reset-header names is **fail-open**: Anthropic also sends per-window forms
  (`-5h-reset`, `-7d-reset`), so a 429 carrying only those, with the aggregate names absent, would
  pass an enumerated check. We shipped that bug first and caught it in review.

The predicate is therefore **fail-closed**: it disqualifies on `retry-after` or on *any* header
whose name starts `anthropic-ratelimit-` or `x-ratelimit-`, found by iterating header names. A
future window shape Anthropic has not invented yet is rejected automatically.

## Safety evidence

Disabling the metadata scan flips exactly the two fail-closed guards, end-to-end through
`proxyWithAccount` — the reset-hint case and the per-window-only case. The predicate's 23 unit
tests were mutation-tested by removing each guard, each list entry, and each individual character
of every header name and status value: 13/13 mutants killed. The verbatim 16-header exhausted-window
capture is pinned as a regression test.

`packages/proxy/src/__tests__/incident-2026-07-09-health-flap.test.ts` passes unchanged — a 429
that *does* report a window still benches the whole account, exactly as it did.

## Limitations, stated up front

1. **The model-fallback arm still benches.** An account with multi-entry model mappings burns its
   fallback list and ends at `all_models_exhausted_429`, which applies a cooldown. Not addressed
   here; `getModelList` returns `null` without mappings, so the covered arm is the default, and
   Claude OAuth accounts only serve their native models anyway.
2. **Auto-refresh probes are now in scope.** The keepalive skip above still short-circuits
   keepalive; an auto-refresh probe drawing a windowless 429 now takes the no-bench path. We think
   that is right — an auto-refresh probe is itself a session-initialising request — but it is a
   behaviour change worth naming.
3. **The rejected request itself still fails.** This does not make Anthropic accept it — the
   failover loop still ends in `All accounts failed to proxy the request`. What it fixes is the
   cascade. Measured on a single-account pool after deploying: three `windowless_429` rows and
   three `All accounts failed` in the log, but **zero** `503 pool_exhausted` rows and **zero**
   `All accounts are temporarily unavailable`, where before the change the same event produced
   both. Because the account stays routable, the client's own immediate retry lands on it and
   succeeds, so nothing surfaced to the user at all. The determinant is not pool size — it is
   whether the account is still available a second later.

## Two notes on the diff

- **`EXPECTED_SITE_COUNT` in `bun-leak-273-regression.test.ts` moves 12 → 13.** The new branch is a
  13th discard site and calls `cancelDiscardedResponseBody(rawResponse)` before returning, per
  `discard-body-cancel.ts`. We bumped the exact count rather than loosening the assertion to `>=`,
  so the guard keeps its full strength.
- **Baseline.** `bun test packages/proxy packages/types packages/core` on clean `main` gives
  **905 pass / 9 fail / 6 errors**; with this branch, **938 pass / 9 fail / 6 errors**. Same
  failures, same errors, **+33 tests, none of them failing**. For what it is worth, of those 9:
  three are in `bun-leak-273-safety.test.ts` and six in `request-handler-client-abort.test.ts`.
  Both files pass when run on their own and fail only in the full run, so it looks like
  cross-file state leaking between suites in one `bun test` process rather than product bugs —
  flagging it in case that is news. The 6 errors are SQLite `wal_checkpoint` teardown noise.
- Rebased onto current `main`, including `fix: abort the upstream fetch when the client
  disconnects`. That commit's new `req.signal.aborted` guard sits in the error path well below
  this branch's `return null`, so the two do not interact; like the neighbouring
  `out_of_credits` and `model_fallback_429` returns, this one does not consult the signal.
  Also verified against `fix(proxy): dispose orphaned response clones on the 529 overload path`:
  its own added discard call uses a different variable name, so the `EXPECTED_SITE_COUNT` regex
  counted 12 before this branch and 13 after.

## Verified in production

Deployed to the install where the data above was gathered. Since deployment: windowless 429s
continue to arrive and are recorded as `windowless_429`, and **zero** cooldowns have been applied.
`rate_limited_until` stays null, the consecutive-429 counter stays put, and ordinary traffic
resumes within seconds of a rejection instead of waiting out a lockout. Force-resetting accounts
is no longer necessary.

## Open question worth its own issue

Why Anthropic rejects a session-initialising request on an account that is concurrently serving
another session on the same model, in the same second. That is upstream behaviour we cannot fix
here, but it is the actual cause, and this PR only stops the proxy from making it worse.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
