### PR TITLE
feat(providers): opt-in xAI cache-native conversation identity with sticky account affinity

### DIFF
--- a/packages/providers/src/providers/index.ts
+++ b/packages/providers/src/providers/index.ts
@@ -28,6 +28,13 @@ export { OpenAICompatibleProvider } from "./openai/index";
 export { OpenRouterProvider } from "./openrouter/index";
 export { type VertexAIConfig, VertexAIProvider } from "./vertex-ai/index";
 export {
+	applyXaiConvIdHeader,
+	deriveXaiConvId,
+	isOfficialXaiEndpoint,
+	isValidSessionId,
+	isXaiCacheNativeEnabled,
+	XAI_CACHE_NATIVE_ENV,
+	XAI_CONV_ID_HEADER,
 	XAI_DEFAULT_CLIENT_ID,
 	XAI_DEFAULT_ENDPOINT,
 	XAI_MODEL_MAPPINGS,

--- a/packages/providers/src/providers/xai/cache-native.test.ts
+++ b/packages/providers/src/providers/xai/cache-native.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from "bun:test";
+import type { Account } from "@better-ccflare/types";
+import {
+	applyXaiConvIdHeader,
+	deriveXaiConvId,
+	isOfficialXaiEndpoint,
+	isValidSessionId,
+	isXaiCacheNativeEnabled,
+	XAI_CACHE_NATIVE_ENV,
+	XAI_CONV_ID_HEADER,
+} from "./cache-native";
+
+const VALID_SESSION_ID = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+const OTHER_SESSION_ID = "11111111-2222-4333-8444-555555555555";
+
+function account(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "xai-1",
+		name: "xai-test",
+		provider: "xai",
+		api_key: null,
+		refresh_token: "refresh-token",
+		access_token: "access-token",
+		expires_at: Date.now() + 60_000,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: Date.now(),
+		rate_limited_until: null,
+		rate_limited_reason: null,
+		rate_limited_at: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 50,
+		auto_fallback_enabled: true,
+		auto_refresh_enabled: true,
+		auto_pause_on_overage_enabled: false,
+		peak_hours_pause_enabled: false,
+		custom_endpoint: null,
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		billing_type: null,
+		pause_reason: null,
+		refresh_token_issued_at: null,
+		consecutive_rate_limits: 0,
+		...overrides,
+	};
+}
+
+const enabledEnv = {
+	[XAI_CACHE_NATIVE_ENV]: "1",
+} as unknown as NodeJS.ProcessEnv;
+const disabledEnv = {} as NodeJS.ProcessEnv;
+
+describe("constants", () => {
+	it("uses the official xAI Chat Completions affinity header name", () => {
+		expect(XAI_CONV_ID_HEADER).toBe("x-grok-conv-id");
+	});
+
+	it("uses CCFLARE_XAI_CACHE_NATIVE as the opt-in env var", () => {
+		expect(XAI_CACHE_NATIVE_ENV).toBe("CCFLARE_XAI_CACHE_NATIVE");
+	});
+});
+
+describe("isXaiCacheNativeEnabled", () => {
+	it("is disabled by default (no env var set)", () => {
+		expect(isXaiCacheNativeEnabled(disabledEnv)).toBe(false);
+	});
+
+	it("is enabled only for the exact string '1'", () => {
+		expect(isXaiCacheNativeEnabled(enabledEnv)).toBe(true);
+		expect(
+			isXaiCacheNativeEnabled({
+				[XAI_CACHE_NATIVE_ENV]: "true",
+			} as unknown as NodeJS.ProcessEnv),
+		).toBe(false);
+		expect(
+			isXaiCacheNativeEnabled({
+				[XAI_CACHE_NATIVE_ENV]: "yes",
+			} as unknown as NodeJS.ProcessEnv),
+		).toBe(false);
+		expect(
+			isXaiCacheNativeEnabled({
+				[XAI_CACHE_NATIVE_ENV]: "0",
+			} as unknown as NodeJS.ProcessEnv),
+		).toBe(false);
+		expect(
+			isXaiCacheNativeEnabled({
+				[XAI_CACHE_NATIVE_ENV]: "",
+			} as unknown as NodeJS.ProcessEnv),
+		).toBe(false);
+	});
+});
+
+describe("isValidSessionId", () => {
+	it("accepts a well-formed session UUID", () => {
+		expect(isValidSessionId(VALID_SESSION_ID)).toBe(true);
+	});
+
+	it("accepts uppercase UUIDs", () => {
+		expect(isValidSessionId(VALID_SESSION_ID.toUpperCase())).toBe(true);
+	});
+
+	it("rejects junk, empty, and non-UUID-shaped input", () => {
+		expect(isValidSessionId("not-a-uuid")).toBe(false);
+		expect(isValidSessionId("")).toBe(false);
+		expect(isValidSessionId(null)).toBe(false);
+		expect(isValidSessionId(undefined)).toBe(false);
+		expect(isValidSessionId("3fa85f6457174562b3fc2c963f66afa6")).toBe(false); // no dashes
+		expect(isValidSessionId("'; DROP TABLE accounts; --")).toBe(false);
+		expect(isValidSessionId("00000000-0000-0000-0000-000000000000")).toBe(
+			false,
+		); // version nibble 0 is out of range
+	});
+});
+
+describe("isOfficialXaiEndpoint", () => {
+	it("is official for a bare xai account with no custom endpoint", () => {
+		expect(isOfficialXaiEndpoint(account())).toBe(true);
+	});
+
+	it("is official for an account explicitly pointed at api.x.ai", () => {
+		expect(
+			isOfficialXaiEndpoint(
+				account({ custom_endpoint: "https://api.x.ai/v1" }),
+			),
+		).toBe(true);
+	});
+
+	it("is NOT official for a custom/proxy endpoint", () => {
+		expect(
+			isOfficialXaiEndpoint(
+				account({ custom_endpoint: "https://my-proxy.example.com/v1" }),
+			),
+		).toBe(false);
+	});
+
+	it("is NOT official for a non-xai provider account", () => {
+		expect(isOfficialXaiEndpoint(account({ provider: "anthropic" }))).toBe(
+			false,
+		);
+	});
+
+	it("treats a missing account as targeting the official default endpoint", () => {
+		expect(isOfficialXaiEndpoint(null)).toBe(true);
+		expect(isOfficialXaiEndpoint(undefined)).toBe(true);
+	});
+});
+
+describe("deriveXaiConvId — gating", () => {
+	it("returns null when the feature flag is off, even with a valid session id", () => {
+		expect(deriveXaiConvId(VALID_SESSION_ID, disabledEnv)).toBeNull();
+	});
+
+	it("returns null for a missing session id even when enabled", () => {
+		expect(deriveXaiConvId(null, enabledEnv)).toBeNull();
+		expect(deriveXaiConvId(undefined, enabledEnv)).toBeNull();
+	});
+
+	it("returns null for a malformed session id even when enabled", () => {
+		expect(deriveXaiConvId("not-a-uuid", enabledEnv)).toBeNull();
+		expect(deriveXaiConvId("", enabledEnv)).toBeNull();
+	});
+});
+
+describe("deriveXaiConvId — privacy-safe derivation", () => {
+	it("derives a non-null id for a valid session id when enabled", () => {
+		expect(deriveXaiConvId(VALID_SESSION_ID, enabledEnv)).not.toBeNull();
+	});
+
+	it("is stable for the same session id", () => {
+		const a = deriveXaiConvId(VALID_SESSION_ID, enabledEnv);
+		const b = deriveXaiConvId(VALID_SESSION_ID, enabledEnv);
+		expect(a).toBe(b);
+	});
+
+	it("is case-insensitive on the session id", () => {
+		const lower = deriveXaiConvId(VALID_SESSION_ID, enabledEnv);
+		const upper = deriveXaiConvId(VALID_SESSION_ID.toUpperCase(), enabledEnv);
+		expect(lower).toBe(upper);
+	});
+
+	it("produces different ids for different session ids", () => {
+		const a = deriveXaiConvId(VALID_SESSION_ID, enabledEnv);
+		const b = deriveXaiConvId(OTHER_SESSION_ID, enabledEnv);
+		expect(a).not.toBe(b);
+	});
+
+	it("never includes the raw session UUID (or its dash-stripped form) anywhere in the derived id", () => {
+		const id = deriveXaiConvId(VALID_SESSION_ID, enabledEnv) ?? "";
+		expect(id).not.toContain(VALID_SESSION_ID);
+		expect(id.toLowerCase()).not.toContain(VALID_SESSION_ID.toLowerCase());
+		expect(id).not.toContain(VALID_SESSION_ID.replace(/-/g, ""));
+		// Guard every dash-delimited fragment individually too.
+		for (const fragment of VALID_SESSION_ID.split("-")) {
+			expect(id.toLowerCase()).not.toContain(fragment.toLowerCase());
+		}
+	});
+
+	it("does not just re-encode the session id (e.g. base64) — output must be a hash digest", () => {
+		const id = deriveXaiConvId(VALID_SESSION_ID, enabledEnv) ?? "";
+		const b64 = Buffer.from(VALID_SESSION_ID).toString("base64");
+		expect(id).not.toContain(b64);
+	});
+});
+
+describe("applyXaiConvIdHeader", () => {
+	it("attaches the header when provider is xai, endpoint is official, and a conv id is present", () => {
+		const headers = new Headers();
+		applyXaiConvIdHeader(headers, "xai", account(), "ccflare-xai-abc123");
+		expect(headers.get(XAI_CONV_ID_HEADER)).toBe("ccflare-xai-abc123");
+	});
+
+	it("does not attach for a non-xai provider", () => {
+		const headers = new Headers();
+		applyXaiConvIdHeader(
+			headers,
+			"anthropic",
+			account({ provider: "anthropic" }),
+			"ccflare-xai-abc123",
+		);
+		expect(headers.has(XAI_CONV_ID_HEADER)).toBe(false);
+	});
+
+	it("does not attach when the conv id is null (not derivable)", () => {
+		const headers = new Headers();
+		applyXaiConvIdHeader(headers, "xai", account(), null);
+		expect(headers.has(XAI_CONV_ID_HEADER)).toBe(false);
+	});
+
+	it("does not attach for a custom/proxy xai endpoint", () => {
+		const headers = new Headers();
+		applyXaiConvIdHeader(
+			headers,
+			"xai",
+			account({ custom_endpoint: "https://my-proxy.example.com/v1" }),
+			"ccflare-xai-abc123",
+		);
+		expect(headers.has(XAI_CONV_ID_HEADER)).toBe(false);
+	});
+
+	it("overwrites any pre-existing header value with the derived one (never trusts client input)", () => {
+		const headers = new Headers({ [XAI_CONV_ID_HEADER]: "client-supplied" });
+		applyXaiConvIdHeader(headers, "xai", account(), "ccflare-xai-real");
+		expect(headers.get(XAI_CONV_ID_HEADER)).toBe("ccflare-xai-real");
+	});
+});

