### PR TITLE
feat(proxy): allow a combo slot to forward the client's own model

### DIFF
--- a/packages/dashboard-web/src/components/combos/ComboSlotBuilder.tsx
+++ b/packages/dashboard-web/src/components/combos/ComboSlotBuilder.tsx
@@ -22,6 +22,7 @@ import {
 	useRemoveComboSlot,
 	useReorderComboSlots,
 } from "../../hooks/queries";
+import { providerAllowsClientModelPassthrough } from "../../utils/provider-utils";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
@@ -94,7 +95,11 @@ function SortableSlotRow({
 			</div>
 
 			<span className="shrink-0 font-mono text-xs text-muted-foreground">
-				{slot.model}
+				{slot.model?.trim() ? (
+					slot.model
+				) : (
+					<span className="italic">client model</span>
+				)}
 			</span>
 
 			<Button
@@ -159,8 +164,20 @@ export function ComboSlotBuilder({ combo }: ComboSlotBuilderProps) {
 		});
 	};
 
+	// Derived on every render rather than mirrored into state: the account is
+	// picked in the Select above this field and can be changed after the model
+	// has been typed, so no click order may leave an invalid slot behind.
+	const selectedProvider = accounts.find(
+		(a) => a.id === newAccountId,
+	)?.provider;
+	const passthroughAllowed =
+		providerAllowsClientModelPassthrough(selectedProvider);
+	const missingRequiredModel = !passthroughAllowed && !newModel.trim();
+
 	const handleAddSlot = () => {
-		if (!newAccountId || !newModel.trim()) return;
+		// An empty model means passthrough, which is only valid where the
+		// upstream serves Claude model ids. Elsewhere the model is required.
+		if (!newAccountId || missingRequiredModel) return;
 		addSlot.mutate(
 			{
 				comboId: combo.id,
@@ -230,12 +247,19 @@ export function ComboSlotBuilder({ combo }: ComboSlotBuilderProps) {
 							</Select>
 						</div>
 						<div className="space-y-1.5">
-							<Label>Model</Label>
+							<Label>{passthroughAllowed ? "Model (optional)" : "Model"}</Label>
 							<Input
 								value={newModel}
 								onChange={(e) => setNewModel(e.target.value)}
-								placeholder="claude-3-opus"
+								placeholder="Model id"
 							/>
+							<p className="text-xs text-muted-foreground">
+								{!newAccountId
+									? "Whether the model is required depends on the provider of the account you pick."
+									: passthroughAllowed
+										? "Leave empty to forward the model the client asked for."
+										: `Required for ${selectedProvider}: this provider does not serve Claude model ids, so there is nothing to forward.`}
+							</p>
 						</div>
 						<div className="flex justify-end gap-2">
 							<Button
@@ -253,7 +277,7 @@ export function ComboSlotBuilder({ combo }: ComboSlotBuilderProps) {
 								size="sm"
 								onClick={handleAddSlot}
 								disabled={
-									!newAccountId || !newModel.trim() || addSlot.isPending
+									!newAccountId || missingRequiredModel || addSlot.isPending
 								}
 							>
 								{addSlot.isPending ? "Adding..." : "Add"}

--- a/packages/dashboard-web/src/utils/provider-utils.ts
+++ b/packages/dashboard-web/src/utils/provider-utils.ts
@@ -21,6 +21,39 @@ export function providerSupportsAutoFeatures(provider: string): boolean {
 }
 
 /**
+ * Providers whose upstream answers by the SAME model ids the client asks for.
+ *
+ * This is the one and only definition of the passthrough rule. An empty model
+ * field means "forward whatever model the client sent, untouched" — which is
+ * only meaningful when the upstream natively accepts Claude model ids, i.e.
+ * Anthropic OAuth accounts and Claude Console API accounts.
+ *
+ * On every other provider the Claude id sent by the client lands on a foreign
+ * catalog and gets coerced by an embedded default map. That is the exact path
+ * that produced `400 The 'gpt-5.3-codex' model is not supported...` on a codex
+ * account. So outside this list, choosing a model is mandatory.
+ *
+ * Never compare `provider === "anthropic"` at a call site: use the helper
+ * below, so the criterion stays in a single place.
+ */
+export const PASSTHROUGH_PROVIDERS: readonly string[] = [
+	PROVIDER_NAMES.ANTHROPIC,
+	PROVIDER_NAMES.CLAUDE_CONSOLE_API,
+];
+
+/**
+ * True when the model field may be left empty (passthrough) for this provider.
+ *
+ * An absent/unknown provider (no account picked yet) is NOT passthrough: we
+ * cannot promise a behaviour we do not know the upstream supports.
+ */
+export function providerAllowsClientModelPassthrough(
+	provider?: string | null,
+): boolean {
+	return PASSTHROUGH_PROVIDERS.includes((provider ?? "").trim());
+}
+
+/**
  * Check if a provider supports custom billing type configuration
  * (anthropic-compatible and openai-compatible providers)
  */

--- a/packages/http-api/src/handlers/__tests__/combo-slot-model-required.test.ts
+++ b/packages/http-api/src/handlers/__tests__/combo-slot-model-required.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "bun:test";
+import { createSlotAddHandler, createSlotUpdateHandler } from "../combos";
+
+/**
+ * Passthrough (a combo slot with an empty model) forwards the model the CLIENT
+ * asked for. That only works where the upstream accepts Claude model ids —
+ * Anthropic accounts. On a codex account the Claude name falls through to the
+ * provider's built-in default map, which is the path that produced
+ * `400 The 'gpt-5.3-codex' model is not supported when using Codex with a
+ * ChatGPT account`.
+ */
+
+type Slot = {
+	id: string;
+	combo_id: string;
+	account_id: string;
+	model: string;
+	priority: number;
+	enabled: boolean;
+};
+
+function makeDbOps(provider: string, slots: Slot[] = []) {
+	const added: Array<{ accountId: string; model: string }> = [];
+	const updated: Array<Record<string, unknown>> = [];
+	return {
+		added,
+		updated,
+		ops: {
+			getCombo: async () => ({ id: "combo-1", name: "C", enabled: true }),
+			getAccount: async (id: string) => ({ id, name: "acc", provider }),
+			getComboSlots: async () => slots,
+			addComboSlot: async (
+				_comboId: string,
+				accountId: string,
+				model: string,
+			) => {
+				added.push({ accountId, model });
+				return { id: "slot-new", model };
+			},
+			updateComboSlot: async (_id: string, fields: Record<string, unknown>) => {
+				updated.push(fields);
+				return { id: "slot-1", ...fields };
+			},
+		},
+	};
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: minimal DatabaseOperations mock
+const asOps = (o: unknown) => o as any;
+
+function postSlot(body: unknown) {
+	return new Request("http://local/api/combos/combo-1/slots", {
+		method: "POST",
+		body: JSON.stringify(body),
+	});
+}
+
+describe("combo slot: model required depending on the provider", () => {
+	it("accepts a slot with no model on an anthropic account (passthrough)", async () => {
+		const db = makeDbOps("anthropic");
+		const res = await createSlotAddHandler(asOps(db.ops))(
+			postSlot({ account_id: "acc-1" }),
+			"combo-1",
+		);
+
+		expect(res.status).toBe(201);
+		expect(db.added).toEqual([{ accountId: "acc-1", model: "" }]);
+	});
+
+	it("rejects a slot with no model on a codex account", async () => {
+		const db = makeDbOps("codex");
+		const res = await createSlotAddHandler(asOps(db.ops))(
+			postSlot({ account_id: "acc-1" }),
+			"combo-1",
+		);
+
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as { error?: string };
+		expect(String(body.error)).toContain("codex");
+		// Nothing was written: the refusal happens before the insert.
+		expect(db.added).toHaveLength(0);
+	});
+
+	it("accepts a slot WITH a model on a codex account", async () => {
+		const db = makeDbOps("codex");
+		const res = await createSlotAddHandler(asOps(db.ops))(
+			postSlot({ account_id: "acc-1", model: "gpt-5.6-sol" }),
+			"combo-1",
+		);
+
+		expect(res.status).toBe(201);
+		expect(db.added).toEqual([{ accountId: "acc-1", model: "gpt-5.6-sol" }]);
+	});
+
+	// Without the same rule on the update route the validation is bypassable in
+	// two steps: create the slot with a model, then empty it.
+	it("rejects emptying the model of an existing codex slot", async () => {
+		const slots: Slot[] = [
+			{
+				id: "slot-1",
+				combo_id: "combo-1",
+				account_id: "acc-1",
+				model: "gpt-5.6-sol",
+				priority: 0,
+				enabled: true,
+			},
+		];
+		const db = makeDbOps("codex", slots);
+		const res = await createSlotUpdateHandler(asOps(db.ops))(
+			new Request("http://local/api/combos/combo-1/slots/slot-1", {
+				method: "PUT",
+				body: JSON.stringify({ model: "" }),
+			}),
+			"combo-1",
+			"slot-1",
+		);
+
+		expect(res.status).toBe(400);
+		expect(db.updated).toHaveLength(0);
+	});
+
+	// Regression for the cross-combo bypass: updateComboSlot resolves the slot
+	// globally, so a slot id addressed through a combo that does not own it used
+	// to skip the provider check entirely and still be updated.
+	it("rejects emptying a slot addressed through a combo that does not own it", async () => {
+		// The combo in the path owns no slots, so the lookup finds nothing.
+		const db = makeDbOps("codex", []);
+		const res = await createSlotUpdateHandler(asOps(db.ops))(
+			new Request("http://local/api/combos/other-combo/slots/slot-1", {
+				method: "PUT",
+				body: JSON.stringify({ model: "" }),
+			}),
+			"other-combo",
+			"slot-1",
+		);
+
+		expect(res.status).toBe(404);
+		expect(db.updated).toHaveLength(0);
+	});
+
+	it("allows emptying the model of an anthropic slot", async () => {
+		const slots: Slot[] = [
+			{
+				id: "slot-1",
+				combo_id: "combo-1",
+				account_id: "acc-1",
+				model: "claude-opus-5",
+				priority: 0,
+				enabled: true,
+			},
+		];
+		const db = makeDbOps("anthropic", slots);
+		const res = await createSlotUpdateHandler(asOps(db.ops))(
+			new Request("http://local/api/combos/combo-1/slots/slot-1", {
+				method: "PUT",
+				body: JSON.stringify({ model: "" }),
+			}),
+			"combo-1",
+			"slot-1",
+		);
+
+		expect(res.status).toBe(200);
+		expect(db.updated).toEqual([{ model: "" }]);
+	});
+});

--- a/packages/http-api/src/handlers/combos.ts
+++ b/packages/http-api/src/handlers/combos.ts
@@ -8,6 +8,24 @@ import type {
 import { errorResponse } from "../utils/http-error";
 
 /**
+ * Providers whose upstream natively accepts Claude model ids. Only for these
+ * does a slot without a model (passthrough) make sense: the model the client
+ * asked for arrives intact and is understood on the other side.
+ *
+ * On any other provider, passthrough would hand a Claude name to an upstream
+ * that does not know it, and translation would fall to the embedded default
+ * map — the path that produced `400 gpt-5.3-codex ... ChatGPT account`.
+ */
+const PROVIDERS_ACCEPTING_CLIENT_MODEL = new Set([
+	"anthropic",
+	"claude-console-api",
+]);
+
+function allowsClientModel(provider: string | null | undefined): boolean {
+	return PROVIDERS_ACCEPTING_CLIENT_MODEL.has(provider ?? "anthropic");
+}
+
+/**
  * GET /api/combos — List all combos with slot counts (lightweight)
  */
 export function createCombosListHandler(dbOps: DatabaseOperations) {
@@ -198,11 +216,31 @@ export function createSlotAddHandler(dbOps: DatabaseOperations) {
 				typeof account_id !== "string" ||
 				account_id.trim().length === 0
 			) {
-				return errorResponse(BadRequest("account_id and model are required"));
+				return errorResponse(BadRequest("account_id is required"));
 			}
 
-			if (!model || typeof model !== "string" || model.trim().length === 0) {
-				return errorResponse(BadRequest("account_id and model are required"));
+			// `model` is optional: a slot with no model means passthrough — the
+			// model the client asked for goes upstream untouched. We store an
+			// empty string (not NULL) because combo_slots.model is NOT NULL and the
+			// unique index (combo_id, account_id, model) only blocks duplicates with "".
+			if (model !== undefined && model !== null && typeof model !== "string") {
+				return errorResponse(
+					BadRequest("model must be a string when provided"),
+				);
+			}
+			const slotModel = typeof model === "string" ? model.trim() : "";
+
+			// Passthrough only holds where the upstream speaks the same model
+			// namespace as the client. See PROVIDERS_ACCEPTING_CLIENT_MODEL.
+			if (slotModel.length === 0) {
+				const account = await dbOps.getAccount(account_id);
+				if (account && !allowsClientModel(account.provider)) {
+					return errorResponse(
+						BadRequest(
+							`model is required for provider "${account.provider}": only accounts that serve Claude model ids can forward the client model unchanged`,
+						),
+					);
+				}
 			}
 
 			const existingSlots = await dbOps.getComboSlots(comboId);
@@ -210,7 +248,7 @@ export function createSlotAddHandler(dbOps: DatabaseOperations) {
 			const newSlot = await dbOps.addComboSlot(
 				comboId,
 				account_id,
-				model.trim(),
+				slotModel,
 				nextPriority,
 			);
 
@@ -243,10 +281,35 @@ export function createSlotUpdateHandler(dbOps: DatabaseOperations) {
 			}> = {};
 
 			if (model !== undefined) {
-				if (typeof model !== "string" || model.trim().length === 0) {
-					return errorResponse(BadRequest("model must be a non-empty string"));
+				// An empty string clears the override and makes the slot passthrough.
+				if (typeof model !== "string") {
+					return errorResponse(BadRequest("model must be a string"));
 				}
 				fields.model = model.trim();
+
+				// Same rule as the POST, now for whoever clears a slot that already
+				// exists: without it, the validation could be bypassed in two steps.
+				if (fields.model.length === 0) {
+					const slots = await dbOps.getComboSlots(_comboId);
+					const slot = slots.find((s) => s.id === slotId);
+					// A slot id that this combo does not own must not silently skip
+					// the check: updateComboSlot resolves the slot globally, so a
+					// mismatched combo id in the path would let an incompatible slot
+					// become passthrough.
+					if (!slot) {
+						return errorResponse(NotFound("Combo slot not found"));
+					}
+					{
+						const account = await dbOps.getAccount(slot.account_id);
+						if (account && !allowsClientModel(account.provider)) {
+							return errorResponse(
+								BadRequest(
+									`model is required for provider "${account.provider}": only accounts that serve Claude model ids can forward the client model unchanged`,
+								),
+							);
+						}
+					}
+				}
 			}
 
 			if (enabled !== undefined) {

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -2289,6 +2289,28 @@ describe("CodexProvider.transformRequestBody", () => {
 		expect(body.model).toBe("gpt-5.3-codex");
 	});
 
+	// Regression: the fable entry alone is not enough for codex. mapModel
+	// resolves by substring and had no fable branch, so the map entry would
+	// never be looked up and the Claude model id would reach the upstream
+	// verbatim.
+	it("maps fable-family models to the codex default", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-fable-5",
+				max_tokens: 10,
+				messages: [{ role: "user", content: "hello" }],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request, undefined);
+		const body = await transformed.json();
+
+		expect(body.model).toBe("gpt-5.3-codex");
+	});
+
 	it("uses account sonnet mapping for sonnet-family models", async () => {
 		const provider = new CodexProvider();
 		const account = {

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -99,6 +99,7 @@ const CODEX_ERROR_TYPE_BY_CODE: Record<string, string> = {
 
 // Default model mapping: Anthropic model name prefixes → Codex model names
 const DEFAULT_MODEL_MAP: Record<string, string> = {
+	fable: "gpt-5.3-codex",
 	opus: "gpt-5.3-codex",
 	sonnet: "gpt-5.3-codex",
 	haiku: "gpt-5.4-mini",
@@ -691,6 +692,7 @@ export class CodexProvider extends BaseProvider {
 		}
 
 		const lower = anthropicModel.toLowerCase();
+		if (lower.includes("fable")) return DEFAULT_MODEL_MAP.fable;
 		if (lower.includes("haiku")) return DEFAULT_MODEL_MAP.haiku;
 		if (lower.includes("sonnet")) return DEFAULT_MODEL_MAP.sonnet;
 		if (lower.includes("opus")) return DEFAULT_MODEL_MAP.opus;

--- a/packages/providers/src/providers/qwen/__tests__/provider.test.ts
+++ b/packages/providers/src/providers/qwen/__tests__/provider.test.ts
@@ -195,6 +195,7 @@ describe("QwenProvider", () => {
 			const result = provider.beforeConvert({}, account);
 			expect(result).toBeDefined();
 			const mappings = JSON.parse(result?.model_mappings as string);
+			expect(mappings.fable).toBe("coder-model");
 			expect(mappings.opus).toBe("coder-model");
 			expect(mappings.sonnet).toBe("coder-model");
 			expect(mappings.haiku).toBe("coder-model");

--- a/packages/providers/src/providers/qwen/provider.ts
+++ b/packages/providers/src/providers/qwen/provider.ts
@@ -23,6 +23,7 @@ const STAINLESS_HEADERS: Record<string, string> = {
 
 // All Anthropic model tiers map to coder-model (Qwen's unified coding model)
 const QWEN_MODEL_MAPPINGS = {
+	fable: "coder-model",
 	opus: "coder-model",
 	sonnet: "coder-model",
 	haiku: "coder-model",

--- a/packages/proxy/src/handlers/__tests__/account-selector-model-capacity.test.ts
+++ b/packages/proxy/src/handlers/__tests__/account-selector-model-capacity.test.ts
@@ -6,6 +6,7 @@ import type {
 	RequestMeta,
 } from "@better-ccflare/types";
 import {
+	getComboSlotInfo,
 	getModelFamilyExhaustionInfo,
 	selectAccountsForRequest,
 } from "../account-selector";
@@ -231,6 +232,127 @@ describe("selectAccountsForRequest — model-scoped capacity filter (combo routi
 		// Only the non-exhausted slot (acc-2) is returned; the combo pool isn't
 		// fully empty so no fallback and no exhaustion signal.
 		expect(result.map((a) => a.id)).toEqual(["acc-2"]);
+	});
+
+	// -- passthrough slots (empty slot.model) --------------------------------
+	//
+	// A passthrough slot carries no model override, so there is no slot model to
+	// scope the capacity check to. The check must fall back to the model the
+	// CLIENT asked for - that is what will actually be sent upstream on this
+	// slot. Passing the raw empty string makes getModelFamily("") return null,
+	// which turns isAccountCapacityExcluded into a silent no-op and lets a
+	// capacity-exhausted account back into rotation.
+	it("applies the capacity check to a passthrough slot using the REQUEST model", async () => {
+		const acc1 = makeAccount({ id: "acc-1" });
+		const acc2 = makeAccount({ id: "acc-2" });
+		usageCache.set(acc1.id, exhaustedUsage("Sonnet", Date.now()));
+		const combo = makeCombo([
+			{
+				id: "slot-1",
+				combo_id: "combo-1",
+				account_id: "acc-1",
+				model: "", // passthrough
+				priority: 0,
+				enabled: true,
+			},
+			{
+				id: "slot-2",
+				combo_id: "combo-1",
+				account_id: "acc-2",
+				model: "claude-sonnet-4-5",
+				priority: 1,
+				enabled: true,
+			},
+		]);
+		const ctx = makeCtx({
+			accounts: [acc1, acc2],
+			activeCombo: combo,
+			capacityRoutingMode: "exhausted",
+		});
+		const meta = makeRequestMeta();
+
+		const result = await selectAccountsForRequest(
+			meta,
+			ctx,
+			"claude-sonnet-4-5",
+		);
+
+		// Without the request-model fallback the empty slot model yields a null
+		// family, the filter no-ops, and acc-1 is returned first.
+		expect(result.map((a) => a.id)).toEqual(["acc-2"]);
+		expect(getComboSlotInfo(meta)?.slots).toEqual([
+			{ accountId: "acc-2", modelOverride: "claude-sonnet-4-5" },
+		]);
+	});
+
+	it("keeps a passthrough slot whose account still has capacity for the request model", async () => {
+		const acc = makeAccount({ id: "acc-healthy" });
+		// Exhausted for a DIFFERENT family than the request - must not exclude.
+		usageCache.set(acc.id, exhaustedUsage("Opus", Date.now()));
+		const combo = makeCombo([
+			{
+				id: "slot-1",
+				combo_id: "combo-1",
+				account_id: "acc-healthy",
+				model: "", // passthrough
+				priority: 0,
+				enabled: true,
+			},
+		]);
+		const ctx = makeCtx({
+			accounts: [acc],
+			activeCombo: combo,
+			capacityRoutingMode: "exhausted",
+		});
+		const meta = makeRequestMeta();
+
+		const result = await selectAccountsForRequest(
+			meta,
+			ctx,
+			"claude-sonnet-4-5",
+		);
+
+		expect(result.map((a) => a.id)).toEqual(["acc-healthy"]);
+		expect(getComboSlotInfo(meta)?.slots).toEqual([
+			{ accountId: "acc-healthy", modelOverride: "" },
+		]);
+	});
+
+	// -- non-regression: a populated slot model still wins --------------------
+	//
+	// The request-model fallback is a `||`, so it must only fire for an EMPTY
+	// slot model. When the slot carries its own model, the capacity check stays
+	// scoped to that model.
+	it("still scopes the capacity check to the slot's own model when it diverges from the request model", async () => {
+		const acc = makeAccount({ id: "acc-slot-model" });
+		usageCache.set(acc.id, exhaustedUsage("Sonnet", Date.now()));
+		const combo = makeCombo([
+			{
+				id: "slot-1",
+				combo_id: "combo-1",
+				account_id: "acc-slot-model",
+				model: "claude-opus-4-5",
+				priority: 0,
+				enabled: true,
+			},
+		]);
+		const ctx = makeCtx({
+			accounts: [acc],
+			activeCombo: combo,
+			capacityRoutingMode: "exhausted",
+		});
+		const meta = makeRequestMeta();
+
+		const result = await selectAccountsForRequest(
+			meta,
+			ctx,
+			"claude-sonnet-4-5",
+		);
+
+		expect(result.map((a) => a.id)).toEqual(["acc-slot-model"]);
+		expect(getComboSlotInfo(meta)?.slots).toEqual([
+			{ accountId: "acc-slot-model", modelOverride: "claude-opus-4-5" },
+		]);
 	});
 
 	it("falls back to SessionStrategy when every combo slot is exhausted", async () => {

--- a/packages/proxy/src/handlers/__tests__/account-selector.test.ts
+++ b/packages/proxy/src/handlers/__tests__/account-selector.test.ts
@@ -267,6 +267,43 @@ describe("selectAccountsForRequest — combo routing", () => {
 		expect(slotInfo?.slots[0]?.modelOverride).toBe("claude-opus-4-5");
 	});
 
+	// An empty slot model means passthrough: the client's requested model is
+	// sent upstream untouched. The slot still routes to its account - only the
+	// override is absent. Downstream (proxy-operations.ts) guards with
+	// `if (modelOverride && ...)`, so an empty string already means "do not
+	// overwrite the model"; this test pins that the selector propagates it
+	// verbatim instead of substituting the request model.
+	it("propagates an empty slot model as an empty modelOverride (passthrough slot)", async () => {
+		const acc = makeAccount({ id: "acc-passthrough" });
+		const combo = makeCombo([
+			{
+				id: "slot-1",
+				combo_id: "combo-1",
+				account_id: "acc-passthrough",
+				model: "", // passthrough - no model override
+				priority: 0,
+				enabled: true,
+			},
+		]);
+
+		const ctx = makeCtx({ accounts: [acc], activeCombo: combo });
+		const meta = makeRequestMeta();
+
+		const result = await selectAccountsForRequest(
+			meta,
+			ctx,
+			"claude-sonnet-4-5",
+		);
+
+		expect(result.map((a) => a.id)).toEqual(["acc-passthrough"]);
+		const slotInfo = getComboSlotInfo(meta);
+		expect(slotInfo?.comboName).toBe("Test Combo");
+		expect(slotInfo?.slots).toEqual([
+			{ accountId: "acc-passthrough", modelOverride: "" },
+		]);
+		expect(meta.comboName).toBe("Test Combo");
+	});
+
 	it("sets meta.comboName when combo routing is active", async () => {
 		const acc = makeAccount({ id: "acc-1" });
 		const combo = makeCombo([

--- a/packages/proxy/src/handlers/account-selector.ts
+++ b/packages/proxy/src/handlers/account-selector.ts
@@ -400,9 +400,20 @@ export async function selectAccountsForRequest(
 				const combo = await ctx.dbOps.getActiveComboForFamily(
 					family as ComboFamily,
 				);
-				if (combo) {
+				if (!combo) {
+					// Without this line the detour is silent: a family with no active
+					// combo falls into normal pool routing and can be served by any
+					// provider, with nothing in the log to say so.
 					log.info(
-						`Combo routing active: ${combo.name} for family ${family} (${combo.slots.length} slots)`,
+						`No active combo for family ${family} - falling back to normal routing`,
+					);
+				}
+				if (combo) {
+					const passthroughSlots = combo.slots.filter(
+						(s) => !s.model || s.model.trim().length === 0,
+					).length;
+					log.info(
+						`Combo routing active: ${combo.name} for family ${family} (${combo.slots.length} slots, ${passthroughSlots} passthrough)`,
 					);
 
 					const allAccounts = await ctx.dbOps.getAllAccounts();
@@ -446,8 +457,15 @@ export async function selectAccountsForRequest(
 						// distinct concrete models within the same family.
 						if (
 							capacityRoutingEnabled &&
-							isAccountCapacityExcluded(account, slot.model, capacityNow)
-								.excluded
+							isAccountCapacityExcluded(
+								account,
+								// Passthrough slots (empty model) carry no model of their
+								// own: fall back to the request's model, otherwise
+								// getModelFamily("") returns null and this filter would
+								// silently no-op for those slots.
+								slot.model || model,
+								capacityNow,
+							).excluded
 						) {
 							continue;
 						}


### PR DESCRIPTION
## What

A combo slot may now be saved with an **empty model**, meaning "do not override". The combo becomes a pure account filter and the model the client asked for reaches the upstream untouched.

> **Stacked on #394.** This branch builds on it, so the diff below includes that commit until it merges. Review only `feat(proxy): allow a combo slot to forward the client's own model`.

## Why

The slot's model rewrites the request body, so combo routing was all-or-nothing: enable it and every request in the family is pinned to one model id (`claude-opus-5[1m]` became `claude-opus-5`), disable it and nothing binds the family to a set of accounts — which is how an Opus request ended up on a `codex` account in #393.

## How

**Empty string as the sentinel, not `NULL`.** `combo_slots.model` is `NOT NULL`, SQLite cannot relax that without rebuilding the table, and `UNIQUE(combo_id, account_id, model)` stops barring duplicates under `NULL`. **No migration.** The consumer already guards with `if (modelOverride && ...)`, so an empty value already meant "leave it alone" — the data is also readable by an older build, which keeps rollback cheap.

**Two things ship with it, because the feature is unsafe alone:**

1. *Answering the triage note on #393 directly* — an empty model is only accepted for providers that serve Claude model ids (`PROVIDERS_ACCEPTING_CLIENT_MODEL`). Anywhere else, passthrough would hand a Claude id to an upstream that does not know it, which is the exact failure this change exists to avoid. Validated on **both** the create and the update route: validating only the create is bypassable in two steps (create with a model, then empty it). There is a test for that bypass.
2. The per-slot capacity filter used `slot.model`. With an empty model, `getModelFamily("")` returns `null` and the filter silently no-ops — it now falls back to the request's model. This one is easy to miss in review and has a dedicated test.

**Logging.** The "no active combo for this family" path was completely silent, which is what made the original misroute expensive to diagnose; it now says so, and the combo line reports how many slots are passthrough.

**UI.** The model field is optional only where passthrough applies; elsewhere the label drops "(optional)", the Add button is blocked and the reason is visible. The rule is derived on every render, so changing the account after typing cannot leave an invalid slot behind.

## Testing

- 4 new cases in the existing `account-selector` suites, 5 in a new `combo-slot-model-required` suite.
- Baseline comparison on a clean checkout of `main`: 666 pass / 89 fail before, 671 pass / 89 fail after — same failures, all pre-existing in that environment, plus the 5 new tests.
- `bunx tsc --noEmit` clean.

Part of #393.
