### PR TITLE
fix(providers): add the fable family to the codex and qwen default model maps

### DIFF
--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -2289,6 +2289,28 @@ describe("CodexProvider.transformRequestBody", () => {
 		expect(body.model).toBe("gpt-5.3-codex");
 	});
 
+	// Regression: the fable entry alone is not enough for codex. mapModel
+	// resolves by substring and had no fable branch, so the map entry would
+	// never be looked up and the Claude model id would reach the upstream
+	// verbatim.
+	it("maps fable-family models to the codex default", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-fable-5",
+				max_tokens: 10,
+				messages: [{ role: "user", content: "hello" }],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request, undefined);
+		const body = await transformed.json();
+
+		expect(body.model).toBe("gpt-5.3-codex");
+	});
+
 	it("uses account sonnet mapping for sonnet-family models", async () => {
 		const provider = new CodexProvider();
 		const account = {

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -99,6 +99,7 @@ const CODEX_ERROR_TYPE_BY_CODE: Record<string, string> = {
 
 // Default model mapping: Anthropic model name prefixes → Codex model names
 const DEFAULT_MODEL_MAP: Record<string, string> = {
+	fable: "gpt-5.3-codex",
 	opus: "gpt-5.3-codex",
 	sonnet: "gpt-5.3-codex",
 	haiku: "gpt-5.4-mini",
@@ -691,6 +692,7 @@ export class CodexProvider extends BaseProvider {
 		}
 
 		const lower = anthropicModel.toLowerCase();
+		if (lower.includes("fable")) return DEFAULT_MODEL_MAP.fable;
 		if (lower.includes("haiku")) return DEFAULT_MODEL_MAP.haiku;
 		if (lower.includes("sonnet")) return DEFAULT_MODEL_MAP.sonnet;
 		if (lower.includes("opus")) return DEFAULT_MODEL_MAP.opus;

--- a/packages/providers/src/providers/qwen/__tests__/provider.test.ts
+++ b/packages/providers/src/providers/qwen/__tests__/provider.test.ts
@@ -195,6 +195,7 @@ describe("QwenProvider", () => {
 			const result = provider.beforeConvert({}, account);
 			expect(result).toBeDefined();
 			const mappings = JSON.parse(result?.model_mappings as string);
+			expect(mappings.fable).toBe("coder-model");
 			expect(mappings.opus).toBe("coder-model");
 			expect(mappings.sonnet).toBe("coder-model");
 			expect(mappings.haiku).toBe("coder-model");

--- a/packages/providers/src/providers/qwen/provider.ts
+++ b/packages/providers/src/providers/qwen/provider.ts
@@ -23,6 +23,7 @@ const STAINLESS_HEADERS: Record<string, string> = {
 
 // All Anthropic model tiers map to coder-model (Qwen's unified coding model)
 const QWEN_MODEL_MAPPINGS = {
+	fable: "coder-model",
 	opus: "coder-model",
 	sonnet: "coder-model",
 	haiku: "coder-model",


### PR DESCRIPTION
## What

`DEFAULT_MODEL_MAP` (codex) and `QWEN_MODEL_MAPPINGS` list `opus`/`sonnet`/`haiku` but not `fable`; xai already has all four.

## Why

A request in the Fable family reaches those providers untranslated — the Claude model id is forwarded verbatim to an upstream that does not know it.

Adding the map entry alone is **not enough for codex**: `CodexProvider.mapModel` resolves by substring and had no `fable` branch, so the new entry would never be looked up and would sit there decorative. That is the part worth reviewing.

## How

- `fable` → `gpt-5.3-codex` for codex, the same value as `opus`/`sonnet`.
- `fable` → `coder-model` for qwen, the same as the other three (Qwen has a single unified coding model).
- The missing `fable` branch in `CodexProvider.mapModel`.
- Regression test asserting a `claude-fable-*` request is translated, so the branch cannot be dropped again without a red test.

qwen and xai need no resolver change: they inject their map as `model_mappings` and `mapModelName` already resolves by family, which knows `fable`.

## Testing

`bun test packages/providers/src/providers/codex/provider.test.ts` — 104 pass, 0 fail, including the new case.

Part of #393.