--- a/packages/providers/src/providers/xai/cache-native.ts
+++ b/packages/providers/src/providers/xai/cache-native.ts
@@ -1,0 +1,130 @@
+import { createHash } from "node:crypto";
+import { getEndpointUrl } from "@better-ccflare/core";
+import type { Account } from "@better-ccflare/types";
+
+/**
+ * Opt-in flag for the xAI cache-native conversation identity minimal slice
+ * (issue #319): conv-id header + sticky account affinity only. Default OFF —
+ * every function below is a no-op (or returns null/false) unless this is
+ * exactly "1", so the flag-off path is byte-for-byte the pre-existing
+ * behavior.
+ */
+export const XAI_CACHE_NATIVE_ENV = "CCFLARE_XAI_CACHE_NATIVE";
+
+/** Official xAI Chat Completions conversation-affinity header (xAI docs). */
+export const XAI_CONV_ID_HEADER = "x-grok-conv-id";
+
+// Mirrors XaiProvider.XAI_DEFAULT_ENDPOINT (./provider.ts). Duplicated
+// (not imported) to avoid a cache-native.ts <-> provider.ts import cycle:
+// provider-facing callers (proxy-operations.ts) import this module, and this
+// module has no reason to import the provider class itself.
+const XAI_DEFAULT_ENDPOINT = "https://api.x.ai/v1";
+const OFFICIAL_XAI_HOSTS = new Set(["api.x.ai"]);
+
+// Loosely mirrors a Claude session UUID (v1-v8, RFC 4122 variant). Purely a
+// shape guard before hashing — not a cryptographic or exhaustive UUID
+// validator.
+const SESSION_UUID_RE =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const CONV_ID_PREFIX = "ccflare-xai-";
+/** Truncated sha256 hex length: long enough to be collision-safe for one deployment's concurrent session count, short enough to stay a sane header value. */
+const CONV_ID_HASH_LENGTH = 32;
+
+/** Whether the xAI cache-native minimal slice is enabled. */
+export function isXaiCacheNativeEnabled(
+	env: NodeJS.ProcessEnv = process.env,
+): boolean {
+	return env[XAI_CACHE_NATIVE_ENV] === "1";
+}
+
+/**
+ * Whether `account` targets official xAI infrastructure (api.x.ai). A
+ * custom or proxy endpoint must never receive the cache-native affinity
+ * header or participate in sticky affinity — conv-id partitioning is only
+ * meaningful against xAI's own cache. Invalid custom endpoints fall back to
+ * the official default, matching XaiProvider.buildUrl's own fallback
+ * behavior. A missing account has nothing to disqualify it, so it defaults
+ * to "official".
+ */
+export function isOfficialXaiEndpoint(account?: Account | null): boolean {
+	if (account && account.provider !== "xai") return false;
+
+	let endpoint = XAI_DEFAULT_ENDPOINT;
+	try {
+		endpoint = account?.custom_endpoint
+			? getEndpointUrl(account)
+			: XAI_DEFAULT_ENDPOINT;
+	} catch {
+		endpoint = XAI_DEFAULT_ENDPOINT;
+	}
+
+	try {
+		return OFFICIAL_XAI_HOSTS.has(new URL(endpoint).hostname.toLowerCase());
+	} catch {
+		return false;
+	}
+}
+
+/** Whether `sessionId` looks like a Claude session UUID. */
+export function isValidSessionId(
+	sessionId: string | null | undefined,
+): sessionId is string {
+	return typeof sessionId === "string" && SESSION_UUID_RE.test(sessionId);
+}
+
+/**
+ * Derive a privacy-safe xAI conversation id from a Claude client session id
+ * (`RequestMeta.clientSessionId`, itself sourced from the request body's
+ * `metadata.user_id`). Returns null when the feature is disabled, or the
+ * session id is missing/malformed — callers must treat null as "no affinity
+ * for this request", never fall back to some other identity.
+ *
+ * The raw session id is NEVER included in the returned value: only a
+ * truncated sha256 digest survives, one-way and unrecoverable. This is the
+ * single derivation point — both the header attachment and the sticky
+ * account-affinity map (packages/proxy/src/handlers/account-selector.ts)
+ * consume the same value via the `RequestMeta`-keyed WeakMap side channel,
+ * so the two can never disagree on identity for a given request.
+ */
+export function deriveXaiConvId(
+	clientSessionId: string | null | undefined,
+	env: NodeJS.ProcessEnv = process.env,
+): string | null {
+	if (!isXaiCacheNativeEnabled(env)) return null;
+	if (!isValidSessionId(clientSessionId)) return null;
+
+	const digest = createHash("sha256")
+		.update(clientSessionId.toLowerCase())
+		.digest("hex");
+
+	return `${CONV_ID_PREFIX}${digest.slice(0, CONV_ID_HASH_LENGTH)}`;
+}
+
+/**
+ * Attach the xAI conversation-affinity header to outbound `headers` when
+ * (and only when) the request is xai-routed, targets the official xAI
+ * endpoint, and carries a derivable conv id. A no-op in every other case,
+ * including when `convId` is null (feature disabled or id not derivable) —
+ * see `deriveXaiConvId`.
+ *
+ * Called from the proxy request-preparation seam (proxy-operations.ts)
+ * rather than from `Provider.prepareHeaders`: that hook receives only
+ * `(headers, accessToken, apiKey)`, with no account or RequestMeta, so the
+ * conv id computed elsewhere isn't reachable there without widening the
+ * shared `Provider` interface for one provider's feature.
+ *
+ * Always overwrites any pre-existing header value — a client-supplied
+ * `x-grok-conv-id` must never be trusted or forwarded verbatim.
+ */
+export function applyXaiConvIdHeader(
+	headers: Headers,
+	providerName: string,
+	account: Account,
+	convId: string | null,
+): void {
+	if (providerName !== "xai") return;
+	if (!convId) return;
+	if (!isOfficialXaiEndpoint(account)) return;
+	headers.set(XAI_CONV_ID_HEADER, convId);
+}

