### PR TITLE
feat(config): make provider default model maps editable

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1,6 +1,10 @@
 import { existsSync, readFileSync } from "node:fs";
 import { dirname } from "node:path";
-import { Config, type RuntimeConfig } from "@better-ccflare/config";
+import {
+	Config,
+	filterEnabledProviderModelDefaultOverrides,
+	type RuntimeConfig,
+} from "@better-ccflare/config";
 import {
 	CACHE,
 	DEFAULT_STRATEGY,
@@ -38,6 +42,7 @@ import {
 	fetchCodexUsageOnDemand,
 	getProvider,
 	getRepresentativeUtilizationForProvider,
+	setProviderModelDefaultOverrides,
 	usageCache,
 } from "@better-ccflare/providers";
 import {
@@ -733,6 +738,12 @@ export default async function startServer(options?: {
 
 	// Initialize components
 	const config = container.resolve<Config>(SERVICE_KEYS.Config);
+	setProviderModelDefaultOverrides(
+		filterEnabledProviderModelDefaultOverrides(
+			config.getEnabledProviderModelDefaultProviders(),
+			config.getProviderModelDefaultOverrides(),
+		),
+	);
 	installOutboundProxy(() => config.getOutboundProxy());
 	const outboundProxyUrl = config.getOutboundProxy();
 	if (outboundProxyUrl) {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -61,6 +61,47 @@ export interface RuntimeConfig {
 	};
 }
 
+export type ProviderModelDefaultOverrides = Record<
+	string,
+	Record<string, string>
+>;
+
+/**
+ * Env var that expands which providers accept editable model-default
+ * overrides (via the config file, the API, and the dashboard tab).
+ * Absent or empty => only "codex" is editable. This gates only the
+ * override SURFACE (listing, accepting POSTs, showing a dashboard
+ * tab) — the built-in factory maps for every provider (xai, qwen,
+ * ...) keep translating models exactly as before; nothing here
+ * touches model resolution itself.
+ */
+export const PROVIDER_MODEL_DEFAULTS_ENV_VAR =
+	"CCFLARE_MODEL_DEFAULTS_PROVIDERS";
+
+const DEFAULT_PROVIDER_MODEL_DEFAULTS_PROVIDERS: readonly string[] = ["codex"];
+
+/**
+ * Drops overrides for providers outside `enabledProviders` without
+ * mutating the input. Callers pass in the full, persisted overrides
+ * map and push the filtered result into the in-memory registry (see
+ * setProviderModelDefaultOverrides in @better-ccflare/providers) at
+ * boot and after a successful POST. The persisted file always keeps
+ * the full map — a disabled provider's stored override is never
+ * erased, just excluded here, so it re-applies automatically once
+ * CCFLARE_MODEL_DEFAULTS_PROVIDERS re-enables that provider.
+ */
+export function filterEnabledProviderModelDefaultOverrides(
+	enabledProviders: Iterable<string>,
+	overrides: ProviderModelDefaultOverrides,
+): ProviderModelDefaultOverrides {
+	const enabled = new Set(enabledProviders);
+	const filtered: ProviderModelDefaultOverrides = {};
+	for (const [provider, families] of Object.entries(overrides)) {
+		if (enabled.has(provider)) filtered[provider] = families;
+	}
+	return filtered;
+}
+
 export interface ConfigData {
 	lb_strategy?: StrategyName;
 	client_id?: string;
@@ -80,6 +121,7 @@ export interface ConfigData {
 	usage_throttling_five_hour_enabled?: boolean;
 	usage_throttling_weekly_enabled?: boolean;
 	model_scoped_capacity_routing?: ModelScopedCapacityRoutingMode;
+	provider_model_default_overrides?: ProviderModelDefaultOverrides;
 	agent_frontmatter_model_fallback?: boolean;
 	model_catalog_oauth_refresh_enabled?: boolean;
 	health_detail_enabled?: boolean;
@@ -110,7 +152,12 @@ export interface ConfigData {
 	db_retry_delay_ms?: number;
 	db_retry_backoff?: number;
 	db_retry_max_delay_ms?: number;
-	[key: string]: string | number | boolean | undefined;
+	[key: string]:
+		| string
+		| number
+		| boolean
+		| ProviderModelDefaultOverrides
+		| undefined;
 }
 
 /**
@@ -250,7 +297,12 @@ export class Config extends EventEmitter {
 		defaultValue?: string | number | boolean,
 	): string | number | boolean | undefined {
 		if (key in this.data) {
-			return this.data[key];
+			const value = this.data[key];
+			// Settings with an object value (e.g.
+			// provider_model_default_overrides) have their own typed getter.
+			// This generic accessor serves scalars only — returning the object
+			// here would misrepresent the declared type.
+			return typeof value === "object" ? undefined : value;
 		}
 
 		if (defaultValue !== undefined) {
@@ -655,6 +707,53 @@ export class Config extends EventEmitter {
 		this.set("model_scoped_capacity_routing", mode);
 	}
 
+	getProviderModelDefaultOverrides(): ProviderModelDefaultOverrides {
+		const raw = this.data.provider_model_default_overrides;
+		if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+		const overrides: ProviderModelDefaultOverrides = {};
+		for (const [provider, families] of Object.entries(raw)) {
+			if (!families || typeof families !== "object" || Array.isArray(families))
+				continue;
+			const values: Record<string, string> = {};
+			for (const [family, model] of Object.entries(families)) {
+				if (typeof model === "string" && model.trim())
+					values[family] = model.trim();
+			}
+			if (Object.keys(values).length > 0) overrides[provider] = values;
+		}
+		return overrides;
+	}
+
+	setProviderModelDefaultOverrides(
+		overrides: ProviderModelDefaultOverrides,
+	): void {
+		this.data.provider_model_default_overrides = overrides;
+		this.saveConfig();
+		this.emit("change", {
+			key: "provider_model_default_overrides",
+			newValue: overrides,
+		});
+	}
+
+	/**
+	 * Providers currently allowed to edit their model-default overrides:
+	 * "codex" by default, or the exact CCFLARE_MODEL_DEFAULTS_PROVIDERS
+	 * list when that env var is set (comma-separated, trimmed). Never
+	 * affects which providers HAVE a built-in factory map — only which
+	 * of them expose that map for override via the API/dashboard.
+	 */
+	getEnabledProviderModelDefaultProviders(): string[] {
+		const fromEnv = process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS;
+		if (fromEnv) {
+			const parsed = fromEnv
+				.split(",")
+				.map((provider) => provider.trim())
+				.filter(Boolean);
+			if (parsed.length > 0) return parsed;
+		}
+		return [...DEFAULT_PROVIDER_MODEL_DEFAULTS_PROVIDERS];
+	}
+
 	getHealthDetailEnabled(): boolean {
 		const fromEnv = parseEnabledEnvFlag(process.env.HEALTH_DETAIL_ENABLED);
 		if (fromEnv !== undefined) {
@@ -805,7 +904,10 @@ export class Config extends EventEmitter {
 		this.set("alert_webhook_url", value);
 	}
 
-	getAllSettings(): Record<string, string | number | boolean | undefined> {
+	getAllSettings(): Record<
+		string,
+		string | number | boolean | ProviderModelDefaultOverrides | undefined
+	> {
 		// Include current strategy (which might come from env)
 		return {
 			...this.data,

--- a/packages/config/src/provider-model-default-overrides.test.ts
+++ b/packages/config/src/provider-model-default-overrides.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Config, filterEnabledProviderModelDefaultOverrides } from "./index";
+
+describe("provider model default overrides", () => {
+	it("keeps only non-empty provider-family overrides", () => {
+		const directory = mkdtempSync(join(tmpdir(), "ccflare-provider-defaults-"));
+		const path = join(directory, "config.json");
+		try {
+			writeFileSync(
+				path,
+				JSON.stringify({
+					provider_model_default_overrides: {
+						codex: { opus: "gpt-custom", haiku: "" },
+					},
+				}),
+			);
+			const config = new Config(path);
+			expect(config.getProviderModelDefaultOverrides()).toEqual({
+				codex: { opus: "gpt-custom" },
+			});
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("provider model default enabled providers (CCFLARE_MODEL_DEFAULTS_PROVIDERS)", () => {
+	const ORIGINAL_ENV = process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS;
+
+	afterEach(() => {
+		if (ORIGINAL_ENV === undefined) {
+			delete process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS;
+		} else {
+			process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS = ORIGINAL_ENV;
+		}
+	});
+
+	function makeConfig(initial: Record<string, Record<string, string>> = {}) {
+		const directory = mkdtempSync(
+			join(tmpdir(), "ccflare-provider-defaults-enabled-"),
+		);
+		const path = join(directory, "config.json");
+		writeFileSync(
+			path,
+			JSON.stringify({ provider_model_default_overrides: initial }),
+		);
+		return {
+			config: new Config(path),
+			cleanup: () => rmSync(directory, { recursive: true, force: true }),
+		};
+	}
+
+	it("defaults to only codex when the env var is absent or blank", () => {
+		delete process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS;
+		const { config, cleanup } = makeConfig();
+		try {
+			expect(config.getEnabledProviderModelDefaultProviders()).toEqual([
+				"codex",
+			]);
+		} finally {
+			cleanup();
+		}
+
+		process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS = "  ,  ";
+		const { config: blankConfig, cleanup: cleanupBlank } = makeConfig();
+		try {
+			expect(blankConfig.getEnabledProviderModelDefaultProviders()).toEqual([
+				"codex",
+			]);
+		} finally {
+			cleanupBlank();
+		}
+	});
+
+	it("parses a trimmed comma-separated list when the env var is set", () => {
+		process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS = "codex, xai ,qwen";
+		const { config, cleanup } = makeConfig();
+		try {
+			expect(config.getEnabledProviderModelDefaultProviders()).toEqual([
+				"codex",
+				"xai",
+				"qwen",
+			]);
+		} finally {
+			cleanup();
+		}
+	});
+});
+
+describe("filterEnabledProviderModelDefaultOverrides", () => {
+	it("drops overrides for providers outside the enabled set without mutating the input", () => {
+		const overrides = {
+			codex: { opus: "gpt-custom" },
+			xai: { sonnet: "grok-custom" },
+		};
+		const filtered = filterEnabledProviderModelDefaultOverrides(
+			["codex"],
+			overrides,
+		);
+		expect(filtered).toEqual({ codex: { opus: "gpt-custom" } });
+		// A entrada do provider desabilitado permanece no mapa original.
+		expect(overrides.xai).toEqual({ sonnet: "grok-custom" });
+	});
+
+	it("brings a previously-disabled provider back once it is enabled", () => {
+		const overrides = {
+			codex: { opus: "gpt-custom" },
+			xai: { sonnet: "grok-custom" },
+		};
+		expect(
+			filterEnabledProviderModelDefaultOverrides(["codex", "xai"], overrides),
+		).toEqual(overrides);
+	});
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -80,9 +80,11 @@ export {
 	uninstallOutboundProxy,
 } from "./outbound-proxy";
 export {
+	type CatalogueModelEntry,
 	estimateCostUSD,
 	getModelRates,
 	initializeNanoGPTPricingIfAccountsExist,
+	listCatalogueModels,
 	type ModelRates,
 	resetNanoGPTPricingCacheForTest,
 	setPricingLogger,

--- a/packages/core/src/pricing.ts
+++ b/packages/core/src/pricing.ts
@@ -22,6 +22,13 @@ interface ModelDef {
 	id: string;
 	name: string;
 	cost?: ModelCost;
+	/**
+	 * models.dev also publishes each model's modalities. Only read by
+	 * listCatalogueModels (to drop models that provably cannot emit text);
+	 * pricing itself ignores it. Optional because the bundled fallback
+	 * entries do not carry it.
+	 */
+	modalities?: { input?: string[]; output?: string[] };
 }
 
 interface ApiResponse {
@@ -839,6 +846,50 @@ export async function initializeNanoGPTPricingIfAccountsExist(
  */
 export function setPricingLogger(logger: Logger): void {
 	PriceCatalogue.get().setLogger(logger);
+}
+
+export interface CatalogueModelEntry {
+	id: string;
+	name: string;
+}
+
+/**
+ * List the models the shared models.dev catalogue knows for one provider
+ * section (e.g. "openai", "anthropic").
+ *
+ * Deliberately built on PriceCatalogue.getPricing() rather than a second
+ * fetcher: pricing already downloads, merges and caches this exact document
+ * (in memory + on disk, honouring CF_PRICING_OFFLINE and
+ * CF_PRICING_REFRESH_HOURS), so listing models costs no extra network call.
+ *
+ * Models that provably cannot emit text (embeddings, image generation) are
+ * dropped — this list exists to be offered as a chat model. Entries with no
+ * declared modalities are kept: the catalogue is not validated, and absence
+ * of data is not evidence of absence.
+ *
+ * Never throws, and never distinguishes "section is empty" from "catalogue
+ * unavailable" — both return []. Callers must treat an empty list as
+ * inconclusive, not as proof that the provider has no models.
+ */
+export async function listCatalogueModels(
+	providerSection: string,
+): Promise<CatalogueModelEntry[]> {
+	try {
+		const pricing = await PriceCatalogue.get().getPricing();
+		const models = pricing[providerSection]?.models;
+		if (!models) return [];
+		const entries: CatalogueModelEntry[] = [];
+		for (const [key, def] of Object.entries(models)) {
+			const output = def?.modalities?.output;
+			if (Array.isArray(output) && !output.includes("text")) continue;
+			const id = def?.id || key;
+			if (!id) continue;
+			entries.push({ id, name: def?.name || id });
+		}
+		return entries;
+	} catch {
+		return [];
+	}
 }
 
 /**

--- a/packages/dashboard-web/src/components/SettingsTab.tsx
+++ b/packages/dashboard-web/src/components/SettingsTab.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { AdvancedSettingsCard } from "./overview/AdvancedSettingsCard";
 import { CacheKeepaliveCard } from "./overview/CacheKeepaliveCard";
 import { DataRetentionCard } from "./overview/DataRetentionCard";
 import { RoutingCard } from "./overview/RoutingCard";
@@ -15,6 +16,7 @@ export const SettingsTab = React.memo(() => {
 				<SystemCacheTtlCard />
 				<UsageThrottlingCard />
 				<DataRetentionCard />
+				<AdvancedSettingsCard />
 			</div>
 		</div>
 	);

--- a/packages/dashboard-web/src/components/accounts/AccountModelMappingsDialog.tsx
+++ b/packages/dashboard-web/src/components/accounts/AccountModelMappingsDialog.tsx
@@ -6,6 +6,9 @@ import {
 } from "@better-ccflare/core";
 import React, { useState } from "react";
 import type { Account } from "../../api";
+import { firstModelInList } from "../../lib/model-api";
+import { providerAllowsClientModelPassthrough } from "../../utils/provider-utils";
+import { ModelCombobox } from "../models/ModelCombobox";
 import { Button } from "../ui/button";
 import {
 	Dialog,
@@ -15,7 +18,6 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "../ui/dialog";
-import { Input } from "../ui/input";
 import { Label } from "../ui/label";
 
 interface AccountModelMappingsDialogProps {
@@ -117,6 +119,13 @@ export function AccountModelMappingsDialog({
 
 	if (!account) return null;
 
+	// Same single rule as the combo slot. Here it does not block Save (mapping
+	// only the families this account actually uses is legitimate), but the
+	// user needs to know that "empty" is not passthrough on this provider.
+	const passthroughAllowed = providerAllowsClientModelPassthrough(
+		account.provider,
+	);
+
 	return (
 		<Dialog open={isOpen} onOpenChange={onOpenChange}>
 			<DialogContent className="sm:max-w-[600px] flex flex-col max-h-[85vh]">
@@ -136,56 +145,87 @@ export function AccountModelMappingsDialog({
 							<code className="text-xs bg-muted px-1 rounded">
 								model-a, model-b
 							</code>
-							) to cycle on rate limits.
+							) to cycle on rate limits. Pick from the provider list or type the
+							name; Test sends one real request with the first model of the
+							field and consumes quota.
 						</p>
+						{!passthroughAllowed && (
+							<p className="text-xs text-warning mb-3">
+								{account.provider} does not serve Claude model ids, so a family
+								left empty here is not passthrough: the built-in default map of
+								the provider decides instead, and it may point at a model this
+								account is not entitled to call. Map every family this account
+								is actually used for.
+							</p>
+						)}
 						<div className="grid grid-cols-2 gap-3">
 							<div className="space-y-1">
 								<Label htmlFor="fable" className="text-xs">
 									Fable
 								</Label>
-								<Input
-									id="fable"
-									value={modelMappings.fable}
-									onChange={(e) => handleInputChange("fable", e.target.value)}
-									placeholder={`e.g., ${LATEST_FABLE_MODEL}`}
-									className="h-8"
-								/>
+								<div className="flex items-center gap-1.5">
+									<ModelCombobox
+										id="fable"
+										mode="list"
+										provider={account.provider}
+										value={modelMappings.fable}
+										onChange={(value) => handleInputChange("fable", value)}
+										placeholder={`e.g., ${LATEST_FABLE_MODEL}`}
+										className="flex-1"
+										inputClassName="h-8"
+									/>
+								</div>
 							</div>
 							<div className="space-y-1">
 								<Label htmlFor="opus" className="text-xs">
 									Opus
 								</Label>
-								<Input
-									id="opus"
-									value={modelMappings.opus}
-									onChange={(e) => handleInputChange("opus", e.target.value)}
-									placeholder={`e.g., ${LATEST_OPUS_MODEL}`}
-									className="h-8"
-								/>
+								<div className="flex items-center gap-1.5">
+									<ModelCombobox
+										id="opus"
+										mode="list"
+										provider={account.provider}
+										value={modelMappings.opus}
+										onChange={(value) => handleInputChange("opus", value)}
+										placeholder={`e.g., ${LATEST_OPUS_MODEL}`}
+										className="flex-1"
+										inputClassName="h-8"
+									/>
+								</div>
 							</div>
 							<div className="space-y-1">
 								<Label htmlFor="sonnet" className="text-xs">
 									Sonnet
 								</Label>
-								<Input
-									id="sonnet"
-									value={modelMappings.sonnet}
-									onChange={(e) => handleInputChange("sonnet", e.target.value)}
-									placeholder={`e.g., ${LATEST_SONNET_MODEL}`}
-									className="h-8"
-								/>
+								<div className="flex items-center gap-1.5">
+									<ModelCombobox
+										id="sonnet"
+										mode="list"
+										provider={account.provider}
+										value={modelMappings.sonnet}
+										onChange={(value) => handleInputChange("sonnet", value)}
+										placeholder={`e.g., ${LATEST_SONNET_MODEL}`}
+										className="flex-1"
+										inputClassName="h-8"
+									/>
+								</div>
 							</div>
 							<div className="space-y-1">
 								<Label htmlFor="haiku" className="text-xs">
 									Haiku
 								</Label>
-								<Input
-									id="haiku"
-									value={modelMappings.haiku}
-									onChange={(e) => handleInputChange("haiku", e.target.value)}
-									placeholder={`e.g., ${LATEST_HAIKU_MODEL}`}
-									className="h-8"
-								/>
+								<div className="flex items-center gap-1.5">
+									<ModelCombobox
+										id="haiku"
+										mode="list"
+										provider={account.provider}
+										value={modelMappings.haiku}
+										onChange={(value) => handleInputChange("haiku", value)}
+										placeholder={`e.g., ${LATEST_HAIKU_MODEL}`}
+										className="flex-1"
+										inputClassName="h-8"
+									/>
+								</div>
 							</div>
 						</div>
 					</div>

--- a/packages/dashboard-web/src/components/combos/ComboSlotBuilder.tsx
+++ b/packages/dashboard-web/src/components/combos/ComboSlotBuilder.tsx
@@ -22,6 +22,7 @@ import {
 	useRemoveComboSlot,
 	useReorderComboSlots,
 } from "../../hooks/queries";
+import { providerAllowsClientModelPassthrough } from "../../utils/provider-utils";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
@@ -94,7 +95,11 @@ function SortableSlotRow({
 			</div>
 
 			<span className="shrink-0 font-mono text-xs text-muted-foreground">
-				{slot.model}
+				{slot.model?.trim() ? (
+					slot.model
+				) : (
+					<span className="italic">client model</span>
+				)}
 			</span>
 
 			<Button
@@ -159,8 +164,20 @@ export function ComboSlotBuilder({ combo }: ComboSlotBuilderProps) {
 		});
 	};
 
+	// Derived on every render rather than mirrored into state: the account is
+	// picked in the Select above this field and can be changed after the model
+	// has been typed, so no click order may leave an invalid slot behind.
+	const selectedProvider = accounts.find(
+		(a) => a.id === newAccountId,
+	)?.provider;
+	const passthroughAllowed =
+		providerAllowsClientModelPassthrough(selectedProvider);
+	const missingRequiredModel = !passthroughAllowed && !newModel.trim();
+
 	const handleAddSlot = () => {
-		if (!newAccountId || !newModel.trim()) return;
+		// An empty model means passthrough, which is only valid where the
+		// upstream serves Claude model ids. Elsewhere the model is required.
+		if (!newAccountId || missingRequiredModel) return;
 		addSlot.mutate(
 			{
 				comboId: combo.id,
@@ -230,12 +247,19 @@ export function ComboSlotBuilder({ combo }: ComboSlotBuilderProps) {
 							</Select>
 						</div>
 						<div className="space-y-1.5">
-							<Label>Model</Label>
+							<Label>{passthroughAllowed ? "Model (optional)" : "Model"}</Label>
 							<Input
 								value={newModel}
 								onChange={(e) => setNewModel(e.target.value)}
-								placeholder="claude-3-opus"
+								placeholder="Model id"
 							/>
+							<p className="text-xs text-muted-foreground">
+								{!newAccountId
+									? "Whether the model is required depends on the provider of the account you pick."
+									: passthroughAllowed
+										? "Leave empty to forward the model the client asked for."
+										: `Required for ${selectedProvider}: this provider does not serve Claude model ids, so there is nothing to forward.`}
+							</p>
 						</div>
 						<div className="flex justify-end gap-2">
 							<Button
@@ -253,7 +277,7 @@ export function ComboSlotBuilder({ combo }: ComboSlotBuilderProps) {
 								size="sm"
 								onClick={handleAddSlot}
 								disabled={
-									!newAccountId || !newModel.trim() || addSlot.isPending
+									!newAccountId || missingRequiredModel || addSlot.isPending
 								}
 							>
 								{addSlot.isPending ? "Adding..." : "Add"}

--- a/packages/dashboard-web/src/components/combos/ComboSlotBuilder.tsx
+++ b/packages/dashboard-web/src/components/combos/ComboSlotBuilder.tsx
@@ -23,10 +23,10 @@ import {
 	useReorderComboSlots,
 } from "../../hooks/queries";
 import { providerAllowsClientModelPassthrough } from "../../utils/provider-utils";
+import { ModelCombobox } from "../models/ModelCombobox";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
-import { Input } from "../ui/input";
 import { Label } from "../ui/label";
 import {
 	Select,
@@ -115,6 +115,24 @@ function SortableSlotRow({
 	);
 }
 
+/**
+ * Help line under the model field — must state the rule that applies TO THE
+ * SELECTED ACCOUNT, not a universal "Empty = passthrough" that only holds
+ * on the Anthropic provider.
+ */
+function modelFieldHint(
+	provider: string | null,
+	passthroughAllowed: boolean,
+): string {
+	if (!provider) {
+		return "Pick an account first: whether the model is required depends on the provider.";
+	}
+	if (passthroughAllowed) {
+		return "Empty = passthrough: the model sent by the client goes upstream untouched.";
+	}
+	return `Required for ${provider}: this provider does not serve Claude model ids, so there is no passthrough.`;
+}
+
 interface ComboSlotBuilderProps {
 	combo: ComboWithSlots;
 }
@@ -133,6 +151,19 @@ export function ComboSlotBuilder({ combo }: ComboSlotBuilderProps) {
 	const accounts = accountsQuery.data ?? [];
 	const families = familiesQuery.data?.families ?? [];
 	const assignedFamily = families.find((f) => f.combo_id === combo.id);
+	// The combobox needs the provider of the chosen account: without it the
+	// list suggested a Claude model for an OpenAI account.
+	const selectedProvider =
+		accounts.find((a) => a.id === newAccountId)?.provider ?? null;
+	// DERIVED on every render from (selected account + field text). None of
+	// this is copied into useState or synced via useEffect — that is what
+	// guarantees coherence when the user types first and switches the account
+	// afterward: label, hint, and the Add button's disabled state are all
+	// recomputed in the same render, so no click order lets an invalid slot through.
+	const passthroughAllowed =
+		providerAllowsClientModelPassthrough(selectedProvider);
+	const modelRequired = Boolean(selectedProvider) && !passthroughAllowed;
+	const missingRequiredModel = modelRequired && newModel.trim().length === 0;
 
 	const sensors = useSensors(
 		useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -164,19 +195,11 @@ export function ComboSlotBuilder({ combo }: ComboSlotBuilderProps) {
 		});
 	};
 
-	// Derived on every render rather than mirrored into state: the account is
-	// picked in the Select above this field and can be changed after the model
-	// has been typed, so no click order may leave an invalid slot behind.
-	const selectedProvider = accounts.find(
-		(a) => a.id === newAccountId,
-	)?.provider;
-	const passthroughAllowed =
-		providerAllowsClientModelPassthrough(selectedProvider);
-	const missingRequiredModel = !passthroughAllowed && !newModel.trim();
-
 	const handleAddSlot = () => {
-		// An empty model means passthrough, which is only valid where the
-		// upstream serves Claude model ids. Elsewhere the model is required.
+		// The model is only optional on a passthrough provider (the rule lives in
+		// utils/provider-utils). Outside those, an empty field means an invalid
+		// slot: the button is already disabled, this guard is the seatbelt against
+		// any code path that calls this anyway.
 		if (!newAccountId || missingRequiredModel) return;
 		addSlot.mutate(
 			{
@@ -248,20 +271,26 @@ export function ComboSlotBuilder({ combo }: ComboSlotBuilderProps) {
 						</div>
 						<div className="space-y-1.5">
 							<Label>{passthroughAllowed ? "Model (optional)" : "Model"}</Label>
-							<Input
-								value={newModel}
-								onChange={(e) => setNewModel(e.target.value)}
-								placeholder="Model id"
-							/>
-							<p className="text-xs text-muted-foreground">
-								{!newAccountId
-									? "Whether the model is required depends on the provider of the account you pick."
-									: passthroughAllowed
-										? "Leave empty to forward the model the client asked for."
-										: `Required for ${selectedProvider}: this provider does not serve Claude model ids, so there is nothing to forward.`}
+							<div className="flex items-center gap-1.5">
+								<ModelCombobox
+									provider={selectedProvider}
+									value={newModel}
+									onChange={setNewModel}
+									placeholder="Model id"
+									className="flex-1"
+								/>
+							</div>
+							<p className="text-[11px] text-muted-foreground">
+								{modelFieldHint(selectedProvider, passthroughAllowed)} Test
+								sends one real request to the provider and consumes quota.
 							</p>
 						</div>
-						<div className="flex justify-end gap-2">
+						<div className="flex items-center justify-end gap-2">
+							{missingRequiredModel && (
+								<p className="mr-auto text-[11px] text-destructive">
+									Pick a model: {selectedProvider} does not accept passthrough.
+								</p>
+							)}
 							<Button
 								variant="outline"
 								size="sm"
@@ -278,6 +307,11 @@ export function ComboSlotBuilder({ combo }: ComboSlotBuilderProps) {
 								onClick={handleAddSlot}
 								disabled={
 									!newAccountId || missingRequiredModel || addSlot.isPending
+								}
+								title={
+									missingRequiredModel
+										? `A model is required for ${selectedProvider}: this provider does not serve Claude model ids, so there is no passthrough.`
+										: undefined
 								}
 							>
 								{addSlot.isPending ? "Adding..." : "Add"}

--- a/packages/dashboard-web/src/components/models/ModelCombobox.tsx
+++ b/packages/dashboard-web/src/components/models/ModelCombobox.tsx
@@ -1,0 +1,343 @@
+import { Check, ChevronDown, Loader2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useProviderModels } from "../../hooks/useProviderModels";
+import {
+	formatModelList,
+	type ProviderModel,
+	parseModelList,
+} from "../../lib/model-api";
+import { cn } from "../../lib/utils";
+import { providerAllowsClientModelPassthrough } from "../../utils/provider-utils";
+import { Badge } from "../ui/badge";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import {
+	Popover,
+	PopoverAnchor,
+	PopoverContent,
+	PopoverTrigger,
+} from "../ui/popover";
+
+export interface ModelComboboxProps {
+	/** Provider for the target account ("anthropic", "codex", ...). Null = no list. */
+	provider?: string | null;
+	value: string;
+	onChange: (value: string) => void;
+	/**
+	 * "single": the field holds one model (a combo slot).
+	 * "list": the field holds a comma-separated list that rotates on rate
+	 * limits (account mappings). Picking an item toggles its presence in the
+	 * list instead of replacing the whole field.
+	 */
+	mode?: "single" | "list";
+	placeholder?: string;
+	id?: string;
+	/** Wrapper class (use flex-1 to share the row with the test button). */
+	className?: string;
+	inputClassName?: string;
+	disabled?: boolean;
+	/**
+	 * Completely hides the "use the client model" (passthrough) option from
+	 * the popover, even when the provider would allow it. Used on the
+	 * per-provider default-model map screen: there, an empty field means "no
+	 * override", never passthrough, so the option must not appear.
+	 * Defaults to false — ComboSlotBuilder and AccountModelMappingsDialog do
+	 * not pass this prop, so their behavior remains unchanged.
+	 */
+}
+
+interface ModelOptionProps {
+	model: ProviderModel;
+	picked: boolean;
+	onPick: (id: string) => void;
+}
+
+function ModelOption({ model, picked, onPick }: ModelOptionProps) {
+	return (
+		<button
+			type="button"
+			onClick={() => onPick(model.id)}
+			className={cn(
+				"flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left hover:bg-accent hover:text-accent-foreground",
+				picked && "bg-accent/60",
+			)}
+		>
+			<Check
+				className={cn(
+					"h-3.5 w-3.5 shrink-0",
+					picked ? "opacity-100" : "opacity-0",
+				)}
+			/>
+			<span className="min-w-0 flex-1">
+				<span className="block truncate font-mono text-xs">{model.id}</span>
+				{model.displayName !== model.id && (
+					<span className="block truncate text-[11px] text-muted-foreground">
+						{model.displayName}
+					</span>
+				)}
+			</span>
+		</button>
+	);
+}
+
+/**
+ * Passthrough option text, accurate for the target account provider.
+ *
+ * The old copy promised "the client model goes upstream untouched" for every
+ * provider — false outside passthrough providers, and that promise caused the
+ * broken slot in the incident.
+ */
+function clientModelHint(
+	mode: "single" | "list",
+	provider: string | null | undefined,
+	passthroughAllowed: boolean,
+): string {
+	if (passthroughAllowed) {
+		return mode === "list"
+			? "Clears the field. With no mapping, the model requested by the client goes upstream untouched."
+			: "Leaves the field empty (passthrough): the model requested by the client goes upstream untouched.";
+	}
+	const name = provider?.trim();
+	if (!name) {
+		return "Pick an account first: whether the model can be left empty depends on the provider.";
+	}
+	return mode === "list"
+		? `Not passthrough on ${name}: with no mapping, the built-in default map of the provider decides — and it may point at a model this account cannot call.`
+		: `Unavailable on ${name}: this provider does not serve Claude model ids, so an empty model would be coerced by a default map into something this account may not be able to call. Pick a model.`;
+}
+
+/**
+ * Model field with a provider list.
+ *
+ * It remains a free-text input: a new model works before it appears in the
+ * list. The list exists to reduce typing errors, not to close the set of
+ * options.
+ */
+export function ModelCombobox({
+	provider,
+	value,
+	onChange,
+	mode = "single",
+	placeholder,
+	id,
+	className,
+	inputClassName,
+	disabled,
+}: ModelComboboxProps) {
+	const [open, setOpen] = useState(false);
+	const [filter, setFilter] = useState("");
+	const query = useProviderModels(provider);
+
+	const selected = useMemo(() => parseModelList(value), [value]);
+	const usesClientModel = value.trim().length === 0;
+	const hasProvider = Boolean(provider?.trim());
+	// Single rule in utils/provider-utils: an empty field only means something
+	// when the upstream serves the same model IDs requested by the client.
+	const passthroughAllowed = providerAllowsClientModelPassthrough(provider);
+	// In mode="list", the same button CLEARs a mapping — a legitimate action
+	// for every provider — so only the copy changes there. In mode="single"
+	// (combo slot), an empty field would be an invalid slot: disable it and
+	// explain why rather than making it disappear without explanation.
+	const clientModelDisabled = mode === "single" && !passthroughAllowed;
+	const clientModelTitle =
+		mode === "list" && !passthroughAllowed
+			? "Clear this mapping"
+			: "Use the model sent by the client";
+
+	const { known, reference } = useMemo(() => {
+		const models = query.data?.models ?? [];
+		const needle = filter.trim().toLowerCase();
+		const matches = (model: ProviderModel) =>
+			needle.length === 0 ||
+			model.id.toLowerCase().includes(needle) ||
+			model.displayName.toLowerCase().includes(needle);
+		return {
+			known: models.filter((m) => m.source !== "reference" && matches(m)),
+			reference: models.filter((m) => m.source === "reference" && matches(m)),
+		};
+	}, [query.data, filter]);
+
+	const isPicked = (modelId: string) =>
+		mode === "list" ? selected.includes(modelId) : value.trim() === modelId;
+
+	const handlePick = (modelId: string) => {
+		if (mode === "list") {
+			// The list rotates on rate limits, so choosing toggles presence instead
+			// of deleting what is already there — and the popover stays open to build
+			// the whole list at once.
+			const next = selected.includes(modelId)
+				? selected.filter((m) => m !== modelId)
+				: [...selected, modelId];
+			onChange(formatModelList(next));
+			return;
+		}
+		onChange(modelId);
+		setOpen(false);
+	};
+
+	const handleUseClientModel = () => {
+		onChange("");
+		setOpen(false);
+	};
+
+	const nothingListed =
+		!query.isLoading &&
+		!query.isError &&
+		known.length === 0 &&
+		reference.length === 0;
+
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverAnchor asChild>
+				<div className={cn("relative w-full", className)}>
+					<Input
+						id={id}
+						value={value}
+						onChange={(e) => onChange(e.target.value)}
+						placeholder={placeholder}
+						disabled={disabled}
+						autoComplete="off"
+						spellCheck={false}
+						className={cn("pr-9 font-mono text-xs", inputClassName)}
+					/>
+					<PopoverTrigger asChild>
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							disabled={disabled}
+							aria-label="Show models for this provider"
+							title="Show models for this provider"
+							className="absolute right-0 top-0 h-full px-2 text-muted-foreground hover:bg-transparent hover:text-foreground"
+						>
+							<ChevronDown className="h-4 w-4" />
+						</Button>
+					</PopoverTrigger>
+				</div>
+			</PopoverAnchor>
+			<PopoverContent
+				align="start"
+				portal={false}
+				className="w-[max(var(--radix-popover-trigger-width),22rem)] p-0"
+			>
+				<div className="space-y-1 border-b p-2">
+					<Input
+						value={filter}
+						onChange={(e) => setFilter(e.target.value)}
+						placeholder="Filter models..."
+						className="h-8"
+					/>
+					<p className="px-1 text-[11px] text-muted-foreground">
+						{hasProvider
+							? `Models for provider: ${provider}`
+							: "No account selected yet, so there is no provider list to show."}
+						{mode === "list"
+							? " Click an item to add or remove it from the list."
+							: ""}
+					</p>
+				</div>
+				<div
+					className="max-h-72 overflow-y-auto overscroll-contain p-1"
+					onWheelCapture={(e) => e.stopPropagation()}
+				>
+					<button
+						type="button"
+						onClick={handleUseClientModel}
+						disabled={clientModelDisabled}
+						className={cn(
+							"mb-1 flex w-full items-start gap-2 rounded-sm border border-dashed px-2 py-2 text-left hover:bg-accent hover:text-accent-foreground",
+							usesClientModel &&
+								!clientModelDisabled &&
+								"border-primary bg-accent/60",
+							clientModelDisabled &&
+								"cursor-not-allowed opacity-60 hover:bg-transparent hover:text-inherit",
+						)}
+					>
+						<Check
+							className={cn(
+								"mt-0.5 h-3.5 w-3.5 shrink-0",
+								usesClientModel && !clientModelDisabled
+									? "opacity-100"
+									: "opacity-0",
+							)}
+						/>
+						<span className="min-w-0 flex-1">
+							<span className="block text-sm font-medium">
+								{clientModelTitle}
+							</span>
+							<span className="block text-[11px] text-muted-foreground">
+								{clientModelHint(mode, provider, passthroughAllowed)}
+							</span>
+						</span>
+					</button>
+
+					{query.isLoading && (
+						<div className="flex items-center gap-2 px-2 py-3 text-xs text-muted-foreground">
+							<Loader2 className="h-3.5 w-3.5 animate-spin" />
+							Loading models...
+						</div>
+					)}
+
+					{query.isError && (
+						<p className="px-2 py-3 text-xs text-destructive">
+							Could not load the model list. Typing the model name still works.{" "}
+							{query.error instanceof Error
+								? query.error.message
+								: "unknown error"}
+						</p>
+					)}
+
+					{hasProvider && nothingListed && (
+						<p className="px-2 py-3 text-xs text-muted-foreground">
+							No model matched. Type the name — a brand new model works before
+							it shows up here.
+						</p>
+					)}
+
+					{known.length > 0 && (
+						<>
+							<div className="px-2 pb-1 pt-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+								Known to ccflare
+							</div>
+							{known.map((model) => (
+								<ModelOption
+									key={model.id}
+									model={model}
+									picked={isPicked(model.id)}
+									onPick={handlePick}
+								/>
+							))}
+						</>
+					)}
+
+					{reference.length > 0 && (
+						<>
+							<div className="flex flex-wrap items-center gap-1.5 px-2 pb-1 pt-3">
+								<span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+									Provider catalog (reference)
+								</span>
+								<Badge variant="warning" className="px-1.5 py-0 text-[10px]">
+									may not be released for this plan
+								</Badge>
+							</div>
+							<p className="px-2 pb-1 text-[11px] text-muted-foreground">
+								Listed in the public catalog of the provider. Being here is no
+								proof that the plan of this account can call it: a subscription
+								account still gets HTTP 400 for a model it is not entitled to.
+								Use Test to find out.
+							</p>
+							{reference.map((model) => (
+								<ModelOption
+									key={model.id}
+									model={model}
+									picked={isPicked(model.id)}
+									onPick={handlePick}
+								/>
+							))}
+						</>
+					)}
+				</div>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/packages/dashboard-web/src/components/models/ModelCombobox.tsx
+++ b/packages/dashboard-web/src/components/models/ModelCombobox.tsx
@@ -44,6 +44,7 @@ export interface ModelComboboxProps {
 	 * Defaults to false — ComboSlotBuilder and AccountModelMappingsDialog do
 	 * not pass this prop, so their behavior remains unchanged.
 	 */
+	hideClientModelOption?: boolean;
 }
 
 interface ModelOptionProps {
@@ -123,6 +124,7 @@ export function ModelCombobox({
 	className,
 	inputClassName,
 	disabled,
+	hideClientModelOption = false,
 }: ModelComboboxProps) {
 	const [open, setOpen] = useState(false);
 	const [filter, setFilter] = useState("");
@@ -240,36 +242,38 @@ export function ModelCombobox({
 					className="max-h-72 overflow-y-auto overscroll-contain p-1"
 					onWheelCapture={(e) => e.stopPropagation()}
 				>
-					<button
-						type="button"
-						onClick={handleUseClientModel}
-						disabled={clientModelDisabled}
-						className={cn(
-							"mb-1 flex w-full items-start gap-2 rounded-sm border border-dashed px-2 py-2 text-left hover:bg-accent hover:text-accent-foreground",
-							usesClientModel &&
-								!clientModelDisabled &&
-								"border-primary bg-accent/60",
-							clientModelDisabled &&
-								"cursor-not-allowed opacity-60 hover:bg-transparent hover:text-inherit",
-						)}
-					>
-						<Check
+					{!hideClientModelOption && (
+						<button
+							type="button"
+							onClick={handleUseClientModel}
+							disabled={clientModelDisabled}
 							className={cn(
-								"mt-0.5 h-3.5 w-3.5 shrink-0",
-								usesClientModel && !clientModelDisabled
-									? "opacity-100"
-									: "opacity-0",
+								"mb-1 flex w-full items-start gap-2 rounded-sm border border-dashed px-2 py-2 text-left hover:bg-accent hover:text-accent-foreground",
+								usesClientModel &&
+									!clientModelDisabled &&
+									"border-primary bg-accent/60",
+								clientModelDisabled &&
+									"cursor-not-allowed opacity-60 hover:bg-transparent hover:text-inherit",
 							)}
-						/>
-						<span className="min-w-0 flex-1">
-							<span className="block text-sm font-medium">
-								{clientModelTitle}
+						>
+							<Check
+								className={cn(
+									"mt-0.5 h-3.5 w-3.5 shrink-0",
+									usesClientModel && !clientModelDisabled
+										? "opacity-100"
+										: "opacity-0",
+								)}
+							/>
+							<span className="min-w-0 flex-1">
+								<span className="block text-sm font-medium">
+									{clientModelTitle}
+								</span>
+								<span className="block text-[11px] text-muted-foreground">
+									{clientModelHint(mode, provider, passthroughAllowed)}
+								</span>
 							</span>
-							<span className="block text-[11px] text-muted-foreground">
-								{clientModelHint(mode, provider, passthroughAllowed)}
-							</span>
-						</span>
-					</button>
+						</button>
+					)}
 
 					{query.isLoading && (
 						<div className="flex items-center gap-2 px-2 py-3 text-xs text-muted-foreground">

--- a/packages/dashboard-web/src/components/overview/AdvancedSettingsCard.tsx
+++ b/packages/dashboard-web/src/components/overview/AdvancedSettingsCard.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from "react";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "../ui/card";
+import { Separator } from "../ui/separator";
+import { ProviderModelDefaultsDialog } from "./ProviderModelDefaultsDialog";
+
+/**
+ * Advanced settings: rarely changed items, each behind its own modal so they
+ * do not compete for space with frequently used cards in the SettingsTab
+ * grid.
+ *
+ * To add an item: add an ADVANCED_SETTINGS_ITEMS entry with a title, one
+ * description line, and the dialog it opens (already with its own trigger
+ * button; see ProviderModelDefaultsDialog). The card itself knows nothing
+ * about the content of each item.
+ */
+interface AdvancedSettingItem {
+	id: string;
+	title: string;
+	description: string;
+	dialog: ReactNode;
+}
+
+const ADVANCED_SETTINGS_ITEMS: AdvancedSettingItem[] = [
+	{
+		id: "provider-model-defaults",
+		title: "Provider Model Defaults",
+		description:
+			"Built-in fallback model per provider and Claude family, used only as a last resort.",
+		dialog: <ProviderModelDefaultsDialog />,
+	},
+];
+
+export function AdvancedSettingsCard() {
+	return (
+		<Card className="card-hover">
+			<CardHeader>
+				<CardTitle>Advanced</CardTitle>
+				<CardDescription>
+					Settings you rarely need to touch, each behind its own dialog.
+				</CardDescription>
+			</CardHeader>
+			<CardContent className="space-y-3">
+				{ADVANCED_SETTINGS_ITEMS.map((item, index) => (
+					<div key={item.id}>
+						{index > 0 && <Separator className="mb-3" />}
+						<div className="flex items-center justify-between gap-3">
+							<div className="space-y-0.5">
+								<p className="text-sm font-medium">{item.title}</p>
+								<p className="text-xs text-muted-foreground">
+									{item.description}
+								</p>
+							</div>
+							{item.dialog}
+						</div>
+					</div>
+				))}
+			</CardContent>
+		</Card>
+	);
+}

--- a/packages/dashboard-web/src/components/overview/ProviderModelDefaultsDialog.tsx
+++ b/packages/dashboard-web/src/components/overview/ProviderModelDefaultsDialog.tsx
@@ -1,0 +1,296 @@
+import { AlertCircle, Info, Loader2, RefreshCw, Save } from "lucide-react";
+import { useEffect, useState } from "react";
+import {
+	useProviderModelDefaults,
+	useSaveProviderModelDefaults,
+} from "../../hooks/useProviderModelDefaults";
+import type { ProviderModelDefaultOverrideInput } from "../../lib/provider-model-defaults-api";
+import { ModelCombobox } from "../models/ModelCombobox";
+import { Button } from "../ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "../ui/dialog";
+import { Label } from "../ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
+
+// Display order for known families; any future family sent by the backend that
+// is unknown here goes last, alphabetically — it never disappears from the
+// screen merely because it is absent from this list.
+const FAMILY_ORDER = ["fable", "opus", "sonnet", "haiku"];
+
+function familyLabel(family: string): string {
+	return family.charAt(0).toUpperCase() + family.slice(1);
+}
+
+function fieldKey(provider: string, family: string): string {
+	return `${provider}:${family}`;
+}
+
+function domId(provider: string, family: string): string {
+	return `provider-model-default-${provider}-${family}`;
+}
+
+function sortFamilies<T extends { family: string }>(fields: T[]): T[] {
+	return [...fields].sort((a, b) => {
+		const ia = FAMILY_ORDER.indexOf(a.family);
+		const ib = FAMILY_ORDER.indexOf(b.family);
+		if (ia === -1 && ib === -1) return a.family.localeCompare(b.family);
+		if (ia === -1) return 1;
+		if (ib === -1) return -1;
+		return ia - ib;
+	});
+}
+
+/**
+ * Per-provider default model map: the LAST word in the resolution chain
+ * (combo slot -> account mapping -> this map embedded in code). It has a UI
+ * only because one hardcoded map sent a Codex/ChatGPT account to a model its
+ * subscription cannot use — and until now rebuilding was the only fix.
+ *
+ * Empty field == no override == use the factory value (shown in the
+ * placeholder and hint below the field). This is NOT the ModelCombobox "use
+ * the client model" (passthrough) option — that option is deliberately
+ * hidden here with `hideClientModelOption`: this field exists specifically
+ * for providers that do not speak Claude, so passthrough never makes sense
+ * on this screen.
+ *
+ * It lives in a modal (opened from the SettingsTab "Advanced" card) because
+ * it is rarely changed. One tab per provider deliberately keeps each tab
+ * short (at most 4 fields): ModelCombobox renders its popover without a
+ * portal (see ModelCombobox) because when portalized, Radix Dialog scroll
+ * locking swallows the mouse wheel inside modals — and an `overflow-y-auto`
+ * between the dialog and field would clip the dropdown list. Therefore this
+ * modal does not scroll: the tabs exist to guarantee that, not just to organize.
+ */
+export function ProviderModelDefaultsDialog() {
+	const query = useProviderModelDefaults();
+	const save = useSaveProviderModelDefaults();
+	// Local draft per field (key `${provider}:${family}`). It becomes a real
+	// override only when the user clicks Save — nothing here saves on every
+	// keystroke.
+	const [drafts, setDrafts] = useState<Record<string, string>>({});
+	const [activeTab, setActiveTab] = useState<string | undefined>(undefined);
+
+	// Resynchronizes the draft whenever the query brings a fresh server
+	// snapshot: on initial load and after Save invalidates the query. An empty
+	// override in the draft means "no customization; use the factory value".
+	useEffect(() => {
+		if (!query.data) return;
+		const next: Record<string, string> = {};
+		for (const provider of query.data) {
+			for (const field of provider.fields) {
+				next[fieldKey(provider.provider, field.family)] = field.override ?? "";
+			}
+		}
+		setDrafts(next);
+	}, [query.data]);
+
+	const providers = query.data ?? [];
+	const sortedProviders = [...providers].sort((a, b) =>
+		a.provider.localeCompare(b.provider),
+	);
+
+	// Keeps the active tab valid as providers arrive or change; selects the
+	// first one by default once the list arrives.
+	useEffect(() => {
+		if (sortedProviders.length === 0) return;
+		if (
+			activeTab &&
+			sortedProviders.some((provider) => provider.provider === activeTab)
+		) {
+			return;
+		}
+		setActiveTab(sortedProviders[0].provider);
+	}, [sortedProviders, activeTab]);
+
+	const handleChange = (provider: string, family: string, value: string) => {
+		setDrafts((prev) => ({ ...prev, [fieldKey(provider, family)]: value }));
+	};
+
+	const handleReset = (provider: string, family: string) => {
+		setDrafts((prev) => ({ ...prev, [fieldKey(provider, family)]: "" }));
+	};
+
+	// Derived on every render: fields whose drafts differ from what is saved
+	// now. It is also the Save payload — no parallel "dirty" state can drift
+	// from what will actually be sent. It runs over ALL providers, not only
+	// the active tab: Save applies to the entire modal.
+	const dirtyOverrides: ProviderModelDefaultOverrideInput[] = [];
+	for (const provider of providers) {
+		for (const field of provider.fields) {
+			const key = fieldKey(provider.provider, field.family);
+			const draft = (drafts[key] ?? "").trim();
+			const saved = field.override ?? "";
+			if (draft !== saved) {
+				dirtyOverrides.push({
+					provider: provider.provider,
+					family: field.family,
+					model: draft,
+				});
+			}
+		}
+	}
+
+	const handleSave = () => {
+		if (dirtyOverrides.length === 0) return;
+		save.mutate(dirtyOverrides);
+	};
+
+	const disableFields = query.isLoading || save.isPending;
+
+	return (
+		<Dialog>
+			<DialogTrigger asChild>
+				<Button variant="outline" size="sm">
+					Configure
+				</Button>
+			</DialogTrigger>
+			<DialogContent className="max-w-2xl">
+				<DialogHeader>
+					<DialogTitle>Provider Model Defaults</DialogTitle>
+					<DialogDescription>
+						The built-in model this proxy falls back to per provider and Claude
+						family, for providers that do not speak Claude model ids natively.
+					</DialogDescription>
+				</DialogHeader>
+
+				<p className="flex items-start gap-1.5 text-xs text-muted-foreground">
+					<Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+					Last resort in the routing chain: only used when the requested model
+					has no slot in the combo and no mapping on the account.
+				</p>
+
+				{query.isLoading && (
+					<div className="flex items-center gap-2 py-4 text-sm text-muted-foreground">
+						<Loader2 className="h-4 w-4 animate-spin" />
+						Loading provider defaults...
+					</div>
+				)}
+
+				{query.isError && (
+					<p className="flex items-center gap-2 py-2 text-sm text-destructive">
+						<AlertCircle className="h-4 w-4 shrink-0" />
+						Could not load provider defaults.{" "}
+						{query.error instanceof Error
+							? query.error.message
+							: "unknown error"}
+					</p>
+				)}
+
+				{!query.isLoading && !query.isError && sortedProviders.length === 0 && (
+					<p className="py-2 text-sm text-muted-foreground">
+						No provider has a built-in default map to configure.
+					</p>
+				)}
+
+				{sortedProviders.length > 0 && activeTab && (
+					<Tabs value={activeTab} onValueChange={setActiveTab}>
+						<TabsList>
+							{sortedProviders.map((provider) => (
+								<TabsTrigger key={provider.provider} value={provider.provider}>
+									{provider.provider}
+								</TabsTrigger>
+							))}
+						</TabsList>
+						{sortedProviders.map((provider) => (
+							<TabsContent
+								key={provider.provider}
+								value={provider.provider}
+								className="grid grid-cols-1 gap-3 sm:grid-cols-2"
+							>
+								{sortFamilies(provider.fields).map((field) => {
+									const key = fieldKey(provider.provider, field.family);
+									const id = domId(provider.provider, field.family);
+									const draft = drafts[key] ?? "";
+									const customized = draft.trim().length > 0;
+									return (
+										<div key={key} className="space-y-1">
+											<Label htmlFor={id} className="text-xs">
+												{familyLabel(field.family)}
+											</Label>
+											<div className="flex items-center gap-1.5">
+												<ModelCombobox
+													id={id}
+													provider={provider.provider}
+													value={draft}
+													onChange={(value) =>
+														handleChange(provider.provider, field.family, value)
+													}
+													placeholder={`${field.factory} (factory)`}
+													hideClientModelOption
+													className="flex-1"
+													inputClassName="h-8"
+													disabled={disableFields}
+												/>
+												{customized && (
+													<Button
+														type="button"
+														variant="ghost"
+														size="sm"
+														title={`Reset to factory: ${field.factory}`}
+														onClick={() =>
+															handleReset(provider.provider, field.family)
+														}
+														disabled={save.isPending}
+													>
+														<RefreshCw className="h-3.5 w-3.5" />
+													</Button>
+												)}
+											</div>
+											<p className="text-[11px] text-muted-foreground">
+												{customized
+													? `Customized. Factory: ${field.factory}`
+													: `Factory: ${field.factory}`}
+											</p>
+										</div>
+									);
+								})}
+							</TabsContent>
+						))}
+					</Tabs>
+				)}
+
+				<div className="flex items-center gap-2 pt-1">
+					<Button
+						size="sm"
+						onClick={handleSave}
+						disabled={
+							dirtyOverrides.length === 0 || save.isPending || query.isLoading
+						}
+					>
+						{save.isPending ? (
+							<>
+								<Loader2 className="h-3.5 w-3.5 animate-spin" />
+								Saving...
+							</>
+						) : (
+							<>
+								<Save className="h-3.5 w-3.5" />
+								Save
+							</>
+						)}
+					</Button>
+					{dirtyOverrides.length > 0 && !save.isPending && (
+						<span className="text-xs text-muted-foreground">
+							{dirtyOverrides.length} field
+							{dirtyOverrides.length === 1 ? "" : "s"} changed
+						</span>
+					)}
+				</div>
+
+				{save.isError && (
+					<p className="flex items-center gap-2 text-xs text-destructive">
+						<AlertCircle className="h-3.5 w-3.5 shrink-0" />
+						Could not save.{" "}
+						{save.error instanceof Error ? save.error.message : "unknown error"}
+					</p>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/packages/dashboard-web/src/components/ui/popover.tsx
+++ b/packages/dashboard-web/src/components/ui/popover.tsx
@@ -7,23 +7,43 @@ const Popover = PopoverPrimitive.Root;
 
 const PopoverTrigger = PopoverPrimitive.Trigger;
 
+// Optional anchor: lets the popover be positioned by an element other than
+// the trigger (e.g. open aligned to the field, not the button inside it).
+const PopoverAnchor = PopoverPrimitive.Anchor;
+
 const PopoverContent = React.forwardRef<
 	React.ElementRef<typeof PopoverPrimitive.Content>,
-	React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-	<PopoverPrimitive.Portal>
-		<PopoverPrimitive.Content
-			ref={ref}
-			align={align}
-			sideOffset={sideOffset}
-			className={cn(
-				"z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-				className,
-			)}
-			{...props}
-		/>
-	</PopoverPrimitive.Portal>
-));
+	React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> & {
+		/** false renders without a Portal (needed inside a Dialog so the mouse wheel can scroll) */
+		portal?: boolean;
+	}
+>(
+	(
+		{ className, align = "center", sideOffset = 4, portal = true, ...props },
+		ref,
+	) => {
+		const content = (
+			<PopoverPrimitive.Content
+				ref={ref}
+				align={align}
+				sideOffset={sideOffset}
+				className={cn(
+					"z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+					className,
+				)}
+				{...props}
+			/>
+		);
+		// Without a portal, the content stays in the subtree of the dialog that
+		// contains it — and that is what makes the mouse wheel work: Radix
+		// Dialog's react-remove-scroll blocks scrolling on any node outside it.
+		return portal ? (
+			<PopoverPrimitive.Portal>{content}</PopoverPrimitive.Portal>
+		) : (
+			content
+		);
+	},
+);
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
-export { Popover, PopoverContent, PopoverTrigger };
+export { Popover, PopoverAnchor, PopoverContent, PopoverTrigger };

--- a/packages/dashboard-web/src/hooks/useProviderModelDefaults.ts
+++ b/packages/dashboard-web/src/hooks/useProviderModelDefaults.ts
@@ -1,0 +1,36 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+	fetchProviderModelDefaults,
+	type ProviderModelDefaultOverrideInput,
+	saveProviderModelDefaultOverrides,
+} from "../lib/provider-model-defaults-api";
+import { queryKeys } from "../lib/query-keys";
+
+/**
+ * Per-provider-and-family default model map (the one embedded in code, the
+ * last word in the resolution chain). Few records: short staleTime only to
+ * avoid duplicate calls between re-renders, with no polling.
+ */
+export const useProviderModelDefaults = () =>
+	useQuery({
+		queryKey: queryKeys.providerModelDefaults(),
+		queryFn: fetchProviderModelDefaults,
+		staleTime: 30 * 1000,
+	});
+
+/**
+ * Saves the overrides edited on screen in one operation. Invalidates the query
+ * above to reload the effective value after saving.
+ */
+export const useSaveProviderModelDefaults = () => {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (overrides: ProviderModelDefaultOverrideInput[]) =>
+			saveProviderModelDefaultOverrides(overrides),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: queryKeys.providerModelDefaults(),
+			});
+		},
+	});
+};

--- a/packages/dashboard-web/src/hooks/useProviderModels.ts
+++ b/packages/dashboard-web/src/hooks/useProviderModels.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchProviderModels } from "../lib/model-api";
+import { queryKeys } from "../lib/query-keys";
+
+/**
+ * Provider model list. Disabled while the provider is unknown (no selected
+ * account), so the combobox never suggests the wrong provider list.
+ */
+export const useProviderModels = (provider?: string | null) => {
+	const normalized = provider?.trim() ?? "";
+	return useQuery({
+		queryKey: queryKeys.providerModels(normalized),
+		queryFn: () => fetchProviderModels(normalized),
+		enabled: normalized.length > 0,
+		staleTime: 5 * 60 * 1000,
+		gcTime: 30 * 60 * 1000,
+		// The list is a convenience: a failure must not become a retry storm,
+		// because the field still accepts free text.
+		retry: false,
+	});
+};

--- a/packages/dashboard-web/src/lib/model-api.ts
+++ b/packages/dashboard-web/src/lib/model-api.ts
@@ -1,0 +1,111 @@
+import { HttpError } from "@better-ccflare/http-common";
+import { api } from "../api";
+
+/**
+ * Adapter for the two endpoints used by the model selector.
+ *
+ * Everything the dashboard knows about these response shapes lives here: if
+ * the backend changes the contract, this is the only file to update.
+ *
+ *   GET  /api/models?provider=<anthropic|codex|...>
+ *     -> { provider, fetchedAt, source, models: [{ id, displayName, source }] }
+ *   POST /api/accounts/:id/test-model    body { model }
+ *     -> { ok, inconclusive?, status, error?, durationMs }
+ *
+ * Authentication comes for free from the shared `api` client, which injects
+ * `x-api-key` into every request and opens the auth dialog on 401.
+ */
+
+export type ProviderModelSource = "builtin" | "catalog" | "reference";
+
+export interface ProviderModel {
+	id: string;
+	displayName: string;
+	/**
+	 * "builtin"/"catalog": ccflare knows this model for the provider.
+	 * "reference": it exists in the provider public catalog — which is NOT a
+	 * promise that the account plan can call it.
+	 */
+	source: ProviderModelSource;
+}
+
+export interface ProviderModels {
+	provider: string;
+	fetchedAt: number | null;
+	source: string | null;
+	models: ProviderModel[];
+}
+
+const MODEL_SOURCES: ProviderModelSource[] = [
+	"builtin",
+	"catalog",
+	"reference",
+];
+
+function normalizeSource(value: unknown): ProviderModelSource {
+	return MODEL_SOURCES.includes(value as ProviderModelSource)
+		? (value as ProviderModelSource)
+		: "catalog";
+}
+
+function normalizeModel(raw: unknown): ProviderModel | null {
+	if (typeof raw === "string") {
+		const id = raw.trim();
+		return id ? { id, displayName: id, source: "catalog" } : null;
+	}
+	if (!raw || typeof raw !== "object") return null;
+	const entry = raw as Record<string, unknown>;
+	const id = typeof entry.id === "string" ? entry.id.trim() : "";
+	if (!id) return null;
+	const displayName =
+		typeof entry.displayName === "string" && entry.displayName.trim()
+			? entry.displayName.trim()
+			: id;
+	return { id, displayName, source: normalizeSource(entry.source) };
+}
+
+function asRecord(raw: unknown): Record<string, unknown> {
+	return raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+}
+
+/** Model list for a provider. Tolerant: malformed input becomes an empty list. */
+export async function fetchProviderModels(
+	provider: string,
+): Promise<ProviderModels> {
+	const body = asRecord(
+		await api.get<unknown>(
+			`/api/models?provider=${encodeURIComponent(provider)}`,
+		),
+	);
+	const list: unknown[] = Array.isArray(body.models) ? body.models : [];
+	const seen = new Set<string>();
+	const models: ProviderModel[] = [];
+	for (const item of list) {
+		const model = normalizeModel(item);
+		if (!model || seen.has(model.id)) continue;
+		seen.add(model.id);
+		models.push(model);
+	}
+	return {
+		provider: typeof body.provider === "string" ? body.provider : provider,
+		fetchedAt: typeof body.fetchedAt === "number" ? body.fetchedAt : null,
+		source: typeof body.source === "string" ? body.source : null,
+		models,
+	};
+}
+
+export function parseModelList(value: string): string[] {
+	return value
+		.split(",")
+		.map((part) => part.trim())
+		.filter(Boolean);
+}
+
+export function formatModelList(models: string[]): string {
+	return models.join(", ");
+}
+
+/** First model in the list — the one the proxy tries before the others. */
+export function firstModelInList(value: string): string {
+	return parseModelList(value)[0] ?? "";
+}

--- a/packages/dashboard-web/src/lib/provider-model-defaults-api.ts
+++ b/packages/dashboard-web/src/lib/provider-model-defaults-api.ts
@@ -1,0 +1,112 @@
+import { api } from "../api";
+
+/**
+ * Adapter for ONE endpoint: the per-provider-and-family default model map
+ * currently embedded in code (codex, xai, qwen, ...) and used as the LAST
+ * word when neither the combo slot nor account mapping supplies a model. One
+ * of these hardcoded maps caused the incident
+ * `400 The 'gpt-5.3-codex' model is not supported when using Codex with a
+ * ChatGPT account` — the account subscription cannot use that model, and
+ * until now rebuilding was the only possible fix.
+ *
+ * Everything the dashboard knows about these response shapes lives here: if
+ * the backend changes the contract, this is the only file to update.
+ *
+ *   GET  /api/config/provider-model-defaults
+ *     -> per provider and family: factory value, override (if any), and
+ *        effective value. Expected shape (tolerant of shape variation):
+ *        { providers: [ { provider, fields: [
+ *            { family, factory, override, effective },
+ *        ] } ] }
+ *   POST /api/config/provider-model-defaults   body { overrides: [{ provider, family, model }] }
+ *     -> saves overrides; model === "" removes the override for that
+ *        provider and family (returns to the factory value).
+ *
+ * Authentication comes for free from the shared `api` client, which injects
+ * `x-api-key` into every request and opens the auth dialog on 401.
+ */
+
+export interface ProviderModelDefaultField {
+	family: string;
+	/** Value embedded in code — what applies with no override. */
+	factory: string;
+	/** Override saved today; null when there is no customization. */
+	override: string | null;
+	/** What the proxy actually uses now (override if present, otherwise factory). */
+	effective: string;
+}
+
+export interface ProviderModelDefaults {
+	provider: string;
+	fields: ProviderModelDefaultField[];
+}
+
+export interface ProviderModelDefaultOverrideInput {
+	provider: string;
+	family: string;
+	/** An empty string removes the override (returns to the factory value). */
+	model: string;
+}
+
+function asRecord(raw: unknown): Record<string, unknown> {
+	return raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+}
+
+function asString(raw: unknown): string {
+	return typeof raw === "string" ? raw.trim() : "";
+}
+
+function normalizeField(raw: unknown): ProviderModelDefaultField | null {
+	const entry = asRecord(raw);
+	const family = asString(entry.family);
+	if (!family) return null;
+	const factory = asString(entry.factory);
+	const overrideRaw = entry.override;
+	const override =
+		typeof overrideRaw === "string" && overrideRaw.trim()
+			? overrideRaw.trim()
+			: null;
+	// effective tolerates being absent: falls back to override, then factory.
+	const effective = asString(entry.effective) || override || factory;
+	return { family, factory, override, effective };
+}
+
+function normalizeProvider(raw: unknown): ProviderModelDefaults | null {
+	const entry = asRecord(raw);
+	const provider = asString(entry.provider);
+	if (!provider) return null;
+	const list: unknown[] = Array.isArray(entry.fields) ? entry.fields : [];
+	const fields: ProviderModelDefaultField[] = [];
+	for (const item of list) {
+		const field = normalizeField(item);
+		if (field) fields.push(field);
+	}
+	return { provider, fields };
+}
+
+/** Default model map for all providers. Malformed input becomes an empty list. */
+export async function fetchProviderModelDefaults(): Promise<
+	ProviderModelDefaults[]
+> {
+	const body = asRecord(
+		await api.get<unknown>("/api/config/provider-model-defaults"),
+	);
+	const list: unknown[] = Array.isArray(body.providers) ? body.providers : [];
+	const providers: ProviderModelDefaults[] = [];
+	for (const item of list) {
+		const provider = normalizeProvider(item);
+		if (provider) providers.push(provider);
+	}
+	return providers;
+}
+
+/**
+ * Saves overrides in one operation, triggered by explicit action (the Save
+ * button): this card does not save on every keystroke. A field with
+ * model === "" removes that provider-and-family override (returns to factory).
+ */
+export async function saveProviderModelDefaultOverrides(
+	overrides: ProviderModelDefaultOverrideInput[],
+): Promise<void> {
+	await api.post("/api/config/provider-model-defaults", { overrides });
+}

--- a/packages/dashboard-web/src/lib/query-keys.ts
+++ b/packages/dashboard-web/src/lib/query-keys.ts
@@ -37,4 +37,13 @@ export const queryKeys = {
 	usageHistory: (account?: string, range?: string) =>
 		[...queryKeys.all, "usage-history", { account, range }] as const,
 	models: () => [...queryKeys.all, "models"] as const,
+	// Deliberately kept under the 'models' key: invalidating models() also
+	// invalidates the per-provider lists.
+	providerModels: (provider?: string | null) =>
+		[...queryKeys.all, "models", "provider", provider ?? ""] as const,
+	// Single record for the default-model map per provider+family (today the
+	// last word in the chain, hardcoded). No parameter: the screen reads
+	// and writes everything at once.
+	providerModelDefaults: () =>
+		[...queryKeys.all, "config", "provider-model-defaults"] as const,
 } as const;

--- a/packages/dashboard-web/src/utils/provider-utils.ts
+++ b/packages/dashboard-web/src/utils/provider-utils.ts
@@ -21,6 +21,39 @@ export function providerSupportsAutoFeatures(provider: string): boolean {
 }
 
 /**
+ * Providers whose upstream answers by the SAME model ids the client asks for.
+ *
+ * This is the one and only definition of the passthrough rule. An empty model
+ * field means "forward whatever model the client sent, untouched" — which is
+ * only meaningful when the upstream natively accepts Claude model ids, i.e.
+ * Anthropic OAuth accounts and Claude Console API accounts.
+ *
+ * On every other provider the Claude id sent by the client lands on a foreign
+ * catalog and gets coerced by an embedded default map. That is the exact path
+ * that produced `400 The 'gpt-5.3-codex' model is not supported...` on a codex
+ * account. So outside this list, choosing a model is mandatory.
+ *
+ * Never compare `provider === "anthropic"` at a call site: use the helper
+ * below, so the criterion stays in a single place.
+ */
+export const PASSTHROUGH_PROVIDERS: readonly string[] = [
+	PROVIDER_NAMES.ANTHROPIC,
+	PROVIDER_NAMES.CLAUDE_CONSOLE_API,
+];
+
+/**
+ * True when the model field may be left empty (passthrough) for this provider.
+ *
+ * An absent/unknown provider (no account picked yet) is NOT passthrough: we
+ * cannot promise a behaviour we do not know the upstream supports.
+ */
+export function providerAllowsClientModelPassthrough(
+	provider?: string | null,
+): boolean {
+	return PASSTHROUGH_PROVIDERS.includes((provider ?? "").trim());
+}
+
+/**
  * Check if a provider supports custom billing type configuration
  * (anthropic-compatible and openai-compatible providers)
  */

--- a/packages/http-api/src/handlers/__tests__/combo-slot-model-required.test.ts
+++ b/packages/http-api/src/handlers/__tests__/combo-slot-model-required.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "bun:test";
+import { createSlotAddHandler, createSlotUpdateHandler } from "../combos";
+
+/**
+ * Passthrough (a combo slot with an empty model) forwards the model the CLIENT
+ * asked for. That only works where the upstream accepts Claude model ids —
+ * Anthropic accounts. On a codex account the Claude name falls through to the
+ * provider's built-in default map, which is the path that produced
+ * `400 The 'gpt-5.3-codex' model is not supported when using Codex with a
+ * ChatGPT account`.
+ */
+
+type Slot = {
+	id: string;
+	combo_id: string;
+	account_id: string;
+	model: string;
+	priority: number;
+	enabled: boolean;
+};
+
+function makeDbOps(provider: string, slots: Slot[] = []) {
+	const added: Array<{ accountId: string; model: string }> = [];
+	const updated: Array<Record<string, unknown>> = [];
+	return {
+		added,
+		updated,
+		ops: {
+			getCombo: async () => ({ id: "combo-1", name: "C", enabled: true }),
+			getAccount: async (id: string) => ({ id, name: "acc", provider }),
+			getComboSlots: async () => slots,
+			addComboSlot: async (
+				_comboId: string,
+				accountId: string,
+				model: string,
+			) => {
+				added.push({ accountId, model });
+				return { id: "slot-new", model };
+			},
+			updateComboSlot: async (_id: string, fields: Record<string, unknown>) => {
+				updated.push(fields);
+				return { id: "slot-1", ...fields };
+			},
+		},
+	};
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: minimal DatabaseOperations mock
+const asOps = (o: unknown) => o as any;
+
+function postSlot(body: unknown) {
+	return new Request("http://local/api/combos/combo-1/slots", {
+		method: "POST",
+		body: JSON.stringify(body),
+	});
+}
+
+describe("combo slot: model required depending on the provider", () => {
+	it("accepts a slot with no model on an anthropic account (passthrough)", async () => {
+		const db = makeDbOps("anthropic");
+		const res = await createSlotAddHandler(asOps(db.ops))(
+			postSlot({ account_id: "acc-1" }),
+			"combo-1",
+		);
+
+		expect(res.status).toBe(201);
+		expect(db.added).toEqual([{ accountId: "acc-1", model: "" }]);
+	});
+
+	it("rejects a slot with no model on a codex account", async () => {
+		const db = makeDbOps("codex");
+		const res = await createSlotAddHandler(asOps(db.ops))(
+			postSlot({ account_id: "acc-1" }),
+			"combo-1",
+		);
+
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as { error?: string };
+		expect(String(body.error)).toContain("codex");
+		// Nothing was written: the refusal happens before the insert.
+		expect(db.added).toHaveLength(0);
+	});
+
+	it("accepts a slot WITH a model on a codex account", async () => {
+		const db = makeDbOps("codex");
+		const res = await createSlotAddHandler(asOps(db.ops))(
+			postSlot({ account_id: "acc-1", model: "gpt-5.6-sol" }),
+			"combo-1",
+		);
+
+		expect(res.status).toBe(201);
+		expect(db.added).toEqual([{ accountId: "acc-1", model: "gpt-5.6-sol" }]);
+	});
+
+	// Without the same rule on the update route the validation is bypassable in
+	// two steps: create the slot with a model, then empty it.
+	it("rejects emptying the model of an existing codex slot", async () => {
+		const slots: Slot[] = [
+			{
+				id: "slot-1",
+				combo_id: "combo-1",
+				account_id: "acc-1",
+				model: "gpt-5.6-sol",
+				priority: 0,
+				enabled: true,
+			},
+		];
+		const db = makeDbOps("codex", slots);
+		const res = await createSlotUpdateHandler(asOps(db.ops))(
+			new Request("http://local/api/combos/combo-1/slots/slot-1", {
+				method: "PUT",
+				body: JSON.stringify({ model: "" }),
+			}),
+			"combo-1",
+			"slot-1",
+		);
+
+		expect(res.status).toBe(400);
+		expect(db.updated).toHaveLength(0);
+	});
+
+	// Regression for the cross-combo bypass: updateComboSlot resolves the slot
+	// globally, so a slot id addressed through a combo that does not own it used
+	// to skip the provider check entirely and still be updated.
+	it("rejects emptying a slot addressed through a combo that does not own it", async () => {
+		// The combo in the path owns no slots, so the lookup finds nothing.
+		const db = makeDbOps("codex", []);
+		const res = await createSlotUpdateHandler(asOps(db.ops))(
+			new Request("http://local/api/combos/other-combo/slots/slot-1", {
+				method: "PUT",
+				body: JSON.stringify({ model: "" }),
+			}),
+			"other-combo",
+			"slot-1",
+		);
+
+		expect(res.status).toBe(404);
+		expect(db.updated).toHaveLength(0);
+	});
+
+	it("allows emptying the model of an anthropic slot", async () => {
+		const slots: Slot[] = [
+			{
+				id: "slot-1",
+				combo_id: "combo-1",
+				account_id: "acc-1",
+				model: "claude-opus-5",
+				priority: 0,
+				enabled: true,
+			},
+		];
+		const db = makeDbOps("anthropic", slots);
+		const res = await createSlotUpdateHandler(asOps(db.ops))(
+			new Request("http://local/api/combos/combo-1/slots/slot-1", {
+				method: "PUT",
+				body: JSON.stringify({ model: "" }),
+			}),
+			"combo-1",
+			"slot-1",
+		);
+
+		expect(res.status).toBe(200);
+		expect(db.updated).toEqual([{ model: "" }]);
+	});
+});

--- a/packages/http-api/src/handlers/__tests__/models-provider.test.ts
+++ b/packages/http-api/src/handlers/__tests__/models-provider.test.ts
@@ -1,0 +1,227 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { CODEX_KNOWN_MODELS } from "@better-ccflare/providers";
+import type { APIContext } from "@better-ccflare/types";
+
+// listCatalogueModels is the seam to the shared models.dev catalogue, and the
+// real one performs network I/O. Stub it so these tests are offline and
+// deterministic.
+//
+// mock.module must run at top level and replaces the WHOLE module globally
+// and across file boundaries in Bun (no per-file isolation without
+// --isolate), so we capture the real @better-ccflare/core exports first,
+// spread them, and restore them in afterAll — same discipline as
+// oauth.test.ts. The handler is then imported dynamically, AFTER the mock is
+// registered, so its `listCatalogueModels` binding is the stub beyond any
+// doubt about import ordering.
+const actualCore = await import("@better-ccflare/core");
+
+/** What the stubbed catalogue returns; set per test. */
+let catalogueEntries: Array<{ id: string; name: string }> = [];
+/** Every models.dev section the handler asked for, in order. */
+let catalogueCalls: string[] = [];
+
+const stubListCatalogueModels = async (section: string) => {
+	catalogueCalls.push(section);
+	return catalogueEntries;
+};
+
+mock.module("@better-ccflare/core", () => ({
+	...actualCore,
+	listCatalogueModels: stubListCatalogueModels,
+}));
+
+afterAll(() => {
+	mock.module("@better-ccflare/core", () => actualCore);
+});
+
+const { createModelsHandler } = await import("../models");
+
+interface ListedModel {
+	id: string;
+	displayName: string;
+	source: string;
+	createdAt?: string | null;
+}
+
+interface ModelsBody {
+	models: ListedModel[];
+	fetchedAt: number;
+	source: string;
+	provider: string;
+	referenceSection?: string;
+	warning?: string;
+}
+
+const CATALOG_FETCHED_AT = 1_700_000_000_000;
+
+/** Context carrying a canned Anthropic catalog — the only dependency of the
+ * no-provider / anthropic branch. */
+function makeContext(): APIContext {
+	return {
+		modelCatalog: {
+			get: async () => ({
+				models: [
+					{
+						id: "claude-sonnet-4-5-20250929",
+						displayName: "Claude Sonnet 4.5",
+						createdAt: "2025-09-29T00:00:00Z",
+					},
+				],
+				fetchedAt: CATALOG_FETCHED_AT,
+				source: "live" as const,
+			}),
+			refresh: async () => ({ success: true }),
+		},
+	} as unknown as APIContext;
+}
+
+/** Find one listed model, failing loudly instead of returning undefined. */
+function listed(body: ModelsBody, id: string): ListedModel {
+	const found = body.models.find((model) => model.id === id);
+	if (!found) {
+		throw new Error(
+			`Expected model "${id}" in listing, got: ${body.models
+				.map((model) => model.id)
+				.join(", ")}`,
+		);
+	}
+	return found;
+}
+
+describe("GET /api/models", () => {
+	beforeEach(() => {
+		catalogueEntries = [];
+		catalogueCalls = [];
+	});
+
+	// Non-regression: the agents screen consumes this body. `provider` and the
+	// per-entry `source` are additive; nothing that was there may move.
+	it("without ?provider keeps the legacy Anthropic body shape", async () => {
+		const handler = createModelsHandler(makeContext());
+
+		const response = await handler(new URL("http://localhost/api/models"));
+		const body = (await response.json()) as ModelsBody;
+
+		expect(response.status).toBe(200);
+		expect(body.fetchedAt).toBe(CATALOG_FETCHED_AT);
+		expect(body.source).toBe("live");
+		expect(body.models).toHaveLength(1);
+		expect(body.models[0]).toMatchObject({
+			id: "claude-sonnet-4-5-20250929",
+			displayName: "Claude Sonnet 4.5",
+			createdAt: "2025-09-29T00:00:00Z",
+			source: "catalog",
+		});
+		expect(body.provider).toBe("anthropic");
+		// The Anthropic branch must never consult the models.dev catalogue.
+		expect(catalogueCalls).toEqual([]);
+
+		// The URL argument is optional — calling with none behaves identically.
+		const bare = (await (await handler()).json()) as ModelsBody;
+		expect(bare.provider).toBe("anthropic");
+		expect(bare.models).toHaveLength(1);
+	});
+
+	it("?provider=codex lists the builtins first, in map order, tagged builtin", async () => {
+		catalogueEntries = [
+			{ id: "gpt-4.1", name: "GPT-4.1" },
+			{ id: "gpt-4o", name: "GPT-4o" },
+		];
+		const handler = createModelsHandler(makeContext());
+
+		const response = await handler(
+			new URL("http://localhost/api/models?provider=codex"),
+		);
+		const body = (await response.json()) as ModelsBody;
+
+		expect(response.status).toBe(200);
+		expect(body.provider).toBe("codex");
+		// codex is served by the "openai" section of models.dev.
+		expect(catalogueCalls).toEqual(["openai"]);
+		expect(body.referenceSection).toBe("openai");
+		expect(body.source).toBe("mixed");
+
+		const ids = body.models.map((model) => model.id);
+		// Builtins come first and in the declaration order of the provider's
+		// own context-window table.
+		expect(ids.slice(0, CODEX_KNOWN_MODELS.length)).toEqual([
+			...CODEX_KNOWN_MODELS,
+		]);
+		// The model at the heart of the incident this endpoint exists for.
+		expect(ids).toContain("gpt-5.3-codex");
+		for (const id of CODEX_KNOWN_MODELS) {
+			expect(listed(body, id).source).toBe("builtin");
+		}
+		// Reference entries follow, alphabetically.
+		expect(ids.slice(CODEX_KNOWN_MODELS.length)).toEqual(["gpt-4.1", "gpt-4o"]);
+		expect(listed(body, "gpt-4.1").source).toBe("reference");
+		expect(listed(body, "gpt-4.1").displayName).toBe("GPT-4.1");
+	});
+
+	// listCatalogueModels is contractually non-throwing: it swallows fetch
+	// failures and an unknown section alike, and reports both as an empty
+	// list. That empty list is therefore the "catalogue unavailable" signal
+	// the handler has to survive — the endpoint must degrade, never fail.
+	it("?provider=codex degrades to builtins plus a warning when the catalogue is unavailable", async () => {
+		catalogueEntries = [];
+		const handler = createModelsHandler(makeContext());
+
+		const response = await handler(
+			new URL("http://localhost/api/models?provider=codex"),
+		);
+		const body = (await response.json()) as ModelsBody;
+
+		expect(response.status).toBe(200);
+		expect(body.source).toBe("builtin");
+		expect(body.models).toHaveLength(CODEX_KNOWN_MODELS.length);
+		expect(body.models.every((model) => model.source === "builtin")).toBe(true);
+		expect(body.warning).toBeDefined();
+		expect(body.warning).toContain("openai");
+	});
+
+	it("deduplicates by id, keeping the stronger marking", async () => {
+		catalogueEntries = [
+			// Also a builtin: must survive once, as builtin.
+			{ id: "gpt-5.6-sol", name: "GPT-5.6 Sol (catalogue name)" },
+			{ id: "gpt-4.1", name: "GPT-4.1" },
+			// Repeated inside the reference list itself.
+			{ id: "gpt-4.1", name: "GPT-4.1 (again)" },
+		];
+		const handler = createModelsHandler(makeContext());
+
+		const response = await handler(
+			new URL("http://localhost/api/models?provider=codex"),
+		);
+		const body = (await response.json()) as ModelsBody;
+
+		const ids = body.models.map((model) => model.id);
+		expect(ids.filter((id) => id === "gpt-5.6-sol")).toHaveLength(1);
+		expect(ids.filter((id) => id === "gpt-4.1")).toHaveLength(1);
+
+		const sol = listed(body, "gpt-5.6-sol");
+		expect(sol.source).toBe("builtin");
+		// The builtin entry wins whole — the catalogue's display name must not
+		// leak in and make a builtin look like a catalogue find.
+		expect(sol.displayName).toBe("gpt-5.6-sol");
+		expect(listed(body, "gpt-4.1").source).toBe("reference");
+		expect(body.models).toHaveLength(CODEX_KNOWN_MODELS.length + 1);
+	});
+
+	it("an unknown provider yields an empty listing rather than an error", async () => {
+		catalogueEntries = [];
+		const handler = createModelsHandler(makeContext());
+
+		const response = await handler(
+			new URL("http://localhost/api/models?provider=nope"),
+		);
+		const body = (await response.json()) as ModelsBody;
+
+		expect(response.status).toBe(200);
+		expect(body.provider).toBe("nope");
+		// No override in the section map: the provider name is used verbatim.
+		expect(catalogueCalls).toEqual(["nope"]);
+		expect(body.models).toEqual([]);
+		expect(body.source).toBe("unavailable");
+		expect(body.warning).toBeDefined();
+	});
+});

--- a/packages/http-api/src/handlers/__tests__/provider-model-defaults.test.ts
+++ b/packages/http-api/src/handlers/__tests__/provider-model-defaults.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { PROVIDER_MODEL_DEFAULTS_ENV_VAR } from "@better-ccflare/config";
+import {
+	resolveProviderModelDefault,
+	setProviderModelDefaultOverrides,
+} from "@better-ccflare/providers";
+import { createConfigHandlers } from "../config";
+
+function makeConfig(initial: Record<string, Record<string, string>> = {}) {
+	let saved = initial;
+	return {
+		getProviderModelDefaultOverrides: () => structuredClone(saved),
+		setProviderModelDefaultOverrides: (
+			value: Record<string, Record<string, string>>,
+		) => {
+			saved = structuredClone(value);
+		},
+		getEnabledProviderModelDefaultProviders: () => {
+			const fromEnv = process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS;
+			if (fromEnv) {
+				const parsed = fromEnv
+					.split(",")
+					.map((provider) => provider.trim())
+					.filter(Boolean);
+				if (parsed.length > 0) return parsed;
+			}
+			return ["codex"];
+		},
+	} as unknown as import("@better-ccflare/config").Config;
+}
+
+function request(overrides: unknown): Request {
+	return new Request("http://localhost/api/config/provider-model-defaults", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ overrides }),
+	});
+}
+
+const ORIGINAL_MODEL_DEFAULTS_PROVIDERS_ENV =
+	process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS;
+
+afterEach(() => {
+	setProviderModelDefaultOverrides({});
+	if (ORIGINAL_MODEL_DEFAULTS_PROVIDERS_ENV === undefined) {
+		delete process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS;
+	} else {
+		process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS =
+			ORIGINAL_MODEL_DEFAULTS_PROVIDERS_ENV;
+	}
+});
+
+describe("provider model defaults", () => {
+	it("merges one family override without erasing the provider factory map", async () => {
+		const handlers = createConfigHandlers(makeConfig());
+		const response = await handlers.setProviderModelDefaults(
+			request([{ provider: "codex", family: "opus", model: "gpt-custom" }]),
+		);
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as {
+			providers: Array<{
+				provider: string;
+				fields: Array<{ family: string; effective: string }>;
+			}>;
+		};
+		const codex = body.providers.find(
+			(provider) => provider.provider === "codex",
+		)!;
+		expect(
+			codex.fields.find((field) => field.family === "opus")?.effective,
+		).toBe("gpt-custom");
+		expect(
+			codex.fields.find((field) => field.family === "haiku")?.effective,
+		).toBe("gpt-5.4-mini");
+	});
+
+	it("empty model removes an override and resolver returns factory", async () => {
+		const handlers = createConfigHandlers(
+			makeConfig({ codex: { opus: "gpt-custom" } }),
+		);
+		setProviderModelDefaultOverrides({ codex: { opus: "gpt-custom" } });
+		const response = await handlers.setProviderModelDefaults(
+			request([{ provider: "codex", family: "opus", model: "" }]),
+		);
+		expect(response.status).toBe(200);
+		expect(resolveProviderModelDefault("codex", "opus")).toBe("gpt-5.3-codex");
+	});
+
+	it("rejects unknown providers and families", async () => {
+		const handlers = createConfigHandlers(makeConfig());
+		expect(
+			(
+				await handlers.setProviderModelDefaults(
+					request([{ provider: "nope", family: "opus", model: "x" }]),
+				)
+			).status,
+		).toBe(400);
+		// `fable` now exists in the codex map; the nonexistent family is
+		// now another one, and `fable` must be ACCEPTED.
+		expect(
+			(
+				await handlers.setProviderModelDefaults(
+					request([{ provider: "codex", family: "inexistente", model: "x" }]),
+				)
+			).status,
+		).toBe(400);
+		expect(
+			(
+				await handlers.setProviderModelDefaults(
+					request([
+						{ provider: "codex", family: "fable", model: "gpt-5.6-sol" },
+					]),
+				)
+			).status,
+		).toBe(200);
+	});
+
+	it("resolver returns factory when no override exists", () => {
+		expect(resolveProviderModelDefault("xai", "sonnet")).toBe("grok-4.3");
+	});
+
+	it("GET lists only codex by default (CCFLARE_MODEL_DEFAULTS_PROVIDERS unset)", async () => {
+		delete process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS;
+		const handlers = createConfigHandlers(makeConfig());
+		const response = handlers.getProviderModelDefaults();
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as {
+			providers: Array<{ provider: string }>;
+		};
+		expect(body.providers.map((provider) => provider.provider)).toEqual([
+			"codex",
+		]);
+	});
+
+	it("POST rejects a disabled provider with 400 citing the env var", async () => {
+		delete process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS;
+		const handlers = createConfigHandlers(makeConfig());
+		const response = await handlers.setProviderModelDefaults(
+			request([{ provider: "xai", family: "sonnet", model: "grok-x" }]),
+		);
+		expect(response.status).toBe(400);
+		const body = (await response.json()) as { error?: string };
+		expect(JSON.stringify(body)).toContain(PROVIDER_MODEL_DEFAULTS_ENV_VAR);
+		expect(JSON.stringify(body)).toContain("xai");
+	});
+
+	it("CCFLARE_MODEL_DEFAULTS_PROVIDERS=codex,xai lists and accepts xai again", async () => {
+		process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS = "codex,xai";
+		const handlers = createConfigHandlers(makeConfig());
+		const getBody = (await handlers.getProviderModelDefaults().json()) as {
+			providers: Array<{ provider: string }>;
+		};
+		expect(
+			getBody.providers.map((provider) => provider.provider).sort(),
+		).toEqual(["codex", "xai"]);
+
+		const response = await handlers.setProviderModelDefaults(
+			request([{ provider: "xai", family: "sonnet", model: "grok-x" }]),
+		);
+		expect(response.status).toBe(200);
+		expect(resolveProviderModelDefault("xai", "sonnet")).toBe("grok-x");
+	});
+
+	it("a disabled provider's stored override stays inert and does not affect resolution", async () => {
+		process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS = "codex,xai";
+		const config = makeConfig({ xai: { sonnet: "grok-custom" } });
+		const handlers = createConfigHandlers(config);
+		// A POST to codex already pushes the whole map (filtered by enabled
+		// providers) to the in-memory registry, just as boot does.
+		await handlers.setProviderModelDefaults(
+			request([{ provider: "codex", family: "opus", model: "gpt-custom" }]),
+		);
+		expect(resolveProviderModelDefault("xai", "sonnet")).toBe("grok-custom");
+
+		process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS = "codex";
+		await handlers.setProviderModelDefaults(
+			request([{ provider: "codex", family: "opus", model: "gpt-custom" }]),
+		);
+		expect(resolveProviderModelDefault("xai", "sonnet")).toBe("grok-4.3");
+	});
+
+	it("codex keeps translating even when left out of CCFLARE_MODEL_DEFAULTS_PROVIDERS", async () => {
+		process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS = "xai";
+		const handlers = createConfigHandlers(makeConfig());
+		const response = await handlers.setProviderModelDefaults(
+			request([{ provider: "codex", family: "opus", model: "gpt-custom" }]),
+		);
+		expect(response.status).toBe(400);
+		expect(resolveProviderModelDefault("codex", "opus")).toBe("gpt-5.3-codex");
+	});
+});

--- a/packages/http-api/src/handlers/combos.ts
+++ b/packages/http-api/src/handlers/combos.ts
@@ -8,6 +8,24 @@ import type {
 import { errorResponse } from "../utils/http-error";
 
 /**
+ * Providers whose upstream natively accepts Claude model ids. Only for these
+ * does a slot without a model (passthrough) make sense: the model the client
+ * asked for arrives intact and is understood on the other side.
+ *
+ * On any other provider, passthrough would hand a Claude name to an upstream
+ * that does not know it, and translation would fall to the embedded default
+ * map — the path that produced `400 gpt-5.3-codex ... ChatGPT account`.
+ */
+const PROVIDERS_ACCEPTING_CLIENT_MODEL = new Set([
+	"anthropic",
+	"claude-console-api",
+]);
+
+function allowsClientModel(provider: string | null | undefined): boolean {
+	return PROVIDERS_ACCEPTING_CLIENT_MODEL.has(provider ?? "anthropic");
+}
+
+/**
  * GET /api/combos — List all combos with slot counts (lightweight)
  */
 export function createCombosListHandler(dbOps: DatabaseOperations) {
@@ -198,11 +216,31 @@ export function createSlotAddHandler(dbOps: DatabaseOperations) {
 				typeof account_id !== "string" ||
 				account_id.trim().length === 0
 			) {
-				return errorResponse(BadRequest("account_id and model are required"));
+				return errorResponse(BadRequest("account_id is required"));
 			}
 
-			if (!model || typeof model !== "string" || model.trim().length === 0) {
-				return errorResponse(BadRequest("account_id and model are required"));
+			// `model` is optional: a slot with no model means passthrough — the
+			// model the client asked for goes upstream untouched. We store an
+			// empty string (not NULL) because combo_slots.model is NOT NULL and the
+			// unique index (combo_id, account_id, model) only blocks duplicates with "".
+			if (model !== undefined && model !== null && typeof model !== "string") {
+				return errorResponse(
+					BadRequest("model must be a string when provided"),
+				);
+			}
+			const slotModel = typeof model === "string" ? model.trim() : "";
+
+			// Passthrough only holds where the upstream speaks the same model
+			// namespace as the client. See PROVIDERS_ACCEPTING_CLIENT_MODEL.
+			if (slotModel.length === 0) {
+				const account = await dbOps.getAccount(account_id);
+				if (account && !allowsClientModel(account.provider)) {
+					return errorResponse(
+						BadRequest(
+							`model is required for provider "${account.provider}": only accounts that serve Claude model ids can forward the client model unchanged`,
+						),
+					);
+				}
 			}
 
 			const existingSlots = await dbOps.getComboSlots(comboId);
@@ -210,7 +248,7 @@ export function createSlotAddHandler(dbOps: DatabaseOperations) {
 			const newSlot = await dbOps.addComboSlot(
 				comboId,
 				account_id,
-				model.trim(),
+				slotModel,
 				nextPriority,
 			);
 
@@ -243,10 +281,35 @@ export function createSlotUpdateHandler(dbOps: DatabaseOperations) {
 			}> = {};
 
 			if (model !== undefined) {
-				if (typeof model !== "string" || model.trim().length === 0) {
-					return errorResponse(BadRequest("model must be a non-empty string"));
+				// An empty string clears the override and makes the slot passthrough.
+				if (typeof model !== "string") {
+					return errorResponse(BadRequest("model must be a string"));
 				}
 				fields.model = model.trim();
+
+				// Same rule as the POST, now for whoever clears a slot that already
+				// exists: without it, the validation could be bypassed in two steps.
+				if (fields.model.length === 0) {
+					const slots = await dbOps.getComboSlots(_comboId);
+					const slot = slots.find((s) => s.id === slotId);
+					// A slot id that this combo does not own must not silently skip
+					// the check: updateComboSlot resolves the slot globally, so a
+					// mismatched combo id in the path would let an incompatible slot
+					// become passthrough.
+					if (!slot) {
+						return errorResponse(NotFound("Combo slot not found"));
+					}
+					{
+						const account = await dbOps.getAccount(slot.account_id);
+						if (account && !allowsClientModel(account.provider)) {
+							return errorResponse(
+								BadRequest(
+									`model is required for provider "${account.provider}": only accounts that serve Claude model ids can forward the client model unchanged`,
+								),
+							);
+						}
+					}
+				}
 			}
 
 			if (enabled !== undefined) {

--- a/packages/http-api/src/handlers/config.ts
+++ b/packages/http-api/src/handlers/config.ts
@@ -1,4 +1,8 @@
-import type { Config } from "@better-ccflare/config";
+import {
+	type Config,
+	filterEnabledProviderModelDefaultOverrides,
+	PROVIDER_MODEL_DEFAULTS_ENV_VAR,
+} from "@better-ccflare/config";
 import {
 	DEFAULT_AGENT_MODEL,
 	NETWORK,
@@ -13,6 +17,11 @@ import {
 	errorResponse,
 	jsonResponse,
 } from "@better-ccflare/http-common";
+import {
+	getProviderModelDefaultFactories,
+	getProviderModelDefaultOverrides,
+	setProviderModelDefaultOverrides,
+} from "@better-ccflare/providers";
 import type { APIContext } from "@better-ccflare/types";
 import {
 	allowedModelErrorMessage,
@@ -248,6 +257,106 @@ export function createConfigHandlers(
 			config.setUsageThrottlingFiveHourEnabled(body.fiveHourEnabled);
 			config.setUsageThrottlingWeeklyEnabled(body.weeklyEnabled);
 			return new Response(null, { status: 204 });
+		},
+
+		getProviderModelDefaults: (): Response => {
+			const enabledProviders = new Set(
+				config.getEnabledProviderModelDefaultProviders(),
+			);
+			const factories = getProviderModelDefaultFactories();
+			const overrides = config.getProviderModelDefaultOverrides();
+			return jsonResponse({
+				providers: Object.entries(factories)
+					.filter(([provider]) => enabledProviders.has(provider))
+					.map(([provider, families]) => ({
+						provider,
+						fields: Object.entries(families).map(([family, factory]) => ({
+							family,
+							factory,
+							override: overrides[provider]?.[family] ?? null,
+							effective:
+								getProviderModelDefaultOverrides()[provider]?.[family] ??
+								factory,
+						})),
+					})),
+			});
+		},
+
+		setProviderModelDefaults: async (req: Request): Promise<Response> => {
+			let body: unknown;
+			try {
+				body = await req.json();
+			} catch {
+				return errorResponse(BadRequest("Body must be JSON"));
+			}
+			const entries = (body as { overrides?: unknown } | null)?.overrides;
+			if (!Array.isArray(entries)) {
+				return errorResponse(
+					BadRequest(
+						"Invalid provider model defaults payload: expected 'overrides' array",
+					),
+				);
+			}
+			const factories = getProviderModelDefaultFactories();
+			const enabledProviders = new Set(
+				config.getEnabledProviderModelDefaultProviders(),
+			);
+			const next = config.getProviderModelDefaultOverrides();
+			for (const entry of entries) {
+				const value = entry as {
+					provider?: unknown;
+					family?: unknown;
+					model?: unknown;
+				} | null;
+				const provider =
+					typeof value?.provider === "string" ? value.provider.trim() : "";
+				const family =
+					typeof value?.family === "string" ? value.family.trim() : "";
+				if (!factories[provider])
+					return errorResponse(
+						BadRequest(`Unknown provider: ${provider || "(empty)"}`),
+					);
+				if (!enabledProviders.has(provider))
+					return errorResponse(
+						BadRequest(
+							`Provider "${provider}" is not editable; set ${PROVIDER_MODEL_DEFAULTS_ENV_VAR} to enable it`,
+						),
+					);
+				if (!factories[provider][family])
+					return errorResponse(
+						BadRequest(
+							`Unknown family '${family || "(empty)"}' for provider '${provider}'`,
+						),
+					);
+				if (typeof value?.model !== "string")
+					return errorResponse(BadRequest("model must be a string"));
+				const model = value.model.trim();
+				if (model) {
+					next[provider] = { ...next[provider], [family]: model };
+				} else if (next[provider]) {
+					delete next[provider][family];
+					if (Object.keys(next[provider]).length === 0) delete next[provider];
+				}
+			}
+			config.setProviderModelDefaultOverrides(next);
+			setProviderModelDefaultOverrides(
+				filterEnabledProviderModelDefaultOverrides(enabledProviders, next),
+			);
+			return jsonResponse({
+				providers: Object.entries(factories)
+					.filter(([provider]) => enabledProviders.has(provider))
+					.map(([provider, families]) => ({
+						provider,
+						fields: Object.entries(families).map(([family, factory]) => ({
+							family,
+							factory,
+							override: next[provider]?.[family] ?? null,
+							effective:
+								getProviderModelDefaultOverrides()[provider]?.[family] ??
+								factory,
+						})),
+					})),
+			});
 		},
 
 		getModelCapacityRouting: (): Response => {

--- a/packages/http-api/src/handlers/models.ts
+++ b/packages/http-api/src/handlers/models.ts
@@ -1,17 +1,135 @@
+import { listCatalogueModels } from "@better-ccflare/core";
 import { errorResponse, jsonResponse } from "@better-ccflare/http-common";
+import { CODEX_KNOWN_MODELS } from "@better-ccflare/providers";
 import type { APIContext } from "../types";
 
 /**
- * GET /api/models — return the cached Anthropic model catalog (live if a
- * successful fetch has occurred, otherwise the bundled static fallback).
+ * Where a listed model id came from — the whole point of the endpoint.
+ *
+ *  - "builtin"   ccflare itself knows this model for that provider (it is in
+ *                the provider adapter's own table). Strongest signal there is.
+ *  - "catalog"   the provider's own live listing (Anthropic /v1/models),
+ *                fetched with a real account's credentials.
+ *  - "reference" the public models.dev catalogue. Says the model EXISTS at
+ *                the vendor and says NOTHING about whether a given account's
+ *                plan may call it: ChatGPT-subscription accounts reject
+ *                gpt-5.3-codex with HTTP 400 while OpenAI lists it happily.
+ *                Never collapse this into the other two.
+ */
+export type ModelListingSource = "builtin" | "catalog" | "reference";
+
+export interface ProviderModelEntry {
+	id: string;
+	displayName: string;
+	source: ModelListingSource;
+}
+
+/**
+ * ccflare provider name -> models.dev top-level section. Only names that
+ * differ need an entry; anything else falls through to the provider name
+ * itself, which models.dev uses verbatim for "anthropic", "zai", "minimax",
+ * and friends.
+ */
+const MODELS_DEV_SECTION_BY_PROVIDER: Record<string, string> = {
+	codex: "openai",
+};
+
+/** Model ids ccflare ships knowledge of, per provider. */
+const BUILTIN_MODELS_BY_PROVIDER: Record<string, readonly string[]> = {
+	codex: CODEX_KNOWN_MODELS,
+};
+
+/**
+ * Providers served by the live Anthropic catalog. Both auth modes (OAuth and
+ * console API key) talk to the same /v1/models listing, so both get it.
+ */
+function isAnthropicProvider(provider: string): boolean {
+	return provider === "anthropic" || provider === "claude-console-api";
+}
+
+/**
+ * GET /api/models[?provider=<name>] — list the models available for one
+ * provider, each entry tagged with where the knowledge came from.
+ *
+ * Without `provider` (and for the Anthropic providers) the body is exactly
+ * what this endpoint has always returned — the cached live catalog, or the
+ * bundled static fallback — so existing callers keep working; `provider` and
+ * the per-entry `source` are purely additive fields.
+ *
+ * For every other provider the answer is the union of what ccflare knows
+ * built in and what the public models.dev catalogue lists, deduplicated by
+ * id with the stronger marking winning, builtin entries first. A failed or
+ * unavailable catalogue fetch degrades to the builtin list plus a warning —
+ * it never fails the request.
  */
 export function createModelsHandler(context: APIContext) {
-	return async (): Promise<Response> => {
-		if (!context.modelCatalog) {
-			return errorResponse("Model catalog is not available");
+	return async (url?: URL): Promise<Response> => {
+		const requested = url?.searchParams.get("provider")?.trim() || "";
+
+		if (requested === "" || isAnthropicProvider(requested)) {
+			if (!context.modelCatalog) {
+				return errorResponse("Model catalog is not available");
+			}
+			const catalog = await context.modelCatalog.get();
+			return jsonResponse({
+				...catalog,
+				provider: requested || "anthropic",
+				models: catalog.models.map((model) => ({
+					...model,
+					source: "catalog" as const,
+				})),
+			});
 		}
-		const catalog = await context.modelCatalog.get();
-		return jsonResponse(catalog);
+
+		const builtinIds = BUILTIN_MODELS_BY_PROVIDER[requested] ?? [];
+		const section = MODELS_DEV_SECTION_BY_PROVIDER[requested] ?? requested;
+		const reference = await listCatalogueModels(section);
+
+		const builtinById = new Map<string, ProviderModelEntry>();
+		for (const id of builtinIds) {
+			builtinById.set(id, { id, displayName: id, source: "builtin" });
+		}
+
+		// A reference entry never overwrites a builtin one — the stronger
+		// marking wins, and the UI shows the two groups apart on purpose.
+		const referenceById = new Map<string, ProviderModelEntry>();
+		for (const entry of reference) {
+			if (!entry.id) continue;
+			if (builtinById.has(entry.id) || referenceById.has(entry.id)) continue;
+			referenceById.set(entry.id, {
+				id: entry.id,
+				displayName: entry.name || entry.id,
+				source: "reference",
+			});
+		}
+
+		const referenceEntries = Array.from(referenceById.values()).sort((a, b) =>
+			a.id.localeCompare(b.id),
+		);
+		const models = [...builtinById.values(), ...referenceEntries];
+
+		const hasBuiltin = builtinById.size > 0;
+		const hasReference = referenceEntries.length > 0;
+		const source = hasBuiltin
+			? hasReference
+				? "mixed"
+				: "builtin"
+			: hasReference
+				? "reference"
+				: "unavailable";
+
+		return jsonResponse({
+			provider: requested,
+			models,
+			fetchedAt: Date.now(),
+			source,
+			referenceSection: section,
+			...(hasReference
+				? {}
+				: {
+						warning: `No reference models for "${section}" in the models.dev catalogue (unknown provider, catalogue offline, or fetch failed)`,
+					}),
+		});
 	};
 }
 

--- a/packages/http-api/src/router.ts
+++ b/packages/http-api/src/router.ts
@@ -398,6 +398,12 @@ export class APIRouter {
 		this.handlers.set("POST:/api/config/usage-throttling", (req) =>
 			configHandlers.setUsageThrottling(req),
 		);
+		this.handlers.set("GET:/api/config/provider-model-defaults", () =>
+			configHandlers.getProviderModelDefaults(),
+		);
+		this.handlers.set("POST:/api/config/provider-model-defaults", (req) =>
+			configHandlers.setProviderModelDefaults(req),
+		);
 		this.handlers.set("GET:/api/config/model-capacity-routing", () =>
 			configHandlers.getModelCapacityRouting(),
 		);
@@ -714,6 +720,7 @@ export class APIRouter {
 					modelFallbacksHandler(req, accountId),
 				)(req, url);
 			}
+
 
 			// Account removal
 			if (parts.length === 4 && method === "DELETE") {

--- a/packages/http-api/src/router.ts
+++ b/packages/http-api/src/router.ts
@@ -479,7 +479,7 @@ export class APIRouter {
 		// Model catalog routes
 		const modelsHandler = createModelsHandler(this.context);
 		const modelsRefreshHandler = createModelsRefreshHandler(this.context);
-		this.handlers.set("GET:/api/models", () => modelsHandler());
+		this.handlers.set("GET:/api/models", (_req, url) => modelsHandler(url));
 		this.handlers.set("POST:/api/models/refresh", () => modelsRefreshHandler());
 	}
 

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -12,6 +12,7 @@ export * from "./minimax-usage-fetcher";
 export * from "./nanogpt-usage-fetcher";
 // Export OAuth utilities
 export * from "./oauth";
+export * from "./provider-model-defaults";
 // Factory functions for creating providers
 export {
 	type AnthropicCompatibleConfig,

--- a/packages/providers/src/provider-model-defaults.ts
+++ b/packages/providers/src/provider-model-defaults.ts
@@ -1,0 +1,53 @@
+export type ProviderModelDefaultOverrides = Record<
+	string,
+	Record<string, string>
+>;
+
+const factoryDefaults: ProviderModelDefaultOverrides = {};
+let overrides: ProviderModelDefaultOverrides = {};
+
+function copyMappings(
+	mappings: ProviderModelDefaultOverrides,
+): ProviderModelDefaultOverrides {
+	const copied: ProviderModelDefaultOverrides = {};
+	for (const [provider, families] of Object.entries(mappings)) {
+		const values: Record<string, string> = {};
+		for (const [family, model] of Object.entries(families)) {
+			if (typeof model === "string" && model.trim())
+				values[family] = model.trim();
+		}
+		if (Object.keys(values).length > 0) copied[provider] = values;
+	}
+	return copied;
+}
+
+/** Register a provider-owned built-in map without coupling providers to config. */
+export function registerProviderModelDefaultFactory(
+	provider: string,
+	mappings: Record<string, string>,
+): void {
+	factoryDefaults[provider] = { ...mappings };
+}
+
+/** Replace the process-wide overrides after config load or a successful POST. */
+export function setProviderModelDefaultOverrides(
+	value: ProviderModelDefaultOverrides | undefined,
+): void {
+	overrides = copyMappings(value ?? {});
+}
+
+/** Factory first, then a configured override when that exact family has one. */
+export function resolveProviderModelDefault(
+	provider: string,
+	family: string,
+): string | undefined {
+	return overrides[provider]?.[family] ?? factoryDefaults[provider]?.[family];
+}
+
+export function getProviderModelDefaultFactories(): ProviderModelDefaultOverrides {
+	return copyMappings(factoryDefaults);
+}
+
+export function getProviderModelDefaultOverrides(): ProviderModelDefaultOverrides {
+	return copyMappings(overrides);
+}

--- a/packages/providers/src/providers/codex/index.ts
+++ b/packages/providers/src/providers/codex/index.ts
@@ -8,6 +8,8 @@ export type { CodexUsageRefreshFetchResult } from "./on-demand-fetch";
 export { fetchCodexUsageOnDemand } from "./on-demand-fetch";
 export {
 	CODEX_DEFAULT_ENDPOINT,
+	CODEX_KNOWN_MODELS,
+	CODEX_MODEL_CONTEXT_WINDOWS,
 	CODEX_PING_MODEL,
 	CODEX_USER_AGENT,
 	CODEX_VERSION,

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -2289,6 +2289,28 @@ describe("CodexProvider.transformRequestBody", () => {
 		expect(body.model).toBe("gpt-5.3-codex");
 	});
 
+	// Regression: the fable entry alone is not enough for codex. mapModel
+	// resolves by substring and had no fable branch, so the map entry would
+	// never be looked up and the Claude model id would reach the upstream
+	// verbatim.
+	it("maps fable-family models to the codex default", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-fable-5",
+				max_tokens: 10,
+				messages: [{ role: "user", content: "hello" }],
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request, undefined);
+		const body = await transformed.json();
+
+		expect(body.model).toBe("gpt-5.3-codex");
+	});
+
 	it("uses account sonnet mapping for sonnet-family models", async () => {
 		const provider = new CodexProvider();
 		const account = {

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -12,6 +12,10 @@ import {
 } from "@better-ccflare/openai-formats";
 import type { Account } from "@better-ccflare/types";
 import { BaseProvider } from "../../base";
+import {
+	registerProviderModelDefaultFactory,
+	resolveProviderModelDefault,
+} from "../../provider-model-defaults";
 import type { RateLimitInfo, TokenRefreshResult } from "../../types";
 import { normalizeCodexInputUsage } from "./usage";
 
@@ -109,6 +113,7 @@ const DEFAULT_MODEL_MAP: Record<string, string> = {
 	haiku: "gpt-5.4-mini",
 };
 
+registerProviderModelDefaultFactory("codex", DEFAULT_MODEL_MAP);
 
 // Synced from the Codex CLI model cache (~/.codex/models_cache.json,
 // codex-cli 0.144.1). Missing entries mean no context_window block is
@@ -714,13 +719,13 @@ export class CodexProvider extends BaseProvider {
 		const lower = anthropicModel.toLowerCase();
 		// Precedence: combo slot -> account.model_mappings -> global override -> factory map.
 		if (lower.includes("fable"))
-			return DEFAULT_MODEL_MAP.fable;
+			return resolveProviderModelDefault("codex", "fable") ?? anthropicModel;
 		if (lower.includes("haiku"))
-			return DEFAULT_MODEL_MAP.haiku;
+			return resolveProviderModelDefault("codex", "haiku") ?? anthropicModel;
 		if (lower.includes("sonnet"))
-			return DEFAULT_MODEL_MAP.sonnet;
+			return resolveProviderModelDefault("codex", "sonnet") ?? anthropicModel;
 		if (lower.includes("opus"))
-			return DEFAULT_MODEL_MAP.opus;
+			return resolveProviderModelDefault("codex", "opus") ?? anthropicModel;
 		return anthropicModel;
 	}
 

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -99,6 +99,7 @@ const CODEX_ERROR_TYPE_BY_CODE: Record<string, string> = {
 
 // Default model mapping: Anthropic model name prefixes → Codex model names
 const DEFAULT_MODEL_MAP: Record<string, string> = {
+	fable: "gpt-5.3-codex",
 	opus: "gpt-5.3-codex",
 	sonnet: "gpt-5.3-codex",
 	haiku: "gpt-5.4-mini",
@@ -691,6 +692,7 @@ export class CodexProvider extends BaseProvider {
 		}
 
 		const lower = anthropicModel.toLowerCase();
+		if (lower.includes("fable")) return DEFAULT_MODEL_MAP.fable;
 		if (lower.includes("haiku")) return DEFAULT_MODEL_MAP.haiku;
 		if (lower.includes("sonnet")) return DEFAULT_MODEL_MAP.sonnet;
 		if (lower.includes("opus")) return DEFAULT_MODEL_MAP.opus;

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -99,17 +99,22 @@ const CODEX_ERROR_TYPE_BY_CODE: Record<string, string> = {
 
 // Default model mapping: Anthropic model name prefixes → Codex model names
 const DEFAULT_MODEL_MAP: Record<string, string> = {
+	// Same value as opus/sonnet, for consistency in the factory map. ChatGPT
+	// subscription accounts reject 5.3-codex (HTTP 400); in those cases the
+	// fix lives in the layers above — per-account mapping or a global
+	// override in Settings — not here.
 	fable: "gpt-5.3-codex",
 	opus: "gpt-5.3-codex",
 	sonnet: "gpt-5.3-codex",
 	haiku: "gpt-5.4-mini",
 };
 
+
 // Synced from the Codex CLI model cache (~/.codex/models_cache.json,
 // codex-cli 0.144.1). Missing entries mean no context_window block is
 // reported to the client, which disables its context gauge and compaction
 // triggers for that model.
-const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
+export const CODEX_MODEL_CONTEXT_WINDOWS: Record<string, number> = {
 	"gpt-5.3-codex": 272_000,
 	"gpt-5.3-codex-spark": 128_000,
 	"gpt-5.4": 272_000,
@@ -121,6 +126,21 @@ const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
 };
 
 /**
+ * The Codex model ids ccflare itself knows about, derived from the context
+ * window table above so the two can never drift apart.
+ *
+ * Being on this list means "ccflare ships knowledge of this model", NOT
+ * "the account you are about to use may call it": a ChatGPT-subscription
+ * account rejects gpt-5.3-codex with HTTP 400 even though the model plainly
+ * exists. Callers that surface this list to a human must keep that
+ * distinction visible (see GET /api/models, which tags these as `builtin`
+ * and the models.dev entries as `reference`).
+ */
+export const CODEX_KNOWN_MODELS: readonly string[] = Object.freeze(
+	Object.keys(CODEX_MODEL_CONTEXT_WINDOWS),
+);
+
+/**
  * Exact lookup first, then longest-prefix fallback so dated or suffixed
  * variants the API may return (e.g. "gpt-5.6-sol-2026-05-13") still resolve
  * to their family's window instead of silently losing the client's context
@@ -128,10 +148,10 @@ const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
  * "gpt-5.5".
  */
 function lookupContextWindow(model: string): number | undefined {
-	const exact = MODEL_CONTEXT_WINDOWS[model];
+	const exact = CODEX_MODEL_CONTEXT_WINDOWS[model];
 	if (exact) return exact;
 	let bestKey: string | undefined;
-	for (const key of Object.keys(MODEL_CONTEXT_WINDOWS)) {
+	for (const key of Object.keys(CODEX_MODEL_CONTEXT_WINDOWS)) {
 		if (
 			model.startsWith(`${key}-`) &&
 			(bestKey === undefined || key.length > bestKey.length)
@@ -139,7 +159,7 @@ function lookupContextWindow(model: string): number | undefined {
 			bestKey = key;
 		}
 	}
-	return bestKey ? MODEL_CONTEXT_WINDOWS[bestKey] : undefined;
+	return bestKey ? CODEX_MODEL_CONTEXT_WINDOWS[bestKey] : undefined;
 }
 
 // ── Codex Responses API types ─────────────────────────────────────────────────
@@ -692,10 +712,15 @@ export class CodexProvider extends BaseProvider {
 		}
 
 		const lower = anthropicModel.toLowerCase();
-		if (lower.includes("fable")) return DEFAULT_MODEL_MAP.fable;
-		if (lower.includes("haiku")) return DEFAULT_MODEL_MAP.haiku;
-		if (lower.includes("sonnet")) return DEFAULT_MODEL_MAP.sonnet;
-		if (lower.includes("opus")) return DEFAULT_MODEL_MAP.opus;
+		// Precedence: combo slot -> account.model_mappings -> global override -> factory map.
+		if (lower.includes("fable"))
+			return DEFAULT_MODEL_MAP.fable;
+		if (lower.includes("haiku"))
+			return DEFAULT_MODEL_MAP.haiku;
+		if (lower.includes("sonnet"))
+			return DEFAULT_MODEL_MAP.sonnet;
+		if (lower.includes("opus"))
+			return DEFAULT_MODEL_MAP.opus;
 		return anthropicModel;
 	}
 

--- a/packages/providers/src/providers/index.ts
+++ b/packages/providers/src/providers/index.ts
@@ -15,6 +15,8 @@ export { BedrockProvider, parseBedrockConfig } from "./bedrock/index";
 export type { CodexUsageRefreshFetchResult } from "./codex/index";
 export {
 	CODEX_DEFAULT_ENDPOINT,
+	CODEX_KNOWN_MODELS,
+	CODEX_MODEL_CONTEXT_WINDOWS,
 	CodexOAuthProvider,
 	CodexProvider,
 	fetchCodexUsageOnDemand,

--- a/packages/providers/src/providers/qwen/provider.ts
+++ b/packages/providers/src/providers/qwen/provider.ts
@@ -1,6 +1,10 @@
 import { Logger } from "@better-ccflare/logger";
 import type { OpenAIRequest } from "@better-ccflare/openai-formats";
 import type { Account } from "@better-ccflare/types";
+import {
+	registerProviderModelDefaultFactory,
+	resolveProviderModelDefault,
+} from "../../provider-model-defaults";
 import type { RateLimitInfo } from "../../types";
 import { OpenAICompatibleProvider } from "../openai/provider";
 
@@ -28,6 +32,17 @@ const QWEN_MODEL_MAPPINGS = {
 	sonnet: "coder-model",
 	haiku: "coder-model",
 };
+
+registerProviderModelDefaultFactory("qwen", QWEN_MODEL_MAPPINGS);
+
+function resolvedQwenModelMappings(): Record<string, string> {
+	return Object.fromEntries(
+		Object.entries(QWEN_MODEL_MAPPINGS).map(([family, factory]) => [
+			family,
+			resolveProviderModelDefault("qwen", family) ?? factory,
+		]),
+	);
+}
 
 // Lines in the Claude Code system prompt that are environment/model-specific
 // and should be dropped entirely when proxying to Qwen.
@@ -155,7 +170,7 @@ export class QwenProvider extends OpenAICompatibleProvider {
 		return {
 			...account,
 			model_mappings:
-				account.model_mappings ?? JSON.stringify(QWEN_MODEL_MAPPINGS),
+				account.model_mappings ?? JSON.stringify(resolvedQwenModelMappings()),
 		};
 	}
 

--- a/packages/providers/src/providers/qwen/provider.ts
+++ b/packages/providers/src/providers/qwen/provider.ts
@@ -23,6 +23,7 @@ const STAINLESS_HEADERS: Record<string, string> = {
 
 // All Anthropic model tiers map to coder-model (Qwen's unified coding model)
 const QWEN_MODEL_MAPPINGS = {
+	fable: "coder-model",
 	opus: "coder-model",
 	sonnet: "coder-model",
 	haiku: "coder-model",

--- a/packages/providers/src/providers/xai/provider.ts
+++ b/packages/providers/src/providers/xai/provider.ts
@@ -2,6 +2,10 @@ import { getEndpointUrl, validateEndpointUrl } from "@better-ccflare/core";
 import { Logger } from "@better-ccflare/logger";
 import type { OpenAIRequest } from "@better-ccflare/openai-formats";
 import type { Account } from "@better-ccflare/types";
+import {
+	registerProviderModelDefaultFactory,
+	resolveProviderModelDefault,
+} from "../../provider-model-defaults";
 import type { TokenRefreshResult } from "../../types";
 import { OpenAICompatibleProvider } from "../openai/provider";
 
@@ -17,6 +21,17 @@ export const XAI_MODEL_MAPPINGS = {
 	haiku: "grok-4.3",
 	fable: "grok-4.3",
 };
+
+registerProviderModelDefaultFactory("xai", XAI_MODEL_MAPPINGS);
+
+function resolvedXaiModelMappings(): Record<string, string> {
+	return Object.fromEntries(
+		Object.entries(XAI_MODEL_MAPPINGS).map(([family, factory]) => [
+			family,
+			resolveProviderModelDefault("xai", family) ?? factory,
+		]),
+	);
+}
 
 export class XaiProvider extends OpenAICompatibleProvider {
 	override name = "xai";
@@ -128,7 +143,7 @@ export class XaiProvider extends OpenAICompatibleProvider {
 			...account,
 			custom_endpoint: account.custom_endpoint ?? XAI_DEFAULT_ENDPOINT,
 			model_mappings:
-				account.model_mappings ?? JSON.stringify(XAI_MODEL_MAPPINGS),
+				account.model_mappings ?? JSON.stringify(resolvedXaiModelMappings()),
 		};
 	}
 

--- a/packages/proxy/src/handlers/__tests__/account-selector-model-capacity.test.ts
+++ b/packages/proxy/src/handlers/__tests__/account-selector-model-capacity.test.ts
@@ -6,6 +6,7 @@ import type {
 	RequestMeta,
 } from "@better-ccflare/types";
 import {
+	getComboSlotInfo,
 	getModelFamilyExhaustionInfo,
 	selectAccountsForRequest,
 } from "../account-selector";
@@ -231,6 +232,127 @@ describe("selectAccountsForRequest — model-scoped capacity filter (combo routi
 		// Only the non-exhausted slot (acc-2) is returned; the combo pool isn't
 		// fully empty so no fallback and no exhaustion signal.
 		expect(result.map((a) => a.id)).toEqual(["acc-2"]);
+	});
+
+	// -- passthrough slots (empty slot.model) --------------------------------
+	//
+	// A passthrough slot carries no model override, so there is no slot model to
+	// scope the capacity check to. The check must fall back to the model the
+	// CLIENT asked for - that is what will actually be sent upstream on this
+	// slot. Passing the raw empty string makes getModelFamily("") return null,
+	// which turns isAccountCapacityExcluded into a silent no-op and lets a
+	// capacity-exhausted account back into rotation.
+	it("applies the capacity check to a passthrough slot using the REQUEST model", async () => {
+		const acc1 = makeAccount({ id: "acc-1" });
+		const acc2 = makeAccount({ id: "acc-2" });
+		usageCache.set(acc1.id, exhaustedUsage("Sonnet", Date.now()));
+		const combo = makeCombo([
+			{
+				id: "slot-1",
+				combo_id: "combo-1",
+				account_id: "acc-1",
+				model: "", // passthrough
+				priority: 0,
+				enabled: true,
+			},
+			{
+				id: "slot-2",
+				combo_id: "combo-1",
+				account_id: "acc-2",
+				model: "claude-sonnet-4-5",
+				priority: 1,
+				enabled: true,
+			},
+		]);
+		const ctx = makeCtx({
+			accounts: [acc1, acc2],
+			activeCombo: combo,
+			capacityRoutingMode: "exhausted",
+		});
+		const meta = makeRequestMeta();
+
+		const result = await selectAccountsForRequest(
+			meta,
+			ctx,
+			"claude-sonnet-4-5",
+		);
+
+		// Without the request-model fallback the empty slot model yields a null
+		// family, the filter no-ops, and acc-1 is returned first.
+		expect(result.map((a) => a.id)).toEqual(["acc-2"]);
+		expect(getComboSlotInfo(meta)?.slots).toEqual([
+			{ accountId: "acc-2", modelOverride: "claude-sonnet-4-5" },
+		]);
+	});
+
+	it("keeps a passthrough slot whose account still has capacity for the request model", async () => {
+		const acc = makeAccount({ id: "acc-healthy" });
+		// Exhausted for a DIFFERENT family than the request - must not exclude.
+		usageCache.set(acc.id, exhaustedUsage("Opus", Date.now()));
+		const combo = makeCombo([
+			{
+				id: "slot-1",
+				combo_id: "combo-1",
+				account_id: "acc-healthy",
+				model: "", // passthrough
+				priority: 0,
+				enabled: true,
+			},
+		]);
+		const ctx = makeCtx({
+			accounts: [acc],
+			activeCombo: combo,
+			capacityRoutingMode: "exhausted",
+		});
+		const meta = makeRequestMeta();
+
+		const result = await selectAccountsForRequest(
+			meta,
+			ctx,
+			"claude-sonnet-4-5",
+		);
+
+		expect(result.map((a) => a.id)).toEqual(["acc-healthy"]);
+		expect(getComboSlotInfo(meta)?.slots).toEqual([
+			{ accountId: "acc-healthy", modelOverride: "" },
+		]);
+	});
+
+	// -- non-regression: a populated slot model still wins --------------------
+	//
+	// The request-model fallback is a `||`, so it must only fire for an EMPTY
+	// slot model. When the slot carries its own model, the capacity check stays
+	// scoped to that model.
+	it("still scopes the capacity check to the slot's own model when it diverges from the request model", async () => {
+		const acc = makeAccount({ id: "acc-slot-model" });
+		usageCache.set(acc.id, exhaustedUsage("Sonnet", Date.now()));
+		const combo = makeCombo([
+			{
+				id: "slot-1",
+				combo_id: "combo-1",
+				account_id: "acc-slot-model",
+				model: "claude-opus-4-5",
+				priority: 0,
+				enabled: true,
+			},
+		]);
+		const ctx = makeCtx({
+			accounts: [acc],
+			activeCombo: combo,
+			capacityRoutingMode: "exhausted",
+		});
+		const meta = makeRequestMeta();
+
+		const result = await selectAccountsForRequest(
+			meta,
+			ctx,
+			"claude-sonnet-4-5",
+		);
+
+		expect(result.map((a) => a.id)).toEqual(["acc-slot-model"]);
+		expect(getComboSlotInfo(meta)?.slots).toEqual([
+			{ accountId: "acc-slot-model", modelOverride: "claude-opus-4-5" },
+		]);
 	});
 
 	it("falls back to SessionStrategy when every combo slot is exhausted", async () => {

--- a/packages/proxy/src/handlers/__tests__/account-selector.test.ts
+++ b/packages/proxy/src/handlers/__tests__/account-selector.test.ts
@@ -267,6 +267,43 @@ describe("selectAccountsForRequest — combo routing", () => {
 		expect(slotInfo?.slots[0]?.modelOverride).toBe("claude-opus-4-5");
 	});
 
+	// An empty slot model means passthrough: the client's requested model is
+	// sent upstream untouched. The slot still routes to its account - only the
+	// override is absent. Downstream (proxy-operations.ts) guards with
+	// `if (modelOverride && ...)`, so an empty string already means "do not
+	// overwrite the model"; this test pins that the selector propagates it
+	// verbatim instead of substituting the request model.
+	it("propagates an empty slot model as an empty modelOverride (passthrough slot)", async () => {
+		const acc = makeAccount({ id: "acc-passthrough" });
+		const combo = makeCombo([
+			{
+				id: "slot-1",
+				combo_id: "combo-1",
+				account_id: "acc-passthrough",
+				model: "", // passthrough - no model override
+				priority: 0,
+				enabled: true,
+			},
+		]);
+
+		const ctx = makeCtx({ accounts: [acc], activeCombo: combo });
+		const meta = makeRequestMeta();
+
+		const result = await selectAccountsForRequest(
+			meta,
+			ctx,
+			"claude-sonnet-4-5",
+		);
+
+		expect(result.map((a) => a.id)).toEqual(["acc-passthrough"]);
+		const slotInfo = getComboSlotInfo(meta);
+		expect(slotInfo?.comboName).toBe("Test Combo");
+		expect(slotInfo?.slots).toEqual([
+			{ accountId: "acc-passthrough", modelOverride: "" },
+		]);
+		expect(meta.comboName).toBe("Test Combo");
+	});
+
 	it("sets meta.comboName when combo routing is active", async () => {
 		const acc = makeAccount({ id: "acc-1" });
 		const combo = makeCombo([

--- a/packages/proxy/src/handlers/account-selector.ts
+++ b/packages/proxy/src/handlers/account-selector.ts
@@ -400,9 +400,20 @@ export async function selectAccountsForRequest(
 				const combo = await ctx.dbOps.getActiveComboForFamily(
 					family as ComboFamily,
 				);
-				if (combo) {
+				if (!combo) {
+					// Without this line the detour is silent: a family with no active
+					// combo falls into normal pool routing and can be served by any
+					// provider, with nothing in the log to say so.
 					log.info(
-						`Combo routing active: ${combo.name} for family ${family} (${combo.slots.length} slots)`,
+						`No active combo for family ${family} - falling back to normal routing`,
+					);
+				}
+				if (combo) {
+					const passthroughSlots = combo.slots.filter(
+						(s) => !s.model || s.model.trim().length === 0,
+					).length;
+					log.info(
+						`Combo routing active: ${combo.name} for family ${family} (${combo.slots.length} slots, ${passthroughSlots} passthrough)`,
 					);
 
 					const allAccounts = await ctx.dbOps.getAllAccounts();
@@ -446,8 +457,15 @@ export async function selectAccountsForRequest(
 						// distinct concrete models within the same family.
 						if (
 							capacityRoutingEnabled &&
-							isAccountCapacityExcluded(account, slot.model, capacityNow)
-								.excluded
+							isAccountCapacityExcluded(
+								account,
+								// Passthrough slots (empty model) carry no model of their
+								// own: fall back to the request's model, otherwise
+								// getModelFamily("") returns null and this filter would
+								// silently no-op for those slots.
+								slot.model || model,
+								capacityNow,
+							).excluded
 						) {
 							continue;
 						}


### PR DESCRIPTION
## What

`GET`/`POST /api/config/provider-model-defaults`, and an **Advanced** card in Settings that opens a dialog for editing the provider default model maps.

> **Stacked on #394, #395, #399 and #400** (it reuses the model picker from #399). Review only the commit `feat(config): make provider default model maps editable`.

## Why

See #401. The built-in maps are the last word when a request has no combo slot model and no account mapping, and they are compiled in — so a plan that rejects the default leaves no way out but a rebuild.

## How

```
combo slot → account.model_mappings → global override (new) → factory map
```

- **Merged per family**: overriding `codex.opus` never clears `codex.haiku`. Worth noting this is *more* consistent than the per-account layer, where xai/qwen replace the whole map (`account.model_mappings ?? JSON.stringify(...)`) while codex falls back per family. I did **not** change that behaviour — altering it silently would break existing configurations — but the new layer is uniform.
- **Empty string removes an override** rather than mapping to empty.
- The **factory value stays in the response**, which is what makes "reset to default" concrete instead of a guess.
- **`packages/providers` gains no dependency on `@better-ccflare/config`.** The override lives in a small in-memory registry populated by `apps/server` at boot and refreshed by the POST, so a change applies without a restart and the provider package still knows nothing about configuration files.

## Scope: only codex is editable by default

`xai` and `qwen` are supported by the same code and enabled with `CCFLARE_MODEL_DEFAULTS_PROVIDERS` (absent or blank ⇒ `codex`). They were never exercised against a real account here, and shipping a configuration surface nobody has used is how a setting ends up quietly doing the wrong thing.

What the env var gates is the **editing surface**, never the translation — every provider's built-in map keeps working regardless, and a test covers exactly that. A `POST` for a disabled provider answers 400 **naming the variable**, so whoever hits it knows how to enable it. A stored override for a disabled provider goes inert without being deleted, so enabling the variable later brings it back rather than having silently discarded it.

If you would rather ship it with all providers enabled and the variable used to *restrict* instead, that is a one-line change to the default.

## UI note

The dialog uses one **tab per provider** rather than an inner scroll area, and that is a technical constraint rather than taste: the model picker renders without a portal (so the mouse wheel works inside dialogs), and an `overflow` container between the dialog and the field would clip the picker's list.

## Testing

- 14 new cases across config and the endpoints: per-family merge, empty-string reset, unknown provider/family → 400, resolver falling back to factory, the env gate, and a stored override going inert then reactivating.
- Baseline on this branch: 1521 pass / 15 fail before, 1535 / 15 after — same pre-existing failures, plus the 14 new tests.
- `bunx tsc --noEmit` clean.

Fixes #401.
