### PR TITLE
security: validate workspace-path project names against isLowRiskProjectSlug

### DIFF
--- a/packages/proxy/src/__tests__/project-attribution.test.ts
+++ b/packages/proxy/src/__tests__/project-attribution.test.ts
@@ -139,6 +139,46 @@ describe("extractProjectAttributionFromRequest", () => {
 		expect(result.projectAttributionSource).toBe("path_project");
 	});
 
+	describe("workspace-path segments are validated like header/heading values (#373)", () => {
+		it("rejects a path segment that runs on past the directory name into leaked prompt text", () => {
+			// Same signature as the original report: a collapsed-newline system
+			// prompt makes WORKSPACE_PATH_RE's [^/]+ capture group run on past the
+			// real directory name into following prompt text, producing a
+			// multi-word, `#`-containing value that must be rejected wholesale
+			// rather than truncated to 64 chars and kept.
+			const headers = new Headers();
+			const body = {
+				system:
+					"/home/will/projects/better-ccflare # Some Leaked System Prompt Heading Text/more",
+			};
+			const result = extractProjectAttributionFromRequest(headers, body);
+			expect(result.project).toBeNull();
+			expect(result.projectAttributionSource).toBe("none");
+		});
+
+		it("falls through to an eligible H1 heading when the workspace path segment is rejected", () => {
+			const headers = new Headers();
+			const body = {
+				system:
+					"/home/will/projects/leaked system prompt fragment with many words/more\n# Harness\nWelcome.",
+			};
+			const result = extractProjectAttributionFromRequest(headers, body);
+			expect(result.project).toBe("Harness");
+			expect(result.projectAttributionSource).toBe("heading_project");
+		});
+
+		it("rejects a path segment carrying a secret past the 64-char truncation boundary", () => {
+			const cleanPrefix = `${"x".repeat(15)}-`.repeat(4);
+			const headers = new Headers();
+			const body = {
+				system: `/home/will/projects/${cleanPrefix}${"Z".repeat(25)}/file.ts`,
+			};
+			const result = extractProjectAttributionFromRequest(headers, body);
+			expect(result.project).toBeNull();
+			expect(result.projectAttributionSource).toBe("none");
+		});
+	});
+
 	it("uses the first eligible non-Claude H1 heading as the project when no header/path match", () => {
 		const headers = new Headers();
 		const body = { system: "# Harness\nWelcome to the project." };

--- a/packages/proxy/src/__tests__/project-attribution.test.ts
+++ b/packages/proxy/src/__tests__/project-attribution.test.ts
@@ -24,6 +24,7 @@ import {
 	extractProjectAttributionFromParts,
 	extractProjectAttributionFromRequest,
 	extractSystemPromptFromBase64,
+	isLowRiskPathSegment,
 	isLowRiskProjectSlug,
 } from "../project-attribution";
 
@@ -177,6 +178,30 @@ describe("extractProjectAttributionFromRequest", () => {
 			expect(result.project).toBeNull();
 			expect(result.projectAttributionSource).toBe("none");
 		});
+
+		// Regression (Greptile review on #378): isLowRiskProjectSlug's label-based
+		// heuristics (credential/incident/hostname labels) are tuned for free-text
+		// headings and headers, and false-positive on ordinary directory names.
+		// The path-segment capture is structurally a single path component, so it
+		// must use the narrower isLowRiskPathSegment validator instead.
+		const legitDirNames: Array<[string, string]> = [
+			["password-manager", "password-manager"],
+			["customer-portal", "customer-portal"],
+			["auth-token-service", "auth-token-service"],
+			["account-billing", "account-billing"],
+			["ui.v2", "ui.v2"],
+		];
+		for (const [label, dirName] of legitDirNames) {
+			it(`still extracts legit workspace directory name: ${label}`, () => {
+				const headers = new Headers();
+				const body = {
+					system: `/home/will/projects/${dirName}/file.ts`,
+				};
+				const result = extractProjectAttributionFromRequest(headers, body);
+				expect(result.project).toBe(dirName);
+				expect(result.projectAttributionSource).toBe("path_project");
+			});
+		}
 	});
 
 	it("uses the first eligible non-Claude H1 heading as the project when no header/path match", () => {
@@ -481,6 +506,52 @@ describe("isLowRiskProjectSlug", () => {
 			const boundaryStraddlingSecret = `${CLEAN_64_PREFIX}${"Z".repeat(25)}`;
 			expect(isLowRiskProjectSlug(boundaryStraddlingSecret)).toBe(false);
 		});
+	});
+});
+
+describe("isLowRiskPathSegment", () => {
+	it("accepts ordinary directory names that isLowRiskProjectSlug's label heuristics would reject", () => {
+		// These are all real, unremarkable workspace directory names that
+		// CREDENTIAL_LABEL_RE / INCIDENT_LABEL_RE / DOTTED_HOSTNAME_LABEL_RE
+		// false-positive on when applied to free text (Greptile review on #378).
+		expect(isLowRiskPathSegment("password-manager")).toBe(true);
+		expect(isLowRiskPathSegment("customer-portal")).toBe(true);
+		expect(isLowRiskPathSegment("auth-token-service")).toBe(true);
+		expect(isLowRiskPathSegment("account-billing")).toBe(true);
+		expect(isLowRiskPathSegment("ui.v2")).toBe(true);
+		expect(isLowRiskPathSegment("better-ccflare")).toBe(true);
+		expect(isLowRiskPathSegment("MyProj")).toBe(true);
+	});
+
+	it("still rejects a runaway sentence-shaped capture (the #373 leak signature)", () => {
+		expect(
+			isLowRiskPathSegment(
+				"better-ccflare # Some Leaked System Prompt Heading Text",
+			),
+		).toBe(false);
+		expect(
+			isLowRiskPathSegment("leaked system prompt fragment with many words"),
+		).toBe(false);
+	});
+
+	it("still rejects secrets, keys, IPs, and opaque high-entropy tokens", () => {
+		expect(isLowRiskPathSegment("Bearer sk_live_abc123456789")).toBe(false);
+		expect(isLowRiskPathSegment("AKIAIOSFODNN7EXAMPLE")).toBe(false);
+		expect(isLowRiskPathSegment("10.0.0.5")).toBe(false);
+		expect(isLowRiskPathSegment("sess1234567890qwerty")).toBe(false);
+		expect(isLowRiskPathSegment("deadbeefcafebabe")).toBe(false);
+	});
+
+	it("still rejects URL/URI-scheme and traversal shapes", () => {
+		expect(isLowRiskPathSegment("https://example.com")).toBe(false);
+		expect(isLowRiskPathSegment("www.example.com")).toBe(false);
+		expect(isLowRiskPathSegment("..")).toBe(false);
+	});
+
+	it("rejects the FULL value rather than a 64-char-truncated prefix", () => {
+		const cleanPrefix = `${"x".repeat(15)}-`.repeat(4);
+		const boundaryStraddlingSecret = `${cleanPrefix}${"Z".repeat(25)}`;
+		expect(isLowRiskPathSegment(boundaryStraddlingSecret)).toBe(false);
 	});
 });
 

