### PR TITLE
fix(proxy): skip mid-stream rate-limit cooldown for cache-keepalive replays

### DIFF
--- a/docs/reports/keepalive-cooldown-gap.md
+++ b/docs/reports/keepalive-cooldown-gap.md
@@ -1,0 +1,160 @@
+# Mid-stream keepalive cooldown gap — report
+
+- **Issue:** greptile-apps comment on merged upstream `tombii/better-ccflare` PR #196.
+- **Branch:** `ao/ccflare-158/keepalive-midstream-skip` (off `upstream/main` `6f2c9d28`).
+- **Author:** AO worker `ao/ccflare-158`.
+- **Date:** 2026-08-06.
+
+## Falsification (pre-fix)
+
+Located all 4 cooldowns that fire on a 429 / mid-stream rate-limit signal and
+counted how many carry the keepalive exemption. Results on `upstream/main`
+`6f2c9d28`:
+
+| # | File | Site | Cooldown call | Has keepalive skip |
+|---|------|------|---------------|--------------------|
+| 1 | `packages/proxy/src/handlers/proxy-operations.ts:944` | pre-stream, out_of_credits 429 | `return null` after keepalive block | ✅ |
+| 2 | `packages/proxy/src/handlers/proxy-operations.ts:1004` | pre-stream, no-fallback-model 429 | `return null` after keepalive block | ✅ |
+| 3 | `packages/proxy/src/handlers/proxy-operations.ts:1230` | pre-stream, post-model-list 429 | gated `if (isKeepalive) { ... } else { applyRateLimitCooldown(...) }` | ✅ |
+| 4 | `packages/proxy/src/handlers/response-processor.ts:341` | pre-stream, header-based 429 (`processProxyResponse`) | `if (isKeepalive) { ...skipping cooldown }` then `else if/else` | ✅ |
+| 5 | `packages/proxy/src/response-handler.ts:~286` | **mid-stream SSE rate-limit frame** | unconditional `applyRateLimitCooldown(...)` | ❌ |
+
+3 of 4 sites pre-stream already skip the cooldown on synthetic keepalive
+replays. The mid-stream SSE path (the 4th) does not. The gap is real.
+
+## Why the gap matters
+
+The cache-keepalive scheduler fires parallel requests to every cached
+account simultaneously. A burst of 4+ concurrent requests can trip
+Anthropic's per-IP burst limit and 429 every account at the same instant —
+even though no real user-visible quota was hit on any individual account.
+Treating those as real per-account rate limits drains the pool to zero
+routable accounts.
+
+Until the fix, a keepalive replay whose upstream returned 200 OK but later
+emitted a mid-stream `event: error\ndata: {type: "error", error: {type:
+"rate_limit_error"|"overloaded_error"}}` SSE frame would still write
+`rate_limited_until` and cool the account, defeating the keepalive
+scheduler's design.
+
+## Fix shape
+
+Applied the keepalive exemption to the mid-stream SSE path in
+`packages/proxy/src/response-handler.ts`, matching the existing idiom from
+the other 3 sites:
+
+```ts
+const isKeepalive = isInternalProbe(requestHeaders, ctx, "keepalive");
+if (isKeepalive) {
+    log.warn(
+        `Keepalive replay for ${account.name} hit mid-stream rate-limit — ` +
+        `skipping cooldown (synthetic burst, not a real per-account rate limit)`,
+    );
+} else if (rateLimitSniffer.firedReason === "overloaded_error") {
+    applyRateLimitCooldown(account, { reason: "upstream_529_overloaded_no_reset" }, ctx);
+} else {
+    applyRateLimitCooldown(
+        account,
+        { resetTime: Date.now() + getMidStreamRateLimitCooldownMs(), reason: "upstream_429_with_reset" },
+        ctx,
+    );
+}
+```
+
+Why the existing helper rather than a new one: `isInternalProbe` is already
+imported in this file (used at line 171 for `isAutoRefreshProbe`), already
+returns false for external clients forging the marker (the
+`x-better-ccflare-internal-probe-secret` must match
+`ctx.internalProbeSecret`), and is the same call the 3 other sites use.
+
+## Regression tests (in `packages/proxy/src/handlers/__tests__/response-handler-midstream.test.ts`)
+
+Added a `describe("forwardToClient — mid-stream keepalive exemption")` block
+with 3 tests:
+
+1. **`overloaded_error` mid-stream on a keepalive replay — `applyRateLimitCooldown`
+   is NOT called.** Drives the real `forwardToClient` flow with keepalive
+   headers + matching secret + a stream that emits an `overloaded_error`
+   SSE frame. Asserts the spy is not called.
+
+2. **`rate_limit_error` mid-stream on a keepalive replay — `applyRateLimitCooldown`
+   is NOT called.** Same shape, different `firedReason`.
+
+3. **Keepalive header WITHOUT the matching internal-probe secret —
+   `applyRateLimitCooldown` IS called.** Pins the anti-forgery gate. An
+   external client forging the marker alone cannot suppress cooldowns.
+
+### Verification
+
+Tests FAIL on unfixed `upstream/main` (`6f2c9d28`) code, PASS with the fix:
+
+```
+$ bun test packages/proxy/src/handlers/__tests__/response-handler-midstream.test.ts
+# On upstream/main (no fix):
+ 8 pass, 2 fail
+   FAIL: overloaded_error mid-stream on a keepalive replay: applyRateLimitCooldown is NOT called
+     Expected number of calls: 0
+     Received number of calls: 1
+   FAIL: rate_limit_error mid-stream on a keepalive replay: applyRateLimitCooldown is NOT called
+     Expected number of calls: 0
+     Received number of calls: 1
+
+# With fix:
+$ bun test packages/proxy/src/handlers/__tests__/response-handler-midstream.test.ts
+ 10 pass, 0 fail
+   7 pre-existing + 3 new
+```
+
+## Files changed
+
+```
+packages/proxy/src/response-handler.ts                                     | 43 +/-
+packages/proxy/src/handlers/__tests__/response-handler-midstream.test.ts  | 199 +
+docs/reports/keepalive-cooldown-gap.md                                     | new
+```
+
+## Broader test run
+
+`bun test packages/proxy/src/...` reports `823 pass / 26 fail / 849 tests`
+before AND after the fix. The 26 failures are pre-existing (port-binding in
+`request-handler-client-abort.test.ts`, UsageCollector / issue #354 / Agent
+Interceptor suites) and unrelated — confirmed by running the same suite
+against both the pre-fix and post-fix trees and seeing identical failure
+sets.
+
+## Disposition: SECONDARY hygiene finding (CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS consolidation)
+
+The pattern
+
+```ts
+Number(process.env.CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS) ||
+    TIME_CONSTANTS.DEFAULT_RATE_LIMIT_NO_RESET_COOLDOWN_MS
+```
+
+appears in 3 places:
+
+- `packages/proxy/src/handlers/proxy-operations.ts` (`extractCooldownUntil`)
+- `packages/proxy/src/handlers/response-processor.ts` (`processProxyResponse` — proxied via `extractCooldownUntil`)
+- `packages/proxy/src/response-handler.ts` (`getMidStreamRateLimitCooldownMs`)
+
+**Folded out of this PR.** Bundling a 3-site refactor into the same PR as
+the correctness fix would obscure both: reviewers could not easily verify
+the keepalive skip in isolation, and a reviewer asking for the refactor to
+be split (it's a real candidate for a `TIME_CONSTANTS` accessor or a new
+shared helper) could not do so without also rejecting the bug fix. A clean
+small PR beats a bundled one.
+
+Recommended follow-up PR (separate, base on `upstream/main`): move the
+expression to a small named helper (e.g. `getNoResetCooldownMs()` in
+`packages/proxy/src/handlers/proxy-types.ts` or a new
+`cooldown-defaults.ts`) and update all 3 sites in one atomic commit. The
+`||` vs `??` choice would be settled there.
+
+## Open follow-ups
+
+- Reply to greptile-apps on PR #196 thread pointing at this PR.
+- Open `upstream/main` PR to `tombii/better-ccflare` from
+  `ao/ccflare-158/keepalive-midstream-skip` (`fix(proxy): ...` so the
+  automated release system picks it up).
+- Track the `CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS` consolidation as a
+  follow-up card.