--- a/packages/providers/src/providers/xai/index.ts
+++ b/packages/providers/src/providers/xai/index.ts
@@ -1,4 +1,13 @@
 export {
+	applyXaiConvIdHeader,
+	deriveXaiConvId,
+	isOfficialXaiEndpoint,
+	isValidSessionId,
+	isXaiCacheNativeEnabled,
+	XAI_CACHE_NATIVE_ENV,
+	XAI_CONV_ID_HEADER,
+} from "./cache-native";
+export {
 	XAI_DEFAULT_CLIENT_ID,
 	XAI_DEFAULT_ENDPOINT,
 	XAI_MODEL_MAPPINGS,

--- a/packages/proxy/src/handlers/__tests__/account-selector-xai-cache-affinity.test.ts
+++ b/packages/proxy/src/handlers/__tests__/account-selector-xai-cache-affinity.test.ts
@@ -1,0 +1,418 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import type {
+	Account,
+	ComboWithSlots,
+	RequestMeta,
+} from "@better-ccflare/types";
+import {
+	getXaiConvId,
+	resetXaiCacheAffinityForTests,
+	selectAccountsForRequest,
+	setXaiConvId,
+	XAI_AFFINITY_MAX_ENTRIES,
+	XAI_AFFINITY_TTL_MS,
+} from "../account-selector";
+import type { ProxyContext } from "../proxy-types";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+// Deliberately duplicated (not imported) from account-selector.test.ts /
+// account-selector-model-capacity.test.ts, matching this directory's existing
+// convention of a self-contained fixture set per concern-scoped test file.
+
+afterEach(() => {
+	resetXaiCacheAffinityForTests();
+});
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "acc-1",
+		name: "test-account",
+		provider: "xai",
+		api_key: null,
+		refresh_token: "rt",
+		access_token: "at",
+		expires_at: Date.now() + 3_600_000,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: Date.now(),
+		rate_limited_until: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		custom_endpoint: null,
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		...overrides,
+	};
+}
+
+function makeRequestMeta(overrides: Partial<RequestMeta> = {}): RequestMeta {
+	return {
+		id: "req-1",
+		method: "POST",
+		path: "/v1/messages",
+		timestamp: Date.now(),
+		headers: new Headers(),
+		...overrides,
+	};
+}
+
+function makeCombo(slots: ComboWithSlots["slots"]): ComboWithSlots {
+	return {
+		id: "combo-1",
+		name: "Test Combo",
+		description: null,
+		enabled: true,
+		created_at: Date.now(),
+		updated_at: Date.now(),
+		slots,
+	};
+}
+
+function makeCtx(
+	opts: { accounts?: Account[]; activeCombo?: ComboWithSlots | null } = {},
+): ProxyContext {
+	const accounts = opts.accounts ?? [makeAccount()];
+	return {
+		strategy: {
+			select: mock((_all: Account[], _meta: RequestMeta) => accounts),
+		},
+		dbOps: {
+			getAllAccounts: mock(async () => accounts),
+			getActiveComboForFamily: mock(async () => opts.activeCombo ?? null),
+		},
+		refreshInFlight: new Map(),
+		asyncWriter: { enqueue: mock(() => {}) },
+	} as unknown as ProxyContext;
+}
+
+// ── setXaiConvId / getXaiConvId ────────────────────────────────────────────
+
+describe("setXaiConvId / getXaiConvId", () => {
+	it("stores and retrieves a conv id on a RequestMeta", () => {
+		const meta = makeRequestMeta();
+		setXaiConvId(meta, "ccflare-xai-abc123");
+		expect(getXaiConvId(meta)).toBe("ccflare-xai-abc123");
+	});
+
+	it("returns null for a meta that was never set", () => {
+		const meta = makeRequestMeta();
+		expect(getXaiConvId(meta)).toBeNull();
+	});
+
+	it("is isolated per RequestMeta object (WeakMap semantics)", () => {
+		const meta1 = makeRequestMeta();
+		const meta2 = makeRequestMeta();
+		setXaiConvId(meta1, "ccflare-xai-meta1");
+		expect(getXaiConvId(meta2)).toBeNull();
+	});
+});
+
+// ── selectAccountsForRequest — xAI cache-native affinity ───────────────────
+
+describe("selectAccountsForRequest — xAI cache-native affinity", () => {
+	it("does not reorder when no conv id is set on the request (flag-off path)", async () => {
+		// deriveXaiConvId (packages/providers) returns null whenever
+		// CCFLARE_XAI_CACHE_NATIVE is not exactly "1" (see cache-native.test.ts),
+		// and proxy.ts only ever calls setXaiConvId with that non-null result —
+		// so "no conv id set" IS the flag-off path as observed from
+		// account-selector.ts. This test guards the consuming side: absent a
+		// conv id, selection must be byte-for-byte the pre-existing order.
+		const xaiA = makeAccount({ id: "xai-a" });
+		const xaiB = makeAccount({ id: "xai-b" });
+		const ctx = makeCtx({ accounts: [xaiA, xaiB] });
+		const meta = makeRequestMeta();
+
+		const result = await selectAccountsForRequest(meta, ctx);
+		expect(result.map((a) => a.id)).toEqual(["xai-a", "xai-b"]);
+	});
+
+	it("records ownership on first use without reordering (nothing to prefer yet)", async () => {
+		const xaiA = makeAccount({ id: "xai-a" });
+		const xaiB = makeAccount({ id: "xai-b" });
+		const ctx = makeCtx({ accounts: [xaiA, xaiB] });
+		const meta = makeRequestMeta();
+		setXaiConvId(meta, "conv-first-use");
+
+		const result = await selectAccountsForRequest(meta, ctx);
+		expect(result.map((a) => a.id)).toEqual(["xai-a", "xai-b"]);
+	});
+
+	it("prefers the owning account when it is present and routable on a later request", async () => {
+		const xaiA = makeAccount({ id: "xai-a" });
+		const xaiB = makeAccount({ id: "xai-b" });
+
+		// First request establishes ownership on whichever account the strategy
+		// puts first — xai-a.
+		const ctx1 = makeCtx({ accounts: [xaiA, xaiB] });
+		const meta1 = makeRequestMeta();
+		setXaiConvId(meta1, "conv-owner-preferred");
+		await selectAccountsForRequest(meta1, ctx1);
+
+		// Second request: strategy now ranks xai-b first, but the sticky owner
+		// (xai-a) must still be promoted to the front.
+		const ctx2 = makeCtx({ accounts: [xaiB, xaiA] });
+		const meta2 = makeRequestMeta();
+		setXaiConvId(meta2, "conv-owner-preferred");
+		const result = await selectAccountsForRequest(meta2, ctx2);
+
+		expect(result.map((a) => a.id)).toEqual(["xai-a", "xai-b"]);
+	});
+
+	it("falls back to normal order and transfers ownership when the owner is absent from the candidate list", async () => {
+		const xaiA = makeAccount({ id: "xai-a" });
+		const xaiB = makeAccount({ id: "xai-b" });
+
+		// Establish ownership on xai-a.
+		const ctx1 = makeCtx({ accounts: [xaiA, xaiB] });
+		const meta1 = makeRequestMeta();
+		setXaiConvId(meta1, "conv-transfer");
+		await selectAccountsForRequest(meta1, ctx1);
+
+		// xai-a is no longer routable/present (e.g. paused/rate-limited and
+		// filtered out upstream) — only xai-b is a candidate.
+		const ctx2 = makeCtx({ accounts: [xaiB] });
+		const meta2 = makeRequestMeta();
+		setXaiConvId(meta2, "conv-transfer");
+		const result2 = await selectAccountsForRequest(meta2, ctx2);
+		expect(result2.map((a) => a.id)).toEqual(["xai-b"]);
+
+		// Ownership must have transferred to xai-b: a third request where both
+		// are candidates again, with xai-a ranked first by the strategy, must
+		// still promote xai-b (the new owner), not fall back to stale xai-a
+		// ownership.
+		const ctx3 = makeCtx({ accounts: [xaiA, xaiB] });
+		const meta3 = makeRequestMeta();
+		setXaiConvId(meta3, "conv-transfer");
+		const result3 = await selectAccountsForRequest(meta3, ctx3);
+		expect(result3.map((a) => a.id)).toEqual(["xai-b", "xai-a"]);
+	});
+
+	it("treats an owner past the TTL window as absent", async () => {
+		const xaiA = makeAccount({ id: "xai-a" });
+		const xaiB = makeAccount({ id: "xai-b" });
+		const realDateNow = Date.now;
+		const baseNow = realDateNow();
+
+		try {
+			Date.now = () => baseNow;
+			const ctx1 = makeCtx({ accounts: [xaiA, xaiB] });
+			const meta1 = makeRequestMeta({ timestamp: baseNow });
+			setXaiConvId(meta1, "conv-ttl");
+			await selectAccountsForRequest(meta1, ctx1);
+
+			// Advance past the TTL window.
+			Date.now = () => baseNow + XAI_AFFINITY_TTL_MS + 1;
+			const ctx2 = makeCtx({ accounts: [xaiB, xaiA] });
+			const meta2 = makeRequestMeta({
+				timestamp: baseNow + XAI_AFFINITY_TTL_MS + 1,
+			});
+			setXaiConvId(meta2, "conv-ttl");
+			const result = await selectAccountsForRequest(meta2, ctx2);
+
+			// Expired ownership: no promotion, strategy order (xai-b, xai-a) wins.
+			expect(result.map((a) => a.id)).toEqual(["xai-b", "xai-a"]);
+		} finally {
+			Date.now = realDateNow;
+		}
+	});
+
+	it("evicts the oldest entry once the cap is exceeded", async () => {
+		const evictedConvId = "conv-cap-0";
+		const ctxSeed = makeCtx({ accounts: [makeAccount({ id: "acc-cap" })] });
+		const metaSeed = makeRequestMeta();
+		setXaiConvId(metaSeed, evictedConvId);
+		await selectAccountsForRequest(metaSeed, ctxSeed);
+
+		// Push the table past its cap with distinct conv ids so the very first
+		// entry (evictedConvId) becomes the oldest and gets evicted.
+		for (let i = 1; i <= XAI_AFFINITY_MAX_ENTRIES; i++) {
+			const ctx = makeCtx({ accounts: [makeAccount({ id: `acc-cap-${i}` })] });
+			const meta = makeRequestMeta();
+			setXaiConvId(meta, `conv-cap-${i}`);
+			await selectAccountsForRequest(meta, ctx);
+		}
+
+		// The evicted conv id's former owner ("acc-cap") must no longer be
+		// promoted — selection falls back to the strategy's own order.
+		const accX = makeAccount({ id: "acc-new-first" });
+		const accY = makeAccount({ id: "acc-cap" });
+		const ctxCheck = makeCtx({ accounts: [accX, accY] });
+		const metaCheck = makeRequestMeta();
+		setXaiConvId(metaCheck, evictedConvId);
+		const result = await selectAccountsForRequest(metaCheck, ctxCheck);
+
+		expect(result.map((a) => a.id)).toEqual(["acc-new-first", "acc-cap"]);
+	});
+
+	it("scopes ownership per conv id — different conversations do not interfere", async () => {
+		const xaiA = makeAccount({ id: "xai-a" });
+		const xaiB = makeAccount({ id: "xai-b" });
+
+		const ctx1 = makeCtx({ accounts: [xaiA, xaiB] });
+		const meta1 = makeRequestMeta();
+		setXaiConvId(meta1, "conv-scope-1");
+		await selectAccountsForRequest(meta1, ctx1);
+
+		const ctx2 = makeCtx({ accounts: [xaiB, xaiA] });
+		const meta2 = makeRequestMeta();
+		setXaiConvId(meta2, "conv-scope-2");
+		await selectAccountsForRequest(meta2, ctx2);
+
+		// conv-scope-1's owner (xai-a) must still be promoted for its own
+		// conversation, independent of conv-scope-2's owner (xai-b).
+		const ctx3 = makeCtx({ accounts: [xaiB, xaiA] });
+		const meta3 = makeRequestMeta();
+		setXaiConvId(meta3, "conv-scope-1");
+		const result = await selectAccountsForRequest(meta3, ctx3);
+		expect(result.map((a) => a.id)).toEqual(["xai-a", "xai-b"]);
+	});
+
+	it("never promotes the owner ahead of a non-xai account the strategy preferred (mixed pool)", async () => {
+		const xaiA = makeAccount({ id: "xai-a" });
+		const xaiB = makeAccount({ id: "xai-b" });
+		const anthropicAcc = makeAccount({
+			id: "anthropic-1",
+			provider: "anthropic",
+		});
+
+		// Seed ownership of xai-b (it leads an all-xai pool).
+		const ctxSeed = makeCtx({ accounts: [xaiB, xaiA] });
+		const metaSeed = makeRequestMeta();
+		setXaiConvId(metaSeed, "conv-mixed-pool");
+		await selectAccountsForRequest(metaSeed, ctxSeed);
+
+		// Mixed pool with a non-xai account the strategy put first: affinity
+		// must only reorder WITHIN the xai subset — anthropic-1 keeps the
+		// lead, xai-b (owner) moves ahead of xai-a only.
+		const ctx = makeCtx({ accounts: [anthropicAcc, xaiA, xaiB] });
+		const meta = makeRequestMeta();
+		setXaiConvId(meta, "conv-mixed-pool");
+		const result = await selectAccountsForRequest(meta, ctx);
+		expect(result.map((a) => a.id)).toEqual(["anthropic-1", "xai-b", "xai-a"]);
+	});
+
+	it("does not transfer ownership while a non-xai account is the presumptive server", async () => {
+		const xaiA = makeAccount({ id: "xai-a" });
+		const xaiB = makeAccount({ id: "xai-b" });
+		const anthropicAcc = makeAccount({
+			id: "anthropic-1",
+			provider: "anthropic",
+		});
+
+		// Seed ownership of xai-b.
+		const ctxSeed = makeCtx({ accounts: [xaiB, xaiA] });
+		const metaSeed = makeRequestMeta();
+		setXaiConvId(metaSeed, "conv-no-steal");
+		await selectAccountsForRequest(metaSeed, ctxSeed);
+
+		// Non-xai leader: the request won't touch any xai cache partition, so
+		// ownership must NOT be reassigned to xai-a merely for being the
+		// first xai account in this pool.
+		const ctxMixed = makeCtx({ accounts: [anthropicAcc, xaiA, xaiB] });
+		const metaMixed = makeRequestMeta();
+		setXaiConvId(metaMixed, "conv-no-steal");
+		await selectAccountsForRequest(metaMixed, ctxMixed);
+
+		// Back to an all-xai pool: xai-b must still own the conversation.
+		const ctxCheck = makeCtx({ accounts: [xaiA, xaiB] });
+		const metaCheck = makeRequestMeta();
+		setXaiConvId(metaCheck, "conv-no-steal");
+		const result = await selectAccountsForRequest(metaCheck, ctxCheck);
+		expect(result.map((a) => a.id)).toEqual(["xai-b", "xai-a"]);
+	});
+
+	it("ignores non-xai and custom-endpoint xai accounts as affinity owners", async () => {
+		const anthropicAcc = makeAccount({
+			id: "anthropic-1",
+			provider: "anthropic",
+		});
+		const customXai = makeAccount({
+			id: "xai-custom",
+			custom_endpoint: "https://my-proxy.example.com/v1",
+		});
+		const ctx = makeCtx({ accounts: [anthropicAcc, customXai] });
+		const meta = makeRequestMeta();
+		setXaiConvId(meta, "conv-no-eligible-owner");
+
+		const result = await selectAccountsForRequest(meta, ctx);
+		// No eligible (official xai) candidate to record as owner — order must
+		// be left completely untouched.
+		expect(result.map((a) => a.id)).toEqual(["anthropic-1", "xai-custom"]);
+	});
+
+	it("does not affect the forced-account header path even when a conv id and prior ownership exist", async () => {
+		const xaiA = makeAccount({ id: "xai-a" });
+		const xaiB = makeAccount({ id: "xai-b" });
+
+		// Establish ownership on xai-a for this conv id.
+		const ctx1 = makeCtx({ accounts: [xaiA, xaiB] });
+		const meta1 = makeRequestMeta();
+		setXaiConvId(meta1, "conv-forced");
+		await selectAccountsForRequest(meta1, ctx1);
+
+		// A forced-account request for xai-b must return exactly xai-b,
+		// regardless of xai-a's sticky ownership — the forced-account path
+		// (x-better-ccflare-account-id) is out of scope for affinity.
+		const ctx2 = makeCtx({ accounts: [xaiA, xaiB] });
+		const meta2 = makeRequestMeta({
+			headers: new Headers({ "x-better-ccflare-account-id": "xai-b" }),
+		});
+		setXaiConvId(meta2, "conv-forced");
+		const result = await selectAccountsForRequest(meta2, ctx2);
+		expect(result.map((a) => a.id)).toEqual(["xai-b"]);
+	});
+
+	it("does not affect combo-routed selection even when a conv id and prior ownership exist", async () => {
+		const xaiA = makeAccount({ id: "xai-a" });
+		const xaiB = makeAccount({ id: "xai-b" });
+		// Combos are provider-agnostic (a slot is just account_id + model
+		// override), so an xai account can sit in a Claude-family combo slot —
+		// this is what exercises the combo-routing return point (line ~474)
+		// with an xai owner in play.
+		const comboAcc = makeAccount({ id: "combo-acc", provider: "xai" });
+
+		// Establish ownership on xai-a for this conv id via normal (non-combo,
+		// no model) selection first.
+		const ctxSeed = makeCtx({ accounts: [xaiA, xaiB] });
+		const metaSeed = makeRequestMeta();
+		setXaiConvId(metaSeed, "conv-combo");
+		await selectAccountsForRequest(metaSeed, ctxSeed);
+
+		// A combo-routed request (model resolves to a known family + an active
+		// combo for it) must return exactly the combo's own slot accounts,
+		// unaffected by xai-a's sticky ownership — combo routing returns before
+		// either of the two affinity-wrapped return points is ever reached.
+		const combo = makeCombo([
+			{
+				id: "slot-1",
+				combo_id: "combo-1",
+				account_id: "combo-acc",
+				model: "claude-sonnet-4-5",
+				priority: 0,
+				enabled: true,
+			},
+		]);
+		const ctx = makeCtx({
+			accounts: [comboAcc, xaiA, xaiB],
+			activeCombo: combo,
+		});
+		const meta = makeRequestMeta();
+		setXaiConvId(meta, "conv-combo");
+		const result = await selectAccountsForRequest(
+			meta,
+			ctx,
+			"claude-sonnet-4-5",
+		);
+		expect(result.map((a) => a.id)).toEqual(["combo-acc"]);
+	});
+});