--- a/packages/proxy/src/__tests__/project-attribution.test.ts
+++ b/packages/proxy/src/__tests__/project-attribution.test.ts
@@ -179,6 +179,21 @@ describe("extractProjectAttributionFromRequest", () => {
 			expect(result.projectAttributionSource).toBe("none");
 		});
 
+		it("rejects a short space-separated run-on rather than persisting it as the project (round-2 Greptile review on #378)", () => {
+			// "repo short words" is short enough to dodge the six-word sentence
+			// cap and slug-shaped enough to pass SLUG_SHAPE_RE, but a real
+			// directory name never contains a literal space — this is leaked
+			// prompt text riding along with the real "repo" directory, not a
+			// directory name itself.
+			const headers = new Headers();
+			const body = {
+				system: "/home/u/projects/repo short words/more",
+			};
+			const result = extractProjectAttributionFromRequest(headers, body);
+			expect(result.project).toBeNull();
+			expect(result.projectAttributionSource).toBe("none");
+		});
+
 		// Regression (Greptile review on #378): isLowRiskProjectSlug's label-based
 		// heuristics (credential/incident/hostname labels) are tuned for free-text
 		// headings and headers, and false-positive on ordinary directory names.
@@ -532,6 +547,15 @@ describe("isLowRiskPathSegment", () => {
 		expect(
 			isLowRiskPathSegment("leaked system prompt fragment with many words"),
 		).toBe(false);
+	});
+
+	it("rejects any whitespace, even a short run-on that dodges the sentence heuristic (round-2 Greptile review on #378)", () => {
+		// A real directory name is never space-separated, so a short capture
+		// like "repo short words" must be rejected outright rather than only
+		// once it crosses a word-count threshold.
+		expect(isLowRiskPathSegment("repo short words")).toBe(false);
+		expect(isLowRiskPathSegment("two words")).toBe(false);
+		expect(isLowRiskPathSegment("a b")).toBe(false);
 	});
 
 	it("still rejects secrets, keys, IPs, and opaque high-entropy tokens", () => {

--- a/packages/proxy/src/__tests__/project-attribution.test.ts
+++ b/packages/proxy/src/__tests__/project-attribution.test.ts
@@ -194,6 +194,20 @@ describe("extractProjectAttributionFromRequest", () => {
 			expect(result.projectAttributionSource).toBe("none");
 		});
 
+		it("rejects a path segment where a control char fuses the real directory with leaked text (round-3 Greptile review on #378)", () => {
+			// A naive strip-then-check validator deletes \n/\t before checking for
+			// whitespace, silently fusing "repo" + "leaked-fragment" into the
+			// clean-looking slug "repoleaked-fragment". The control char must be
+			// detected in the RAW captured value before any stripping happens.
+			const headers = new Headers();
+			const body = {
+				system: "/home/u/projects/repo\nleaked-fragment/more",
+			};
+			const result = extractProjectAttributionFromRequest(headers, body);
+			expect(result.project).toBeNull();
+			expect(result.projectAttributionSource).toBe("none");
+		});
+
 		// Regression (Greptile review on #378): isLowRiskProjectSlug's label-based
 		// heuristics (credential/incident/hostname labels) are tuned for free-text
 		// headings and headers, and false-positive on ordinary directory names.
@@ -556,6 +570,15 @@ describe("isLowRiskPathSegment", () => {
 		expect(isLowRiskPathSegment("repo short words")).toBe(false);
 		expect(isLowRiskPathSegment("two words")).toBe(false);
 		expect(isLowRiskPathSegment("a b")).toBe(false);
+	});
+
+	it("rejects a control-char-fused value rather than silently deleting the separator (round-3 Greptile review on #378)", () => {
+		// The raw value must be checked for control chars BEFORE they're
+		// stripped, or "repo\nleaked" silently fuses into "repoleaked" and
+		// passes the whitespace/shape checks.
+		expect(isLowRiskPathSegment("repo\nleaked-fragment")).toBe(false);
+		expect(isLowRiskPathSegment("repo\tleaked-fragment")).toBe(false);
+		expect(isLowRiskPathSegment("repo\rleaked-fragment")).toBe(false);
 	});
 
 	it("still rejects secrets, keys, IPs, and opaque high-entropy tokens", () => {

--- a/packages/proxy/src/project-attribution.ts
+++ b/packages/proxy/src/project-attribution.ts
@@ -277,13 +277,21 @@ export function extractProjectAttribution(
 	}
 
 	if (systemPrompt) {
+		// Validate the FULL captured path segment, then length-cap only after it
+		// passes — same reject-wholesale-before-truncating rule as the header and
+		// H1 heading paths. A collapsed-newline system prompt can make `[^/]+` run
+		// on past the directory name into following prompt text, so this needs the
+		// same secret/slug validation as attacker-influenced text (#373).
 		const pathMatch = systemPrompt.match(WORKSPACE_PATH_RE);
-		const sanitizedPath = sanitizeProjectName(pathMatch?.[1]);
-		if (sanitizedPath) {
-			return {
-				project: sanitizedPath,
-				projectAttributionSource: "path_project",
-			};
+		const rawPath = pathMatch?.[1];
+		if (rawPath && isLowRiskProjectSlug(rawPath)) {
+			const sanitizedPath = sanitizeProjectName(rawPath);
+			if (sanitizedPath) {
+				return {
+					project: sanitizedPath,
+					projectAttributionSource: "path_project",
+				};
+			}
 		}
 
 		// Walk EVERY H1 heading (not just the first) and use the first one that

--- a/packages/proxy/src/project-attribution.ts
+++ b/packages/proxy/src/project-attribution.ts
@@ -251,8 +251,15 @@ export function isLowRiskProjectSlug(value: string): boolean {
  * review on #378).
  */
 export function isLowRiskPathSegment(value: string): boolean {
-	// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping them is the point
-	const cleaned = value.replace(/[\x00-\x1F\x7F]/g, "").trim();
+	// Check for control chars BEFORE stripping them — sanitizeProjectName's
+	// strip-then-keep behavior would otherwise silently fuse a control-char
+	// boundary (e.g. "repo\nleaked-fragment" -> "repoleaked-fragment"),
+	// deleting the very separator that would have made the leaked half read
+	// as a second word and get caught by whitespace/word-count checks
+	// (round-3 Greptile review on #378).
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: detecting them is the point
+	if (/[\x00-\x1F\x7F]/.test(value)) return false;
+	const cleaned = value.trim();
 	if (!cleaned) return false;
 	const lower = cleaned.toLowerCase();
 

--- a/packages/proxy/src/project-attribution.ts
+++ b/packages/proxy/src/project-attribution.ts
@@ -228,6 +228,70 @@ export function isLowRiskProjectSlug(value: string): boolean {
 	return SLUG_SHAPE_RE.test(cleaned);
 }
 
+/**
+ * Validator for the captured segment of `WORKSPACE_PATH_RE` (#373 follow-up).
+ *
+ * The capture is structurally a single path segment (`[^/]+`), not
+ * free-form attacker text, so `isLowRiskProjectSlug`'s label-based
+ * heuristics (CREDENTIAL_LABEL_RE, INCIDENT_LABEL_RE, JIRA_TICKET_RE,
+ * DOTTED_HOSTNAME_LABEL_RE) are miscalibrated here: they exist to catch
+ * free-text sentences and hostnames, and false-positive on completely
+ * ordinary directory names like "password-manager", "customer-portal",
+ * "auth-token-service", or "ui.v2".
+ *
+ * What's actually dangerous in this branch is the capture running on past
+ * the real directory boundary when the system prompt's newlines have been
+ * collapsed, pulling in following prompt text — so this keeps the
+ * shape/length/word-count/opaque-token checks (which catch that runaway
+ * text) and drops the label-matching ones.
+ */
+export function isLowRiskPathSegment(value: string): boolean {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping them is the point
+	const cleaned = value.replace(/[\x00-\x1F\x7F]/g, "").trim();
+	if (!cleaned) return false;
+	const lower = cleaned.toLowerCase();
+
+	if (
+		lower.includes("://") ||
+		lower.includes("www.") ||
+		URI_SCHEME_RE.test(cleaned)
+	) {
+		return false;
+	}
+
+	if (
+		cleaned.startsWith("/") ||
+		cleaned.startsWith("\\") ||
+		cleaned.includes("..")
+	) {
+		return false;
+	}
+
+	const atIndex = cleaned.indexOf("@");
+	if (atIndex !== -1 && cleaned.indexOf(".", atIndex) !== -1) return false;
+
+	if (UUID_RE.test(cleaned)) return false;
+
+	if (
+		SECRET_TOKEN_RE.test(cleaned) ||
+		KNOWN_SECRET_PREFIX_RE.test(cleaned) ||
+		MULTI_SEGMENT_TOKEN_RE.test(cleaned) ||
+		lower.includes("bearer ") ||
+		AWS_KEY_RE.test(cleaned) ||
+		IPV4_RE.test(cleaned) ||
+		LONG_TOKEN_RE.test(cleaned) ||
+		HEX_OPAQUE_TOKEN_RE.test(cleaned) ||
+		OPAQUE_MIXED_TOKEN_RE.test(cleaned)
+	) {
+		return false;
+	}
+
+	// Sentence-shaped free text (a runaway capture reads as a sentence).
+	if (cleaned.split(/\s+/).filter(Boolean).length > 6) return false;
+
+	return SLUG_SHAPE_RE.test(cleaned);
+}
+
 const WORKSPACE_PATH_RE =
 	/\/(?:Users|home)\/[^/]+\/(?:Desktop|projects|repos|src)\/([^/]+)\//;
 // Global so extractProjectAttribution can walk every H1 heading in the system
@@ -280,11 +344,14 @@ export function extractProjectAttribution(
 		// Validate the FULL captured path segment, then length-cap only after it
 		// passes — same reject-wholesale-before-truncating rule as the header and
 		// H1 heading paths. A collapsed-newline system prompt can make `[^/]+` run
-		// on past the directory name into following prompt text, so this needs the
-		// same secret/slug validation as attacker-influenced text (#373).
+		// on past the directory name into following prompt text, so this needs
+		// shape/length/word-count validation against that (#373). Uses
+		// isLowRiskPathSegment rather than isLowRiskProjectSlug because the
+		// latter's label-based heuristics false-positive on ordinary directory
+		// names (see isLowRiskPathSegment's doc comment).
 		const pathMatch = systemPrompt.match(WORKSPACE_PATH_RE);
 		const rawPath = pathMatch?.[1];
-		if (rawPath && isLowRiskProjectSlug(rawPath)) {
+		if (rawPath && isLowRiskPathSegment(rawPath)) {
 			const sanitizedPath = sanitizeProjectName(rawPath);
 			if (sanitizedPath) {
 				return {

--- a/packages/proxy/src/project-attribution.ts
+++ b/packages/proxy/src/project-attribution.ts
@@ -242,8 +242,13 @@ export function isLowRiskProjectSlug(value: string): boolean {
  * What's actually dangerous in this branch is the capture running on past
  * the real directory boundary when the system prompt's newlines have been
  * collapsed, pulling in following prompt text — so this keeps the
- * shape/length/word-count/opaque-token checks (which catch that runaway
- * text) and drops the label-matching ones.
+ * shape/length/opaque-token checks (which catch that runaway text) and
+ * drops the label-matching ones. Whitespace is rejected outright (rather
+ * than just capped at 6 words like isLowRiskProjectSlug) because a real
+ * directory name is never space-separated — even a short run-on like
+ * "repo short words" is unambiguously leaked prompt text riding along with
+ * the real directory name, not a directory name itself (round-2 Greptile
+ * review on #378).
  */
 export function isLowRiskPathSegment(value: string): boolean {
 	// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping them is the point
@@ -286,8 +291,10 @@ export function isLowRiskPathSegment(value: string): boolean {
 		return false;
 	}
 
-	// Sentence-shaped free text (a runaway capture reads as a sentence).
-	if (cleaned.split(/\s+/).filter(Boolean).length > 6) return false;
+	// Any whitespace at all means this isn't a directory name — real path
+	// segments don't contain spaces, so even a short space-separated run is
+	// leaked text riding along with the real directory name.
+	if (/\s/.test(cleaned)) return false;
 
 	return SLUG_SHAPE_RE.test(cleaned);
 }


### PR DESCRIPTION
## Summary
- Fixes #373 — the workspace-path branch of `extractProjectAttribution` (`packages/proxy/src/project-attribution.ts`) called `sanitizeProjectName()` directly on the `WORKSPACE_PATH_RE` capture group with no `isLowRiskProjectSlug()` gate.
- `c65d7aa6` fixed the header-derived path but missed this third branch. As `@zenprocess` confirmed in the issue thread, live traffic sampling showed 39/40 polluted rows came from `path_project`, not `header_project`.
- A system prompt with collapsed newlines lets the `[^/]+` capture group run on past the real directory name into following prompt text, which then gets hard-truncated to 64 chars and persisted to `requests.project` — matching the exact signature from the original report (64 chars, six tokens, contains `#`).
- Applies the same reject-wholesale-before-truncating validation already used by the header and H1 heading paths, and falls through to the H1 branch on rejection rather than returning null outright (a doc with a bad path segment but a legitimate H1 heading should still get attribution).

## Test plan
- [x] Added tests reproducing the collapsed-newline leak signature, fallthrough to H1 on rejection, and the 64-char truncation-boundary secret case (`packages/proxy/src/__tests__/project-attribution.test.ts`)
- [x] `bun test packages/proxy/src/__tests__/project-attribution.test.ts` — 72 pass, 0 fail
- [x] `bun run lint && bun run typecheck && bun run format` — clean (pre-existing warnings in unrelated files only)
- [x] GitNexus impact analysis: LOW risk, only two same-file wrapper callers
- [x] GitNexus `detect_changes()`: changes scoped to `extractProjectAttribution` and its test file only

🤖 Generated with [Claude Code](https://claude.com/claude-code)