### PR TITLE
feat: multi-instance guard warns when another live process shares the DB (#351)

### DIFF
--- a/packages/database/src/__tests__/multi-instance-guard.test.ts
+++ b/packages/database/src/__tests__/multi-instance-guard.test.ts
@@ -168,6 +168,47 @@ describe("multi-instance-guard (SQLite)", () => {
 		).rejects.toThrow(MultiInstanceRefusedError);
 	});
 
+	it("NEGATIVE 4: refuse mode clears own heartbeat before throwing so a retry does not false-positive", async () => {
+		// Simulate a peer that is already running.
+		const now = Date.now();
+		adapter.getSQLiteDb().run(
+			`INSERT INTO instance_heartbeats
+				(instance_id, hostname, pid, started_at, last_heartbeat,
+				 node_version, db_dialect)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			[
+				"peer-uuid-refuse",
+				"peer-host",
+				4321,
+				now - 5_000,
+				now - 1_000,
+				"v20.0.0",
+				"sqlite",
+			],
+		);
+
+		// Refuse: should throw.
+		await expect(
+			runStartupGuard(adapter, { now, mode: "refuse" }),
+		).rejects.toThrow(MultiInstanceRefusedError);
+
+		// After the throw, this process's own heartbeat row must be gone.
+		// The only remaining row should be the peer we wrote directly.
+		// Without the Greptile fix, our own row would still be present and
+		// a fast retry would see it as a (self) peer and refuse again for
+		// up to HEARTBEAT_EXPIRY_MS.
+		const remaining = adapter
+			.getSQLiteDb()
+			.query<
+				{ instance_id: string },
+				[]
+			>("SELECT instance_id FROM instance_heartbeats ORDER BY instance_id")
+			.all();
+
+		expect(remaining.length).toBe(1);
+		expect(remaining[0].instance_id).toBe("peer-uuid-refuse");
+	});
+
 	it("warn mode does NOT throw even when peers are present", async () => {
 		const now = Date.now();
 		adapter.getSQLiteDb().run(

--- a/packages/database/src/__tests__/multi-instance-guard.test.ts
+++ b/packages/database/src/__tests__/multi-instance-guard.test.ts
@@ -1,0 +1,456 @@
+/**
+ * Tests for the multi-instance guard (tombii/better-ccflare#351).
+ *
+ * Three negative controls, required by the issue:
+ *   1. Second instance detected when first is alive.
+ *   2. Stale/dead predecessor does NOT block a legitimate restart.
+ *   3. Single-instance startup is silent (no warning emitted).
+ *
+ * Plus: refuse-mode throws MultiInstanceRefusedError, the operator-facing
+ * message names the seven divergence categories, and the schema is present
+ * in both SQLite and PostgreSQL migrations.
+ */
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { BunSqlAdapter } from "../adapters/bun-sql-adapter";
+import { ensureSchema } from "../migrations";
+import { ensureSchemaPg } from "../migrations-pg";
+import {
+	clearHeartbeat,
+	formatGuardMessage,
+	HEARTBEAT_EXPIRY_MS,
+	MultiInstanceRefusedError,
+	purgeStaleHeartbeats,
+	readMultiInstanceMode,
+	runStartupGuard,
+	scanHeartbeats,
+	writeHeartbeat,
+} from "../multi-instance-guard";
+
+function freshSqlite(): BunSqlAdapter {
+	const db = new Database(":memory:");
+	ensureSchema(db);
+	return new BunSqlAdapter(db);
+}
+
+describe("multi-instance-guard (SQLite)", () => {
+	let adapter: BunSqlAdapter;
+	beforeEach(() => {
+		adapter = freshSqlite();
+	});
+	afterEach(() => {
+		// Don't close the in-memory DB; it's GC'd.
+	});
+
+	it("NEGATIVE 1: detects a second instance whose heartbeat is fresh", async () => {
+		// Simulate another live process by writing a peer row directly.
+		// We use a different "now" so it appears live to the scanner.
+		const now = Date.now();
+		adapter.getSQLiteDb().run(
+			`INSERT INTO instance_heartbeats
+				(instance_id, hostname, pid, started_at, last_heartbeat,
+				 node_version, db_dialect)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			[
+				"peer-uuid-aaaa",
+				"peer-host",
+				4321,
+				now - 5_000,
+				now - 1_000,
+				"v20.0.0",
+				"sqlite",
+			],
+		);
+
+		const result = await scanHeartbeats(adapter, now);
+		expect(result.peers.length).toBe(1);
+		expect(result.peers[0].instance_id).toBe("peer-uuid-aaaa");
+		expect(result.peers[0].hostname).toBe("peer-host");
+		expect(result.expired.length).toBe(0);
+	});
+
+	it("NEGATIVE 2: a stale predecessor does NOT block startup", async () => {
+		// Simulate a crashed predecessor: row exists, but its heartbeat
+		// is older than the expiry window.
+		const now = Date.now();
+		const stale = now - HEARTBEAT_EXPIRY_MS - 5_000;
+		adapter.getSQLiteDb().run(
+			`INSERT INTO instance_heartbeats
+				(instance_id, hostname, pid, started_at, last_heartbeat,
+				 node_version, db_dialect)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			[
+				"crashed-predecessor",
+				"old-host",
+				1234,
+				stale - 60_000,
+				stale,
+				"v18.0.0",
+				"sqlite",
+			],
+		);
+
+		// Capture any warning emission.
+		const warnings: string[] = [];
+		const result = await runStartupGuard(adapter, {
+			now,
+			mode: "warn",
+			log: (msg) => warnings.push(msg),
+		});
+
+		// The stale predecessor must NOT appear in peers — that was the
+		// design risk called out in #351.
+		expect(result.peers.length).toBe(0);
+		// runStartupGuard purges stale rows before scanning, so the
+		// expired row is no longer in the table by the time scanHeartbeats
+		// runs. That's the desired behaviour — the table does not grow
+		// forever from crashed predecessors.
+		expect(result.expired.length).toBe(0);
+
+		// No warning should have been emitted.
+		expect(warnings.length).toBe(0);
+
+		// And the stale row was purged so the table doesn't grow forever.
+		const remaining = adapter
+			.getSQLiteDb()
+			.query<
+				{ instance_id: string },
+				[]
+			>("SELECT instance_id FROM instance_heartbeats")
+			.all();
+		// Only our row (auto-written by runStartupGuard) remains.
+		expect(remaining.length).toBe(1);
+	});
+
+	it("NEGATIVE 3: single-instance startup is silent", async () => {
+		const now = Date.now();
+		const warnings: string[] = [];
+		const result = await runStartupGuard(adapter, {
+			now,
+			mode: "warn",
+			log: (msg) => warnings.push(msg),
+		});
+		expect(result.peers.length).toBe(0);
+		expect(result.expired.length).toBe(0);
+		expect(warnings.length).toBe(0);
+
+		// Our row was written.
+		const rows = adapter
+			.getSQLiteDb()
+			.query<
+				{ instance_id: string; hostname: string },
+				[]
+			>("SELECT instance_id, hostname FROM instance_heartbeats")
+			.all();
+		expect(rows.length).toBe(1);
+	});
+
+	it("refuse mode throws when peers are present", async () => {
+		const now = Date.now();
+		adapter.getSQLiteDb().run(
+			`INSERT INTO instance_heartbeats
+				(instance_id, hostname, pid, started_at, last_heartbeat,
+				 node_version, db_dialect)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			[
+				"peer-uuid-bbbb",
+				"peer-host",
+				4321,
+				now - 5_000,
+				now - 1_000,
+				"v20.0.0",
+				"sqlite",
+			],
+		);
+
+		await expect(
+			runStartupGuard(adapter, { now, mode: "refuse" }),
+		).rejects.toThrow(MultiInstanceRefusedError);
+	});
+
+	it("warn mode does NOT throw even when peers are present", async () => {
+		const now = Date.now();
+		adapter.getSQLiteDb().run(
+			`INSERT INTO instance_heartbeats
+				(instance_id, hostname, pid, started_at, last_heartbeat,
+				 node_version, db_dialect)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			[
+				"peer-uuid-cccc",
+				"peer-host",
+				4321,
+				now - 5_000,
+				now - 1_000,
+				"v20.0.0",
+				"sqlite",
+			],
+		);
+
+		const warnings: string[] = [];
+		const result = await runStartupGuard(adapter, {
+			now,
+			mode: "warn",
+			log: (msg) => warnings.push(msg),
+		});
+		expect(result.peers.length).toBe(1);
+		expect(warnings.length).toBe(1);
+		// The warning names the divergence categories so the operator
+		// understands the consequence.
+		expect(warnings[0]).toContain("SessionAffinityStrategy");
+		expect(warnings[0]).toContain("AutoRefreshScheduler");
+		expect(warnings[0]).toContain("#351");
+	});
+
+	it("formatGuardMessage names all seven divergence categories", () => {
+		const msg = formatGuardMessage([
+			{
+				instance_id: "1234567890abcdef",
+				hostname: "host-x",
+				pid: 999,
+				started_at: 0,
+				last_heartbeat: 0,
+				node_version: "v0",
+				db_dialect: "sqlite",
+			},
+		]);
+		// All seven categories from issue #351.
+		expect(msg).toContain("SessionAffinityStrategy");
+		expect(msg).toContain("LeastUsedStrategy");
+		expect(msg).toContain("SessionDrainSoonestStrategy");
+		expect(msg).toContain("UsageCache");
+		expect(msg).toContain("CacheBodyStore");
+		expect(msg).toContain("AutoRefreshScheduler");
+		expect(msg).toContain("probeLeases");
+		expect(msg).toContain("SessionGovernor");
+	});
+
+	it("writeHeartbeat is upsert: same instance_id refreshes the row", async () => {
+		// The runtime uses a single instance_id per process. The first call
+		// writes the row; subsequent calls must update the same row, not
+		// create duplicates. We simulate by manually upserting on the same id.
+		const now = Date.now();
+		await writeHeartbeat(adapter, now);
+		await writeHeartbeat(adapter, now + 100);
+		await writeHeartbeat(adapter, now + 200);
+		const rows = adapter
+			.getSQLiteDb()
+			.query<{ c: number }, []>(
+				"SELECT COUNT(*) as c FROM instance_heartbeats",
+			)
+			.all();
+		// Only our row (one — the process instance_id) plus the rows written
+		// here. Since each call writes with the same THIS_INSTANCE_ID, total
+		// must be exactly 1.
+		expect(rows[0].c).toBe(1);
+	});
+
+	it("clearHeartbeat removes this instance's row", async () => {
+		await writeHeartbeat(adapter);
+		let rows = adapter
+			.getSQLiteDb()
+			.query<{ c: number }, []>(
+				"SELECT COUNT(*) as c FROM instance_heartbeats",
+			)
+			.all();
+		expect(rows[0].c).toBe(1);
+		await clearHeartbeat(adapter);
+		rows = adapter
+			.getSQLiteDb()
+			.query<{ c: number }, []>(
+				"SELECT COUNT(*) as c FROM instance_heartbeats",
+			)
+			.all();
+		expect(rows[0].c).toBe(0);
+	});
+
+	it("purgeStaleHeartbeats removes only rows older than expiry", async () => {
+		const now = Date.now();
+		const fresh = now - 1_000;
+		const stale = now - HEARTBEAT_EXPIRY_MS - 1_000;
+		adapter.getSQLiteDb().run(
+			`INSERT INTO instance_heartbeats VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			["fresh-row", "h", 1, now, fresh, "v", "sqlite"],
+		);
+		adapter.getSQLiteDb().run(
+			`INSERT INTO instance_heartbeats VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			["stale-row", "h", 1, stale - 60_000, stale, "v", "sqlite"],
+		);
+
+		const purged = await purgeStaleHeartbeats(adapter, now);
+		expect(purged).toBe(1);
+
+		const remaining = adapter
+			.getSQLiteDb()
+			.query<{ instance_id: string }, []>(
+				"SELECT instance_id FROM instance_heartbeats",
+			)
+			.all()
+			.map((r) => r.instance_id);
+		expect(remaining).toEqual(["fresh-row"]);
+	});
+
+	it("readMultiInstanceMode defaults to warn and respects refuse", () => {
+		const prev = process.env.BETTER_CCFLARE_MULTI_INSTANCE;
+		try {
+			delete process.env.BETTER_CCFLARE_MULTI_INSTANCE;
+			expect(readMultiInstanceMode()).toBe("warn");
+			process.env.BETTER_CCFLARE_MULTI_INSTANCE = "refuse";
+			expect(readMultiInstanceMode()).toBe("refuse");
+			process.env.BETTER_CCFLARE_MULTI_INSTANCE = "WARN";
+			expect(readMultiInstanceMode()).toBe("warn");
+			process.env.BETTER_CCFLARE_MULTI_INSTANCE = "unknown";
+			expect(readMultiInstanceMode()).toBe("warn"); // unknown -> warn
+		} finally {
+			if (prev === undefined) {
+				delete process.env.BETTER_CCFLARE_MULTI_INSTANCE;
+			} else {
+				process.env.BETTER_CCFLARE_MULTI_INSTANCE = prev;
+			}
+		}
+	});
+});
+
+describe("multi-instance-guard — schema shape", () => {
+	it("SQLite ensureSchema creates the instance_heartbeats table", () => {
+		const db = new Database(":memory:");
+		ensureSchema(db);
+		const row = db
+			.query<{ name: string }, []>(
+				"SELECT name FROM sqlite_master WHERE type='table' AND name='instance_heartbeats'",
+			)
+			.get();
+		expect(row?.name).toBe("instance_heartbeats");
+		const cols = db
+			.query<{ name: string }, []>(
+				"SELECT name FROM pragma_table_info('instance_heartbeats') ORDER BY cid",
+			)
+			.all()
+			.map((c) => c.name);
+		// Schema must include every column the guard writes.
+		for (const col of [
+			"instance_id",
+			"hostname",
+			"pid",
+			"started_at",
+			"last_heartbeat",
+			"node_version",
+			"db_dialect",
+		]) {
+			expect(cols).toContain(col);
+		}
+	});
+
+	it("PG ensureSchemaPg includes the instance_heartbeats CREATE TABLE", () => {
+		// We don't need a live PG database for this — confirm the SQL
+		// text is shipped in migrations-pg.ts. The live-PostgreSQL
+		// test below exercises the actual DDL when DATABASE_URL is set.
+		const fs = require("node:fs") as typeof import("node:fs");
+		const path = require("node:path") as typeof import("node:path");
+		const src = fs.readFileSync(
+			path.join(import.meta.dir, "..", "migrations-pg.ts"),
+			"utf8",
+		);
+		expect(src).toContain("CREATE TABLE IF NOT EXISTS instance_heartbeats");
+		expect(src).toContain(
+			"CREATE INDEX IF NOT EXISTS idx_instance_heartbeats_last_heartbeat",
+		);
+		// All seven columns must be present in the PG schema text.
+		for (const col of [
+			"instance_id",
+			"hostname",
+			"pid",
+			"started_at",
+			"last_heartbeat",
+			"node_version",
+			"db_dialect",
+		]) {
+			expect(src).toContain(`\t\t\t${col} `);
+		}
+	});
+});
+
+// Live PostgreSQL test — same three negative controls, gated on DATABASE_URL.
+// Matches the pattern in migrations-pg.test.ts: skipIf(!databaseUrl).
+const databaseUrl = process.env.DATABASE_URL;
+const livePgAvailable = Boolean(
+	databaseUrl && databaseUrl.startsWith("postgres"),
+);
+
+describe.skipIf(!livePgAvailable)(
+	"multi-instance-guard (PostgreSQL, live, requires DATABASE_URL)",
+	() => {
+		let adapter: BunSqlAdapter;
+		beforeEach(async () => {
+			const sql = new (await import("bun")).SQL(databaseUrl!);
+			adapter = new BunSqlAdapter(sql, false);
+			await ensureSchemaPg(adapter);
+			// Clean any rows left by a previous run.
+			await adapter.run("DELETE FROM instance_heartbeats");
+		});
+		afterEach(async () => {
+			await adapter.run("DELETE FROM instance_heartbeats");
+			await adapter.close();
+		});
+
+		it("NEGATIVE 1 (PG): detects a second instance", async () => {
+			const now = Date.now();
+			await adapter.run(
+				`INSERT INTO instance_heartbeats
+					(instance_id, hostname, pid, started_at, last_heartbeat,
+					 node_version, db_dialect)
+				 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				[
+					"pg-peer-aaaa",
+					"pg-host",
+					4321,
+					now - 5_000,
+					now - 1_000,
+					"v20.0.0",
+					"postgres",
+				],
+			);
+			const result = await scanHeartbeats(adapter, now);
+			expect(result.peers.length).toBe(1);
+			expect(result.peers[0].instance_id).toBe("pg-peer-aaaa");
+		});
+
+		it("NEGATIVE 2 (PG): stale predecessor does NOT block startup", async () => {
+			const now = Date.now();
+			const stale = now - HEARTBEAT_EXPIRY_MS - 5_000;
+			await adapter.run(
+				`INSERT INTO instance_heartbeats
+					(instance_id, hostname, pid, started_at, last_heartbeat,
+					 node_version, db_dialect)
+				 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				[
+					"pg-crashed",
+					"old",
+					1234,
+					stale - 60_000,
+					stale,
+					"v18",
+					"postgres",
+				],
+			);
+			const warnings: string[] = [];
+			const result = await runStartupGuard(adapter, {
+				now,
+				mode: "warn",
+				log: (msg) => warnings.push(msg),
+			});
+			expect(result.peers.length).toBe(0);
+			expect(result.expired.length).toBe(1);
+			expect(warnings.length).toBe(0);
+		});
+
+		it("NEGATIVE 3 (PG): single-instance startup is silent", async () => {
+			const warnings: string[] = [];
+			const result = await runStartupGuard(adapter, {
+				mode: "warn",
+				log: (msg) => warnings.push(msg),
+			});
+			expect(result.peers.length).toBe(0);
+			expect(warnings.length).toBe(0);
+		});
+	},
+);

--- a/packages/database/src/database-operations.ts
+++ b/packages/database/src/database-operations.ts
@@ -26,6 +26,11 @@ import { EMBEDDED_INCREMENTAL_VACUUM_WORKER_CODE } from "./inline-incremental-va
 import { EMBEDDED_VACUUM_WORKER_CODE } from "./inline-vacuum-worker";
 import { ensureSchema, runMigrations } from "./migrations";
 import { ensureSchemaPg, runMigrationsPg } from "./migrations-pg";
+import {
+	readMultiInstanceMode,
+	runStartupGuard,
+	startHeartbeatLoop,
+} from "./multi-instance-guard";
 import { resolveDbPath } from "./paths";
 import {
 	AccountRepository,
@@ -213,6 +218,8 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 	private originalAutoVacuumMode?: number;
 	/** Prevents concurrent compact() calls from spawning multiple vacuum workers */
 	private compacting = false;
+	/** Stop function returned by the multi-instance guard's heartbeat loop. */
+	private heartbeatStop: (() => Promise<void>) | null = null;
 	/**
 	 * Hourly `incrementalVacuum()` ticks that bailed because the worker
 	 * couldn't claim the writer slot (SQLITE_BUSY). Bumped on every failure,
@@ -386,6 +393,15 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 			await ensureSchemaPg(this.adapter);
 			await runMigrationsPg(this.adapter);
 		}
+		// Run the multi-instance guard after migrations so the heartbeat table
+		// exists before we probe it. SQLite migrations are synchronous so they
+		// were applied inside the constructor; for PG we just ran them above.
+		// Default mode is "warn" — see #351.
+		const mode = readMultiInstanceMode();
+		await runStartupGuard(this.adapter, { mode });
+		// Start the heartbeat loop so this instance's row is refreshed
+		// while it lives. The stopper is invoked from close().
+		this.heartbeatStop = startHeartbeatLoop(this.adapter);
 	}
 
 	setRuntimeConfig(runtime: RuntimeConfig): void {
@@ -1294,6 +1310,16 @@ OAuth tokens will need to be re-authenticated.
 	}
 
 	async close(): Promise<void> {
+		// Stop the multi-instance heartbeat loop and remove this instance's
+		// row before closing the adapter. Best-effort — errors here are
+		// logged inside the stopper, not rethrown.
+		if (this.heartbeatStop) {
+			try {
+				await this.heartbeatStop();
+			} finally {
+				this.heartbeatStop = null;
+			}
+		}
 		await this.adapter.close();
 	}
 

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -34,3 +34,25 @@ export type { StatsRepository } from "./repositories/stats.repository";
 // Re-export retry utilities for external use (from your improvements)
 export { withDatabaseRetry, withDatabaseRetrySync } from "./retry";
 export { DatabaseOperations };
+// Multi-instance guard — see tombii/better-ccflare#351. Operators may use
+// these symbols directly (e.g. for custom integration tests) but most
+// callers should rely on DatabaseOperations lifecycle integration.
+export {
+	clearHeartbeat,
+	formatGuardMessage,
+	HEARTBEAT_EXPIRY_MS,
+	HEARTBEAT_INTERVAL_MS,
+	getInstanceId,
+	MultiInstanceRefusedError,
+	purgeStaleHeartbeats,
+	readMultiInstanceMode,
+	runStartupGuard,
+	scanHeartbeats,
+	startHeartbeatLoop,
+	writeHeartbeat,
+} from "./multi-instance-guard";
+export type {
+	HeartbeatRecord,
+	MultiInstanceMode,
+	MultiInstanceScanResult,
+} from "./multi-instance-guard";

--- a/packages/database/src/migrations-pg.ts
+++ b/packages/database/src/migrations-pg.ts
@@ -320,6 +320,27 @@ export async function ensureSchemaPg(adapter: BunSqlAdapter): Promise<void> {
 		`CREATE INDEX IF NOT EXISTS idx_usage_snapshots_ts ON usage_snapshots(timestamp)`,
 	);
 
+	// Create instance_heartbeats table: per-process heartbeat for the
+	// multi-instance guard (see packages/database/src/multi-instance-guard.ts
+	// and tombii/better-ccflare#351). Each instance writes one row and
+	// refreshes `last_heartbeat` on a tick. Rows older than the expiry
+	// window are treated as dead predecessors so a crash never blocks a
+	// legitimate restart.
+	await adapter.unsafe(`
+		CREATE TABLE IF NOT EXISTS instance_heartbeats (
+			instance_id TEXT PRIMARY KEY,
+			hostname TEXT NOT NULL,
+			pid INTEGER NOT NULL,
+			started_at INTEGER NOT NULL,
+			last_heartbeat INTEGER NOT NULL,
+			node_version TEXT NOT NULL,
+			db_dialect TEXT NOT NULL
+		)
+	`);
+	await adapter.unsafe(
+		`CREATE INDEX IF NOT EXISTS idx_instance_heartbeats_last_heartbeat ON instance_heartbeats(last_heartbeat)`,
+	);
+
 	log.info("PostgreSQL schema ensured");
 }
 

--- a/packages/database/src/migrations.ts
+++ b/packages/database/src/migrations.ts
@@ -389,6 +389,27 @@ export function ensureSchema(db: Database): void {
 	db.run(
 		`CREATE INDEX IF NOT EXISTS idx_usage_snapshots_ts ON usage_snapshots(timestamp)`,
 	);
+
+	// Create instance_heartbeats table: per-process heartbeat for the
+	// multi-instance guard (see packages/database/src/multi-instance-guard.ts
+	// and tombii/better-ccflare#351). Each instance writes one row and
+	// refreshes `last_heartbeat` on a tick. Rows older than the expiry
+	// window are treated as dead predecessors so a crash never blocks a
+	// legitimate restart.
+	db.run(`
+		CREATE TABLE IF NOT EXISTS instance_heartbeats (
+			instance_id TEXT PRIMARY KEY,
+			hostname TEXT NOT NULL,
+			pid INTEGER NOT NULL,
+			started_at INTEGER NOT NULL,
+			last_heartbeat INTEGER NOT NULL,
+			node_version TEXT NOT NULL,
+			db_dialect TEXT NOT NULL
+		)
+	`);
+	db.run(
+		`CREATE INDEX IF NOT EXISTS idx_instance_heartbeats_last_heartbeat ON instance_heartbeats(last_heartbeat)`,
+	);
 }
 
 /**

--- a/packages/database/src/multi-instance-guard.ts
+++ b/packages/database/src/multi-instance-guard.ts
@@ -295,6 +295,21 @@ export async function runStartupGuard(
 		const message = formatGuardMessage(result.peers);
 		writeLog(message);
 		if (mode === "refuse") {
+			// Clear this process's own heartbeat before throwing so an
+			// immediate retry does not see a phantom peer (self) and refuse
+			// again for up to HEARTBEAT_EXPIRY_MS. The lifecycle cleanup
+			// callback is not installed yet (it is wired by the caller after
+			// runStartupGuard returns), so the row would otherwise linger.
+			// Fixes Greptile P1 on PR #376.
+			try {
+				await clearHeartbeat(adapter);
+			} catch (err) {
+				// Best-effort cleanup; surface the original refusal even if
+				// the cleanup itself failed.
+				log.warn(
+					`heartbeat cleanup during refuse failed: ${(err as Error).message}`,
+				);
+			}
 			throw new MultiInstanceRefusedError(result.peers);
 		}
 	}

--- a/packages/database/src/multi-instance-guard.ts
+++ b/packages/database/src/multi-instance-guard.ts
@@ -1,0 +1,381 @@
+/**
+ * Multi-instance guard — startup-time detection that warns the operator
+ * when more than one live process shares this database.
+ *
+ * Background: ccflare is designed for single-instance ownership of its
+ * database. A second instance pointing at the same DB will share durable
+ * state (accounts, requests, oauth_sessions) but NOT seven categories of
+ * in-process coordination state that diverge silently across instances:
+ *
+ *   1. SessionAffinityStrategy — sticky client→account map.
+ *   2. LeastUsedStrategy / SessionDrainSoonestStrategy — recency-penalty Map
+ *      (`RECENT_PICK_PENALTY` / `RECENT_PICK_WINDOW_MS`).
+ *   3. UsageCache — utilisation view Maps; routing decisions diverge.
+ *   4. CacheBodyStore — keepalive replay cache.
+ *   5. AutoRefreshScheduler — refresh mutex & failure counters. A second
+ *      instance refreshes the same OAuth token concurrently — a race
+ *      against the provider, not just a duplicate request.
+ *   6. Rate-limit single-flight recovery probe lease map (`probeLeases`).
+ *   7. SessionGovernor — session-volume circuit breaker.
+ *
+ * See tombii/better-ccflare#351 for the maintainer's analysis.
+ *
+ * Design:
+ *   - Each instance writes a row to `instance_heartbeats` and refreshes
+ *     `last_heartbeat` on a fixed tick.
+ *   - A row older than HEARTBEAT_EXPIRY_MS is considered dead; we do not
+ *     hold a bare lock row that would block legitimate restarts after a
+ *     crash. This is the main design risk called out in #351.
+ *   - Detection at startup scans for other rows whose `last_heartbeat` is
+ *     within the expiry window.
+ *   - Default behaviour is WARN (log + continue). The operator may opt
+ *     into hard-failure with the BETTER_CCFLARE_MULTI_INSTANCE=refuse env
+ *     var, matching ccflare's existing pattern of opt-in strictness.
+ *
+ * Schema: the `instance_heartbeats` table is added in both
+ * `migrations.ts` (SQLite) and `migrations-pg.ts` (PostgreSQL).
+ */
+import { hostname as osHostname } from "node:os";
+import { randomUUID } from "node:crypto";
+import { Logger } from "@better-ccflare/logger";
+import type { BunSqlAdapter } from "./adapters/bun-sql-adapter";
+
+const log = new Logger("multi-instance-guard");
+
+/**
+ * How often this instance refreshes its `last_heartbeat` row (ms).
+ * Picked at 5s so a missed tick does not leave us stale for long.
+ */
+export const HEARTBEAT_INTERVAL_MS = 5_000;
+
+/**
+ * A row older than this is treated as a dead predecessor and ignored.
+ * 30s = 6 missed ticks at HEARTBEAT_INTERVAL_MS, which tolerates GC
+ * pauses, container freezes, and short network blips while still
+ * surfacing a real concurrent instance within ~30s of its start.
+ */
+export const HEARTBEAT_EXPIRY_MS = 30_000;
+
+export interface HeartbeatRecord {
+	instance_id: string;
+	hostname: string;
+	pid: number;
+	started_at: number;
+	last_heartbeat: number;
+	node_version: string;
+	db_dialect: "sqlite" | "postgres";
+}
+
+/** Result of a startup scan: peers with a fresh heartbeat, plus the
+ *  caller's own instance row. */
+export interface MultiInstanceScanResult {
+	/** Rows written by OTHER live instances, excluding this one. */
+	peers: HeartbeatRecord[];
+	/** Rows already expired (older than HEARTBEAT_EXPIRY_MS). Useful for
+	 *  logging but not used to block startup. */
+	expired: HeartbeatRecord[];
+}
+
+/**
+ * How the guard should react when peers are found.
+ *  - "warn" (default): log a warning and continue startup.
+ *  - "refuse": throw MultiInstanceRefusedError to abort startup.
+ *
+ * Driven by the env var BETTER_CCFLARE_MULTI_INSTANCE.
+ */
+export type MultiInstanceMode = "warn" | "refuse";
+
+export class MultiInstanceRefusedError extends Error {
+	readonly peers: HeartbeatRecord[];
+	constructor(peers: HeartbeatRecord[]) {
+		super(
+			`ccflare startup refused: ${peers.length} other live instance(s) ` +
+				`share this database (set BETTER_CCFLARE_MULTI_INSTANCE=warn to override)`,
+		);
+		this.name = "MultiInstanceRefusedError";
+		this.peers = peers;
+	}
+}
+
+/**
+ * Read the operator's mode preference. Defaults to "warn" so an
+ * upgrade does not break existing deployments.
+ */
+export function readMultiInstanceMode(): MultiInstanceMode {
+	const raw = (process.env.BETTER_CCFLARE_MULTI_INSTANCE ?? "warn")
+		.trim()
+		.toLowerCase();
+	if (raw === "refuse") return "refuse";
+	if (raw === "warn" || raw === "") return "warn";
+	// Unknown values: be loud but don't refuse.
+	log.warn(
+		`Unknown BETTER_CCFLARE_MULTI_INSTANCE value "${raw}"; defaulting to "warn"`,
+	);
+	return "warn";
+}
+
+/** A locally-generated identifier for this process. Generated once at
+ *  module load so the same value is used across calls in a single run. */
+const THIS_INSTANCE_ID = randomUUID();
+
+/** Cached values for `started_at` etc. Avoid re-fetching os.hostname() on
+ *  every tick. */
+const THIS_HOSTNAME = safeHostname();
+const THIS_PID = process.pid ?? -1;
+const THIS_NODE_VERSION = process.versions.node ?? "unknown";
+
+function safeHostname(): string {
+	try {
+		return osHostname();
+	} catch {
+		return "unknown";
+	}
+}
+
+/** Returns this process's instance_id. Stable for the lifetime of the
+ *  process. */
+export function getInstanceId(): string {
+	return THIS_INSTANCE_ID;
+}
+
+/**
+ * Insert (or update) this instance's heartbeat row. Safe to call at
+ * startup and on every tick — uses UPSERT semantics.
+ */
+export async function writeHeartbeat(
+	adapter: BunSqlAdapter,
+	now: number = Date.now(),
+): Promise<void> {
+	const dialect = adapter.isSQLite ? "sqlite" : "postgres";
+	if (adapter.isSQLite) {
+		const db = adapter.getSQLiteDb();
+		db.run(
+			`INSERT INTO instance_heartbeats (
+				instance_id, hostname, pid, started_at, last_heartbeat,
+				node_version, db_dialect
+			) VALUES (?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(instance_id) DO UPDATE SET
+				last_heartbeat = excluded.last_heartbeat,
+				hostname = excluded.hostname,
+				pid = excluded.pid,
+				node_version = excluded.node_version,
+				db_dialect = excluded.db_dialect`,
+			[
+				THIS_INSTANCE_ID,
+				THIS_HOSTNAME,
+				THIS_PID,
+				now,
+				now,
+				THIS_NODE_VERSION,
+				dialect,
+			],
+		);
+	} else {
+		await adapter.run(
+			`INSERT INTO instance_heartbeats (
+				instance_id, hostname, pid, started_at, last_heartbeat,
+				node_version, db_dialect
+			) VALUES (?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT (instance_id) DO UPDATE SET
+				last_heartbeat = EXCLUDED.last_heartbeat,
+				hostname = EXCLUDED.hostname,
+				pid = EXCLUDED.pid,
+				node_version = EXCLUDED.node_version,
+				db_dialect = EXCLUDED.db_dialect`,
+			[
+				THIS_INSTANCE_ID,
+				THIS_HOSTNAME,
+				THIS_PID,
+				now,
+				now,
+				THIS_NODE_VERSION,
+				dialect,
+			],
+		);
+	}
+}
+
+/**
+ * Scan for other live instances. Returns rows written by other processes
+ * (never this one) whose `last_heartbeat` is within `expiryMs` of `now`.
+ * Also returns stale rows so the caller can log them.
+ */
+export async function scanHeartbeats(
+	adapter: BunSqlAdapter,
+	now: number = Date.now(),
+	expiryMs: number = HEARTBEAT_EXPIRY_MS,
+): Promise<MultiInstanceScanResult> {
+	const cutoffFresh = now - expiryMs;
+	const rows = adapter.isSQLite
+		? (adapter
+				.getSQLiteDb()
+				.query<
+					HeartbeatRecord,
+					[string]
+				>(
+					"SELECT instance_id, hostname, pid, started_at, last_heartbeat, node_version, db_dialect FROM instance_heartbeats WHERE instance_id != ? ORDER BY last_heartbeat DESC",
+				)
+				.all(THIS_INSTANCE_ID) as HeartbeatRecord[])
+		: ((await adapter.query<HeartbeatRecord>(
+				"SELECT instance_id, hostname, pid, started_at, last_heartbeat, node_version, db_dialect FROM instance_heartbeats WHERE instance_id != ? ORDER BY last_heartbeat DESC",
+				[THIS_INSTANCE_ID],
+			)) as HeartbeatRecord[]);
+
+	const peers: HeartbeatRecord[] = [];
+	const expired: HeartbeatRecord[] = [];
+	for (const row of rows) {
+		if (row.last_heartbeat >= cutoffFresh) peers.push(row);
+		else expired.push(row);
+	}
+	return { peers, expired };
+}
+
+/**
+ * Delete this instance's heartbeat row. Called on graceful shutdown.
+ * Idempotent; safe to call multiple times.
+ */
+export async function clearHeartbeat(adapter: BunSqlAdapter): Promise<void> {
+	if (adapter.isSQLite) {
+		adapter.getSQLiteDb().run("DELETE FROM instance_heartbeats WHERE instance_id = ?", [
+			THIS_INSTANCE_ID,
+		]);
+	} else {
+		await adapter.run("DELETE FROM instance_heartbeats WHERE instance_id = ?", [
+			THIS_INSTANCE_ID,
+		]);
+	}
+}
+
+/**
+ * Periodic cleanup of stale rows from crashed predecessors. Called on
+ * every startup so the table does not grow forever. Returns the number
+ * of rows removed.
+ */
+export async function purgeStaleHeartbeats(
+	adapter: BunSqlAdapter,
+	now: number = Date.now(),
+	expiryMs: number = HEARTBEAT_EXPIRY_MS,
+): Promise<number> {
+	const cutoff = now - expiryMs;
+	return adapter.runWithChanges(
+		"DELETE FROM instance_heartbeats WHERE last_heartbeat < ?",
+		[cutoff],
+	);
+}
+
+/**
+ * Run the startup probe. If peers are found, either warn (default) or
+ * throw based on the operator's env-var preference. Returns the scan
+ * result so callers may log additional context.
+ */
+export async function runStartupGuard(
+	adapter: BunSqlAdapter,
+	options: {
+		now?: number;
+		expiryMs?: number;
+		mode?: MultiInstanceMode;
+		log?: (msg: string) => void;
+	} = {},
+): Promise<MultiInstanceScanResult> {
+	const now = options.now ?? Date.now();
+	const expiryMs = options.expiryMs ?? HEARTBEAT_EXPIRY_MS;
+	const mode = options.mode ?? readMultiInstanceMode();
+	const writeLog = options.log ?? ((msg) => log.warn(msg));
+
+	// Purge rows from crashed predecessors so the table does not grow.
+	await purgeStaleHeartbeats(adapter, now, expiryMs);
+
+	// Insert (or refresh) this instance's row.
+	await writeHeartbeat(adapter, now);
+
+	// Scan for peers.
+	const result = await scanHeartbeats(adapter, now, expiryMs);
+
+	if (result.peers.length > 0) {
+		const message = formatGuardMessage(result.peers);
+		writeLog(message);
+		if (mode === "refuse") {
+			throw new MultiInstanceRefusedError(result.peers);
+		}
+	}
+
+	return result;
+}
+
+/** Render the operator-facing warning. Names the seven categories of
+ *  in-process state so the reader understands the consequence. */
+export function formatGuardMessage(peers: HeartbeatRecord[]): string {
+	const peerLines = peers
+		.map(
+			(p) =>
+				`  - instance ${p.instance_id.slice(0, 8)}…  host=${p.hostname}  pid=${p.pid}  ` +
+				`last_heartbeat=${new Date(p.last_heartbeat).toISOString()}`,
+		)
+		.join("\n");
+
+	return [
+		`Multi-instance guard: ${peers.length} other live ccflare process(es) share this database.`,
+		`The database holds durable state, but each instance keeps the following in-process and they DIVERGE silently:`,
+		`  1. SessionAffinityStrategy — sticky client→account map`,
+		`  2. LeastUsedStrategy / SessionDrainSoonestStrategy — recency-penalty Map`,
+		`  3. UsageCache — utilisation view Maps (routing decisions diverge)`,
+		`  4. CacheBodyStore — keepalive replay cache`,
+		`  5. AutoRefreshScheduler — refresh mutex & failure counters (token-refresh race)`,
+		`  6. Rate-limit single-flight recovery probe lease map (probeLeases)`,
+		`  7. SessionGovernor — session-volume circuit breaker`,
+		``,
+		`Other instance(s):`,
+		peerLines,
+		``,
+		`To silence: ensure only one instance owns this database.`,
+		`To hard-fail instead of warn: set BETTER_CCFLARE_MULTI_INSTANCE=refuse.`,
+		`See tombii/better-ccflare#351 for the full analysis.`,
+	].join("\n");
+}
+
+/**
+ * Run the guard, then start a periodic heartbeat timer that refreshes
+ * this instance's row. Returns a stop function that clears the timer
+ * and removes this instance's row from the table.
+ *
+ * Designed to be wired into DatabaseOperations lifecycle: call from
+ * `initializeAsync()`, store the returned stopper, and call it from
+ * `close()`.
+ */
+export function startHeartbeatLoop(
+	adapter: BunSqlAdapter,
+	options: {
+		intervalMs?: number;
+		now?: () => number;
+	} = {},
+): () => Promise<void> {
+	const intervalMs = options.intervalMs ?? HEARTBEAT_INTERVAL_MS;
+	const now = options.now ?? Date.now;
+
+	let stopped = false;
+	const timer = setInterval(() => {
+		if (stopped) return;
+		// Fire-and-forget: write errors are logged inside writeHeartbeat
+		// callers, but here we surface them as warnings so a transient DB
+		// hiccup does not kill the process.
+		writeHeartbeat(adapter, now()).catch((err) => {
+			log.warn(`heartbeat tick failed: ${(err as Error).message}`);
+		});
+	}, intervalMs);
+	// Don't keep the event loop alive just for the heartbeat. Bun's
+	// setInterval return type is `number` under `lib: ["DOM"]` and
+	// `Timeout` under `@types/node`; guard for both.
+	const maybeTimer = timer as { unref?: () => void };
+	if (typeof maybeTimer.unref === "function") maybeTimer.unref();
+
+	return async () => {
+		if (stopped) return;
+		stopped = true;
+		clearInterval(timer);
+		try {
+			await clearHeartbeat(adapter);
+		} catch (err) {
+			log.warn(`heartbeat cleanup failed: ${(err as Error).message}`);
+		}
+	};
+}


### PR DESCRIPTION
Closes #351

## Stage 1 of several — see #351 for the wider design discussion

The wider debate in #351 (leader election, session-affinity sharing,
state externalisation) is contingent on the maintainer's design call.
This PR does the one thing that is right regardless of how that
debate resolves: it makes the failure **loud** instead of silent.

### What it does

A startup-time guard that detects another live instance pointing at
the same database and warns the operator, naming the seven categories
of in-process state that will diverge silently:

1. `SessionAffinityStrategy` — sticky client→account map
2. `LeastUsedStrategy` / `SessionDrainSoonestStrategy` — recency-penalty Map
3. `UsageCache` — utilisation view Maps
4. `CacheBodyStore` — keepalive replay cache
5. `AutoRefreshScheduler` — refresh mutex & failure counters (**token-refresh race**)
6. Rate-limit single-flight recovery probe lease map (`probeLeases`)
7. `SessionGovernor` — session-volume circuit breaker

### Design

- **Heartbeat, not a bare lock row.** Each instance writes a row to a
  new `instance_heartbeats` table and refreshes `last_heartbeat` on
  a 5s tick. A row older than 30s is treated as a dead predecessor and
  ignored. The table is purged of stale rows on every startup so it
  does not grow forever. **A crash never blocks a legitimate restart**
  — that was the main design risk called out in #351.
- **Default = WARN.** An upgrade does not break existing deployments.
- **Refuse behind an opt-in env var:** set
  `BETTER_CCFLARE_MULTI_INSTANCE=refuse` to hard-fail instead.
- **Works on both SQLite and PostgreSQL.** The new table is added in
  both `migrations.ts` and `migrations-pg.ts`; a static-parity test
  in `migrations-pg.test.ts` keeps them in lockstep.
- **Wired into `DatabaseOperations` lifecycle.** `initializeAsync()`
  runs the guard and starts a heartbeat loop; `close()` stops it and
  deletes this instance's row.

### Tests

`packages/database/src/__tests__/multi-instance-guard.test.ts` has the
three negative controls required by #351:

- **NEGATIVE 1:** second instance detected when first is alive.
- **NEGATIVE 2:** stale/dead predecessor does NOT false-positive (and
  the stale row is purged, so the table does not grow forever).
- **NEGATIVE 3:** single-instance startup is silent.

Plus refuse-mode, dual-dialect schema parity, the seven-category
message content, and env-var parsing. Live PostgreSQL tests are gated
on `DATABASE_URL` so they run in any environment with a reachable PG.

### Verification

Baseline vs final counts for `packages/database` (full suite, no
`DATABASE_URL`):

|         | pass | skip | fail | errors | files |
|---------|-----:|-----:|-----:|-------:|------:|
| before  |  189 |    1 |    5 |      5 |    30 |
| after   |  201 |    4 |    5 |      5 |    31 |
| delta   |  +12 |   +3 |    0 |      0 |    +1 |

`+12 pass` are the new tests; `+3 skip` are the PG-live variants
(`DATABASE_URL` not set in this environment). The 5 fail / 5 errors
are unchanged from baseline — pre-existing cross-file mock pollution
noted in repo docs, not regressions from this change.

### Not in scope (intentional)

This PR is intentionally narrow. It does not implement leader
election, session-affinity sharing, or any state externalisation —
those are stage 2+ and depend on the maintainer's call in #351 on
whether multi-instance should be a supported deployment at all.
If the answer is no, this PR is still useful: it makes the failure
mode loud and gives operators a clean kill-switch.