### PR TITLE
docs(comments): replace deployment-specific hostnames with generic wording

### DIFF
--- a/CB-INTEGRATION-REPORT.md
+++ b/CB-INTEGRATION-REPORT.md
@@ -183,7 +183,7 @@ not present here: HEAD's tree differs from upstream/main by 20 files,
 
 - Did NOT push.
 - Did NOT open a PR.
-- Did NOT touch any live service (`ccmax.zp.digital`, etc.).
+- Did NOT touch any live service.
 - Did NOT change the load-balancing strategy.
 - Did NOT merge `24550bed` (V2 tree); ported by hand.
 - Did NOT symlink another worktree's `node_modules`; ran `bun install`

--- a/CB-INTEGRATION-REPORT.md
+++ b/CB-INTEGRATION-REPORT.md
@@ -38,7 +38,7 @@ The spec called out three traps. All three were hit and handled:
 ## Environment
 
 - Worktree: `/tmp/claude-501/cb-integration-check` (sandbox-allowed; the
-  standard `/Users/vvladescu/.ao/data/worktrees/ccflare/` siblings were
+  standard worktree siblings under the operator's usual layout were
   blocked by the sandbox's write allowlist).
 - `bun install` ran fresh in the worktree's own `node_modules` (NOT a
   symlink to another worktree). Required because `packages/providers`

--- a/bench/drain-strategy-harness.ts
+++ b/bench/drain-strategy-harness.ts
@@ -18,8 +18,8 @@
  *   - peak V8 heap delta (using process.memoryUsage().heapUsed over the run)
  *
  * The pinned 73 015-byte upstream body comes from
- * bench/bun-35093-harness.ts in ccflare-42. We use the same URL so the
- * numbers are directly comparable to ccflare-42's table.
+ * bench/bun-35093-harness.ts in an earlier measurement session. We use the same URL so the
+ * numbers are directly comparable to that earlier table.
  *
  * Run:  bun run bench/drain-strategy-harness.ts
  */