--- a/packages/proxy/src/handlers/__tests__/response-handler-midstream.test.ts
+++ b/packages/proxy/src/handlers/__tests__/response-handler-midstream.test.ts
@@ -317,3 +317,202 @@ describe("forwardToClient — real mid-stream sniffer call form", () => {
 		}
 	});
 });
+
+// ── mid-stream keepalive exemption (upstream PR #196 greptile-apps gap) ────
+//
+// The pre-stream 429 paths in proxy-operations.ts (3 sites) and
+// response-processor.ts already skip cooldowns for synthetic keepalive
+// replays — the cache-keepalive scheduler fires parallel requests across
+// every cached account simultaneously, and bursts of 4+ concurrent requests
+// trip Anthropic's per-IP burst limit. Treating those as real per-account
+// rate limits drains the pool to zero routable accounts even though no
+// user-visible quota was actually exhausted.
+//
+// The mid-stream SSE rate-limit path in response-handler.ts did NOT carry
+// the same exemption — a keepalive replay whose 200 OK later emits an
+// `event: error` SSE frame would still write rate_limited_until and cool
+// the account. The tests below pin the exemption: a mid-stream sniffer
+// fire on a request carrying the keepalive marker + matching secret MUST
+// NOT call applyRateLimitCooldown. The anti-forgery gate (matching secret)
+// is also pinned — without it the marker is silently ignored, which is the
+// expected behaviour against an external client forging the header.
+describe("forwardToClient — mid-stream keepalive exemption", () => {
+	const KEEPALIVE_SECRET = "test-secret";
+
+	function createKeepaliveCtx(): ProxyContext {
+		return {
+			provider: { name: "anthropic", isStreamingResponse: () => true },
+			config: { getStorePayloads: () => true },
+			dbOps: {
+				markAccountRateLimited: () =>
+					Promise.resolve({ consecutiveRateLimits: 1, applied: true }),
+			},
+			asyncWriter: {
+				enqueue: (job: () => void | Promise<void>) => {
+					void job();
+				},
+			},
+			internalProbeSecret: KEEPALIVE_SECRET,
+		} as unknown as ProxyContext;
+	}
+
+	function keepaliveMockCollector() {
+		return {
+			handleStart: () => {},
+			handleChunk: () => {},
+			handleEnd: () => Promise.resolve(),
+		};
+	}
+
+	function makeKeepaliveHeaders(): Headers {
+		return new Headers({
+			"content-type": "application/json",
+			"x-better-ccflare-keepalive": "true",
+			"x-better-ccflare-internal-probe-secret": KEEPALIVE_SECRET,
+		});
+	}
+
+	async function feedSseErrorFrameKeepalive(
+		errorType: "overloaded_error" | "rate_limit_error",
+		account: Account,
+		ctx: ProxyContext,
+	): Promise<void> {
+		const collectorSpy = spyOn(
+			usageCollectorModule,
+			"getUsageCollector",
+		).mockReturnValue(
+			keepaliveMockCollector() as unknown as usageCollectorModule.UsageCollector,
+		);
+		try {
+			const body = new ReadableStream<Uint8Array>({
+				start(controller) {
+					controller.enqueue(
+						new TextEncoder().encode(
+							`event: error\ndata: {"type":"error","error":{"type":"${errorType}","message":"Overloaded"}}\n\n`,
+						),
+					);
+					controller.close();
+				},
+			});
+
+			const response = await forwardToClient(
+				{
+					requestId: `req-keepalive-${errorType}`,
+					method: "POST",
+					path: "/v1/messages",
+					account,
+					requestHeaders: makeKeepaliveHeaders(),
+					requestBody: new TextEncoder().encode("{}"),
+					response: new Response(body, {
+						status: 200,
+						headers: { "content-type": "text/event-stream" },
+					}),
+					timestamp: Date.now(),
+					retryAttempt: 0,
+					failoverAttempts: 0,
+				},
+				ctx,
+			);
+			await response.text();
+		} finally {
+			collectorSpy.mockRestore();
+		}
+	}
+
+	it("overloaded_error mid-stream on a keepalive replay: applyRateLimitCooldown is NOT called (regression for PR #196 greptile-apps)", async () => {
+		const account = makeAccount({ id: "acct-keepalive-529" });
+		const ctx = createKeepaliveCtx();
+		const spy = spyOn(rateLimitCooldownModule, "applyRateLimitCooldown");
+
+		try {
+			await feedSseErrorFrameKeepalive("overloaded_error", account, ctx);
+
+			expect(spy).not.toHaveBeenCalled();
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
+	it("rate_limit_error mid-stream on a keepalive replay: applyRateLimitCooldown is NOT called (regression for PR #196 greptile-apps)", async () => {
+		const account = makeAccount({ id: "acct-keepalive-429" });
+		const ctx = createKeepaliveCtx();
+		const spy = spyOn(rateLimitCooldownModule, "applyRateLimitCooldown");
+
+		try {
+			await feedSseErrorFrameKeepalive("rate_limit_error", account, ctx);
+
+			expect(spy).not.toHaveBeenCalled();
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
+	it("keepalive header WITHOUT the matching internal-probe secret: applyRateLimitCooldown IS called (anti-forgery gate still holds)", async () => {
+		// The keepalive marker alone is not enough — isInternalProbe requires
+		// the request to carry the process-local secret too. An external
+		// client forging just the marker must not be able to suppress
+		// cooldowns.
+		const account = makeAccount({ id: "acct-keepalive-forgery" });
+		const ctx = createKeepaliveCtx();
+		const forgedHeaders = new Headers({
+			"content-type": "application/json",
+			"x-better-ccflare-keepalive": "true",
+			// Note: no x-better-ccflare-internal-probe-secret header
+		});
+
+		const collectorSpy = spyOn(
+			usageCollectorModule,
+			"getUsageCollector",
+		).mockReturnValue(
+			keepaliveMockCollector() as unknown as usageCollectorModule.UsageCollector,
+		);
+		const cooldownSpy = spyOn(
+			rateLimitCooldownModule,
+			"applyRateLimitCooldown",
+		);
+
+		try {
+			const body = new ReadableStream<Uint8Array>({
+				start(controller) {
+					controller.enqueue(
+						new TextEncoder().encode(
+							'event: error\ndata: {"type":"error","error":{"type":"rate_limit_error","message":"limit"}}\n\n',
+						),
+					);
+					controller.close();
+				},
+			});
+
+			const response = await forwardToClient(
+				{
+					requestId: "req-keepalive-forgery",
+					method: "POST",
+					path: "/v1/messages",
+					account,
+					requestHeaders: forgedHeaders,
+					requestBody: new TextEncoder().encode("{}"),
+					response: new Response(body, {
+						status: 200,
+						headers: { "content-type": "text/event-stream" },
+					}),
+					timestamp: Date.now(),
+					retryAttempt: 0,
+					failoverAttempts: 0,
+				},
+				ctx,
+			);
+			await response.text();
+
+			expect(cooldownSpy).toHaveBeenCalledTimes(1);
+			const [, rateLimitInfo] = cooldownSpy.mock.calls[0] as [
+				Account,
+				{ resetTime?: number; reason?: string },
+				ProxyContext,
+			];
+			expect(rateLimitInfo.reason).toBe("upstream_429_with_reset");
+		} finally {
+			cooldownSpy.mockRestore();
+			collectorSpy.mockRestore();
+		}
+	});
+});

--- a/packages/proxy/src/response-handler.ts
+++ b/packages/proxy/src/response-handler.ts
@@ -265,24 +265,49 @@ export async function forwardToClient(
 			// Mid-stream rate-limit detection. The sniffer
 			// fires exactly once; after that feed() is a no-op.
 			if (account && rateLimitSniffer?.feed(value)) {
-				// SSE error frames carry no reset header — HTTP headers were
-				// already sent before the error occurred — so any resetTime
-				// passed here is a value ccflare invents, never an upstream
-				// instruction. The two firedReason branches treat that fact
-				// differently on purpose:
-				//   "rate_limit_error" (429, quota) → upstream_429_with_reset,
-				//     WITH the synthetic resetTime below. This is a deliberate
-				//     conservative estimate of the 5h quota window — better to
-				//     under-cool a real quota exhaustion than leave the account
-				//     selectable, and the ramp-capped 429 formula treats
-				//     resetTime only as an upper bound anyway.
-				//   "overloaded_error" (529, transient) → the reason alone
-				//     (upstream_529_overloaded_no_reset), no resetTime. Passing
-				//     a synthetic reset for a 529 would misrepresent a ccflare
-				//     default as an Anthropic Retry-After; the no-reset reason
-				//     routes this to the cooldown core's fixed short overload
-				//     cooldown instead.
-				if (rateLimitSniffer.firedReason === "overloaded_error") {
+				// Skip cooldown on synthetic cache-keepalive replays. The
+				// keepalive scheduler fires parallel requests to every cached
+				// account simultaneously; bursts of 4+ concurrent requests can
+				// trip Anthropic's per-IP burst limit and 429 every account at
+				// the same instant. A keepalive replay whose 200 OK response
+				// later emits a mid-stream `event: error` SSE frame is the
+				// same class of synthetic burst — applying a real cooldown
+				// here drains the pool to zero routable accounts even though
+				// no user-visible quota was actually exhausted. Loop-prevention
+				// header set by cache-keepalive-scheduler.ts; only synthetic
+				// replays carry it. Mirrors the keepalive exemption already
+				// applied in proxy-operations.ts (3 sites) and
+				// response-processor.ts — closing the gap flagged on merged
+				// upstream PR #196 (greptile-apps).
+				const isKeepalive = isInternalProbe(
+					requestHeaders,
+					ctx,
+					"keepalive",
+				);
+				if (isKeepalive) {
+					log.warn(
+						`Keepalive replay for ${account.name} hit mid-stream rate-limit — skipping cooldown (synthetic burst, not a real per-account rate limit)`,
+					);
+				} else if (
+					// SSE error frames carry no reset header — HTTP headers were
+					// already sent before the error occurred — so any resetTime
+					// passed here is a value ccflare invents, never an upstream
+					// instruction. The two firedReason branches treat that fact
+					// differently on purpose:
+					//   "rate_limit_error" (429, quota) → upstream_429_with_reset,
+					//     WITH the synthetic resetTime below. This is a deliberate
+					//     conservative estimate of the 5h quota window — better to
+					//     under-cool a real quota exhaustion than leave the account
+					//     selectable, and the ramp-capped 429 formula treats
+					//     resetTime only as an upper bound anyway.
+					//   "overloaded_error" (529, transient) → the reason alone
+					//     (upstream_529_overloaded_no_reset), no resetTime. Passing
+					//     a synthetic reset for a 529 would misrepresent a ccflare
+					//     default as an Anthropic Retry-After; the no-reset reason
+					//     routes this to the cooldown core's fixed short overload
+					//     cooldown instead.
+					rateLimitSniffer.firedReason === "overloaded_error"
+				) {
 					applyRateLimitCooldown(
 						account,
 						{ reason: "upstream_529_overloaded_no_reset" },


### PR DESCRIPTION
Closes #196

Closes the gap flagged by greptile-apps on merged PR #196 — mid-stream SSE rate-limit path was missing the keepalive exemption applied at the other 3 cooldown sites.

The cache-keepalive scheduler fires parallel requests to every cached account simultaneously. A 200 OK response that later emits an 'event: error' SSE frame carrying `rate_limit_error` or `overloaded_error` was still writing `rate_limited_until` and cooling an account that should have been exempt.

Applies the same `isInternalProbe(requestHeaders, ctx, 'keepalive')` idiom used by the 3 sites in `proxy-operations.ts` and the 1 site in `response-processor.ts`. Anti-forgery gate (matching process-local secret) preserved.

Adds 3 regression tests in `packages/proxy/src/handlers/__tests__/response-handler-midstream.test.ts` that drive the real `forwardToClient` flow and FAIL without the fix.

Reported in docs/reports/keepalive-cooldown-gap.md.

Companion op report for #196 Greptile: the secondary hygiene finding (CCFLARE_DEFAULT_COOLDOWN_NO_RESET_MS duplicated in 3 sites) was deliberately folded out — see report for rationale.