### PR TITLE
fix(providers): treat sub-second reset jitter as the same usage window

### DIFF
--- a/packages/providers/src/__tests__/window-reset-detection.test.ts
+++ b/packages/providers/src/__tests__/window-reset-detection.test.ts
@@ -204,4 +204,137 @@ describe("usageCache window-reset callback", () => {
 
 		expect(callback).not.toHaveBeenCalled();
 	});
+
+	// The upstream reset timestamp jitters by fractions of a second around the
+	// same wall-clock instant, so a bare `newResetAt > prevResetAt` misreads that
+	// jitter as a window rollover. Measured over 48h of production logs: 1554 of
+	// 1564 detections were jitter (largest 1.879s), the 10 genuine rollovers all
+	// advanced by exactly 5.00h — an empty gap of 1.9s…17999s between the classes.
+	// The literals below pin that measurement, deliberately not derived from the
+	// threshold constant so a wrong constant still fails these tests.
+
+	it("does not fire onWindowReset on sub-second jitter (332ms, as observed)", () => {
+		const accountId = "zai-jitter-test";
+		const callback = mock(() => {});
+
+		const base = 1_700_000_000_000;
+		const oldData: ZaiUsageData = {
+			time_limit: null,
+			tokens_limit: {
+				used: 60,
+				remaining: 40,
+				percentage: 60,
+				resetAt: base,
+				type: "tokens_limit",
+			},
+		};
+		const newData: ZaiUsageData = {
+			time_limit: null,
+			tokens_limit: {
+				used: 61,
+				remaining: 39,
+				percentage: 61,
+				resetAt: base + 332,
+				type: "tokens_limit",
+			},
+		};
+
+		usageCache.set(accountId, oldData);
+		usageCache.notifyWindowReset(accountId, newData, "zai", callback);
+
+		expect(callback).not.toHaveBeenCalled();
+
+		usageCache.delete(accountId);
+	});
+
+	it("does not fire onWindowReset when the advance stays below the threshold (59s)", () => {
+		const accountId = "zai-below-threshold-test";
+		const callback = mock(() => {});
+
+		const base = 1_700_000_000_000;
+		const oldData: ZaiUsageData = {
+			time_limit: null,
+			tokens_limit: {
+				used: 60,
+				remaining: 40,
+				percentage: 60,
+				resetAt: base,
+				type: "tokens_limit",
+			},
+		};
+		const newData: ZaiUsageData = {
+			time_limit: null,
+			tokens_limit: {
+				used: 62,
+				remaining: 38,
+				percentage: 62,
+				resetAt: base + 59_000,
+				type: "tokens_limit",
+			},
+		};
+
+		usageCache.set(accountId, oldData);
+		usageCache.notifyWindowReset(accountId, newData, "zai", callback);
+
+		expect(callback).not.toHaveBeenCalled();
+
+		usageCache.delete(accountId);
+	});
+
+	it("fires onWindowReset on a genuine 5h window rollover", () => {
+		const accountId = "zai-real-rollover-test";
+		const callback = mock(() => {});
+
+		const base = 1_700_000_000_000;
+		const oldData: ZaiUsageData = {
+			time_limit: null,
+			tokens_limit: {
+				used: 95,
+				remaining: 5,
+				percentage: 95,
+				resetAt: base,
+				type: "tokens_limit",
+			},
+		};
+		const newData: ZaiUsageData = {
+			time_limit: null,
+			tokens_limit: {
+				used: 1,
+				remaining: 99,
+				percentage: 1,
+				resetAt: base + 5 * 60 * 60 * 1000,
+				type: "tokens_limit",
+			},
+		};
+
+		usageCache.set(accountId, oldData);
+		usageCache.notifyWindowReset(accountId, newData, "zai", callback);
+
+		expect(callback).toHaveBeenCalledTimes(1);
+		expect(callback).toHaveBeenCalledWith(accountId);
+
+		usageCache.delete(accountId);
+	});
+
+	it("does not fire onWindowReset on anthropic five_hour jitter (real payload)", () => {
+		const accountId = "anthropic-jitter-test";
+		const callback = mock(() => {});
+
+		// Verbatim from the production log that surfaced this bug.
+		const oldData: UsageData = {
+			five_hour: { utilization: 74, resets_at: "2026-08-04T07:19:59.388Z" },
+			seven_day: { utilization: 31, resets_at: null },
+		};
+		const newData: UsageData = {
+			five_hour: { utilization: 75, resets_at: "2026-08-04T07:19:59.720Z" },
+			seven_day: { utilization: 31, resets_at: null },
+		};
+
+		usageCache.set(accountId, oldData);
+		usageCache.notifyWindowReset(accountId, newData, "anthropic", callback);
+
+		expect(callback).not.toHaveBeenCalled();
+
+		usageCache.delete(accountId);
+	});
 });

