### PR TITLE
feat(http-api): per-session serving-account endpoint for status-line integrations

### DIFF
--- a/packages/http-api/src/__tests__/router-session-account.test.ts
+++ b/packages/http-api/src/__tests__/router-session-account.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Router-level tests for GET /api/sessions/:sessionId/account (#318).
+ *
+ * These cover behavior that lives in router.ts's dynamic dispatch itself
+ * (not the handler): the percent-encoding decode guard, and that a
+ * structurally-empty session segment reaches the handler as a clean 400
+ * rather than falling through to the generic 404.
+ *
+ * Auth exemption for this path is covered separately in
+ * services/__tests__/auth-service-session-account-exemption.test.ts; here
+ * auth is left disabled (no API keys in the stub dbOps) so these tests stay
+ * focused on routing/decode mechanics.
+ */
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import "@better-ccflare/core";
+import type { Config } from "@better-ccflare/config";
+import {
+	BunSqlAdapter,
+	type DatabaseOperations,
+	ensureSchema,
+	runMigrations,
+} from "@better-ccflare/database";
+import { APIRouter } from "../router";
+import type { APIContext } from "../types";
+
+function makeDb(): Database {
+	const db = new Database(":memory:");
+	ensureSchema(db);
+	runMigrations(db);
+	return db;
+}
+
+describe("APIRouter — GET /api/sessions/:sessionId/account (#318)", () => {
+	let db: Database;
+	let router: APIRouter;
+
+	beforeEach(() => {
+		db = makeDb();
+		const adapter = new BunSqlAdapter(db);
+		const dbOps = {
+			getAdapter: () => adapter,
+			// No active API keys → auth disabled, isolating these tests to
+			// routing/decode-guard behavior.
+			countActiveApiKeys: async () => 0,
+			getActiveApiKeys: async () => [],
+			// createAccountsListHandler (called via the session-account route)
+			// also reads session-window token stats — none in these fixtures.
+			getStatsRepository: () => ({
+				getSessionStats: async () => new Map(),
+			}),
+		} as unknown as DatabaseOperations;
+		const config = {
+			getUsageThrottlingFiveHourEnabled: () => false,
+			getUsageThrottlingWeeklyEnabled: () => false,
+		} as unknown as Config;
+		const alertService = {
+			listAlerts: async () => [],
+			getUnacknowledgedCount: async () => 0,
+			acknowledgeAlert: async () => true,
+			acknowledgeAll: async () => {},
+		};
+		const context = {
+			db: adapter,
+			config,
+			dbOps,
+			alertService,
+		} as unknown as APIContext;
+		router = new APIRouter(context);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("returns a clean 400 for malformed percent-encoding in the session segment", async () => {
+		const url = new URL("http://localhost/api/sessions/%/account");
+		const req = new Request(url);
+		const res = await router.handleRequest(url, req);
+		expect(res).not.toBeNull();
+		expect(res?.status).toBe(400);
+	});
+
+	it("returns a clean 400 for an empty session segment rather than a 404", async () => {
+		const url = new URL("http://localhost/api/sessions//account");
+		const req = new Request(url);
+		const res = await router.handleRequest(url, req);
+		expect(res).not.toBeNull();
+		expect(res?.status).toBe(400);
+	});
+
+	it("resolves a known session end-to-end through the router", async () => {
+		db.run(
+			"INSERT INTO accounts (id, name, provider, created_at) VALUES (?, ?, ?, ?)",
+			["acc-1", "Account One", "anthropic", Date.now()],
+		);
+		db.run(
+			"INSERT INTO requests (id, timestamp, method, path, account_used, client_session_id) VALUES (?, ?, ?, ?, ?, ?)",
+			["r1", 1000, "POST", "/v1/messages", "acc-1", "session-abc"],
+		);
+
+		const url = new URL("http://localhost/api/sessions/session-abc/account");
+		const req = new Request(url);
+		const res = await router.handleRequest(url, req);
+		expect(res?.status).toBe(200);
+		const body = (await res?.json()) as {
+			status: string;
+			account?: { id: string };
+		};
+		expect(body.status).toBe("known");
+		expect(body.account?.id).toBe("acc-1");
+	});
+
+	it("does not match a POST to the same path (falls through to 404)", async () => {
+		const url = new URL("http://localhost/api/sessions/session-abc/account");
+		const req = new Request(url, { method: "POST" });
+		const res = await router.handleRequest(url, req);
+		expect(res).toBeNull();
+	});
+});

--- a/packages/http-api/src/handlers/__tests__/sessions.test.ts
+++ b/packages/http-api/src/handlers/__tests__/sessions.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Tests for GET /api/sessions/:sessionId/account — issue #318, reduced scope
+ * per the maintainer's comment: a DB-backed lookup (session → last-serving
+ * account from `requests`) only, no live in-memory strategy path.
+ *
+ * The handler resolves the most recent `requests` row carrying the given
+ * `client_session_id` with a non-null `account_used`, then reuses
+ * `createAccountsListHandler` (the exact handler backing GET /api/accounts)
+ * to serialize the account — so the returned `account` is byte-for-byte what
+ * /api/accounts would return for that id, not a parallel serialization.
+ */
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+// Side-effect import: load @better-ccflare/core before @better-ccflare/types
+// (types/agent.ts runtime-imports core while core/strategy.ts imports types —
+// a pre-existing cycle that crashes when types is evaluated first). Mirrors
+// packages/database/src/repositories/__tests__/stats-no-account-binding.test.ts.
+import "@better-ccflare/core";
+import type { Config } from "@better-ccflare/config";
+import {
+	BunSqlAdapter,
+	type DatabaseOperations,
+	ensureSchema,
+	runMigrations,
+} from "@better-ccflare/database";
+import { createAccountsListHandler } from "../accounts";
+import { createSessionAccountHandler } from "../sessions";
+
+function makeDb(): Database {
+	const db = new Database(":memory:");
+	ensureSchema(db);
+	runMigrations(db);
+	return db;
+}
+
+function insertAccount(
+	db: Database,
+	row: { id: string; name: string; provider?: string },
+) {
+	db.run(
+		"INSERT INTO accounts (id, name, provider, created_at) VALUES (?, ?, ?, ?)",
+		[row.id, row.name, row.provider ?? "anthropic", Date.now()],
+	);
+}
+
+function insertRequest(
+	db: Database,
+	row: {
+		id: string;
+		timestamp: number;
+		accountUsed: string | null;
+		clientSessionId: string | null;
+	},
+) {
+	db.run(
+		"INSERT INTO requests (id, timestamp, method, path, account_used, client_session_id) VALUES (?, ?, ?, ?, ?, ?)",
+		[
+			row.id,
+			row.timestamp,
+			"POST",
+			"/v1/messages",
+			row.accountUsed,
+			row.clientSessionId,
+		],
+	);
+}
+
+/** Minimal Config stub — createAccountsListHandler only calls these two
+ * methods (usage-throttle display flags), confirmed by reading its body. */
+function makeConfig(): Config {
+	return {
+		getUsageThrottlingFiveHourEnabled: () => false,
+		getUsageThrottlingWeeklyEnabled: () => false,
+	} as unknown as Config;
+}
+
+describe("createSessionAccountHandler", () => {
+	let db: Database;
+	let adapter: BunSqlAdapter;
+	let dbOps: DatabaseOperations;
+	let accountsHandler: () => Promise<Response>;
+
+	beforeEach(() => {
+		db = makeDb();
+		adapter = new BunSqlAdapter(db);
+		// createAccountsListHandler uses dbOps.getAdapter() plus
+		// dbOps.getStatsRepository().getSessionStats() (session-window token
+		// stats for providers with session-based limits — none in these
+		// fixtures, so an empty Map is a faithful stub) — confirmed by reading
+		// the handler body. A minimal stub is enough to genuinely exercise the
+		// real serialization logic.
+		dbOps = {
+			getAdapter: () => adapter,
+			getStatsRepository: () => ({
+				getSessionStats: async () => new Map(),
+			}),
+		} as unknown as DatabaseOperations;
+		accountsHandler = createAccountsListHandler(dbOps, makeConfig());
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("resolves the most recent serving account for a known session", async () => {
+		insertAccount(db, { id: "acc-1", name: "Account One" });
+		insertRequest(db, {
+			id: "r1",
+			timestamp: 1000,
+			accountUsed: "acc-1",
+			clientSessionId: "session-abc",
+		});
+
+		const handler = createSessionAccountHandler(adapter, accountsHandler);
+		const res = await handler("session-abc");
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			status: string;
+			account?: { id: string; name: string };
+		};
+		expect(body.status).toBe("known");
+		expect(body.account?.id).toBe("acc-1");
+		expect(body.account?.name).toBe("Account One");
+	});
+
+	it("returns the exact same account shape /api/accounts returns", async () => {
+		insertAccount(db, { id: "acc-1", name: "Account One" });
+		insertRequest(db, {
+			id: "r1",
+			timestamp: 1000,
+			accountUsed: "acc-1",
+			clientSessionId: "session-abc",
+		});
+
+		const listRes = await accountsHandler();
+		const list = (await listRes.json()) as Array<Record<string, unknown>>;
+		const expected = list.find((a) => a.id === "acc-1");
+
+		const handler = createSessionAccountHandler(adapter, accountsHandler);
+		const res = await handler("session-abc");
+		const body = (await res.json()) as { account?: Record<string, unknown> };
+
+		expect(body.account).toEqual(expected);
+	});
+
+	it("resolves to the account from the most recent request row (most-recent-row-wins)", async () => {
+		insertAccount(db, { id: "acc-old", name: "Old Account" });
+		insertAccount(db, { id: "acc-new", name: "New Account" });
+		insertRequest(db, {
+			id: "r1",
+			timestamp: 1000,
+			accountUsed: "acc-old",
+			clientSessionId: "session-abc",
+		});
+		insertRequest(db, {
+			id: "r2",
+			timestamp: 2000,
+			accountUsed: "acc-new",
+			clientSessionId: "session-abc",
+		});
+
+		const handler = createSessionAccountHandler(adapter, accountsHandler);
+		const res = await handler("session-abc");
+		const body = (await res.json()) as { account?: { id: string } };
+		expect(body.account?.id).toBe("acc-new");
+	});
+
+	it("returns unknown for a session that was never recorded", async () => {
+		const handler = createSessionAccountHandler(adapter, accountsHandler);
+		const res = await handler("never-seen-session");
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body).toEqual({ status: "unknown" });
+	});
+
+	it("returns unknown when the serving account has since been removed", async () => {
+		insertRequest(db, {
+			id: "r1",
+			timestamp: 1000,
+			accountUsed: "acc-deleted",
+			clientSessionId: "session-abc",
+		});
+		// No matching row in `accounts` — account was removed after serving.
+
+		const handler = createSessionAccountHandler(adapter, accountsHandler);
+		const res = await handler("session-abc");
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body).toEqual({ status: "unknown" });
+	});
+
+	it("returns unknown when the only recorded request has a null account_used", async () => {
+		insertRequest(db, {
+			id: "r1",
+			timestamp: 1000,
+			accountUsed: null,
+			clientSessionId: "session-abc",
+		});
+
+		const handler = createSessionAccountHandler(adapter, accountsHandler);
+		const res = await handler("session-abc");
+		const body = await res.json();
+		expect(body).toEqual({ status: "unknown" });
+	});
+
+	it("returns 400 for an empty session id", async () => {
+		const handler = createSessionAccountHandler(adapter, accountsHandler);
+		const res = await handler("");
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBeTruthy();
+	});
+
+	it("returns 400 for a whitespace-only session id", async () => {
+		const handler = createSessionAccountHandler(adapter, accountsHandler);
+		const res = await handler("   ");
+		expect(res.status).toBe(400);
+	});
+
+	it("bounds an oversized session id the same way the write path does (200 chars)", async () => {
+		// Mirrors CLIENT_SESSION_ID_MAX_LEN / sanitizeClientSessionId in
+		// packages/database/src/repositories/request.repository.ts: the write
+		// path truncates to 200 chars before persisting, so a >200-char id
+		// stored as its first-200-chars prefix.
+		const longId = "s".repeat(250);
+		const truncated = longId.slice(0, 200);
+		insertAccount(db, { id: "acc-1", name: "Account One" });
+		insertRequest(db, {
+			id: "r1",
+			timestamp: 1000,
+			accountUsed: "acc-1",
+			clientSessionId: truncated,
+		});
+
+		const handler = createSessionAccountHandler(adapter, accountsHandler);
+		// Query with the full (untruncated) 250-char id, as a caller who saw
+		// the original long id might.
+		const res = await handler(longId);
+		const body = (await res.json()) as {
+			status: string;
+			account?: { id: string };
+		};
+		expect(body.status).toBe("known");
+		expect(body.account?.id).toBe("acc-1");
+	});
+});

--- a/packages/http-api/src/handlers/__tests__/sessions.test.ts
+++ b/packages/http-api/src/handlers/__tests__/sessions.test.ts
@@ -143,6 +143,35 @@ describe("createSessionAccountHandler", () => {
 		expect(body.account).toEqual(expected);
 	});
 
+	it("breaks a millisecond timestamp tie by insertion order (rowid), not arbitrarily", async () => {
+		insertAccount(db, { id: "acc-first", name: "First Account" });
+		insertAccount(db, { id: "acc-second", name: "Second Account" });
+		// Two requests in the SAME millisecond: ORDER BY timestamp alone leaves
+		// the rows tied and SQLite may return either. The `rowid DESC`
+		// tiebreaker pins the later-inserted (= later-served) row.
+		insertRequest(db, {
+			id: "r-tie-1",
+			timestamp: 5000,
+			accountUsed: "acc-first",
+			clientSessionId: "session-tie",
+		});
+		insertRequest(db, {
+			id: "r-tie-2",
+			timestamp: 5000,
+			accountUsed: "acc-second",
+			clientSessionId: "session-tie",
+		});
+
+		const handler = createSessionAccountHandler(adapter, accountsHandler);
+		const res = await handler("session-tie");
+		const body = (await res.json()) as {
+			status: string;
+			account?: { id: string };
+		};
+		expect(body.status).toBe("known");
+		expect(body.account?.id).toBe("acc-second");
+	});
+
 	it("resolves to the account from the most recent request row (most-recent-row-wins)", async () => {
 		insertAccount(db, { id: "acc-old", name: "Old Account" });
 		insertAccount(db, { id: "acc-new", name: "New Account" });

--- a/packages/http-api/src/handlers/sessions.ts
+++ b/packages/http-api/src/handlers/sessions.ts
@@ -74,7 +74,7 @@ export function createSessionAccountHandler(
 			`SELECT account_used
 			 FROM requests
 			 WHERE client_session_id = ? AND account_used IS NOT NULL
-			 ORDER BY timestamp DESC
+			 ORDER BY timestamp DESC, rowid DESC
 			 LIMIT 1`,
 			[sanitized],
 		);

--- a/packages/http-api/src/handlers/sessions.ts
+++ b/packages/http-api/src/handlers/sessions.ts
@@ -1,0 +1,99 @@
+import type { BunSqlAdapter } from "@better-ccflare/database";
+import {
+	BadRequest,
+	errorResponse,
+	jsonResponse,
+} from "@better-ccflare/http-common";
+import type { AccountResponse } from "../types";
+
+/**
+ * Upper bound + sanitation applied to the incoming session id path segment,
+ * mirroring `sanitizeClientSessionId` / `CLIENT_SESSION_ID_MAX_LEN` in
+ * packages/database/src/repositories/request.repository.ts — the write path
+ * for the `requests.client_session_id` column this endpoint reads back.
+ * Applying the same bound here means a hostile or buggy caller can't drive
+ * an unbounded lookup key, and applying the same character-stripping means a
+ * legitimately-stored id (already stripped on write) can still be found.
+ */
+const CLIENT_SESSION_ID_MAX_LEN = 200;
+
+function sanitizeSessionId(raw: string): string | null {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping them is the point
+	const cleaned = raw.replace(/[\x00-\x1F\x7F]/g, "").trim();
+	if (!cleaned) return null;
+	return cleaned.length > CLIENT_SESSION_ID_MAX_LEN
+		? cleaned.slice(0, CLIENT_SESSION_ID_MAX_LEN)
+		: cleaned;
+}
+
+/**
+ * Flat, single-shape payload for GET /api/sessions/:sessionId/account:
+ * `status` is always present; `account` only when `status === "known"`. No
+ * separate "not found" shape — callers always get one of these two.
+ */
+interface SessionAccountData {
+	status: "known" | "unknown";
+	account?: AccountResponse;
+}
+
+function unknownResponse(): Response {
+	return jsonResponse({ status: "unknown" } satisfies SessionAccountData);
+}
+
+/**
+ * GET /api/sessions/:sessionId/account — resolve the account that most
+ * recently served a given client session, for local status-line
+ * integrations (issue #318).
+ *
+ * Reduced-scope implementation per the maintainer's guidance on #318: a
+ * DB-backed lookup only — the most recent `requests` row for this
+ * `client_session_id` with a non-null `account_used`. The optional "live"
+ * path (reading SessionAffinityStrategy's in-memory sticky map directly)
+ * was evaluated and skipped: SessionAffinityStrategy currently exposes only
+ * an aggregate count (`affinityEntries`), not a per-client lookup, and
+ * adding one would mean widening that strategy's public surface beyond a
+ * trivial change. The DB path alone satisfies the issue; a live path is a
+ * possible follow-up.
+ *
+ * `accountsHandler` must be the SAME handler backing GET /api/accounts
+ * (`createAccountsListHandler`), so the `account` this returns is
+ * byte-for-byte what that endpoint would return for this account id — no
+ * parallel serialization to keep in sync.
+ */
+export function createSessionAccountHandler(
+	db: BunSqlAdapter,
+	accountsHandler: () => Promise<Response>,
+) {
+	return async (sessionId: string): Promise<Response> => {
+		const sanitized = sanitizeSessionId(sessionId);
+		if (!sanitized) {
+			return errorResponse(BadRequest("Session id cannot be empty"));
+		}
+
+		const rows = await db.query<{ account_used: string | null }>(
+			`SELECT account_used
+			 FROM requests
+			 WHERE client_session_id = ? AND account_used IS NOT NULL
+			 ORDER BY timestamp DESC
+			 LIMIT 1`,
+			[sanitized],
+		);
+		const accountId = rows[0]?.account_used;
+		if (!accountId) {
+			// No request ever recorded this session (or none carried an account).
+			return unknownResponse();
+		}
+
+		const accountsRes = await accountsHandler();
+		const accounts = (await accountsRes.json()) as AccountResponse[];
+		const account = accounts.find((a) => a.id === accountId);
+		if (!account) {
+			// The serving account was removed since it last served this session —
+			// resolve to unknown so the response stays single-shape.
+			return unknownResponse();
+		}
+
+		const data: SessionAccountData = { status: "known", account };
+		return jsonResponse(data);
+	};
+}

--- a/packages/http-api/src/router.ts
+++ b/packages/http-api/src/router.ts
@@ -1,5 +1,5 @@
 import { validateNumber } from "@better-ccflare/core";
-import { Unauthorized } from "@better-ccflare/errors";
+import { BadRequest, Unauthorized } from "@better-ccflare/errors";
 import {
 	createAccountAddHandler,
 	createAccountAutoFallbackHandler,
@@ -110,6 +110,7 @@ import {
 	createRequestsSummaryHandler,
 } from "./handlers/requests";
 import { createRequestsStreamHandler } from "./handlers/requests-stream";
+import { createSessionAccountHandler } from "./handlers/sessions";
 import { createStatsHandler, createStatsResetHandler } from "./handlers/stats";
 import {
 	createIntegrityCheckHandler,
@@ -912,6 +913,42 @@ export class APIRouter {
 			const sessionId = parts[5];
 			if (sessionId) {
 				return await this.wrapHandler(() => this.codexStatusHandler(sessionId))(
+					req,
+					url,
+				);
+			}
+		}
+
+		// Session→account lookup for the local status-line badge (#318).
+		// GET /api/sessions/:sessionId/account — always dispatch to the handler
+		// (even on an empty session segment) so it returns a well-formed
+		// 400/unknown rather than falling through to the generic 404.
+		if (
+			path.startsWith("/api/sessions/") &&
+			path.endsWith("/account") &&
+			method === "GET"
+		) {
+			const parts = path.split("/");
+			if (parts.length === 5) {
+				// Guard decode: this route is auth-exempt, so a malformed
+				// percent-encoding (e.g. `/api/sessions/%/account`) must return a
+				// clean 400 rather than throw a URIError outside wrapHandler's catch.
+				let sessionId: string;
+				try {
+					sessionId = decodeURIComponent(parts[3]);
+				} catch {
+					return errorResponse(BadRequest("Invalid session id encoding"));
+				}
+				const accountsListHandler = createAccountsListHandler(
+					this.context.dbOps,
+					this.context.config,
+					this.context.getStrategy,
+				);
+				const sessionAccountHandler = createSessionAccountHandler(
+					this.context.db,
+					accountsListHandler,
+				);
+				return await this.wrapHandler(() => sessionAccountHandler(sessionId))(
 					req,
 					url,
 				);

--- a/packages/http-api/src/services/__tests__/auth-service-session-account-exemption.test.ts
+++ b/packages/http-api/src/services/__tests__/auth-service-session-account-exemption.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for the GET /api/sessions/:sessionId/account auth exemption
+ * (issue #318, reduced scope). This route is a read-only, DB-backed lookup
+ * intended for local status-line integrations, so — like /health and
+ * /api/version/check — it must be reachable without an API key.
+ *
+ * The exemption is intentionally GET-only and structurally exact (5 path
+ * segments: "", "api", "sessions", <id>, "account") so it can never widen
+ * into an unauthenticated bypass for some other /api/sessions/* route that
+ * might be added later, or for a non-GET method on this same path.
+ */
+import { describe, expect, it } from "bun:test";
+import type { DatabaseOperations } from "@better-ccflare/database";
+import { AuthService } from "../auth-service";
+
+function makeDbOpsWithApiKeys(): DatabaseOperations {
+	// countActiveApiKeys() > 0 is what flips AuthService into "auth enabled" mode.
+	return {
+		countActiveApiKeys: async () => 1,
+		getActiveApiKeys: async () => [],
+	} as unknown as DatabaseOperations;
+}
+
+describe("AuthService — session-account endpoint exemption (#318)", () => {
+	describe("isStaticPathExempt", () => {
+		it("exempts GET /api/sessions/:id/account", () => {
+			const auth = new AuthService(makeDbOpsWithApiKeys());
+			expect(
+				auth.isStaticPathExempt("/api/sessions/session-abc/account", "GET"),
+			).toBe(true);
+		});
+
+		it("exempts when method is omitted (mirrors other static exemptions)", () => {
+			const auth = new AuthService(makeDbOpsWithApiKeys());
+			expect(auth.isStaticPathExempt("/api/sessions/session-abc/account")).toBe(
+				true,
+			);
+		});
+
+		it("does not exempt POST to the same path", () => {
+			const auth = new AuthService(makeDbOpsWithApiKeys());
+			expect(
+				auth.isStaticPathExempt("/api/sessions/session-abc/account", "POST"),
+			).toBe(false);
+		});
+
+		it("does not exempt a structurally different /api/sessions path", () => {
+			const auth = new AuthService(makeDbOpsWithApiKeys());
+			expect(
+				auth.isStaticPathExempt("/api/sessions/session-abc/other", "GET"),
+			).toBe(false);
+		});
+
+		it("does not exempt a shorter /api/sessions path", () => {
+			const auth = new AuthService(makeDbOpsWithApiKeys());
+			expect(auth.isStaticPathExempt("/api/sessions/account", "GET")).toBe(
+				false,
+			);
+		});
+
+		it("does not exempt a longer /api/sessions path", () => {
+			const auth = new AuthService(makeDbOpsWithApiKeys());
+			expect(
+				auth.isStaticPathExempt(
+					"/api/sessions/session-abc/account/extra",
+					"GET",
+				),
+			).toBe(false);
+		});
+	});
+
+	describe("isPathExempt / authenticateRequest end-to-end", () => {
+		it("allows an unauthenticated GET even when API-key auth is enabled", async () => {
+			const auth = new AuthService(makeDbOpsWithApiKeys());
+			const req = new Request(
+				"http://localhost/api/sessions/session-abc/account",
+			);
+			const result = await auth.authenticateRequest(
+				req,
+				"/api/sessions/session-abc/account",
+				"GET",
+			);
+			expect(result.isAuthenticated).toBe(true);
+		});
+
+		it("still requires auth for a POST to the same path", async () => {
+			const auth = new AuthService(makeDbOpsWithApiKeys());
+			const req = new Request(
+				"http://localhost/api/sessions/session-abc/account",
+				{ method: "POST" },
+			);
+			const result = await auth.authenticateRequest(
+				req,
+				"/api/sessions/session-abc/account",
+				"POST",
+			);
+			expect(result.isAuthenticated).toBe(false);
+		});
+	});
+});

--- a/packages/http-api/src/services/auth-service.ts
+++ b/packages/http-api/src/services/auth-service.ts
@@ -66,6 +66,24 @@ function isLocalControlNotifyPath(path: string): boolean {
  * dashboard fetches it and opens the EventSource in the same tick). */
 const STREAM_TOKEN_TTL_MS = 60_000;
 
+/**
+ * Exact shape of the status-line read route GET /api/sessions/:id/account
+ * (#318): five path segments, `/api/sessions/<id>/account`. Kept identical
+ * to router.ts's own dynamic-route match so this exemption never covers a
+ * path the router won't actually serve as this handler — which would
+ * otherwise open an unauthenticated bypass via fall-through to some other
+ * route (or the upstream proxy).
+ */
+function isSessionAccountPath(path: string): boolean {
+	const parts = path.split("/");
+	return (
+		parts.length === 5 &&
+		parts[1] === "api" &&
+		parts[2] === "sessions" &&
+		parts[4] === "account"
+	);
+}
+
 interface StreamTokenRecord {
 	expiresAt: number;
 	apiKeyId?: string;
@@ -299,8 +317,17 @@ export class AuthService {
 	/**
 	 * Check if a path is statically exempt from authentication
 	 * (does not require async DB check)
+	 *
+	 * `method`, when provided, additionally exempts GET
+	 * /api/sessions/:id/account (#318) — a read-only, DB-backed lookup meant
+	 * for local status-line integrations. Deliberately GET-only: without the
+	 * method check, a POST to the same path would also read as exempt, which
+	 * is unnecessary and needlessly widens the bypass. Omitting `method`
+	 * still exempts the path (matching every other static exemption below,
+	 * none of which are method-gated) — only pass `method` when you want the
+	 * narrower GET-only check.
 	 */
-	isStaticPathExempt(path: string): boolean {
+	isStaticPathExempt(path: string, method?: string): boolean {
 		// Health endpoint is always exempt
 		if (path === "/health") {
 			return true;
@@ -315,6 +342,14 @@ export class AuthService {
 		// dashboard's sidebar tile fires this on load with no API key in
 		// headers, so it must be reachable whether or not auth is enabled.
 		if (path === "/api/version/check") {
+			return true;
+		}
+
+		// Session→account lookup for the local status-line badge (#318).
+		if (
+			(method === undefined || method === "GET") &&
+			isSessionAccountPath(path)
+		) {
 			return true;
 		}
 
@@ -351,7 +386,7 @@ export class AuthService {
 		headers?: Headers,
 	): Promise<boolean> {
 		// Static exemptions first (no DB hit)
-		if (this.isStaticPathExempt(path)) {
+		if (this.isStaticPathExempt(path, method)) {
 			return true;
 		}
 


### PR DESCRIPTION
Closes #318 — the reduced-scope version per your comment there.

## What
`GET /api/sessions/:sessionId/account` → `{ status: "known", account: {…} }` or `{ status: "unknown" }` (flat, single-shape: callers never branch on an error envelope).

- **DB-backed lookup only**: most recent `requests` row for the `client_session_id` with a non-null `account_used` — riding the persistence you landed in 866282e472, exactly as you suggested. No observer, no TTL/tombstone machinery.
- **No parallel serialization**: the `account` payload is produced by the same `createAccountsListHandler` backing `GET /api/accounts`, so the shapes can never drift.
- **Input parity with the write path**: the session-id path segment gets the same 200-char bound + control-char strip as `sanitizeClientSessionId`, so a stored id always round-trips and a hostile caller can't drive an unbounded lookup key.
- **Guard rails** (route is auth-exempt): malformed percent-encoding → clean 400 (decode is guarded, no URIError escaping the handler); empty segment → 400; unknown session → 200 `{status:"unknown"}` (single-shape, not 404).
- **Auth exemption is GET-only and structurally exact** (5 segments, `/api/sessions/<id>/account`), matched to the router's own dispatch so the exemption can never cover a path served by anything else.

## Live path
Evaluated and skipped for now: `SessionAffinityStrategy` exposes only an aggregate `affinityEntries` count, no per-client accessor, and adding one widens that strategy's public surface beyond this PR's minimal footprint. The DB path satisfies the issue; the live path is a clean follow-up if you want it.

## One knob for you
The unauthenticated payload reuses the full `AccountResponse` (no token/key material — `hasRefreshToken`/`tokenStatus` booleans only), per your "reuse that" guidance. Our fork ships a slimmer projection (name/provider/paused + usage windows) on this same route; happy to cut this down to that if you'd prefer less unauthenticated surface.

## Testing
- New: `handlers/__tests__/sessions.test.ts` (9), `services/__tests__/auth-service-session-account-exemption.test.ts` (12), `__tests__/router-session-account.test.ts` — all green.
- Full `packages/http-api` suite: 500 pass / 0 fail (51 pre-existing PG-gated skips).
- `bun run lint` / `typecheck` / `format`: clean.

We run the richer ancestor of this endpoint in production for our status-line badge; this cut is rebuilt against current main rather than ported, to stay inside upstream's surfaces.