--- a/packages/proxy/src/handlers/__tests__/proxy-operations-xai-cache-native-header.test.ts
+++ b/packages/proxy/src/handlers/__tests__/proxy-operations-xai-cache-native-header.test.ts
@@ -1,0 +1,263 @@
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	mock,
+	spyOn,
+} from "bun:test";
+import { CodexProvider, XaiProvider } from "@better-ccflare/providers";
+import type { Account, RequestMeta } from "@better-ccflare/types";
+import * as usageCollectorModule from "../../usage-collector";
+import { setXaiConvId } from "../account-selector";
+import { proxyWithAccount } from "../proxy-operations";
+import type { ProxyContext } from "../proxy-types";
+
+// Header-attachment integration test for the xAI cache-native conversation
+// identity minimal slice (issue #319). Modeled on
+// proxy-operations-count-tokens.test.ts: mock globalThis.fetch to capture
+// the outgoing Request and assert on its headers, rather than unit-testing
+// applyXaiConvIdHeader in isolation (already covered in
+// packages/providers/src/providers/xai/cache-native.test.ts) — this test's
+// job is to prove the seam is actually wired up in proxyWithAccount.
+
+const XAI_CONV_ID_HEADER = "x-grok-conv-id";
+
+function makeXaiAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "xai-1",
+		name: "xai-test",
+		provider: "xai",
+		api_key: null,
+		refresh_token: "refresh-token",
+		access_token: "access-token",
+		expires_at: Date.now() + 60 * 60 * 1000,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: Date.now(),
+		rate_limited_until: null,
+		rate_limited_reason: null,
+		rate_limited_at: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		peak_hours_pause_enabled: false,
+		custom_endpoint: null,
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		billing_type: null,
+		pause_reason: null,
+		refresh_token_issued_at: null,
+		consecutive_rate_limits: 0,
+		...overrides,
+	};
+}
+
+function makeCodexAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "codex-1",
+		name: "codex-test",
+		provider: "codex",
+		api_key: "",
+		refresh_token: "refresh-token",
+		access_token: "access-token",
+		expires_at: Date.now() + 60 * 60 * 1000,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: Date.now(),
+		rate_limited_until: null,
+		rate_limited_reason: null,
+		rate_limited_at: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		peak_hours_pause_enabled: false,
+		custom_endpoint: null,
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		billing_type: null,
+		pause_reason: null,
+		refresh_token_issued_at: null,
+		consecutive_rate_limits: 0,
+		...overrides,
+	};
+}
+
+function makeRequestMeta(path = "/v1/messages"): RequestMeta {
+	return {
+		id: "req-xai-header",
+		method: "POST",
+		path,
+		timestamp: Date.now(),
+		headers: new Headers(),
+	};
+}
+
+function makeProxyContext(provider: XaiProvider | CodexProvider): ProxyContext {
+	return {
+		strategy: { getNextAccount: () => null } as never,
+		dbOps: {
+			markAccountRateLimited: mock(() =>
+				Promise.resolve({ consecutiveRateLimits: 1, applied: true }),
+			),
+			saveRequest: mock(() => Promise.resolve()),
+			updateAccountUsage: mock(() => Promise.resolve()),
+			getAdapter: mock(() => ({
+				run: mock(() => Promise.resolve()),
+				get: mock(() => Promise.resolve(null)),
+			})),
+		} as never,
+		runtime: { port: 8080, clientId: "test" } as never,
+		provider: provider as never,
+		refreshInFlight: new Map(),
+		asyncWriter: { enqueue: mock(() => {}) } as never,
+		config: { getStorePayloads: () => true } as never,
+	};
+}
+
+function makeMessagesRequest(body: ArrayBuffer) {
+	return new Request("https://proxy.local/v1/messages", {
+		method: "POST",
+		body,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+describe("proxyWithAccount — xAI cache-native conv-id header attachment", () => {
+	let originalFetch: typeof globalThis.fetch;
+	let fetchedRequest: Request | null;
+	let fetchMock: ReturnType<typeof mock>;
+	let collectorSpy: ReturnType<typeof spyOn>;
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+		fetchedRequest = null;
+		fetchMock = mock(async (input: RequestInfo | URL) => {
+			fetchedRequest = input instanceof Request ? input : new Request(input);
+			return new Response(JSON.stringify({ ok: true }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		});
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const collector = {
+			handleStart: mock(() => {}),
+			handleChunk: mock(() => {}),
+			handleEnd: mock(() => Promise.resolve()),
+		};
+		collectorSpy = spyOn(
+			usageCollectorModule,
+			"getUsageCollector",
+		).mockReturnValue(
+			collector as unknown as usageCollectorModule.UsageCollector,
+		);
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		collectorSpy.mockRestore();
+	});
+
+	async function runXaiRequest(
+		accountOverrides: Partial<Account> = {},
+		convId: string | null = "ccflare-xai-test-conv",
+	) {
+		const bodyBuffer = new TextEncoder().encode(
+			JSON.stringify({
+				model: "grok-4",
+				messages: [{ role: "user", content: "hello" }],
+				max_tokens: 16,
+			}),
+		).buffer;
+		const requestMeta = makeRequestMeta();
+		if (convId) {
+			setXaiConvId(requestMeta, convId);
+		}
+		const ctx = makeProxyContext(new XaiProvider());
+		const result = await proxyWithAccount(
+			makeMessagesRequest(bodyBuffer),
+			new URL("https://proxy.local/v1/messages"),
+			makeXaiAccount(accountOverrides),
+			requestMeta,
+			bodyBuffer,
+			() => undefined,
+			0,
+			ctx,
+		);
+		await result?.text();
+		return result;
+	}
+
+	it("attaches x-grok-conv-id for an official-endpoint xai request with a conv id set", async () => {
+		await runXaiRequest();
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(fetchedRequest?.url).toBe("https://api.x.ai/v1/chat/completions");
+		expect(fetchedRequest?.headers.get(XAI_CONV_ID_HEADER)).toBe(
+			"ccflare-xai-test-conv",
+		);
+	});
+
+	it("does not attach the header when no conv id is set on the RequestMeta (feature disabled/undeliverable)", async () => {
+		await runXaiRequest({}, null);
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(fetchedRequest?.headers.get(XAI_CONV_ID_HEADER)).toBeNull();
+	});
+
+	it("does not attach the header for a custom/proxy xai endpoint even with a conv id set", async () => {
+		await runXaiRequest({
+			custom_endpoint: "https://my-xai-proxy.example.com/v1",
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(fetchedRequest?.headers.get(XAI_CONV_ID_HEADER)).toBeNull();
+	});
+
+	it("does not attach the header for a non-xai provider even with a conv id set", async () => {
+		const bodyBuffer = new TextEncoder().encode(
+			JSON.stringify({
+				model: "claude-sonnet-4-5",
+				messages: [{ role: "user", content: "hello" }],
+				max_tokens: 16,
+			}),
+		).buffer;
+		const requestMeta = makeRequestMeta();
+		setXaiConvId(requestMeta, "ccflare-xai-test-conv");
+		const ctx = makeProxyContext(new CodexProvider());
+		const result = await proxyWithAccount(
+			makeMessagesRequest(bodyBuffer),
+			new URL("https://proxy.local/v1/messages"),
+			makeCodexAccount(),
+			requestMeta,
+			bodyBuffer,
+			() => undefined,
+			0,
+			ctx,
+		);
+		await result?.text();
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(fetchedRequest?.headers.get(XAI_CONV_ID_HEADER)).toBeNull();
+	});
+});

--- a/packages/proxy/src/handlers/account-selector.ts
+++ b/packages/proxy/src/handlers/account-selector.ts
@@ -8,6 +8,7 @@ import { Logger } from "@better-ccflare/logger";
 import {
 	getRepresentativeUsageResetMs,
 	getRepresentativeUtilizationForProvider,
+	isOfficialXaiEndpoint,
 	usageCache,
 } from "@better-ccflare/providers";
 import type {
@@ -88,6 +89,155 @@ export function getModelFamilyExhaustionInfo(
 	meta: RequestMeta,
 ): ModelFamilyExhaustionInfo | null {
 	return exhaustionInfoMap.get(meta) ?? null;
+}
+
+// ── xAI cache-native conversation affinity (issue #319 minimal slice) ──────
+//
+// Module-level WeakMap to store the derived xAI conv id per RequestMeta,
+// mirroring comboSlotInfoMap/exhaustionInfoMap above rather than widening
+// RequestMeta's shape. proxy.ts populates this once per request (only when
+// the opt-in flag is on and a conv id was derivable — see
+// packages/providers/src/providers/xai/cache-native.ts); the header
+// attachment seam (proxy-operations.ts) and the affinity logic below are the
+// only readers.
+const xaiConvIdMap = new WeakMap<RequestMeta, string>();
+
+/** Store a derived xAI conversation id on a RequestMeta for downstream consumption. */
+export function setXaiConvId(meta: RequestMeta, convId: string): void {
+	xaiConvIdMap.set(meta, convId);
+}
+
+/** Retrieve the derived xAI conversation id from a RequestMeta (null if not set). */
+export function getXaiConvId(meta: RequestMeta): string | null {
+	return xaiConvIdMap.get(meta) ?? null;
+}
+
+/**
+ * Sticky conv-id -> account ownership table for xAI cache-native affinity.
+ *
+ * Deliberately module-level (not per-request, not per-strategy-instance):
+ * ownership must persist ACROSS requests within the same xAI conversation to
+ * keep landing on the same upstream cache partition — that persistence is
+ * the entire point of the feature. This is a dedicated mechanism, not a
+ * reuse/extension of SessionAffinityStrategy
+ * (packages/load-balancer/src/strategies/session-affinity.ts): xai's
+ * `requiresSessionTracking` stays `false` in provider-config.ts — cache
+ * affinity is a separate concern from Anthropic-style 5-hour session
+ * windows and must not piggyback on SessionStrategy/
+ * SessionDrainSoonestStrategy.
+ *
+ * Bounded by XAI_AFFINITY_MAX_ENTRIES with oldest-`assignedAt`-first
+ * eviction; entries refresh (their assignedAt bumps forward) on every read
+ * so an active conversation never ages out mid-use.
+ */
+export const XAI_AFFINITY_TTL_MS = 30 * 60 * 1000;
+export const XAI_AFFINITY_MAX_ENTRIES = 1024;
+
+interface XaiAffinityEntry {
+	accountId: string;
+	assignedAt: number;
+}
+
+const xaiConvAffinity = new Map<string, XaiAffinityEntry>();
+
+/**
+ * Test-only: clear sticky xAI affinity state between test cases. The table
+ * is a module-level singleton (by design — see above), so without this,
+ * conv ids reused across test files/cases would leak ownership between
+ * them.
+ */
+export function resetXaiCacheAffinityForTests(): void {
+	xaiConvAffinity.clear();
+}
+
+function evictOldestXaiAffinityEntryIfOverCap(): void {
+	if (xaiConvAffinity.size <= XAI_AFFINITY_MAX_ENTRIES) return;
+	let oldestKey: string | null = null;
+	let oldestAssignedAt = Number.POSITIVE_INFINITY;
+	for (const [key, entry] of xaiConvAffinity) {
+		if (entry.assignedAt < oldestAssignedAt) {
+			oldestAssignedAt = entry.assignedAt;
+			oldestKey = key;
+		}
+	}
+	if (oldestKey !== null) {
+		xaiConvAffinity.delete(oldestKey);
+	}
+}
+
+function recordXaiAffinity(
+	convId: string,
+	accountId: string,
+	now: number,
+): void {
+	xaiConvAffinity.set(convId, { accountId, assignedAt: now });
+	evictOldestXaiAffinityEntryIfOverCap();
+}
+
+/**
+ * Reorders `accounts` so a conv id's sticky xAI account is tried first, when
+ * that account is present in the (already availability-filtered) candidate
+ * list and its ownership hasn't expired. A no-op whenever `meta` carries no
+ * conv id — which is always true when the feature flag is off, since
+ * deriveXaiConvId only ever returns non-null while enabled (see
+ * cache-native.ts) and proxy.ts never calls setXaiConvId otherwise.
+ *
+ * Only called from the two `selectAccountsForRequest` return points that
+ * represent ordinary, non-forced, non-combo selection (see call sites
+ * below). The forced-account header path and combo routing are both
+ * deliberately out of scope for this minimal slice: a forced or
+ * combo-assigned account already has an explicit, higher-precedence reason
+ * to be first, and reordering either would fight that intent.
+ *
+ * On every call, ownership transfers to whichever eligible (xai, official
+ * endpoint) account ends up first in the result — whether that's the
+ * pre-existing owner (promoted) or the strategy's own top pick (owner
+ * absent/expired) — so the next request for this conv id stays sticky to
+ * whichever account actually served this one.
+ */
+function applyXaiCacheAffinity(
+	accounts: Account[],
+	meta: RequestMeta,
+): Account[] {
+	const convId = getXaiConvId(meta);
+	if (!convId) return accounts;
+
+	const now = Date.now();
+	const isEligible = (a: Account) =>
+		a.provider === "xai" && isOfficialXaiEndpoint(a);
+
+	// Promotion is scoped WITHIN the xai candidate subset: the owner moves
+	// ahead of OTHER xai accounts only, never ahead of a non-xai account the
+	// strategy deliberately preferred (mixed pools are common — an operator
+	// running anthropic + xai accounts must not have cross-provider priority
+	// overridden by cache affinity). If the strategy leads with a non-xai
+	// account, that account still serves; affinity only decides WHICH xai
+	// account handles the conversation whenever xai is reached.
+	const existing = xaiConvAffinity.get(convId);
+	let result = accounts;
+	if (existing && now - existing.assignedAt < XAI_AFFINITY_TTL_MS) {
+		const firstXaiIdx = accounts.findIndex(isEligible);
+		const ownerIdx = accounts.findIndex(
+			(a) => a.id === existing.accountId && isEligible(a),
+		);
+		if (firstXaiIdx !== -1 && ownerIdx > firstXaiIdx) {
+			result = accounts.slice();
+			const [owner] = result.splice(ownerIdx, 1);
+			result.splice(firstXaiIdx, 0, owner);
+		}
+	}
+
+	// Ownership transfers (or refreshes) only when an eligible xai account is
+	// the presumptive server — i.e. it leads the result. When a non-xai
+	// account leads, this request won't touch any xai cache partition, so the
+	// existing ownership is left to age naturally rather than being
+	// reassigned to an account that isn't serving.
+	const leader = result[0];
+	if (leader && isEligible(leader)) {
+		recordXaiAffinity(convId, leader.id, now);
+	}
+
+	return result;
 }
 
 /**
@@ -605,9 +755,9 @@ export async function selectAccountsForRequest(
 				});
 				return [];
 			}
-			return available;
+			return applyXaiCacheAffinity(available, meta);
 		}
 	}
 
-	return orderedAccounts;
+	return applyXaiCacheAffinity(orderedAccounts, meta);
 }

--- a/packages/proxy/src/handlers/index.ts
+++ b/packages/proxy/src/handlers/index.ts
@@ -5,11 +5,13 @@ export {
 export {
 	getComboSlotInfo,
 	getModelFamilyExhaustionInfo,
+	getXaiConvId,
 	type ModelFamilyExhaustionInfo,
 	resolveEffectiveModel,
 	selectAccountsForRequest,
 	setComboSlotInfo,
 	setModelFamilyExhaustionInfo,
+	setXaiConvId,
 } from "./account-selector";
 export {
 	type AgentInterceptResult,

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -13,6 +13,7 @@ import { Logger } from "@better-ccflare/logger";
 import { stripCacheControlFromOpenAIRequest } from "@better-ccflare/openai-formats";
 import {
 	type AnyUsageData,
+	applyXaiConvIdHeader,
 	getProvider,
 	isAnthropicExtraUsageExhausted,
 	isAnthropicOutOfCredits,
@@ -27,6 +28,7 @@ import { cacheBodyStore } from "../cache-body-store";
 import { RequestBodyContext } from "../request-body-context";
 import { forwardToClient } from "../response-handler";
 import { isModelRewrite } from "../worker-messages";
+import { getXaiConvId } from "./account-selector";
 import { markFamilyExhausted } from "./model-capacity";
 import {
 	ERROR_MESSAGES,
@@ -670,6 +672,20 @@ export async function proxyWithAccount(
 		// client-supplied copies before providers transform the outbound request.
 		headers.delete(SYNTHETIC_RESPONSE_HEADER);
 		headers.delete(SYNTHETIC_STATUS_HEADER);
+
+		// xAI cache-native conversation identity (issue #319 minimal slice).
+		// Applied here rather than via Provider.prepareHeaders: that hook only
+		// receives (headers, accessToken, apiKey) — no account or RequestMeta —
+		// so the conv id derived in proxy.ts isn't reachable there without
+		// widening the shared Provider interface for one provider's feature.
+		// A no-op for every non-xai request and whenever the feature is
+		// disabled (getXaiConvId returns null — see account-selector.ts).
+		applyXaiConvIdHeader(
+			headers,
+			provider.name,
+			account,
+			getXaiConvId(requestMeta),
+		);
 		const targetUrl = provider.buildUrl(url.pathname, url.search, account);
 
 		const requestInit: RequestInit & { duplex?: "half" } = {

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -7,6 +7,7 @@ import {
 import { DatabaseFactory } from "@better-ccflare/database";
 import { Logger } from "@better-ccflare/logger";
 import {
+	deriveXaiConvId,
 	getRepresentativeUsageSnapshotForProvider,
 	usageCache,
 } from "@better-ccflare/providers";
@@ -32,6 +33,7 @@ import {
 	type RequestJsonBody,
 	resolveEffectiveModel,
 	selectAccountsForRequest,
+	setXaiConvId,
 	validateProviderPath,
 } from "./handlers";
 import {
@@ -238,6 +240,17 @@ export async function handleProxy(
 	requestMeta.clientSessionId = requestBodyContext.getClientId();
 	requestMeta.originalModel = originalModel;
 	requestMeta.appliedModel = appliedModel;
+
+	// xAI cache-native conversation identity (issue #319 minimal slice):
+	// derive once per request and stash on the RequestMeta-keyed side channel
+	// (see account-selector.ts) rather than widening RequestMeta's shape.
+	// deriveXaiConvId is a no-op (returns null) unless CCFLARE_XAI_CACHE_NATIVE
+	// is exactly "1" and clientSessionId is a valid session UUID, so this is
+	// byte-for-byte a no-op when the feature is disabled.
+	const xaiConvId = deriveXaiConvId(requestMeta.clientSessionId);
+	if (xaiConvId) {
+		setXaiConvId(requestMeta, xaiConvId);
+	}
 
 	// 5b. Session volume circuit breaker: a runaway subagent storm shows up as
 	// one client session hammering /v1/messages. Count it here and, when


### PR DESCRIPTION
Implements the minimal slice of #319 you invited — conv-id header + sticky account affinity only. The extras from our production version (cache-outcome canary, flight recorder, keepalive scheduler) are deliberately excluded and can follow separately if there's appetite.

## Behavior (opt-in, default OFF — flag-off is a byte-for-byte no-op, asserted in tests)
- `CCFLARE_XAI_CACHE_NATIVE=1` derives a privacy-safe conversation id from the client's Claude session id (`RequestMeta.clientSessionId`): UUID-validated, then one-way hashed (truncated sha256) — the raw session id never appears in any outbound header or derived value.
- Attached as `x-grok-conv-id` only on requests to the **official** `api.x.ai` endpoint; custom/proxy xai endpoints never receive it.
- Sticky affinity: a bounded TTL map (~30 min refresh-on-use, 1024-entry cap, oldest-eviction) keeps a conversation on the account that owns its upstream cache partition. Promotion is scoped **within the xai candidate subset** — in a mixed pool, a non-xai account the strategy preferred keeps the lead, and ownership only transfers when an xai account is the presumptive server (both pinned by regression tests). Unroutable/expired owner → normal selection + ownership transfer.

## Your design notes, honored
- Conv id rides a `WeakMap<RequestMeta, …>` side channel in account-selector.ts (`xaiConvIdMap`), exactly the `comboSlotInfoMap`/`exhaustionInfoMap` idiom — RequestMeta's shape is untouched.
- `requiresSessionTracking` for xai stays `false`; affinity is a dedicated check in `selectAccountsForRequest`, not a piggyback on the session strategies. The forced-account header path and combo routing are explicitly untouched (regression-tested).

## Header seam
`applyXaiConvIdHeader` runs in proxy-operations.ts right after `provider.prepareHeaders()` — that hook receives only `(headers, accessToken, apiKey)`, so reaching it from inside `XaiProvider` would mean widening the shared Provider interface for one provider's feature. Mutating `req.headers` was rejected (it would leak the header into logged client request headers), as was provider-instance state (registry singletons race across concurrent requests). `XaiProvider` itself is unchanged. Any client-supplied `x-grok-conv-id` is overwritten, never forwarded.

## Testing
43 new tests across three files (26 derivation/gating unit, 15 selection-affinity incl. mixed-pool + forced/combo regression, 4 header integration (the header seam and count-tokens path)); existing xai provider + account-selector suites pass unmodified. `lint`/`typecheck`/`format` clean.

## Production provenance
The richer ancestor of this mechanism has been serving our production install since mid-July at a **≥99.5% warm-path cache hit rate** (multi-day soak, real agent traffic). This PR re-derives the core against your WeakMap idiom rather than porting our RequestMeta-extension approach.