--- a/packages/providers/src/usage-fetcher.ts
+++ b/packages/providers/src/usage-fetcher.ts
@@ -105,6 +105,19 @@ export type AnyUsageData =
 	| MinimaxUsageData;
 
 /**
+ * Minimum advance of the upstream reset timestamp that counts as a real window
+ * rollover.
+ *
+ * Providers recompute `resets_at` per response and it jitters by fractions of a
+ * second around the same instant, so comparing for any advance at all reports a
+ * rollover on nearly every poll. Measured over 48h of production traffic across
+ * three Anthropic accounts: 1554 of 1564 detections were jitter (largest 1.879s)
+ * and the 10 genuine rollovers all advanced by exactly 5.00h — nothing landed in
+ * between. 60s sits in that empty gap with a wide margin on both sides.
+ */
+export const WINDOW_RESET_MIN_ADVANCE_MS = 60_000;
+
+/**
  * Extract the primary window reset timestamp (ms) from usage data.
  * Returns null if the provider doesn't expose a reset time or it isn't available.
  */
@@ -1158,7 +1171,9 @@ class UsageCache {
 
 	/**
 	 * Check if the usage window has reset by comparing the new data's reset time
-	 * against the previously cached data, and fire the callback if it has advanced.
+	 * against the previously cached data, and fire the callback if it has advanced
+	 * by more than {@link WINDOW_RESET_MIN_ADVANCE_MS} — smaller advances are
+	 * upstream jitter on the same window, not a rollover.
 	 * Should be called after successfully fetching new data, before updating the cache.
 	 * No-ops on the first poll (no previous data) to avoid spurious resets.
 	 */
@@ -1177,7 +1192,7 @@ class UsageCache {
 		if (
 			prevResetAt !== null &&
 			newResetAt !== null &&
-			newResetAt > prevResetAt
+			newResetAt - prevResetAt > WINDOW_RESET_MIN_ADVANCE_MS
 		) {
 			log.info(
 				`Usage window reset detected for account ${accountId} (${provider}): ` +


### PR DESCRIPTION
**Root Cause:** `UsageCache.notifyWindowReset` treats *any* forward movement of the upstream reset timestamp as a window rollover (`newResetAt > prevResetAt`, no tolerance). Providers recompute `resets_at` per response and it jitters by fractions of a second around the same instant, so ordinary polling reports a rollover constantly. Minimal trigger: two consecutive polls whose `five_hour.resets_at` differ by milliseconds — e.g. `2026-08-04T07:19:59.388Z` followed by `2026-08-04T07:19:59.720Z` (332 ms) fires the callback.

Each false positive runs `resetAccountSession`, rewriting `accounts.session_start` and zeroing `session_request_count` — the session-affinity state the `session` and `session-drain-soonest` strategies read to pick an account. So the load balancer's session state is being reset out from under it, plus the write load on the hot `accounts` table.

Measured over 48 h of production traffic across three Anthropic accounts:

| Class | Count | Advance |
|---|---|---|
| Jitter (false positive) | 1554 (99.4 %) | max **1.879 s** |
| Genuine rollover | 10 | all exactly **5.00 h** (min 17998.8 s) |

Nothing landed between 1.9 s and 17999 s — the two classes are separated by an empty gap spanning four orders of magnitude. That works out to ~32 needless `accounts` writes per hour.

**The Fix:** A rollover now requires the timestamp to advance by more than the new `WINDOW_RESET_MIN_ADVANCE_MS` (60 s), which sits inside that empty gap with a 32× margin above the largest observed jitter and a 300× margin below the shortest real window. Everything else stays byte-identical: the log line, the null handling, the first-poll no-op, and the dispatch into `notifyWindowReset` from all four provider arms. Genuine rollovers, equal timestamps, backwards timestamps and the first poll after a restart all behave exactly as before, each pinned by a test.

**Accepted risk:** The measurement covers Anthropic only. zai and minimax document 5h-scale windows in their own source (`zai-usage-fetcher.ts` "5-hour token quota"; `minimax-usage-fetcher.ts` "5h-style per-model-class window"), so the 60 s floor is far below theirs. For xai I confirmed only that it resolves subscription credit resets by picking the earliest future reset — its window length is not measured here. A provider with a sub-minute usage window would have its rollovers suppressed; none appears to exist.

**Validation:** Four tests added to the existing `usageCache window-reset callback` block. Run against the unmodified `notifyWindowReset`, exactly the three negative cases fail (332 ms jitter, 59 s sub-threshold advance, real anthropic payload) while the 5 h rollover case passes — so the tests fail without the fix for the right reason rather than by construction. With the fix: 18/18 in that file, 591/591 in `packages/providers`, 87/87 in `packages/load-balancer` (the strategies consuming the session state). `bun run lint` reports the same 9 pre-existing warnings as `origin/main` and no new ones; `typecheck` clean; `format` applies no changes.

The test literals (332 ms, 59 s, 5 h) are deliberately not derived from `WINDOW_RESET_MIN_ADVANCE_MS` — a test that computes its input from the constant cannot catch a wrong constant.
