### PR TITLE
fix(types): break the types↔core module cycle via core leaf-module subpath imports

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,9 @@
 	"type": "module",
 	"main": "./src/index.ts",
 	"exports": {
-		".": "./src/index.ts"
+		".": "./src/index.ts",
+		"./model-mappings": "./src/model-mappings.ts",
+		"./models": "./src/models.ts"
 	},
 	"scripts": {
 		"typecheck": "bunx tsc --noEmit"

--- a/packages/types/src/agent.ts
+++ b/packages/types/src/agent.ts
@@ -1,4 +1,16 @@
-import { CLAUDE_MODEL_IDS, isValidClaudeModel } from "@better-ccflare/core";
+// Leaf-module subpath imports, NOT the core barrel: this file is evaluated
+// while the @better-ccflare/types barrel is still initializing, and core's
+// barrel loads core/strategy.ts, which reads StrategyName from the types
+// barrel at module scope (`Object.values(StrategyName)` and
+// `StrategyName.Session`) — an uninitialized binding at that point. Any
+// entry point that loads the types barrel before core (e.g.
+// dashboard-web's provider-utils, whose own test crashes with
+// "Object.values requires that input parameter not be null or undefined")
+// hits the cycle. Importing the two leaf modules directly keeps
+// core/strategy.ts (and the rest of core's barrel) out of the
+// types-barrel evaluation window.
+import { isValidClaudeModel } from "@better-ccflare/core/model-mappings";
+import { CLAUDE_MODEL_IDS } from "@better-ccflare/core/models";
 
 export type AgentSource = "global" | "workspace" | "plugin";
 


### PR DESCRIPTION
## The bug — reproducible on current main with your own test

```
bun test packages/dashboard-web/src/components/accounts/provider-utils.test.ts
# TypeError: Object.values requires that input parameter not be null or undefined
# 0 pass, 1 fail
```

`types/agent.ts` imports runtime values from the `@better-ccflare/core` barrel; core's barrel loads `core/strategy.ts`, which reads `StrategyName` back out of the still-initializing `@better-ccflare/types` barrel at module scope (`Object.values(StrategyName)`, `StrategyName.Session`). Whenever the types barrel is the module graph's entry point, its `./agent` line triggers the cycle before `./strategy` has evaluated and module init crashes. `provider-utils.test.ts` (added in v3.5.48) is the first in-repo entry point that trips it in isolation; `auth-service-logs-stream-token.test.ts` hits the same cycle when run alone. Whole-repo `bun test` masks it — import order from earlier files happens to load core first — which is why CI stays green while per-file runs crash.

## The fix — root cause, no consumer workarounds

Export `./models` and `./model-mappings` as package subpaths from `@better-ccflare/core`, and import those leaf modules directly in `types/agent.ts`. Both leaves are runtime-clean (their types imports are type-only), so `core/strategy.ts` — and the rest of core's barrel — never evaluates inside the types-barrel window. Every barrel entry point becomes order-insensitive; no test changes needed.

Considered and rejected: reordering the types barrel (`./strategy` before `./agent`) works but doesn't survive lint's export sorting, and lazy-computing `STRATEGIES`/`DEFAULT_STRATEGY` in core changes public API for two module-scope reads.

## After

Both previously-crashing test files pass in isolation unchanged; `bun run lint` / `typecheck` / `format` clean. 2 files, +16/−2.

(Found while syncing v3.5.48/v3.5.50 into our fork — we run this fix in production.)