### PR TITLE
fix(database): widen instance_heartbeats timestamps to bigint on PostgreSQL

### DIFF
--- a/packages/database/src/migrations-pg.ts
+++ b/packages/database/src/migrations-pg.ts
@@ -1198,14 +1198,27 @@ export async function runMigrationsPg(adapter: BunSqlAdapter): Promise<void> {
 	// to BIGINT (int8). The multi-instance guard writes Date.now() epoch-ms
 	// (~1.79e12), which overflows int4 and crash-loops PG deployments on the
 	// first heartbeat upsert (issue #383). Widening is lossless — every int4
-	// value is a valid int8. Only run the ALTER (and the accompanying purge
-	// of garbage rows left by crash-looping pre-fix incarnations) when the
-	// column is still int4 — this table is shared by every live instance, so
-	// unconditionally deleting rows on every startup would wipe a peer's
-	// fresh heartbeat right before the guard scans for it. Errors are
+	// value is a valid int8. Only run the ALTER when the column is still
+	// int4, so repeat startups after the first are a no-op. Errors are
 	// allowed to propagate: silently swallowing a failed widening would let
 	// startup continue writing epoch-ms into an unchanged int4 column,
 	// reproducing the same overflow crash this migration fixes.
+	//
+	// The type check + ALTER is not synchronised across instances (see the
+	// accounts unique-index migration below for why adapter.transaction()
+	// and pg_advisory_lock both fail to give real atomicity over a pooled
+	// connection). Two instances can both observe int4 and both run the
+	// ALTER; that is harmless since ALTER COLUMN TYPE bigint is idempotent
+	// on an already-bigint column and PostgreSQL serialises the concurrent
+	// DDL. What must NOT happen is a blanket `DELETE FROM instance_heartbeats`
+	// here: that would erase a peer's heartbeat written between this
+	// instance's ALTER and its own scan, defeating the multi-instance guard.
+	// Instead, only purge rows that are actually garbage — int4-overflow
+	// wraparound from crash-looping pre-fix incarnations produces values
+	// wildly outside any plausible epoch-ms range (negative, or before
+	// year 2000), which a live instance's freshly written Date.now() never
+	// is. This scoping makes the purge safe under concurrent startup: it
+	// can never match a row a peer just wrote correctly.
 	const startedAtType = await columnDataType(
 		adapter,
 		"instance_heartbeats",
@@ -1217,7 +1230,12 @@ export async function runMigrationsPg(adapter: BunSqlAdapter): Promise<void> {
 			 ALTER COLUMN started_at TYPE bigint,
 			 ALTER COLUMN last_heartbeat TYPE bigint`,
 		);
-		await adapter.unsafe(`DELETE FROM instance_heartbeats`);
+		const MIN_PLAUSIBLE_EPOCH_MS = 946684800000; // 2000-01-01T00:00:00Z
+		await adapter.unsafe(
+			`DELETE FROM instance_heartbeats
+			 WHERE started_at < ${MIN_PLAUSIBLE_EPOCH_MS}
+			    OR last_heartbeat < ${MIN_PLAUSIBLE_EPOCH_MS}`,
+		);
 		log.info("Widened instance_heartbeats timestamps to bigint (issue #383)");
 	}
 

--- a/packages/database/src/migrations-pg.ts
+++ b/packages/database/src/migrations-pg.ts
@@ -331,8 +331,8 @@ export async function ensureSchemaPg(adapter: BunSqlAdapter): Promise<void> {
 			instance_id TEXT PRIMARY KEY,
 			hostname TEXT NOT NULL,
 			pid INTEGER NOT NULL,
-			started_at INTEGER NOT NULL,
-			last_heartbeat INTEGER NOT NULL,
+			started_at BIGINT NOT NULL,
+			last_heartbeat BIGINT NOT NULL,
 			node_version TEXT NOT NULL,
 			db_dialect TEXT NOT NULL
 		)
@@ -1174,6 +1174,26 @@ export async function runMigrationsPg(adapter: BunSqlAdapter): Promise<void> {
 		log.info("Made refresh_token nullable in accounts table");
 	} catch (_error) {
 		// Already nullable or column doesn't exist — ignore
+	}
+
+	// Widen instance_heartbeats.{started_at,last_heartbeat} from INTEGER (int4)
+	// to BIGINT (int8). The multi-instance guard writes Date.now() epoch-ms
+	// (~1.79e12), which overflows int4 and crash-loops PG deployments on the
+	// first heartbeat upsert (issue #383). Widening is lossless — every int4
+	// value is a valid int8 — and a no-op on installs where the columns are
+	// already bigint, so running it on every startup is safe. Also clear any
+	// rows left behind by crash-looping incarnations before the fix landed,
+	// since their stored values are garbage.
+	try {
+		await adapter.unsafe(
+			`ALTER TABLE instance_heartbeats
+			 ALTER COLUMN started_at TYPE bigint,
+			 ALTER COLUMN last_heartbeat TYPE bigint`,
+		);
+		await adapter.unsafe(`DELETE FROM instance_heartbeats`);
+		log.info("Widened instance_heartbeats timestamps to bigint (issue #383)");
+	} catch (_error) {
+		// Table doesn't exist yet (ensureSchemaPg hasn't run) — ignore
 	}
 
 	// Clean up empty-string sentinels left by old migration

--- a/packages/database/src/migrations-pg.ts
+++ b/packages/database/src/migrations-pg.ts
@@ -45,6 +45,24 @@ async function _tableExists(
 }
 
 /**
+ * Get a column's data_type from information_schema (e.g. "integer", "bigint").
+ * Returns null if the table/column doesn't exist yet.
+ */
+async function columnDataType(
+	adapter: BunSqlAdapter,
+	table: string,
+	column: string,
+): Promise<string | null> {
+	const result = await adapter.get<{ data_type: string }>(
+		`SELECT data_type
+		 FROM information_schema.columns
+		 WHERE table_name = ? AND column_name = ?`,
+		[table, column],
+	);
+	return result?.data_type ?? null;
+}
+
+/**
  * Ensure the full schema exists for PostgreSQL
  */
 export async function ensureSchemaPg(adapter: BunSqlAdapter): Promise<void> {
@@ -1180,11 +1198,20 @@ export async function runMigrationsPg(adapter: BunSqlAdapter): Promise<void> {
 	// to BIGINT (int8). The multi-instance guard writes Date.now() epoch-ms
 	// (~1.79e12), which overflows int4 and crash-loops PG deployments on the
 	// first heartbeat upsert (issue #383). Widening is lossless — every int4
-	// value is a valid int8 — and a no-op on installs where the columns are
-	// already bigint, so running it on every startup is safe. Also clear any
-	// rows left behind by crash-looping incarnations before the fix landed,
-	// since their stored values are garbage.
-	try {
+	// value is a valid int8. Only run the ALTER (and the accompanying purge
+	// of garbage rows left by crash-looping pre-fix incarnations) when the
+	// column is still int4 — this table is shared by every live instance, so
+	// unconditionally deleting rows on every startup would wipe a peer's
+	// fresh heartbeat right before the guard scans for it. Errors are
+	// allowed to propagate: silently swallowing a failed widening would let
+	// startup continue writing epoch-ms into an unchanged int4 column,
+	// reproducing the same overflow crash this migration fixes.
+	const startedAtType = await columnDataType(
+		adapter,
+		"instance_heartbeats",
+		"started_at",
+	);
+	if (startedAtType === "integer") {
 		await adapter.unsafe(
 			`ALTER TABLE instance_heartbeats
 			 ALTER COLUMN started_at TYPE bigint,
@@ -1192,8 +1219,6 @@ export async function runMigrationsPg(adapter: BunSqlAdapter): Promise<void> {
 		);
 		await adapter.unsafe(`DELETE FROM instance_heartbeats`);
 		log.info("Widened instance_heartbeats timestamps to bigint (issue #383)");
-	} catch (_error) {
-		// Table doesn't exist yet (ensureSchemaPg hasn't run) — ignore
 	}
 
 	// Clean up empty-string sentinels left by old migration

--- a/packages/database/src/multi-instance-guard.ts
+++ b/packages/database/src/multi-instance-guard.ts
@@ -321,11 +321,15 @@ export async function runStartupGuard(
  *  in-process state so the reader understands the consequence. */
 export function formatGuardMessage(peers: HeartbeatRecord[]): string {
 	const peerLines = peers
-		.map(
-			(p) =>
+		.map((p) => {
+			const ts = Number.isFinite(p.last_heartbeat)
+				? new Date(p.last_heartbeat).toISOString()
+				: String(p.last_heartbeat);
+			return (
 				`  - instance ${p.instance_id.slice(0, 8)}…  host=${p.hostname}  pid=${p.pid}  ` +
-				`last_heartbeat=${new Date(p.last_heartbeat).toISOString()}`,
-		)
+				`last_heartbeat=${ts}`
+			);
+		})
 		.join("\n");
 
 	return [


### PR DESCRIPTION
## Summary
- On PostgreSQL, `instance_heartbeats.started_at`/`last_heartbeat` were created as `INTEGER` (int4, max ~2.1e9) in `ensureSchemaPg`, but `writeHeartbeat` writes `Date.now()` epoch-ms (~1.79e12), overflowing int4 and crash-looping the server on the very first heartbeat upsert. SQLite is untyped so this never surfaced there — presumably why it passed CI.
- Widens both columns to `BIGINT` in `ensureSchemaPg` for new installs, and adds an idempotent `ALTER COLUMN ... TYPE bigint` migration in `runMigrationsPg` for existing PG deployments (also clears rows left behind by crash-looping incarnations, since their stored values are garbage).
- Guards `formatGuardMessage`'s date formatting against non-finite `last_heartbeat` values so any leftover garbage rows can't throw `RangeError: Invalid Date` when peers are logged (the secondary issue called out in the report).

## Test plan
- [x] `bun test packages/database/src/__tests__/multi-instance-guard.test.ts` — 13 pass, 3 skip (PG-live tests gated on `DATABASE_URL`)
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx biome check` — clean (no new warnings)

Fixes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)