### PR TITLE
feat(models): list provider-specific models for the model pickers

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -80,9 +80,11 @@ export {
 	uninstallOutboundProxy,
 } from "./outbound-proxy";
 export {
+	type CatalogueModelEntry,
 	estimateCostUSD,
 	getModelRates,
 	initializeNanoGPTPricingIfAccountsExist,
+	listCatalogueModels,
 	type ModelRates,
 	resetNanoGPTPricingCacheForTest,
 	setPricingLogger,

--- a/packages/core/src/pricing.ts
+++ b/packages/core/src/pricing.ts
@@ -22,6 +22,13 @@ interface ModelDef {
 	id: string;
 	name: string;
 	cost?: ModelCost;
+	/**
+	 * models.dev also publishes each model's modalities. Only read by
+	 * listCatalogueModels (to drop models that provably cannot emit text);
+	 * pricing itself ignores it. Optional because the bundled fallback
+	 * entries do not carry it.
+	 */
+	modalities?: { input?: string[]; output?: string[] };
 }
 
 interface ApiResponse {
@@ -839,6 +846,50 @@ export async function initializeNanoGPTPricingIfAccountsExist(
  */
 export function setPricingLogger(logger: Logger): void {
 	PriceCatalogue.get().setLogger(logger);
+}
+
+export interface CatalogueModelEntry {
+	id: string;
+	name: string;
+}
+
+/**
+ * List the models the shared models.dev catalogue knows for one provider
+ * section (e.g. "openai", "anthropic").
+ *
+ * Deliberately built on PriceCatalogue.getPricing() rather than a second
+ * fetcher: pricing already downloads, merges and caches this exact document
+ * (in memory + on disk, honouring CF_PRICING_OFFLINE and
+ * CF_PRICING_REFRESH_HOURS), so listing models costs no extra network call.
+ *
+ * Models that provably cannot emit text (embeddings, image generation) are
+ * dropped — this list exists to be offered as a chat model. Entries with no
+ * declared modalities are kept: the catalogue is not validated, and absence
+ * of data is not evidence of absence.
+ *
+ * Never throws, and never distinguishes "section is empty" from "catalogue
+ * unavailable" — both return []. Callers must treat an empty list as
+ * inconclusive, not as proof that the provider has no models.
+ */
+export async function listCatalogueModels(
+	providerSection: string,
+): Promise<CatalogueModelEntry[]> {
+	try {
+		const pricing = await PriceCatalogue.get().getPricing();
+		const models = pricing[providerSection]?.models;
+		if (!models) return [];
+		const entries: CatalogueModelEntry[] = [];
+		for (const [key, def] of Object.entries(models)) {
+			const output = def?.modalities?.output;
+			if (Array.isArray(output) && !output.includes("text")) continue;
+			const id = def?.id || key;
+			if (!id) continue;
+			entries.push({ id, name: def?.name || id });
+		}
+		return entries;
+	} catch {
+		return [];
+	}
 }
 
 /**

--- a/packages/dashboard-web/src/components/accounts/AccountModelMappingsDialog.tsx
+++ b/packages/dashboard-web/src/components/accounts/AccountModelMappingsDialog.tsx
@@ -6,6 +6,9 @@ import {
 } from "@better-ccflare/core";
 import React, { useState } from "react";
 import type { Account } from "../../api";
+import { firstModelInList } from "../../lib/model-api";
+import { providerAllowsClientModelPassthrough } from "../../utils/provider-utils";
+import { ModelCombobox } from "../models/ModelCombobox";
 import { Button } from "../ui/button";
 import {
 	Dialog,
@@ -15,7 +18,6 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "../ui/dialog";
-import { Input } from "../ui/input";
 import { Label } from "../ui/label";
 
 interface AccountModelMappingsDialogProps {
@@ -117,6 +119,13 @@ export function AccountModelMappingsDialog({
 
 	if (!account) return null;
 
+	// Same single rule as the combo slot. Here it does not block Save (mapping
+	// only the families this account actually uses is legitimate), but the
+	// user needs to know that "empty" is not passthrough on this provider.
+	const passthroughAllowed = providerAllowsClientModelPassthrough(
+		account.provider,
+	);
+
 	return (
 		<Dialog open={isOpen} onOpenChange={onOpenChange}>
 			<DialogContent className="sm:max-w-[600px] flex flex-col max-h-[85vh]">
@@ -136,56 +145,87 @@ export function AccountModelMappingsDialog({
 							<code className="text-xs bg-muted px-1 rounded">
 								model-a, model-b
 							</code>
-							) to cycle on rate limits.
+							) to cycle on rate limits. Pick from the provider list or type the
+							name; Test sends one real request with the first model of the
+							field and consumes quota.
 						</p>
+						{!passthroughAllowed && (
+							<p className="text-xs text-warning mb-3">
+								{account.provider} does not serve Claude model ids, so a family
+								left empty here is not passthrough: the built-in default map of
+								the provider decides instead, and it may point at a model this
+								account is not entitled to call. Map every family this account
+								is actually used for.
+							</p>
+						)}
 						<div className="grid grid-cols-2 gap-3">
 							<div className="space-y-1">
 								<Label htmlFor="fable" className="text-xs">
 									Fable
 								</Label>
-								<Input
-									id="fable"
-									value={modelMappings.fable}
-									onChange={(e) => handleInputChange("fable", e.target.value)}
-									placeholder={`e.g., ${LATEST_FABLE_MODEL}`}
-									className="h-8"
-								/>
+								<div className="flex items-center gap-1.5">
+									<ModelCombobox
+										id="fable"
+										mode="list"
+										provider={account.provider}
+										value={modelMappings.fable}
+										onChange={(value) => handleInputChange("fable", value)}
+										placeholder={`e.g., ${LATEST_FABLE_MODEL}`}
+										className="flex-1"
+										inputClassName="h-8"
+									/>
+								</div>
 							</div>
 							<div className="space-y-1">
 								<Label htmlFor="opus" className="text-xs">
 									Opus
 								</Label>
-								<Input
-									id="opus"
-									value={modelMappings.opus}
-									onChange={(e) => handleInputChange("opus", e.target.value)}
-									placeholder={`e.g., ${LATEST_OPUS_MODEL}`}
-									className="h-8"
-								/>
+								<div className="flex items-center gap-1.5">
+									<ModelCombobox
+										id="opus"
+										mode="list"
+										provider={account.provider}
+										value={modelMappings.opus}
+										onChange={(value) => handleInputChange("opus", value)}
+										placeholder={`e.g., ${LATEST_OPUS_MODEL}`}
+										className="flex-1"
+										inputClassName="h-8"
+									/>
+								</div>
 							</div>
 							<div className="space-y-1">
 								<Label htmlFor="sonnet" className="text-xs">
 									Sonnet
 								</Label>
-								<Input
-									id="sonnet"
-									value={modelMappings.sonnet}
-									onChange={(e) => handleInputChange("sonnet", e.target.value)}
-									placeholder={`e.g., ${LATEST_SONNET_MODEL}`}
-									className="h-8"
-								/>
+								<div className="flex items-center gap-1.5">
+									<ModelCombobox
+										id="sonnet"
+										mode="list"
+										provider={account.provider}
+										value={modelMappings.sonnet}
+										onChange={(value) => handleInputChange("sonnet", value)}
+										placeholder={`e.g., ${LATEST_SONNET_MODEL}`}
+										className="flex-1"
+										inputClassName="h-8"
+									/>
+								</div>
 							</div>
 							<div className="space-y-1">
 								<Label htmlFor="haiku" className="text-xs">
 									Haiku
 								</Label>
-								<Input
-									id="haiku"
-									value={modelMappings.haiku}
-									onChange={(e) => handleInputChange("haiku", e.target.value)}
-									placeholder={`e.g., ${LATEST_HAIKU_MODEL}`}
-									className="h-8"
-								/>
+								<div className="flex items-center gap-1.5">
+									<ModelCombobox
+										id="haiku"
+										mode="list"
+										provider={account.provider}
+										value={modelMappings.haiku}
+										onChange={(value) => handleInputChange("haiku", value)}
+										placeholder={`e.g., ${LATEST_HAIKU_MODEL}`}
+										className="flex-1"
+										inputClassName="h-8"
+									/>
+								</div>
 							</div>
 						</div>
 					</div>

--- a/packages/dashboard-web/src/components/combos/ComboSlotBuilder.tsx
+++ b/packages/dashboard-web/src/components/combos/ComboSlotBuilder.tsx
@@ -22,6 +22,7 @@ import {
 	useRemoveComboSlot,
 	useReorderComboSlots,
 } from "../../hooks/queries";
+import { providerAllowsClientModelPassthrough } from "../../utils/provider-utils";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
@@ -94,7 +95,11 @@ function SortableSlotRow({
 			</div>
 
 			<span className="shrink-0 font-mono text-xs text-muted-foreground">
-				{slot.model}
+				{slot.model?.trim() ? (
+					slot.model
+				) : (
+					<span className="italic">client model</span>
+				)}
 			</span>
 
 			<Button
@@ -159,8 +164,20 @@ export function ComboSlotBuilder({ combo }: ComboSlotBuilderProps) {
 		});
 	};
 
+	// Derived on every render rather than mirrored into state: the account is
+	// picked in the Select above this field and can be changed after the model
+	// has been typed, so no click order may leave an invalid slot behind.
+	const selectedProvider = accounts.find(
+		(a) => a.id === newAccountId,
+	)?.provider;
+	const passthroughAllowed =
+		providerAllowsClientModelPassthrough(selectedProvider);
+	const missingRequiredModel = !passthroughAllowed && !newModel.trim();
+
 	const handleAddSlot = () => {
-		if (!newAccountId || !newModel.trim()) return;
+		// An empty model means passthrough, which is only valid where the
+		// upstream serves Claude model ids. Elsewhere the model is required.
+		if (!newAccountId || missingRequiredModel) return;
 		addSlot.mutate(
 			{
 				comboId: combo.id,
@@ -230,12 +247,19 @@ export function ComboSlotBuilder({ combo }: ComboSlotBuilderProps) {
 							</Select>
 						</div>
 						<div className="space-y-1.5">
-							<Label>Model</Label>
+							<Label>{passthroughAllowed ? "Model (optional)" : "Model"}</Label>
 							<Input
 								value={newModel}
 								onChange={(e) => setNewModel(e.target.value)}
-								placeholder="claude-3-opus"
+								placeholder="Model id"
 							/>
+							<p className="text-xs text-muted-foreground">
+								{!newAccountId
+									? "Whether the model is required depends on the provider of the account you pick."
+									: passthroughAllowed
+										? "Leave empty to forward the model the client asked for."
+										: `Required for ${selectedProvider}: this provider does not serve Claude model ids, so there is nothing to forward.`}
+							</p>
 						</div>
 						<div className="flex justify-end gap-2">
 							<Button
@@ -253,7 +277,7 @@ export function ComboSlotBuilder({ combo }: ComboSlotBuilderProps) {
 								size="sm"
 								onClick={handleAddSlot}
 								disabled={
-									!newAccountId || !newModel.trim() || addSlot.isPending
+									!newAccountId || missingRequiredModel || addSlot.isPending
 								}
 							>
 								{addSlot.isPending ? "Adding..." : "Add"}

--- a/packages/dashboard-web/src/components/combos/ComboSlotBuilder.tsx
+++ b/packages/dashboard-web/src/components/combos/ComboSlotBuilder.tsx
@@ -23,10 +23,10 @@ import {
 	useReorderComboSlots,
 } from "../../hooks/queries";
 import { providerAllowsClientModelPassthrough } from "../../utils/provider-utils";
+import { ModelCombobox } from "../models/ModelCombobox";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
-import { Input } from "../ui/input";
 import { Label } from "../ui/label";
 import {
 	Select,
@@ -115,6 +115,24 @@ function SortableSlotRow({
 	);
 }
 
+/**
+ * Help line under the model field — must state the rule that applies TO THE
+ * SELECTED ACCOUNT, not a universal "Empty = passthrough" that only holds
+ * on the Anthropic provider.
+ */
+function modelFieldHint(
+	provider: string | null,
+	passthroughAllowed: boolean,
+): string {
+	if (!provider) {
+		return "Pick an account first: whether the model is required depends on the provider.";
+	}
+	if (passthroughAllowed) {
+		return "Empty = passthrough: the model sent by the client goes upstream untouched.";
+	}
+	return `Required for ${provider}: this provider does not serve Claude model ids, so there is no passthrough.`;
+}
+
 interface ComboSlotBuilderProps {
 	combo: ComboWithSlots;
 }
@@ -133,6 +151,19 @@ export function ComboSlotBuilder({ combo }: ComboSlotBuilderProps) {
 	const accounts = accountsQuery.data ?? [];
 	const families = familiesQuery.data?.families ?? [];
 	const assignedFamily = families.find((f) => f.combo_id === combo.id);
+	// The combobox needs the provider of the chosen account: without it the
+	// list suggested a Claude model for an OpenAI account.
+	const selectedProvider =
+		accounts.find((a) => a.id === newAccountId)?.provider ?? null;
+	// DERIVED on every render from (selected account + field text). None of
+	// this is copied into useState or synced via useEffect — that is what
+	// guarantees coherence when the user types first and switches the account
+	// afterward: label, hint, and the Add button's disabled state are all
+	// recomputed in the same render, so no click order lets an invalid slot through.
+	const passthroughAllowed =
+		providerAllowsClientModelPassthrough(selectedProvider);
+	const modelRequired = Boolean(selectedProvider) && !passthroughAllowed;
+	const missingRequiredModel = modelRequired && newModel.trim().length === 0;
 
 	const sensors = useSensors(
 		useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -164,19 +195,11 @@ export function ComboSlotBuilder({ combo }: ComboSlotBuilderProps) {
 		});
 	};
 
-	// Derived on every render rather than mirrored into state: the account is
-	// picked in the Select above this field and can be changed after the model
-	// has been typed, so no click order may leave an invalid slot behind.
-	const selectedProvider = accounts.find(
-		(a) => a.id === newAccountId,
-	)?.provider;
-	const passthroughAllowed =
-		providerAllowsClientModelPassthrough(selectedProvider);
-	const missingRequiredModel = !passthroughAllowed && !newModel.trim();
-
 	const handleAddSlot = () => {
-		// An empty model means passthrough, which is only valid where the
-		// upstream serves Claude model ids. Elsewhere the model is required.
+		// The model is only optional on a passthrough provider (the rule lives in
+		// utils/provider-utils). Outside those, an empty field means an invalid
+		// slot: the button is already disabled, this guard is the seatbelt against
+		// any code path that calls this anyway.
 		if (!newAccountId || missingRequiredModel) return;
 		addSlot.mutate(
 			{
@@ -248,20 +271,26 @@ export function ComboSlotBuilder({ combo }: ComboSlotBuilderProps) {
 						</div>
 						<div className="space-y-1.5">
 							<Label>{passthroughAllowed ? "Model (optional)" : "Model"}</Label>
-							<Input
-								value={newModel}
-								onChange={(e) => setNewModel(e.target.value)}
-								placeholder="Model id"
-							/>
-							<p className="text-xs text-muted-foreground">
-								{!newAccountId
-									? "Whether the model is required depends on the provider of the account you pick."
-									: passthroughAllowed
-										? "Leave empty to forward the model the client asked for."
-										: `Required for ${selectedProvider}: this provider does not serve Claude model ids, so there is nothing to forward.`}
+							<div className="flex items-center gap-1.5">
+								<ModelCombobox
+									provider={selectedProvider}
+									value={newModel}
+									onChange={setNewModel}
+									placeholder="Model id"
+									className="flex-1"
+								/>
+							</div>
+							<p className="text-[11px] text-muted-foreground">
+								{modelFieldHint(selectedProvider, passthroughAllowed)} Test
+								sends one real request to the provider and consumes quota.
 							</p>
 						</div>
-						<div className="flex justify-end gap-2">
+						<div className="flex items-center justify-end gap-2">
+							{missingRequiredModel && (
+								<p className="mr-auto text-[11px] text-destructive">
+									Pick a model: {selectedProvider} does not accept passthrough.
+								</p>
+							)}
 							<Button
 								variant="outline"
 								size="sm"
@@ -278,6 +307,11 @@ export function ComboSlotBuilder({ combo }: ComboSlotBuilderProps) {
 								onClick={handleAddSlot}
 								disabled={
 									!newAccountId || missingRequiredModel || addSlot.isPending
+								}
+								title={
+									missingRequiredModel
+										? `A model is required for ${selectedProvider}: this provider does not serve Claude model ids, so there is no passthrough.`
+										: undefined
 								}
 							>
 								{addSlot.isPending ? "Adding..." : "Add"}

--- a/packages/dashboard-web/src/components/models/ModelCombobox.tsx
+++ b/packages/dashboard-web/src/components/models/ModelCombobox.tsx
@@ -1,0 +1,343 @@
+import { Check, ChevronDown, Loader2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useProviderModels } from "../../hooks/useProviderModels";
+import {
+	formatModelList,
+	type ProviderModel,
+	parseModelList,
+} from "../../lib/model-api";
+import { cn } from "../../lib/utils";
+import { providerAllowsClientModelPassthrough } from "../../utils/provider-utils";
+import { Badge } from "../ui/badge";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import {
+	Popover,
+	PopoverAnchor,
+	PopoverContent,
+	PopoverTrigger,
+} from "../ui/popover";
+
+export interface ModelComboboxProps {
+	/** Provider for the target account ("anthropic", "codex", ...). Null = no list. */
+	provider?: string | null;
+	value: string;
+	onChange: (value: string) => void;
+	/**
+	 * "single": the field holds one model (a combo slot).
+	 * "list": the field holds a comma-separated list that rotates on rate
+	 * limits (account mappings). Picking an item toggles its presence in the
+	 * list instead of replacing the whole field.
+	 */
+	mode?: "single" | "list";
+	placeholder?: string;
+	id?: string;
+	/** Wrapper class (use flex-1 to share the row with the test button). */
+	className?: string;
+	inputClassName?: string;
+	disabled?: boolean;
+	/**
+	 * Completely hides the "use the client model" (passthrough) option from
+	 * the popover, even when the provider would allow it. Used on the
+	 * per-provider default-model map screen: there, an empty field means "no
+	 * override", never passthrough, so the option must not appear.
+	 * Defaults to false — ComboSlotBuilder and AccountModelMappingsDialog do
+	 * not pass this prop, so their behavior remains unchanged.
+	 */
+}
+
+interface ModelOptionProps {
+	model: ProviderModel;
+	picked: boolean;
+	onPick: (id: string) => void;
+}
+
+function ModelOption({ model, picked, onPick }: ModelOptionProps) {
+	return (
+		<button
+			type="button"
+			onClick={() => onPick(model.id)}
+			className={cn(
+				"flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left hover:bg-accent hover:text-accent-foreground",
+				picked && "bg-accent/60",
+			)}
+		>
+			<Check
+				className={cn(
+					"h-3.5 w-3.5 shrink-0",
+					picked ? "opacity-100" : "opacity-0",
+				)}
+			/>
+			<span className="min-w-0 flex-1">
+				<span className="block truncate font-mono text-xs">{model.id}</span>
+				{model.displayName !== model.id && (
+					<span className="block truncate text-[11px] text-muted-foreground">
+						{model.displayName}
+					</span>
+				)}
+			</span>
+		</button>
+	);
+}
+
+/**
+ * Passthrough option text, accurate for the target account provider.
+ *
+ * The old copy promised "the client model goes upstream untouched" for every
+ * provider — false outside passthrough providers, and that promise caused the
+ * broken slot in the incident.
+ */
+function clientModelHint(
+	mode: "single" | "list",
+	provider: string | null | undefined,
+	passthroughAllowed: boolean,
+): string {
+	if (passthroughAllowed) {
+		return mode === "list"
+			? "Clears the field. With no mapping, the model requested by the client goes upstream untouched."
+			: "Leaves the field empty (passthrough): the model requested by the client goes upstream untouched.";
+	}
+	const name = provider?.trim();
+	if (!name) {
+		return "Pick an account first: whether the model can be left empty depends on the provider.";
+	}
+	return mode === "list"
+		? `Not passthrough on ${name}: with no mapping, the built-in default map of the provider decides — and it may point at a model this account cannot call.`
+		: `Unavailable on ${name}: this provider does not serve Claude model ids, so an empty model would be coerced by a default map into something this account may not be able to call. Pick a model.`;
+}
+
+/**
+ * Model field with a provider list.
+ *
+ * It remains a free-text input: a new model works before it appears in the
+ * list. The list exists to reduce typing errors, not to close the set of
+ * options.
+ */
+export function ModelCombobox({
+	provider,
+	value,
+	onChange,
+	mode = "single",
+	placeholder,
+	id,
+	className,
+	inputClassName,
+	disabled,
+}: ModelComboboxProps) {
+	const [open, setOpen] = useState(false);
+	const [filter, setFilter] = useState("");
+	const query = useProviderModels(provider);
+
+	const selected = useMemo(() => parseModelList(value), [value]);
+	const usesClientModel = value.trim().length === 0;
+	const hasProvider = Boolean(provider?.trim());
+	// Single rule in utils/provider-utils: an empty field only means something
+	// when the upstream serves the same model IDs requested by the client.
+	const passthroughAllowed = providerAllowsClientModelPassthrough(provider);
+	// In mode="list", the same button CLEARs a mapping — a legitimate action
+	// for every provider — so only the copy changes there. In mode="single"
+	// (combo slot), an empty field would be an invalid slot: disable it and
+	// explain why rather than making it disappear without explanation.
+	const clientModelDisabled = mode === "single" && !passthroughAllowed;
+	const clientModelTitle =
+		mode === "list" && !passthroughAllowed
+			? "Clear this mapping"
+			: "Use the model sent by the client";
+
+	const { known, reference } = useMemo(() => {
+		const models = query.data?.models ?? [];
+		const needle = filter.trim().toLowerCase();
+		const matches = (model: ProviderModel) =>
+			needle.length === 0 ||
+			model.id.toLowerCase().includes(needle) ||
+			model.displayName.toLowerCase().includes(needle);
+		return {
+			known: models.filter((m) => m.source !== "reference" && matches(m)),
+			reference: models.filter((m) => m.source === "reference" && matches(m)),
+		};
+	}, [query.data, filter]);
+
+	const isPicked = (modelId: string) =>
+		mode === "list" ? selected.includes(modelId) : value.trim() === modelId;
+
+	const handlePick = (modelId: string) => {
+		if (mode === "list") {
+			// The list rotates on rate limits, so choosing toggles presence instead
+			// of deleting what is already there — and the popover stays open to build
+			// the whole list at once.
+			const next = selected.includes(modelId)
+				? selected.filter((m) => m !== modelId)
+				: [...selected, modelId];
+			onChange(formatModelList(next));
+			return;
+		}
+		onChange(modelId);
+		setOpen(false);
+	};
+
+	const handleUseClientModel = () => {
+		onChange("");
+		setOpen(false);
+	};
+
+	const nothingListed =
+		!query.isLoading &&
+		!query.isError &&
+		known.length === 0 &&
+		reference.length === 0;
+
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverAnchor asChild>
+				<div className={cn("relative w-full", className)}>
+					<Input
+						id={id}
+						value={value}
+						onChange={(e) => onChange(e.target.value)}
+						placeholder={placeholder}
+						disabled={disabled}
+						autoComplete="off"
+						spellCheck={false}
+						className={cn("pr-9 font-mono text-xs", inputClassName)}
+					/>
+					<PopoverTrigger asChild>
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							disabled={disabled}
+							aria-label="Show models for this provider"
+							title="Show models for this provider"
+							className="absolute right-0 top-0 h-full px-2 text-muted-foreground hover:bg-transparent hover:text-foreground"
+						>
+							<ChevronDown className="h-4 w-4" />
+						</Button>
+					</PopoverTrigger>
+				</div>
+			</PopoverAnchor>
+			<PopoverContent
+				align="start"
+				portal={false}
+				className="w-[max(var(--radix-popover-trigger-width),22rem)] p-0"
+			>
+				<div className="space-y-1 border-b p-2">
+					<Input
+						value={filter}
+						onChange={(e) => setFilter(e.target.value)}
+						placeholder="Filter models..."
+						className="h-8"
+					/>
+					<p className="px-1 text-[11px] text-muted-foreground">
+						{hasProvider
+							? `Models for provider: ${provider}`
+							: "No account selected yet, so there is no provider list to show."}
+						{mode === "list"
+							? " Click an item to add or remove it from the list."
+							: ""}
+					</p>
+				</div>
+				<div
+					className="max-h-72 overflow-y-auto overscroll-contain p-1"
+					onWheelCapture={(e) => e.stopPropagation()}
+				>
+					<button
+						type="button"
+						onClick={handleUseClientModel}
+						disabled={clientModelDisabled}
+						className={cn(
+							"mb-1 flex w-full items-start gap-2 rounded-sm border border-dashed px-2 py-2 text-left hover:bg-accent hover:text-accent-foreground",
+							usesClientModel &&
+								!clientModelDisabled &&
+								"border-primary bg-accent/60",
+							clientModelDisabled &&
+								"cursor-not-allowed opacity-60 hover:bg-transparent hover:text-inherit",
+						)}
+					>
+						<Check
+							className={cn(
+								"mt-0.5 h-3.5 w-3.5 shrink-0",
+								usesClientModel && !clientModelDisabled
+									? "opacity-100"
+									: "opacity-0",
+							)}
+						/>
+						<span className="min-w-0 flex-1">
+							<span className="block text-sm font-medium">
+								{clientModelTitle}
+							</span>
+							<span className="block text-[11px] text-muted-foreground">
+								{clientModelHint(mode, provider, passthroughAllowed)}
+							</span>
+						</span>
+					</button>
+
+					{query.isLoading && (
+						<div className="flex items-center gap-2 px-2 py-3 text-xs text-muted-foreground">
+							<Loader2 className="h-3.5 w-3.5 animate-spin" />
+							Loading models...
+						</div>
+					)}
+
+					{query.isError && (
+						<p className="px-2 py-3 text-xs text-destructive">
+							Could not load the model list. Typing the model name still works.{" "}
+							{query.error instanceof Error
+								? query.error.message
+								: "unknown error"}
+						</p>
+					)}
+
+					{hasProvider && nothingListed && (
+						<p className="px-2 py-3 text-xs text-muted-foreground">
+							No model matched. Type the name — a brand new model works before
+							it shows up here.
+						</p>
+					)}
+
+					{known.length > 0 && (
+						<>
+							<div className="px-2 pb-1 pt-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+								Known to ccflare
+							</div>
+							{known.map((model) => (
+								<ModelOption
+									key={model.id}
+									model={model}
+									picked={isPicked(model.id)}
+									onPick={handlePick}
+								/>
+							))}
+						</>
+					)}
+
+					{reference.length > 0 && (
+						<>
+							<div className="flex flex-wrap items-center gap-1.5 px-2 pb-1 pt-3">
+								<span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+									Provider catalog (reference)
+								</span>
+								<Badge variant="warning" className="px-1.5 py-0 text-[10px]">
+									may not be released for this plan
+								</Badge>
+							</div>
+							<p className="px-2 pb-1 text-[11px] text-muted-foreground">
+								Listed in the public catalog of the provider. Being here is no
+								proof that the plan of this account can call it: a subscription
+								account still gets HTTP 400 for a model it is not entitled to.
+								Use Test to find out.
+							</p>
+							{reference.map((model) => (
+								<ModelOption
+									key={model.id}
+									model={model}
+									picked={isPicked(model.id)}
+									onPick={handlePick}
+								/>
+							))}
+						</>
+					)}
+				</div>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/packages/dashboard-web/src/components/ui/popover.tsx
+++ b/packages/dashboard-web/src/components/ui/popover.tsx
@@ -7,23 +7,43 @@ const Popover = PopoverPrimitive.Root;
 
 const PopoverTrigger = PopoverPrimitive.Trigger;
 
+// Optional anchor: lets the popover be positioned by an element other than
+// the trigger (e.g. open aligned to the field, not the button inside it).
+const PopoverAnchor = PopoverPrimitive.Anchor;
+
 const PopoverContent = React.forwardRef<
 	React.ElementRef<typeof PopoverPrimitive.Content>,
-	React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-	<PopoverPrimitive.Portal>
-		<PopoverPrimitive.Content
-			ref={ref}
-			align={align}
-			sideOffset={sideOffset}
-			className={cn(
-				"z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-				className,
-			)}
-			{...props}
-		/>
-	</PopoverPrimitive.Portal>
-));
+	React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> & {
+		/** false renders without a Portal (needed inside a Dialog so the mouse wheel can scroll) */
+		portal?: boolean;
+	}
+>(
+	(
+		{ className, align = "center", sideOffset = 4, portal = true, ...props },
+		ref,
+	) => {
+		const content = (
+			<PopoverPrimitive.Content
+				ref={ref}
+				align={align}
+				sideOffset={sideOffset}
+				className={cn(
+					"z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+					className,
+				)}
+				{...props}
+			/>
+		);
+		// Without a portal, the content stays in the subtree of the dialog that
+		// contains it — and that is what makes the mouse wheel work: Radix
+		// Dialog's react-remove-scroll blocks scrolling on any node outside it.
+		return portal ? (
+			<PopoverPrimitive.Portal>{content}</PopoverPrimitive.Portal>
+		) : (
+			content
+		);
+	},
+);
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
-export { Popover, PopoverContent, PopoverTrigger };
+export { Popover, PopoverAnchor, PopoverContent, PopoverTrigger };

--- a/packages/dashboard-web/src/hooks/useProviderModels.ts
+++ b/packages/dashboard-web/src/hooks/useProviderModels.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchProviderModels } from "../lib/model-api";
+import { queryKeys } from "../lib/query-keys";
+
+/**
+ * Provider model list. Disabled while the provider is unknown (no selected
+ * account), so the combobox never suggests the wrong provider list.
+ */
+export const useProviderModels = (provider?: string | null) => {
+	const normalized = provider?.trim() ?? "";
+	return useQuery({
+		queryKey: queryKeys.providerModels(normalized),
+		queryFn: () => fetchProviderModels(normalized),
+		enabled: normalized.length > 0,
+		staleTime: 5 * 60 * 1000,
+		gcTime: 30 * 60 * 1000,
+		// The list is a convenience: a failure must not become a retry storm,
+		// because the field still accepts free text.
+		retry: false,
+	});
+};

--- a/packages/dashboard-web/src/lib/model-api.ts
+++ b/packages/dashboard-web/src/lib/model-api.ts
@@ -1,0 +1,111 @@
+import { HttpError } from "@better-ccflare/http-common";
+import { api } from "../api";
+
+/**
+ * Adapter for the two endpoints used by the model selector.
+ *
+ * Everything the dashboard knows about these response shapes lives here: if
+ * the backend changes the contract, this is the only file to update.
+ *
+ *   GET  /api/models?provider=<anthropic|codex|...>
+ *     -> { provider, fetchedAt, source, models: [{ id, displayName, source }] }
+ *   POST /api/accounts/:id/test-model    body { model }
+ *     -> { ok, inconclusive?, status, error?, durationMs }
+ *
+ * Authentication comes for free from the shared `api` client, which injects
+ * `x-api-key` into every request and opens the auth dialog on 401.
+ */
+
+export type ProviderModelSource = "builtin" | "catalog" | "reference";
+
+export interface ProviderModel {
+	id: string;
+	displayName: string;
+	/**
+	 * "builtin"/"catalog": ccflare knows this model for the provider.
+	 * "reference": it exists in the provider public catalog — which is NOT a
+	 * promise that the account plan can call it.
+	 */
+	source: ProviderModelSource;
+}
+
+export interface ProviderModels {
+	provider: string;
+	fetchedAt: number | null;
+	source: string | null;
+	models: ProviderModel[];
+}
+
+const MODEL_SOURCES: ProviderModelSource[] = [
+	"builtin",
+	"catalog",
+	"reference",
+];
+
+function normalizeSource(value: unknown): ProviderModelSource {
+	return MODEL_SOURCES.includes(value as ProviderModelSource)
+		? (value as ProviderModelSource)
+		: "catalog";
+}
+
+function normalizeModel(raw: unknown): ProviderModel | null {
+	if (typeof raw === "string") {
+		const id = raw.trim();
+		return id ? { id, displayName: id, source: "catalog" } : null;
+	}
+	if (!raw || typeof raw !== "object") return null;
+	const entry = raw as Record<string, unknown>;
+	const id = typeof entry.id === "string" ? entry.id.trim() : "";
+	if (!id) return null;
+	const displayName =
+		typeof entry.displayName === "string" && entry.displayName.trim()
+			? entry.displayName.trim()
+			: id;
+	return { id, displayName, source: normalizeSource(entry.source) };
+}
+
+function asRecord(raw: unknown): Record<string, unknown> {
+	return raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+}
+
+/** Model list for a provider. Tolerant: malformed input becomes an empty list. */
+export async function fetchProviderModels(
+	provider: string,
+): Promise<ProviderModels> {
+	const body = asRecord(
+		await api.get<unknown>(
+			`/api/models?provider=${encodeURIComponent(provider)}`,
+		),
+	);
+	const list: unknown[] = Array.isArray(body.models) ? body.models : [];
+	const seen = new Set<string>();
+	const models: ProviderModel[] = [];
+	for (const item of list) {
+		const model = normalizeModel(item);
+		if (!model || seen.has(model.id)) continue;
+		seen.add(model.id);
+		models.push(model);
+	}
+	return {
+		provider: typeof body.provider === "string" ? body.provider : provider,
+		fetchedAt: typeof body.fetchedAt === "number" ? body.fetchedAt : null,
+		source: typeof body.source === "string" ? body.source : null,
+		models,
+	};
+}
+
+export function parseModelList(value: string): string[] {
+	return value
+		.split(",")
+		.map((part) => part.trim())
+		.filter(Boolean);
+}
+
+export function formatModelList(models: string[]): string {
+	return models.join(", ");
+}
+
+/** First model in the list — the one the proxy tries before the others. */
+export function firstModelInList(value: string): string {
+	return parseModelList(value)[0] ?? "";
+}

--- a/packages/dashboard-web/src/lib/query-keys.ts
+++ b/packages/dashboard-web/src/lib/query-keys.ts
@@ -37,4 +37,13 @@ export const queryKeys = {
 	usageHistory: (account?: string, range?: string) =>
 		[...queryKeys.all, "usage-history", { account, range }] as const,
 	models: () => [...queryKeys.all, "models"] as const,
+	// Deliberately kept under the 'models' key: invalidating models() also
+	// invalidates the per-provider lists.
+	providerModels: (provider?: string | null) =>
+		[...queryKeys.all, "models", "provider", provider ?? ""] as const,
+	// Single record for the default-model map per provider+family (today the
+	// last word in the chain, hardcoded). No parameter: the screen reads
+	// and writes everything at once.
+	providerModelDefaults: () =>
+		[...queryKeys.all, "config", "provider-model-defaults"] as const,
 } as const;

--- a/packages/dashboard-web/src/utils/provider-utils.ts
+++ b/packages/dashboard-web/src/utils/provider-utils.ts
@@ -21,6 +21,39 @@ export function providerSupportsAutoFeatures(provider: string): boolean {
 }
 
 /**
+ * Providers whose upstream answers by the SAME model ids the client asks for.
+ *
+ * This is the one and only definition of the passthrough rule. An empty model
+ * field means "forward whatever model the client sent, untouched" — which is
+ * only meaningful when the upstream natively accepts Claude model ids, i.e.
+ * Anthropic OAuth accounts and Claude Console API accounts.
+ *
+ * On every other provider the Claude id sent by the client lands on a foreign
+ * catalog and gets coerced by an embedded default map. That is the exact path
+ * that produced `400 The 'gpt-5.3-codex' model is not supported...` on a codex
+ * account. So outside this list, choosing a model is mandatory.
+ *
+ * Never compare `provider === "anthropic"` at a call site: use the helper
+ * below, so the criterion stays in a single place.
+ */
+export const PASSTHROUGH_PROVIDERS: readonly string[] = [
+	PROVIDER_NAMES.ANTHROPIC,
+	PROVIDER_NAMES.CLAUDE_CONSOLE_API,
+];
+
+/**
+ * True when the model field may be left empty (passthrough) for this provider.
+ *
+ * An absent/unknown provider (no account picked yet) is NOT passthrough: we
+ * cannot promise a behaviour we do not know the upstream supports.
+ */
+export function providerAllowsClientModelPassthrough(
+	provider?: string | null,
+): boolean {
+	return PASSTHROUGH_PROVIDERS.includes((provider ?? "").trim());
+}
+
+/**
  * Check if a provider supports custom billing type configuration
  * (anthropic-compatible and openai-compatible providers)
  */

--- a/packages/http-api/src/handlers/__tests__/combo-slot-model-required.test.ts
+++ b/packages/http-api/src/handlers/__tests__/combo-slot-model-required.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "bun:test";
+import { createSlotAddHandler, createSlotUpdateHandler } from "../combos";
+
+/**
+ * Passthrough (a combo slot with an empty model) forwards the model the CLIENT
+ * asked for. That only works where the upstream accepts Claude model ids —
+ * Anthropic accounts. On a codex account the Claude name falls through to the
+ * provider's built-in default map, which is the path that produced
+ * `400 The 'gpt-5.3-codex' model is not supported when using Codex with a
+ * ChatGPT account`.
+ */
+
+type Slot = {
+	id: string;
+	combo_id: string;
+	account_id: string;
+	model: string;
+	priority: number;
+	enabled: boolean;
+};
+
+function makeDbOps(provider: string, slots: Slot[] = []) {
+	const added: Array<{ accountId: string; model: string }> = [];
+	const updated: Array<Record<string, unknown>> = [];
+	return {
+		added,
+		updated,
+		ops: {
+			getCombo: async () => ({ id: "combo-1", name: "C", enabled: true }),
+			getAccount: async (id: string) => ({ id, name: "acc", provider }),
+			getComboSlots: async () => slots,
+			addComboSlot: async (
+				_comboId: string,
+				accountId: string,
+				model: string,
+			) => {
+				added.push({ accountId, model });
+				return { id: "slot-new", model };
+			},
+			updateComboSlot: async (_id: string, fields: Record<string, unknown>) => {
+				updated.push(fields);
+				return { id: "slot-1", ...fields };
+			},
+		},
+	};
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: minimal DatabaseOperations mock
+const asOps = (o: unknown) => o as any;
+
+function postSlot(body: unknown) {
+	return new Request("http://local/api/combos/combo-1/slots", {
+		method: "POST",
+		body: JSON.stringify(body),
+	});
+}
+
+describe("combo slot: model required depending on the provider", () => {
+	it("accepts a slot with no model on an anthropic account (passthrough)", async () => {
+		const db = makeDbOps("anthropic");
+		const res = await createSlotAddHandler(asOps(db.ops))(
+			postSlot({ account_id: "acc-1" }),
+			"combo-1",
+		);
+
+		expect(res.status).toBe(201);
+		expect(db.added).toEqual([{ accountId: "acc-1", model: "" }]);
+	});
+
+	it("rejects a slot with no model on a codex account", async () => {
+		const db = makeDbOps("codex");
+		const res = await createSlotAddHandler(asOps(db.ops))(
+			postSlot({ account_id: "acc-1" }),
+			"combo-1",
+		);
+
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as { error?: string };
+		expect(String(body.error)).toContain("codex");
+		// Nothing was written: the refusal happens before the insert.
+		expect(db.added).toHaveLength(0);
+	});
+
+	it("accepts a slot WITH a model on a codex account", async () => {
+		const db = makeDbOps("codex");
+		const res = await createSlotAddHandler(asOps(db.ops))(
+			postSlot({ account_id: "acc-1", model: "gpt-5.6-sol" }),
+			"combo-1",
+		);
+
+		expect(res.status).toBe(201);
+		expect(db.added).toEqual([{ accountId: "acc-1", model: "gpt-5.6-sol" }]);
+	});
+
+	// Without the same rule on the update route the validation is bypassable in
+	// two steps: create the slot with a model, then empty it.
+	it("rejects emptying the model of an existing codex slot", async () => {
+		const slots: Slot[] = [
+			{
+				id: "slot-1",
+				combo_id: "combo-1",
+				account_id: "acc-1",
+				model: "gpt-5.6-sol",
+				priority: 0,
+				enabled: true,
+			},
+		];
+		const db = makeDbOps("codex", slots);
+		const res = await createSlotUpdateHandler(asOps(db.ops))(
+			new Request("http://local/api/combos/combo-1/slots/slot-1", {
+				method: "PUT",
+				body: JSON.stringify({ model: "" }),
+			}),
+			"combo-1",
+			"slot-1",
+		);
+
+		expect(res.status).toBe(400);
+		expect(db.updated).toHaveLength(0);
+	});
+
+	// Regression for the cross-combo bypass: updateComboSlot resolves the slot
+	// globally, so a slot id addressed through a combo that does not own it used
+	// to skip the provider check entirely and still be updated.
+	it("rejects emptying a slot addressed through a combo that does not own it", async () => {
+		// The combo in the path owns no slots, so the lookup finds nothing.
+		const db = makeDbOps("codex", []);
+		const res = await createSlotUpdateHandler(asOps(db.ops))(
+			new Request("http://local/api/combos/other-combo/slots/slot-1", {
+				method: "PUT",
+				body: JSON.stringify({ model: "" }),
+			}),
+			"other-combo",
+			"slot-1",
+		);
+
+		expect(res.status).toBe(404);
+		expect(db.updated).toHaveLength(0);
+	});
+
+	it("allows emptying the model of an anthropic slot", async () => {
+		const slots: Slot[] = [
+			{
+				id: "slot-1",
+				combo_id: "combo-1",
+				account_id: "acc-1",
+				model: "claude-opus-5",
+				priority: 0,
+				enabled: true,
+			},
+		];
+		const db = makeDbOps("anthropic", slots);
+		const res = await createSlotUpdateHandler(asOps(db.ops))(
+			new Request("http://local/api/combos/combo-1/slots/slot-1", {
+				method: "PUT",
+				body: JSON.stringify({ model: "" }),
+			}),
+			"combo-1",
+			"slot-1",
+		);
+
+		expect(res.status).toBe(200);
+		expect(db.updated).toEqual([{ model: "" }]);
+	});
+});

--- a/packages/http-api/src/handlers/__tests__/models-provider.test.ts
+++ b/packages/http-api/src/handlers/__tests__/models-provider.test.ts
@@ -1,0 +1,227 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { CODEX_KNOWN_MODELS } from "@better-ccflare/providers";
+import type { APIContext } from "@better-ccflare/types";
+
+// listCatalogueModels is the seam to the shared models.dev catalogue, and the
+// real one performs network I/O. Stub it so these tests are offline and
+// deterministic.
+//
+// mock.module must run at top level and replaces the WHOLE module globally
+// and across file boundaries in Bun (no per-file isolation without
+// --isolate), so we capture the real @better-ccflare/core exports first,
+// spread them, and restore them in afterAll — same discipline as
+// oauth.test.ts. The handler is then imported dynamically, AFTER the mock is
+// registered, so its `listCatalogueModels` binding is the stub beyond any
+// doubt about import ordering.
+const actualCore = await import("@better-ccflare/core");
+
+/** What the stubbed catalogue returns; set per test. */
+let catalogueEntries: Array<{ id: string; name: string }> = [];
+/** Every models.dev section the handler asked for, in order. */
+let catalogueCalls: string[] = [];
+
+const stubListCatalogueModels = async (section: string) => {
+	catalogueCalls.push(section);
+	return catalogueEntries;
+};
+
+mock.module("@better-ccflare/core", () => ({
+	...actualCore,
+	listCatalogueModels: stubListCatalogueModels,
+}));
+
+afterAll(() => {
+	mock.module("@better-ccflare/core", () => actualCore);
+});
+
+const { createModelsHandler } = await import("../models");
+
+interface ListedModel {
+	id: string;
+	displayName: string;
+	source: string;
+	createdAt?: string | null;
+}
+
+interface ModelsBody {
+	models: ListedModel[];
+	fetchedAt: number;
+	source: string;
+	provider: string;
+	referenceSection?: string;
+	warning?: string;
+}
+
+const CATALOG_FETCHED_AT = 1_700_000_000_000;
+
+/** Context carrying a canned Anthropic catalog — the only dependency of the
+ * no-provider / anthropic branch. */
+function makeContext(): APIContext {
+	return {
+		modelCatalog: {
+			get: async () => ({
+				models: [
+					{
+						id: "claude-sonnet-4-5-20250929",
+						displayName: "Claude Sonnet 4.5",
+						createdAt: "2025-09-29T00:00:00Z",
+					},
+				],
+				fetchedAt: CATALOG_FETCHED_AT,
+				source: "live" as const,
+			}),
+			refresh: async () => ({ success: true }),
+		},
+	} as unknown as APIContext;
+}
+
+/** Find one listed model, failing loudly instead of returning undefined. */
+function listed(body: ModelsBody, id: string): ListedModel {
+	const found = body.models.find((model) => model.id === id);
+	if (!found) {
+		throw new Error(
+			`Expected model "${id}" in listing, got: ${body.models
+				.map((model) => model.id)
+				.join(", ")}`,
+		);
+	}
+	return found;
+}
+
+describe("GET /api/models", () => {
+	beforeEach(() => {
+		catalogueEntries = [];
+		catalogueCalls = [];
+	});
+
+	// Non-regression: the agents screen consumes this body. `provider` and the
+	// per-entry `source` are additive; nothing that was there may move.
+	it("without ?provider keeps the legacy Anthropic body shape", async () => {
+		const handler = createModelsHandler(makeContext());
+
+		const response = await handler(new URL("http://localhost/api/models"));
+		const body = (await response.json()) as ModelsBody;
+
+		expect(response.status).toBe(200);
+		expect(body.fetchedAt).toBe(CATALOG_FETCHED_AT);
+		expect(body.source).toBe("live");
+		expect(body.models).toHaveLength(1);
+		expect(body.models[0]).toMatchObject({
+			id: "claude-sonnet-4-5-20250929",
+			displayName: "Claude Sonnet 4.5",
+			createdAt: "2025-09-29T00:00:00Z",
+			source: "catalog",
+		});
+		expect(body.provider).toBe("anthropic");
+		// The Anthropic branch must never consult the models.dev catalogue.
+		expect(catalogueCalls).toEqual([]);
+
+		// The URL argument is optional — calling with none behaves identically.
+		const bare = (await (await handler()).json()) as ModelsBody;
+		expect(bare.provider).toBe("anthropic");
+		expect(bare.models).toHaveLength(1);
+	});
+
+	it("?provider=codex lists the builtins first, in map order, tagged builtin", async () => {
+		catalogueEntries = [
+			{ id: "gpt-4.1", name: "GPT-4.1" },
+			{ id: "gpt-4o", name: "GPT-4o" },
+		];
+		const handler = createModelsHandler(makeContext());
+
+		const response = await handler(
+			new URL("http://localhost/api/models?provider=codex"),
+		);
+		const body = (await response.json()) as ModelsBody;
+
+		expect(response.status).toBe(200);
+		expect(body.provider).toBe("codex");
+		// codex is served by the "openai" section of models.dev.
+		expect(catalogueCalls).toEqual(["openai"]);
+		expect(body.referenceSection).toBe("openai");
+		expect(body.source).toBe("mixed");
+
+		const ids = body.models.map((model) => model.id);
+		// Builtins come first and in the declaration order of the provider's
+		// own context-window table.
+		expect(ids.slice(0, CODEX_KNOWN_MODELS.length)).toEqual([
+			...CODEX_KNOWN_MODELS,
+		]);
+		// The model at the heart of the incident this endpoint exists for.
+		expect(ids).toContain("gpt-5.3-codex");
+		for (const id of CODEX_KNOWN_MODELS) {
+			expect(listed(body, id).source).toBe("builtin");
+		}
+		// Reference entries follow, alphabetically.
+		expect(ids.slice(CODEX_KNOWN_MODELS.length)).toEqual(["gpt-4.1", "gpt-4o"]);
+		expect(listed(body, "gpt-4.1").source).toBe("reference");
+		expect(listed(body, "gpt-4.1").displayName).toBe("GPT-4.1");
+	});
+
+	// listCatalogueModels is contractually non-throwing: it swallows fetch
+	// failures and an unknown section alike, and reports both as an empty
+	// list. That empty list is therefore the "catalogue unavailable" signal
+	// the handler has to survive — the endpoint must degrade, never fail.
+	it("?provider=codex degrades to builtins plus a warning when the catalogue is unavailable", async () => {
+		catalogueEntries = [];
+		const handler = createModelsHandler(makeContext());
+
+		const response = await handler(
+			new URL("http://localhost/api/models?provider=codex"),
+		);
+		const body = (await response.json()) as ModelsBody;
+
+		expect(response.status).toBe(200);
+		expect(body.source).toBe("builtin");
+		expect(body.models).toHaveLength(CODEX_KNOWN_MODELS.length);
+		expect(body.models.every((model) => model.source === "builtin")).toBe(true);
+		expect(body.warning).toBeDefined();
+		expect(body.warning).toContain("openai");
+	});
+
+	it("deduplicates by id, keeping the stronger marking", async () => {
+		catalogueEntries = [
+			// Also a builtin: must survive once, as builtin.
+			{ id: "gpt-5.6-sol", name: "GPT-5.6 Sol (catalogue name)" },
+			{ id: "gpt-4.1", name: "GPT-4.1" },
+			// Repeated inside the reference list itself.
+			{ id: "gpt-4.1", name: "GPT-4.1 (again)" },
+		];
+		const handler = createModelsHandler(makeContext());
+
+		const response = await handler(
+			new URL("http://localhost/api/models?provider=codex"),
+		);
+		const body = (await response.json()) as ModelsBody;
+
+		const ids = body.models.map((model) => model.id);
+		expect(ids.filter((id) => id === "gpt-5.6-sol")).toHaveLength(1);
+		expect(ids.filter((id) => id === "gpt-4.1")).toHaveLength(1);
+
+		const sol = listed(body, "gpt-5.6-sol");
+		expect(sol.source).toBe("builtin");
+		// The builtin entry wins whole — the catalogue's display name must not
+		// leak in and make a builtin look like a catalogue find.
+		expect(sol.displayName).toBe("gpt-5.6-sol");
+		expect(listed(body, "gpt-4.1").source).toBe("reference");
+		expect(body.models).toHaveLength(CODEX_KNOWN_MODELS.length + 1);
+	});
+
+	it("an unknown provider yields an empty listing rather than an error", async () => {
+		catalogueEntries = [];
+		const handler = createModelsHandler(makeContext());
+
+		const response = await handler(
+			new URL("http://localhost/api/models?provider=nope"),
+		);
+		const body = (await response.json()) as ModelsBody;
+
+		expect(response.status).toBe(200);
+		expect(body.provider).toBe("nope");
+		// No override in the section map: the provider name is used verbatim.
+		expect(catalogueCalls).toEqual(["nope"]);
+		expect(body.models).toEqual([]);
+		expect(body.source).toBe("unavailable");
+		expect(body.warning).toBeDefined();
+	});
+});

--- a/packages/http-api/src/handlers/combos.ts
+++ b/packages/http-api/src/handlers/combos.ts
@@ -8,6 +8,24 @@ import type {
 import { errorResponse } from "../utils/http-error";
 
 /**
+ * Providers whose upstream natively accepts Claude model ids. Only for these
+ * does a slot without a model (passthrough) make sense: the model the client
+ * asked for arrives intact and is understood on the other side.
+ *
+ * On any other provider, passthrough would hand a Claude name to an upstream
+ * that does not know it, and translation would fall to the embedded default
+ * map — the path that produced `400 gpt-5.3-codex ... ChatGPT account`.
+ */
+const PROVIDERS_ACCEPTING_CLIENT_MODEL = new Set([
+	"anthropic",
+	"claude-console-api",
+]);
+
+function allowsClientModel(provider: string | null | undefined): boolean {
+	return PROVIDERS_ACCEPTING_CLIENT_MODEL.has(provider ?? "anthropic");
+}
+
+/**
  * GET /api/combos — List all combos with slot counts (lightweight)
  */
 export function createCombosListHandler(dbOps: DatabaseOperations) {
@@ -198,11 +216,31 @@ export function createSlotAddHandler(dbOps: DatabaseOperations) {
 				typeof account_id !== "string" ||
 				account_id.trim().length === 0
 			) {
-				return errorResponse(BadRequest("account_id and model are required"));
+				return errorResponse(BadRequest("account_id is required"));
 			}
 
-			if (!model || typeof model !== "string" || model.trim().length === 0) {
-				return errorResponse(BadRequest("account_id and model are required"));
+			// `model` is optional: a slot with no model means passthrough — the
+			// model the client asked for goes upstream untouched. We store an
+			// empty string (not NULL) because combo_slots.model is NOT NULL and the
+			// unique index (combo_id, account_id, model) only blocks duplicates with "".
+			if (model !== undefined && model !== null && typeof model !== "string") {
+				return errorResponse(
+					BadRequest("model must be a string when provided"),
+				);
+			}
+			const slotModel = typeof model === "string" ? model.trim() : "";
+
+			// Passthrough only holds where the upstream speaks the same model
+			// namespace as the client. See PROVIDERS_ACCEPTING_CLIENT_MODEL.
+			if (slotModel.length === 0) {
+				const account = await dbOps.getAccount(account_id);
+				if (account && !allowsClientModel(account.provider)) {
+					return errorResponse(
+						BadRequest(
+							`model is required for provider "${account.provider}": only accounts that serve Claude model ids can forward the client model unchanged`,
+						),
+					);
+				}
 			}
 
 			const existingSlots = await dbOps.getComboSlots(comboId);
@@ -210,7 +248,7 @@ export function createSlotAddHandler(dbOps: DatabaseOperations) {
 			const newSlot = await dbOps.addComboSlot(
 				comboId,
 				account_id,
-				model.trim(),
+				slotModel,
 				nextPriority,
 			);
 
@@ -243,10 +281,35 @@ export function createSlotUpdateHandler(dbOps: DatabaseOperations) {
 			}> = {};
 
 			if (model !== undefined) {
-				if (typeof model !== "string" || model.trim().length === 0) {
-					return errorResponse(BadRequest("model must be a non-empty string"));
+				// An empty string clears the override and makes the slot passthrough.
+				if (typeof model !== "string") {
+					return errorResponse(BadRequest("model must be a string"));
 				}
 				fields.model = model.trim();
+
+				// Same rule as the POST, now for whoever clears a slot that already
+				// exists: without it, the validation could be bypassed in two steps.
+				if (fields.model.length === 0) {
+					const slots = await dbOps.getComboSlots(_comboId);
+					const slot = slots.find((s) => s.id === slotId);
+					// A slot id that this combo does not own must not silently skip
+					// the check: updateComboSlot resolves the slot globally, so a
+					// mismatched combo id in the path would let an incompatible slot
+					// become passthrough.
+					if (!slot) {
+						return errorResponse(NotFound("Combo slot not found"));
+					}
+					{
+						const account = await dbOps.getAccount(slot.account_id);
+						if (account && !allowsClientModel(account.provider)) {
+							return errorResponse(
+								BadRequest(
+									`model is required for provider "${account.provider}": only accounts that serve Claude model ids can forward the client model unchanged`,
+								),
+							);
+						}
+					}
+				}
 			}
 
 			if (enabled !== undefined) {

--- a/packages/http-api/src/handlers/models.ts
+++ b/packages/http-api/src/handlers/models.ts
@@ -1,17 +1,135 @@
+import { listCatalogueModels } from "@better-ccflare/core";
 import { errorResponse, jsonResponse } from "@better-ccflare/http-common";
+import { CODEX_KNOWN_MODELS } from "@better-ccflare/providers";
 import type { APIContext } from "../types";
 
 /**
- * GET /api/models — return the cached Anthropic model catalog (live if a
- * successful fetch has occurred, otherwise the bundled static fallback).
+ * Where a listed model id came from — the whole point of the endpoint.
+ *
+ *  - "builtin"   ccflare itself knows this model for that provider (it is in
+ *                the provider adapter's own table). Strongest signal there is.
+ *  - "catalog"   the provider's own live listing (Anthropic /v1/models),
+ *                fetched with a real account's credentials.
+ *  - "reference" the public models.dev catalogue. Says the model EXISTS at
+ *                the vendor and says NOTHING about whether a given account's
+ *                plan may call it: ChatGPT-subscription accounts reject
+ *                gpt-5.3-codex with HTTP 400 while OpenAI lists it happily.
+ *                Never collapse this into the other two.
+ */
+export type ModelListingSource = "builtin" | "catalog" | "reference";
+
+export interface ProviderModelEntry {
+	id: string;
+	displayName: string;
+	source: ModelListingSource;
+}
+
+/**
+ * ccflare provider name -> models.dev top-level section. Only names that
+ * differ need an entry; anything else falls through to the provider name
+ * itself, which models.dev uses verbatim for "anthropic", "zai", "minimax",
+ * and friends.
+ */
+const MODELS_DEV_SECTION_BY_PROVIDER: Record<string, string> = {
+	codex: "openai",
+};
+
+/** Model ids ccflare ships knowledge of, per provider. */
+const BUILTIN_MODELS_BY_PROVIDER: Record<string, readonly string[]> = {
+	codex: CODEX_KNOWN_MODELS,
+};
+
+/**
+ * Providers served by the live Anthropic catalog. Both auth modes (OAuth and
+ * console API key) talk to the same /v1/models listing, so both get it.
+ */
+function isAnthropicProvider(provider: string): boolean {
+	return provider === "anthropic" || provider === "claude-console-api";
+}
+
+/**
+ * GET /api/models[?provider=<name>] — list the models available for one
+ * provider, each entry tagged with where the knowledge came from.
+ *
+ * Without `provider` (and for the Anthropic providers) the body is exactly
+ * what this endpoint has always returned — the cached live catalog, or the
+ * bundled static fallback — so existing callers keep working; `provider` and
+ * the per-entry `source` are purely additive fields.
+ *
+ * For every other provider the answer is the union of what ccflare knows
+ * built in and what the public models.dev catalogue lists, deduplicated by
+ * id with the stronger marking winning, builtin entries first. A failed or
+ * unavailable catalogue fetch degrades to the builtin list plus a warning —
+ * it never fails the request.
  */
 export function createModelsHandler(context: APIContext) {
-	return async (): Promise<Response> => {
-		if (!context.modelCatalog) {
-			return errorResponse("Model catalog is not available");
+	return async (url?: URL): Promise<Response> => {
+		const requested = url?.searchParams.get("provider")?.trim() || "";
+
+		if (requested === "" || isAnthropicProvider(requested)) {
+			if (!context.modelCatalog) {
+				return errorResponse("Model catalog is not available");
+			}
+			const catalog = await context.modelCatalog.get();
+			return jsonResponse({
+				...catalog,
+				provider: requested || "anthropic",
+				models: catalog.models.map((model) => ({
+					...model,
+					source: "catalog" as const,
+				})),
+			});
 		}
-		const catalog = await context.modelCatalog.get();
-		return jsonResponse(catalog);
+
+		const builtinIds = BUILTIN_MODELS_BY_PROVIDER[requested] ?? [];
+		const section = MODELS_DEV_SECTION_BY_PROVIDER[requested] ?? requested;
+		const reference = await listCatalogueModels(section);
+
+		const builtinById = new Map<string, ProviderModelEntry>();
+		for (const id of builtinIds) {
+			builtinById.set(id, { id, displayName: id, source: "builtin" });
+		}
+
+		// A reference entry never overwrites a builtin one — the stronger
+		// marking wins, and the UI shows the two groups apart on purpose.
+		const referenceById = new Map<string, ProviderModelEntry>();
+		for (const entry of reference) {
+			if (!entry.id) continue;
+			if (builtinById.has(entry.id) || referenceById.has(entry.id)) continue;
+			referenceById.set(entry.id, {
+				id: entry.id,
+				displayName: entry.name || entry.id,
+				source: "reference",
+			});
+		}
+
+		const referenceEntries = Array.from(referenceById.values()).sort((a, b) =>
+			a.id.localeCompare(b.id),
+		);
+		const models = [...builtinById.values(), ...referenceEntries];
+
+		const hasBuiltin = builtinById.size > 0;
+		const hasReference = referenceEntries.length > 0;
+		const source = hasBuiltin
+			? hasReference
+				? "mixed"
+				: "builtin"
+			: hasReference
+				? "reference"
+				: "unavailable";
+
+		return jsonResponse({
+			provider: requested,
+			models,
+			fetchedAt: Date.now(),
+			source,
+			referenceSection: section,
+			...(hasReference
+				? {}
+				: {
+						warning: `No reference models for "${section}" in the models.dev catalogue (unknown provider, catalogue offline, or fetch failed)`,
+					}),
+		});
 	};
 }
 

--- a/packages/http-api/src/router.ts
+++ b/packages/http-api/src/router.ts
@@ -479,7 +479,7 @@ export class APIRouter {
 		// Model catalog routes
 		const modelsHandler = createModelsHandler(this.context);
 		const modelsRefreshHandler = createModelsRefreshHandler(this.context);
-		this.handlers.set("GET:/api/models", () => modelsHandler());
+		this.handlers.set("GET:/api/models", (_req, url) => modelsHandler(url));
 		this.handlers.set("POST:/api/models/refresh", () => modelsRefreshHandler());
 	}
 

--- a/packages/providers/src/providers/codex/index.ts
+++ b/packages/providers/src/providers/codex/index.ts
@@ -8,6 +8,8 @@ export type { CodexUsageRefreshFetchResult } from "./on-demand-fetch";
 export { fetchCodexUsageOnDemand } from "./on-demand-fetch";
 export {
 	CODEX_DEFAULT_ENDPOINT,
+	CODEX_KNOWN_MODELS,
+	CODEX_MODEL_CONTEXT_WINDOWS,
 	CODEX_PING_MODEL,
 	CODEX_USER_AGENT,
 	CODEX_VERSION,

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -2289,6 +2289,28 @@ describe("CodexProvider.transformRequestBody", () => {
 		expect(body.model).toBe("gpt-5.3-codex");
 	});
 
+	// Regression: the fable entry alone is not enough for codex. mapModel
+	// resolves by substring and had no fable branch, so the map entry would
+	// never be looked up and the Claude model id would reach the upstream
+	// verbatim.
+	it("maps fable-family models to the codex default", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-fable-5",
+				max_tokens: 10,
+				messages: [{ role: "user", content: "hello" }],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request, undefined);
+		const body = await transformed.json();
+
+		expect(body.model).toBe("gpt-5.3-codex");
+	});
+
 	it("uses account sonnet mapping for sonnet-family models", async () => {
 		const provider = new CodexProvider();
 		const account = {

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -99,6 +99,7 @@ const CODEX_ERROR_TYPE_BY_CODE: Record<string, string> = {
 
 // Default model mapping: Anthropic model name prefixes → Codex model names
 const DEFAULT_MODEL_MAP: Record<string, string> = {
+	fable: "gpt-5.3-codex",
 	opus: "gpt-5.3-codex",
 	sonnet: "gpt-5.3-codex",
 	haiku: "gpt-5.4-mini",
@@ -691,6 +692,7 @@ export class CodexProvider extends BaseProvider {
 		}
 
 		const lower = anthropicModel.toLowerCase();
+		if (lower.includes("fable")) return DEFAULT_MODEL_MAP.fable;
 		if (lower.includes("haiku")) return DEFAULT_MODEL_MAP.haiku;
 		if (lower.includes("sonnet")) return DEFAULT_MODEL_MAP.sonnet;
 		if (lower.includes("opus")) return DEFAULT_MODEL_MAP.opus;

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -99,17 +99,22 @@ const CODEX_ERROR_TYPE_BY_CODE: Record<string, string> = {
 
 // Default model mapping: Anthropic model name prefixes → Codex model names
 const DEFAULT_MODEL_MAP: Record<string, string> = {
+	// Same value as opus/sonnet, for consistency in the factory map. ChatGPT
+	// subscription accounts reject 5.3-codex (HTTP 400); in those cases the
+	// fix lives in the layers above — per-account mapping or a global
+	// override in Settings — not here.
 	fable: "gpt-5.3-codex",
 	opus: "gpt-5.3-codex",
 	sonnet: "gpt-5.3-codex",
 	haiku: "gpt-5.4-mini",
 };
 
+
 // Synced from the Codex CLI model cache (~/.codex/models_cache.json,
 // codex-cli 0.144.1). Missing entries mean no context_window block is
 // reported to the client, which disables its context gauge and compaction
 // triggers for that model.
-const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
+export const CODEX_MODEL_CONTEXT_WINDOWS: Record<string, number> = {
 	"gpt-5.3-codex": 272_000,
 	"gpt-5.3-codex-spark": 128_000,
 	"gpt-5.4": 272_000,
@@ -121,6 +126,21 @@ const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
 };
 
 /**
+ * The Codex model ids ccflare itself knows about, derived from the context
+ * window table above so the two can never drift apart.
+ *
+ * Being on this list means "ccflare ships knowledge of this model", NOT
+ * "the account you are about to use may call it": a ChatGPT-subscription
+ * account rejects gpt-5.3-codex with HTTP 400 even though the model plainly
+ * exists. Callers that surface this list to a human must keep that
+ * distinction visible (see GET /api/models, which tags these as `builtin`
+ * and the models.dev entries as `reference`).
+ */
+export const CODEX_KNOWN_MODELS: readonly string[] = Object.freeze(
+	Object.keys(CODEX_MODEL_CONTEXT_WINDOWS),
+);
+
+/**
  * Exact lookup first, then longest-prefix fallback so dated or suffixed
  * variants the API may return (e.g. "gpt-5.6-sol-2026-05-13") still resolve
  * to their family's window instead of silently losing the client's context
@@ -128,10 +148,10 @@ const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
  * "gpt-5.5".
  */
 function lookupContextWindow(model: string): number | undefined {
-	const exact = MODEL_CONTEXT_WINDOWS[model];
+	const exact = CODEX_MODEL_CONTEXT_WINDOWS[model];
 	if (exact) return exact;
 	let bestKey: string | undefined;
-	for (const key of Object.keys(MODEL_CONTEXT_WINDOWS)) {
+	for (const key of Object.keys(CODEX_MODEL_CONTEXT_WINDOWS)) {
 		if (
 			model.startsWith(`${key}-`) &&
 			(bestKey === undefined || key.length > bestKey.length)
@@ -139,7 +159,7 @@ function lookupContextWindow(model: string): number | undefined {
 			bestKey = key;
 		}
 	}
-	return bestKey ? MODEL_CONTEXT_WINDOWS[bestKey] : undefined;
+	return bestKey ? CODEX_MODEL_CONTEXT_WINDOWS[bestKey] : undefined;
 }
 
 // ── Codex Responses API types ─────────────────────────────────────────────────
@@ -692,10 +712,15 @@ export class CodexProvider extends BaseProvider {
 		}
 
 		const lower = anthropicModel.toLowerCase();
-		if (lower.includes("fable")) return DEFAULT_MODEL_MAP.fable;
-		if (lower.includes("haiku")) return DEFAULT_MODEL_MAP.haiku;
-		if (lower.includes("sonnet")) return DEFAULT_MODEL_MAP.sonnet;
-		if (lower.includes("opus")) return DEFAULT_MODEL_MAP.opus;
+		// Precedence: combo slot -> account.model_mappings -> global override -> factory map.
+		if (lower.includes("fable"))
+			return DEFAULT_MODEL_MAP.fable;
+		if (lower.includes("haiku"))
+			return DEFAULT_MODEL_MAP.haiku;
+		if (lower.includes("sonnet"))
+			return DEFAULT_MODEL_MAP.sonnet;
+		if (lower.includes("opus"))
+			return DEFAULT_MODEL_MAP.opus;
 		return anthropicModel;
 	}
 

--- a/packages/providers/src/providers/index.ts
+++ b/packages/providers/src/providers/index.ts
@@ -15,6 +15,8 @@ export { BedrockProvider, parseBedrockConfig } from "./bedrock/index";
 export type { CodexUsageRefreshFetchResult } from "./codex/index";
 export {
 	CODEX_DEFAULT_ENDPOINT,
+	CODEX_KNOWN_MODELS,
+	CODEX_MODEL_CONTEXT_WINDOWS,
 	CodexOAuthProvider,
 	CodexProvider,
 	fetchCodexUsageOnDemand,

--- a/packages/providers/src/providers/qwen/__tests__/provider.test.ts
+++ b/packages/providers/src/providers/qwen/__tests__/provider.test.ts
@@ -195,6 +195,7 @@ describe("QwenProvider", () => {
 			const result = provider.beforeConvert({}, account);
 			expect(result).toBeDefined();
 			const mappings = JSON.parse(result?.model_mappings as string);
+			expect(mappings.fable).toBe("coder-model");
 			expect(mappings.opus).toBe("coder-model");
 			expect(mappings.sonnet).toBe("coder-model");
 			expect(mappings.haiku).toBe("coder-model");

--- a/packages/providers/src/providers/qwen/provider.ts
+++ b/packages/providers/src/providers/qwen/provider.ts
@@ -23,6 +23,7 @@ const STAINLESS_HEADERS: Record<string, string> = {
 
 // All Anthropic model tiers map to coder-model (Qwen's unified coding model)
 const QWEN_MODEL_MAPPINGS = {
+	fable: "coder-model",
 	opus: "coder-model",
 	sonnet: "coder-model",
 	haiku: "coder-model",

--- a/packages/proxy/src/handlers/__tests__/account-selector-model-capacity.test.ts
+++ b/packages/proxy/src/handlers/__tests__/account-selector-model-capacity.test.ts
@@ -6,6 +6,7 @@ import type {
 	RequestMeta,
 } from "@better-ccflare/types";
 import {
+	getComboSlotInfo,
 	getModelFamilyExhaustionInfo,
 	selectAccountsForRequest,
 } from "../account-selector";
@@ -231,6 +232,127 @@ describe("selectAccountsForRequest — model-scoped capacity filter (combo routi
 		// Only the non-exhausted slot (acc-2) is returned; the combo pool isn't
 		// fully empty so no fallback and no exhaustion signal.
 		expect(result.map((a) => a.id)).toEqual(["acc-2"]);
+	});
+
+	// -- passthrough slots (empty slot.model) --------------------------------
+	//
+	// A passthrough slot carries no model override, so there is no slot model to
+	// scope the capacity check to. The check must fall back to the model the
+	// CLIENT asked for - that is what will actually be sent upstream on this
+	// slot. Passing the raw empty string makes getModelFamily("") return null,
+	// which turns isAccountCapacityExcluded into a silent no-op and lets a
+	// capacity-exhausted account back into rotation.
+	it("applies the capacity check to a passthrough slot using the REQUEST model", async () => {
+		const acc1 = makeAccount({ id: "acc-1" });
+		const acc2 = makeAccount({ id: "acc-2" });
+		usageCache.set(acc1.id, exhaustedUsage("Sonnet", Date.now()));
+		const combo = makeCombo([
+			{
+				id: "slot-1",
+				combo_id: "combo-1",
+				account_id: "acc-1",
+				model: "", // passthrough
+				priority: 0,
+				enabled: true,
+			},
+			{
+				id: "slot-2",
+				combo_id: "combo-1",
+				account_id: "acc-2",
+				model: "claude-sonnet-4-5",
+				priority: 1,
+				enabled: true,
+			},
+		]);
+		const ctx = makeCtx({
+			accounts: [acc1, acc2],
+			activeCombo: combo,
+			capacityRoutingMode: "exhausted",
+		});
+		const meta = makeRequestMeta();
+
+		const result = await selectAccountsForRequest(
+			meta,
+			ctx,
+			"claude-sonnet-4-5",
+		);
+
+		// Without the request-model fallback the empty slot model yields a null
+		// family, the filter no-ops, and acc-1 is returned first.
+		expect(result.map((a) => a.id)).toEqual(["acc-2"]);
+		expect(getComboSlotInfo(meta)?.slots).toEqual([
+			{ accountId: "acc-2", modelOverride: "claude-sonnet-4-5" },
+		]);
+	});
+
+	it("keeps a passthrough slot whose account still has capacity for the request model", async () => {
+		const acc = makeAccount({ id: "acc-healthy" });
+		// Exhausted for a DIFFERENT family than the request - must not exclude.
+		usageCache.set(acc.id, exhaustedUsage("Opus", Date.now()));
+		const combo = makeCombo([
+			{
+				id: "slot-1",
+				combo_id: "combo-1",
+				account_id: "acc-healthy",
+				model: "", // passthrough
+				priority: 0,
+				enabled: true,
+			},
+		]);
+		const ctx = makeCtx({
+			accounts: [acc],
+			activeCombo: combo,
+			capacityRoutingMode: "exhausted",
+		});
+		const meta = makeRequestMeta();
+
+		const result = await selectAccountsForRequest(
+			meta,
+			ctx,
+			"claude-sonnet-4-5",
+		);
+
+		expect(result.map((a) => a.id)).toEqual(["acc-healthy"]);
+		expect(getComboSlotInfo(meta)?.slots).toEqual([
+			{ accountId: "acc-healthy", modelOverride: "" },
+		]);
+	});
+
+	// -- non-regression: a populated slot model still wins --------------------
+	//
+	// The request-model fallback is a `||`, so it must only fire for an EMPTY
+	// slot model. When the slot carries its own model, the capacity check stays
+	// scoped to that model.
+	it("still scopes the capacity check to the slot's own model when it diverges from the request model", async () => {
+		const acc = makeAccount({ id: "acc-slot-model" });
+		usageCache.set(acc.id, exhaustedUsage("Sonnet", Date.now()));
+		const combo = makeCombo([
+			{
+				id: "slot-1",
+				combo_id: "combo-1",
+				account_id: "acc-slot-model",
+				model: "claude-opus-4-5",
+				priority: 0,
+				enabled: true,
+			},
+		]);
+		const ctx = makeCtx({
+			accounts: [acc],
+			activeCombo: combo,
+			capacityRoutingMode: "exhausted",
+		});
+		const meta = makeRequestMeta();
+
+		const result = await selectAccountsForRequest(
+			meta,
+			ctx,
+			"claude-sonnet-4-5",
+		);
+
+		expect(result.map((a) => a.id)).toEqual(["acc-slot-model"]);
+		expect(getComboSlotInfo(meta)?.slots).toEqual([
+			{ accountId: "acc-slot-model", modelOverride: "claude-opus-4-5" },
+		]);
 	});
 
 	it("falls back to SessionStrategy when every combo slot is exhausted", async () => {

--- a/packages/proxy/src/handlers/__tests__/account-selector.test.ts
+++ b/packages/proxy/src/handlers/__tests__/account-selector.test.ts
@@ -267,6 +267,43 @@ describe("selectAccountsForRequest — combo routing", () => {
 		expect(slotInfo?.slots[0]?.modelOverride).toBe("claude-opus-4-5");
 	});
 
+	// An empty slot model means passthrough: the client's requested model is
+	// sent upstream untouched. The slot still routes to its account - only the
+	// override is absent. Downstream (proxy-operations.ts) guards with
+	// `if (modelOverride && ...)`, so an empty string already means "do not
+	// overwrite the model"; this test pins that the selector propagates it
+	// verbatim instead of substituting the request model.
+	it("propagates an empty slot model as an empty modelOverride (passthrough slot)", async () => {
+		const acc = makeAccount({ id: "acc-passthrough" });
+		const combo = makeCombo([
+			{
+				id: "slot-1",
+				combo_id: "combo-1",
+				account_id: "acc-passthrough",
+				model: "", // passthrough - no model override
+				priority: 0,
+				enabled: true,
+			},
+		]);
+
+		const ctx = makeCtx({ accounts: [acc], activeCombo: combo });
+		const meta = makeRequestMeta();
+
+		const result = await selectAccountsForRequest(
+			meta,
+			ctx,
+			"claude-sonnet-4-5",
+		);
+
+		expect(result.map((a) => a.id)).toEqual(["acc-passthrough"]);
+		const slotInfo = getComboSlotInfo(meta);
+		expect(slotInfo?.comboName).toBe("Test Combo");
+		expect(slotInfo?.slots).toEqual([
+			{ accountId: "acc-passthrough", modelOverride: "" },
+		]);
+		expect(meta.comboName).toBe("Test Combo");
+	});
+
 	it("sets meta.comboName when combo routing is active", async () => {
 		const acc = makeAccount({ id: "acc-1" });
 		const combo = makeCombo([

--- a/packages/proxy/src/handlers/account-selector.ts
+++ b/packages/proxy/src/handlers/account-selector.ts
@@ -400,9 +400,20 @@ export async function selectAccountsForRequest(
 				const combo = await ctx.dbOps.getActiveComboForFamily(
 					family as ComboFamily,
 				);
-				if (combo) {
+				if (!combo) {
+					// Without this line the detour is silent: a family with no active
+					// combo falls into normal pool routing and can be served by any
+					// provider, with nothing in the log to say so.
 					log.info(
-						`Combo routing active: ${combo.name} for family ${family} (${combo.slots.length} slots)`,
+						`No active combo for family ${family} - falling back to normal routing`,
+					);
+				}
+				if (combo) {
+					const passthroughSlots = combo.slots.filter(
+						(s) => !s.model || s.model.trim().length === 0,
+					).length;
+					log.info(
+						`Combo routing active: ${combo.name} for family ${family} (${combo.slots.length} slots, ${passthroughSlots} passthrough)`,
 					);
 
 					const allAccounts = await ctx.dbOps.getAllAccounts();
@@ -446,8 +457,15 @@ export async function selectAccountsForRequest(
 						// distinct concrete models within the same family.
 						if (
 							capacityRoutingEnabled &&
-							isAccountCapacityExcluded(account, slot.model, capacityNow)
-								.excluded
+							isAccountCapacityExcluded(
+								account,
+								// Passthrough slots (empty model) carry no model of their
+								// own: fall back to the request's model, otherwise
+								// getModelFamily("") returns null and this filter would
+								// silently no-op for those slots.
+								slot.model || model,
+								capacityNow,
+							).excluded
 						) {
 							continue;
 						}


### PR DESCRIPTION
## What

`GET /api/models` now accepts `?provider=<x>` and returns the models that make sense for that provider. Without the parameter the response shape is unchanged, so the existing agents screen is untouched. The dashboard gains a shared model picker used by the combo slot form and the per-account model mappings dialog.

> **Stacked on #394 and #395.** Review only the commit `feat(models): list provider-specific models for the model pickers`; the diff shrinks to that once the earlier two merge.

## Why

The model fields were free text. With a `codex` account selected the placeholder still suggested a Claude model, which the provider would then translate through its built-in default map — the exact path that produced the `400` in #393.

## How

- **anthropic** → today's live catalogue, unchanged.
- **codex** → the models ccflare already knows (the context-window map, now exported as `CODEX_KNOWN_MODELS`) **plus** the OpenAI section of `models.dev`, marked `reference`. That catalogue is already fetched for pricing, so this adds no new dependency and no new host.
- Catalogue unavailable → degrades to the built-ins with a `warning` and still answers `200`. A convenience list must never break the endpoint.
- Deduplicated by id, with the stronger marking winning; builtins first.

**The two groups stay visually distinct in the picker, deliberately.** Being in the provider catalogue proves the model *exists*, not that the account's plan may *call* it — `gpt-5.3-codex` is a real OpenAI model that ChatGPT-subscription accounts are refused. Free text is still accepted, so a model released before the list catches up is never blocked.

One UI note worth flagging for review: the picker's popover renders **without a portal** (`portal={false}`, a new opt-out on `PopoverContent` that defaults to the current behaviour). Portalled content sits outside the dialog's subtree, where Radix's scroll lock swallows the mouse wheel — the list then renders but cannot be scrolled inside a modal.

## Testing

- 5 new cases covering the provider parameter, the degraded path, de-duplication and the unchanged default shape.
- Baseline comparison on this branch: 1454 pass / 15 fail before, 1459 pass / 15 fail after — same failures, all pre-existing in a fresh checkout, plus the 5 new tests.
- `bunx tsc --noEmit` clean.

Part of #393.