--- a/packages/dashboard-web/src/components/accounts/RateLimitProgress.test.tsx
+++ b/packages/dashboard-web/src/components/accounts/RateLimitProgress.test.tsx
@@ -268,7 +268,7 @@ describe("RateLimitProgress", () => {
 	// minimax-usage-fetcher.ts). The legacy Anthropic collector requires
 	// snake_case `resets_at`, so without the dedicated MiniMax branch the 7d
 	// row collapses to a single most-restrictive fallback (max of 5h/7d) — the
-	// bug that hid per-window usage on ccmax. See:
+	// bug that hid per-window usage in production. See:
 	// https://github.com/zenprocess/better-ccflare for the operator-reported
 	// dashboard dead-branch class.
 	it("renders MiniMax five_hour and seven_day as separate windows from each window's own utilization (ccflare-95)", () => {

--- a/packages/dashboard-web/src/components/accounts/RateLimitProgress.test.tsx
+++ b/packages/dashboard-web/src/components/accounts/RateLimitProgress.test.tsx
@@ -271,7 +271,7 @@ describe("RateLimitProgress", () => {
 	// bug that hid per-window usage in production. See:
 	// https://github.com/zenprocess/better-ccflare for the operator-reported
 	// dashboard dead-branch class.
-	it("renders MiniMax five_hour and seven_day as separate windows from each window's own utilization (ccflare-95)", () => {
+	it("renders MiniMax five_hour and seven_day as separate windows from each window's own utilization", () => {
 		const fiveHourReset = Date.now() + 5 * 60 * 60 * 1000;
 		const sevenDayReset = Date.now() + 5 * 24 * 60 * 60 * 1000;
 		const html = renderToStaticMarkup(
@@ -312,7 +312,7 @@ describe("RateLimitProgress", () => {
 		expect(html).not.toContain("N/A");
 	});
 
-	it("skips the MiniMax 7-day row entirely when seven_day is null (ccflare-95)", () => {
+	it("skips the MiniMax 7-day row entirely when seven_day is null", () => {
 		const fiveHourReset = Date.now() + 5 * 60 * 60 * 1000;
 		const html = renderToStaticMarkup(
 			<RateLimitProgress
@@ -342,7 +342,7 @@ describe("RateLimitProgress", () => {
 		expect(html).not.toContain("N/A");
 	});
 
-	it("does NOT mis-dispatch an Anthropic seven_day payload to the MiniMax branch (ccflare-95)", () => {
+	it("does NOT mis-dispatch an Anthropic seven_day payload to the MiniMax branch", () => {
 		// Anthropic-style inner windows use snake_case `resets_at` (ISO string),
 		// not camelCase `resetAt`. The shape probe on the inner object is what
 		// keeps the legacy Anthropic collector reachable for its payloads.

--- a/packages/dashboard-web/src/components/accounts/provider-utils.test.ts
+++ b/packages/dashboard-web/src/components/accounts/provider-utils.test.ts
@@ -19,7 +19,7 @@ import { describe, expect, it } from "bun:test";
 import { providerShowsWeeklyUsage } from "../../utils/provider-utils";
 
 describe("providerShowsWeeklyUsage", () => {
-	it("returns true for minimax so AccountListItem passes showWeekly=true (ccflare-100)", () => {
+	it("returns true for minimax so AccountListItem passes showWeekly=true", () => {
 		// Gate A for the MiniMax per-window fix. Without this entry the
 		// component renders a single collapsed bar instead of separate
 		// 5-hour and 7-day windows — the dashboard dead-branch bug this
@@ -27,7 +27,7 @@ describe("providerShowsWeeklyUsage", () => {
 		expect(providerShowsWeeklyUsage("minimax")).toBe(true);
 	});
 
-	it("returns true for alibaba-coding-plan so its five_hour/weekly/monthly branch is reachable (ccflare-100)", () => {
+	it("returns true for alibaba-coding-plan so its five_hour/weekly/monthly branch is reachable", () => {
 		// Gate A for the Alibaba per-window fix. Without this entry the
 		// isAlibabaData branch in RateLimitProgress is unreachable and
 		// the pool-usage eligibility set never sees Alibaba accounts.

--- a/packages/database/src/migrations-dedup-preserving-state.test.ts
+++ b/packages/database/src/migrations-dedup-preserving-state.test.ts
@@ -12,7 +12,7 @@ import { ensureSchema, runMigrations } from "../src/migrations";
  *   live OAuth refresh tokens (the kept row could be the oldest / expired
  *   one), cascade-deleted every combo_slot referencing a discarded id, and
  *   orphaned requests.account_used / usage_snapshots.account_id rows that
- *   pointed at the deleted id. Production ccmax had exactly this state —
+ *   pointed at the deleted id. Production had exactly this state —
  *   two accounts both named "val" with different live traffic — so the
  *   fix is load-bearing, not theoretical.
  *

--- a/packages/http-api/src/handlers/__tests__/health-usage-exhausted.test.ts
+++ b/packages/http-api/src/handlers/__tests__/health-usage-exhausted.test.ts
@@ -283,7 +283,7 @@ describe("createHealthHandler — pool.usage_exhausted in the response", () => {
 	});
 
 	it("reports routable:0 during a total usage-capped outage (incident 2026-07-30 scenario)", async () => {
-		// Production trace: ccproxy2 was down 116 minutes because every account
+		// Production trace: a proxy instance was down for ~2 hours because every account
 		// was usage-capped. Pre-fix /health reported `routable: 3` because
 		// computePoolStatus called isAccountAvailable(a, now) without the
 		// usage argument. This test guards against that regression directly.

--- a/packages/http-api/src/services/__tests__/anomaly-insights.test.ts
+++ b/packages/http-api/src/services/__tests__/anomaly-insights.test.ts
@@ -250,7 +250,7 @@ describe("detectRunawayLoops", () => {
 
 	test("splits groups by project when agent id is absent", () => {
 		// Regression guard for issue #367: when no agent attribution is
-		// present (live ccmax traffic — `agent_used` is NULL on 100% of
+		// present (live traffic — `agent_used` is NULL on 100% of
 		// rows), the project must still split the bucket. 6 requests in
 		// each of two projects: neither reaches minRequests, and the
 		// combined 12-row bucket would falsely report as a loop if the
@@ -317,7 +317,7 @@ describe("detectRunawayLoops", () => {
 	});
 
 	test("N concurrent distinct sessions do NOT fire, one session repeating DOES", () => {
-		// Mirrors the live ccmax fleet: the only stable per-worker signal
+		// Mirrors the live fleet: the only stable per-worker signal
 		// is the x-claude-code-session-id header, surfaced as agentUsed
 		// via the session_header attribution source. 12 concurrent
 		// distinct sessions, 9 requests each — none should reach

--- a/packages/proxy/src/__tests__/anthropic-terminal-recovery.test.ts
+++ b/packages/proxy/src/__tests__/anthropic-terminal-recovery.test.ts
@@ -674,7 +674,7 @@ describe("createAnthropicTerminalRecoveryStream", () => {
 	});
 
 	it("emits 'truncated' via onTerminalState when upstream EOF lands without a stop_reason", async () => {
-		// Mirrors the ccproxy2/anthropic 8-second 200 with 0 output tokens:
+		// Mirrors the anthropic 8-second 200 with 0 output tokens:
 		// stream closed mid-content with no terminal event ever observed.
 		const original =
 			'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n' +

--- a/packages/proxy/src/__tests__/bun-leak-273-regression.test.ts
+++ b/packages/proxy/src/__tests__/bun-leak-273-regression.test.ts
@@ -8,7 +8,7 @@
  * store is released. Without this, every abandoned Response holds ~100KB
  * off-heap until GC.
  *
- * Why drain and not `body.cancel()`: ccflare-42 measured that
+ * Why drain and not `body.cancel()`: an earlier measurement session showed that
  * `body.cancel()` is a NO-OP on every released Bun (1.3.2 / 1.3.14);
  * draining the body in chunks reduces the leak by ~85% on stock Bun
  * (full table in `bench/drain-strategy-harness.ts`). The drain helper

--- a/packages/proxy/src/__tests__/response-handler-anthropic-terminal-recovery.test.ts
+++ b/packages/proxy/src/__tests__/response-handler-anthropic-terminal-recovery.test.ts
@@ -227,7 +227,7 @@ describe("forwardToClient Anthropic terminal recovery integration", () => {
 describe("forwardToClient SSE terminal-state propagation", () => {
 	function makeContentOnlyStream(): ReadableStream<Uint8Array> {
 		// Mid-content only — no terminal message_delta, no message_stop.
-		// Mirrors the ccmax/minimax IncompleteRead signature where bytes
+		// Mirrors the minimax IncompleteRead signature where bytes
 		// flow then the upstream TCP closes before any stop_reason lands.
 		const content =
 			'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n' +

--- a/packages/proxy/src/handlers/discard-body-cancel.ts
+++ b/packages/proxy/src/handlers/discard-body-cancel.ts
@@ -5,7 +5,7 @@
  *
  * We drain the body in chunks rather than calling `body.cancel()`, because
  * `body.cancel()` is a NO-OP on every released Bun (Bun 1.3.2, 1.3.14, and
- * earlier): ccflare-42 measured 78–83 KB/req leak with `cancel()`,
+ * earlier): an earlier measurement session found 78–83 KB/req leak with `cancel()`,
  * indistinguishable from no cancel at all. Draining the body (reading it to
  * `done` in chunks) actually closes the upstream source and frees the
  * backing store — measured at ~85% reduction in RSS growth on stock Bun

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -1529,7 +1529,7 @@ export async function proxyWithAccount(
  * providers/src/usage-fetcher.ts:1065) so a client that respects this header
  * is guaranteed to see fresh usage telemetry on retry. Pre-fix this was the
  * optimistic 60s that triggered CLAUDE_CODE_MAX_RETRIES=5 clients to die in
- * 300s during a 116-minute ccproxy2 outage (production trace 2026-07-30).
+ * 300s during an approximately two-hour outage (production trace).
  */
 export const POOL_EXHAUSTED_UNKNOWN_RESET_RETRY_AFTER_SECONDS = 600;
 


### PR DESCRIPTION
Replaces deployment-specific references (deployment hostnames, a literal operator filesystem path, and orchestration session identifiers) with generic wording across comment and doc text in 12 files. Provider names (anthropic, minimax) are public product names and are preserved. Engineering meaning of each comment is preserved.

Zero behavior change. All edits are confined to comment/doc text or to test descriptions (where the session identifier was an inessential suffix on the behavioural description).

Two synthetic test fixtures in `packages/proxy/src/__tests__/project-attribution.test.ts` (lines 136 and 461) are deliberately left unchanged: the strings `/Users/will/Desktop/MyProj/file.txt` and `C:/Users/alice/acme` are synthetic inputs that exercise the path-extraction and path-rejection logic respectively. The usernames (`will`, `alice`) are not the operator's, and the strings are test data rather than operator paths — replacing them would alter what the tests exercise.