### PR TITLE
fix(proxy): stop leaking native buffers on client disconnect (#382)

### DIFF
--- a/packages/proxy/src/stream-tee.test.ts
+++ b/packages/proxy/src/stream-tee.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "bun:test";
+import { combineChunks, teeStream } from "./stream-tee";
+
+/**
+ * Builds a test "upstream" ReadableStream backed by a fixed list of chunks,
+ * tracking how many chunks were produced (read by pull) and whether the
+ * underlying source's cancel() was invoked.
+ */
+function makeTrackedUpstream(chunks: Uint8Array[]) {
+	let pullCount = 0;
+	let cancelCalled = false;
+	let exhausted = false;
+	let index = 0;
+
+	const stream = new ReadableStream<Uint8Array>({
+		pull(controller) {
+			pullCount++;
+			if (index >= chunks.length) {
+				exhausted = true;
+				controller.close();
+				return;
+			}
+			controller.enqueue(chunks[index]);
+			index++;
+			if (index >= chunks.length) {
+				// Not closed yet — closes on the *next* pull, matching real
+				// fetch-body streams where `done` is observed on a
+				// subsequent read() rather than bundled with the last chunk.
+			}
+		},
+		cancel() {
+			cancelCalled = true;
+		},
+	});
+
+	return {
+		stream,
+		getPullCount: () => pullCount,
+		wasCancelCalled: () => cancelCalled,
+		wasExhausted: () => exhausted,
+	};
+}
+
+function textChunk(text: string): Uint8Array {
+	return new TextEncoder().encode(text);
+}
+
+async function readAll(
+	stream: ReadableStream<Uint8Array>,
+): Promise<Uint8Array[]> {
+	const reader = stream.getReader();
+	const out: Uint8Array[] = [];
+	while (true) {
+		const { value, done } = await reader.read();
+		if (done) break;
+		if (value) out.push(value);
+	}
+	return out;
+}
+
+describe("teeStream", () => {
+	it("passes chunks through to the consumer unmodified", async () => {
+		const chunks = [textChunk("hello "), textChunk("world")];
+		const { stream } = makeTrackedUpstream(chunks);
+
+		const out = teeStream(stream);
+		const received = await readAll(out);
+
+		expect(received.length).toBe(2);
+		expect(new TextDecoder().decode(combineChunks(received))).toBe(
+			"hello world",
+		);
+	});
+
+	it("fires onChunk for each chunk and onClose with the buffered chunks", async () => {
+		const chunks = [textChunk("a"), textChunk("b"), textChunk("c")];
+		const { stream } = makeTrackedUpstream(chunks);
+
+		const seen: Uint8Array[] = [];
+		let closedWith: Uint8Array[] | undefined;
+
+		const out = teeStream(stream, {
+			onChunk: (chunk) => seen.push(chunk),
+			onClose: (buffered) => {
+				closedWith = buffered;
+			},
+		});
+
+		await readAll(out);
+
+		expect(seen.length).toBe(3);
+		expect(closedWith).toBeDefined();
+		expect(closedWith?.length).toBe(3);
+		expect(new TextDecoder().decode(combineChunks(closedWith ?? []))).toBe(
+			"abc",
+		);
+	});
+
+	it("respects maxBytes when buffering, while still passing all bytes through", async () => {
+		const chunks = [textChunk("12345"), textChunk("67890"), textChunk("abcde")];
+		const { stream } = makeTrackedUpstream(chunks);
+
+		let closedWith: Uint8Array[] | undefined;
+		const out = teeStream(stream, {
+			maxBytes: 7,
+			onClose: (buffered) => {
+				closedWith = buffered;
+			},
+		});
+
+		const received = await readAll(out);
+
+		// All bytes still delivered to the consumer despite the buffer cap.
+		expect(new TextDecoder().decode(combineChunks(received))).toBe(
+			"1234567890abcde",
+		);
+
+		// Buffered analytics copy is capped at maxBytes.
+		const bufferedTotal = (closedWith ?? []).reduce(
+			(sum, c) => sum + c.length,
+			0,
+		);
+		expect(bufferedTotal).toBe(7);
+	});
+
+	it("drains the upstream reader to completion on cancel instead of calling reader.cancel()", async () => {
+		const chunks = [
+			textChunk("chunk1"),
+			textChunk("chunk2"),
+			textChunk("chunk3"),
+			textChunk("chunk4"),
+		];
+		const tracked = makeTrackedUpstream(chunks);
+
+		const out = teeStream(tracked.stream);
+
+		// Simulate what Bun does on client disconnect: cancel the outer
+		// stream before it has been read to completion.
+		const reader = out.getReader();
+		await reader.cancel("client disconnected");
+
+		// Give the fire-and-forget drain a chance to run to completion.
+		await new Promise((resolve) => setTimeout(resolve, 10));
+
+		// The regression: the upstream source must have been read to
+		// exhaustion (drained), not merely abandoned via cancel().
+		expect(tracked.wasExhausted()).toBe(true);
+		expect(tracked.getPullCount()).toBeGreaterThanOrEqual(chunks.length);
+
+		// The fix must not call the upstream reader's cancel() — draining
+		// alone must release the native buffer (Bun's cancel() is a no-op,
+		// oven-sh/bun#35093).
+		expect(tracked.wasCancelCalled()).toBe(false);
+	});
+
+	it("swallows drain errors instead of throwing during cancel teardown", async () => {
+		const erroringStream = new ReadableStream<Uint8Array>({
+			pull(controller) {
+				controller.error(new Error("boom during drain"));
+			},
+		});
+
+		const out = teeStream(erroringStream);
+		const reader = out.getReader();
+
+		// Must not reject / throw — cancel() during teardown should not
+		// propagate drain failures.
+		await expect(reader.cancel("client disconnected")).resolves.toBeUndefined();
+
+		// Let any fire-and-forget drain promise settle without an
+		// unhandled rejection surfacing.
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	});
+});

--- a/packages/proxy/src/stream-tee.ts
+++ b/packages/proxy/src/stream-tee.ts
@@ -64,6 +64,9 @@ export function teeStream(
 			// reader.cancel() is a no-op on Bun (oven-sh/bun#35093) and leaks
 			// the upstream's native buffer; drain to `done` instead — see
 			// handlers/discard-body-cancel.ts for the full rationale (#382).
+			// Bounded by the caller's fetch() abort signal (request-handler.ts's
+			// effectiveSignal), which rejects reader.read() once the same
+			// client disconnect that triggered this cancel() propagates there.
 			void (async () => {
 				try {
 					while (true) {
@@ -72,6 +75,8 @@ export function teeStream(
 					}
 				} catch {
 					// Swallow — cancel() must not throw during teardown.
+				} finally {
+					reader.releaseLock();
 				}
 			})();
 		},

--- a/packages/proxy/src/stream-tee.ts
+++ b/packages/proxy/src/stream-tee.ts
@@ -60,8 +60,20 @@ export function teeStream(
 			}
 		},
 
-		cancel(reason) {
-			return reader.cancel(reason);
+		cancel() {
+			// reader.cancel() is a no-op on Bun (oven-sh/bun#35093) and leaks
+			// the upstream's native buffer; drain to `done` instead — see
+			// handlers/discard-body-cancel.ts for the full rationale (#382).
+			void (async () => {
+				try {
+					while (true) {
+						const { done } = await reader.read();
+						if (done) return;
+					}
+				} catch {
+					// Swallow — cancel() must not throw during teardown.
+				}
+			})();
 		},
 	});
 }


### PR DESCRIPTION
## Summary
- `teeStream()` in `packages/proxy/src/stream-tee.ts` wraps every proxied response body (streaming and non-streaming). When a client disconnects mid-response, Bun's HTTP server calls `.cancel(reason)` on this stream, which previously forwarded straight to `reader.cancel(reason)` on the upstream `fetch()` reader.
- Bun's `reader.cancel()` is a documented no-op (`oven-sh/bun#35093`) — it never releases the native off-heap buffer backing the response. Every client disconnect during a streaming response therefore permanently leaked that request's upstream buffer, matching the RSS-vs-heap signature reported in #382 (RSS ~11GB, heap ~26MB).
- This repo already has a proven workaround for the identical Bun bug in `packages/proxy/src/handlers/discard-body-cancel.ts` (draining a body to `done` instead of calling `.cancel()`, ~85% RSS reduction measured there). This PR applies the same pattern directly inside `teeStream`'s `cancel()` handler, reusing the reader it already holds (no second `getReader()` call, since the stream would already be locked).
- Safety: `teeStream`'s internal reader is the sole reader of the upstream body, and `.cancel()` only fires *after* the client has already disconnected — so draining to completion at that point cannot race or truncate a still-connected client. This is a different scenario from the one `discard-body-cancel.ts`'s comments warn about (draining a body still being live-forwarded to a connected client).

## Test plan
- [x] Added `packages/proxy/src/stream-tee.test.ts` (TDD: written first, confirmed failing against the pre-fix `reader.cancel()` implementation, then passing after the fix)
  - normal pass-through / `onChunk` / `onClose` behavior unchanged
  - `maxBytes` buffering cap still respected
  - regression test: cancelling the output stream mid-read drains the upstream source to exhaustion instead of calling its `cancel()`
  - drain errors are swallowed, `cancel()` never throws/rejects
- [x] `bun run lint && bun run typecheck && bun run format` — clean on touched files
- [x] `bun test packages/proxy` — 886 pass / 7 fail, identical pass/fail counts before and after this change (verified via `git stash`); the 7 failures are pre-existing global `fetch` mock pollution in `request-handler-client-abort.test.ts` when run as part of the full suite, unrelated to this change (passes 7/7 in isolation)

Fixes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)