### PR TITLE
feat(providers): derive the codex default model map from the account's own listing

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -55,6 +55,7 @@ import {
 	CacheKeepaliveScheduler,
 	drainUsageCollector,
 	forceCloseCircuit,
+	getCodexModels,
 	getModelCatalog,
 	getUsageCollectorHealth,
 	getValidAccessToken,
@@ -956,6 +957,10 @@ export default async function startServer(options?: {
 		alertService,
 		modelCatalog: {
 			get: () => getModelCatalog(),
+			codexModels: async (accountId: string) => {
+				if (!modelCatalogProxyContext) return null;
+				return getCodexModels(accountId, modelCatalogProxyContext);
+			},
 			refresh: async () => {
 				if (!modelCatalogProxyContext) {
 					return {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1,6 +1,10 @@
 import { existsSync, readFileSync } from "node:fs";
 import { dirname } from "node:path";
-import { Config, type RuntimeConfig } from "@better-ccflare/config";
+import {
+	Config,
+	filterEnabledProviderModelDefaultOverrides,
+	type RuntimeConfig,
+} from "@better-ccflare/config";
 import {
 	CACHE,
 	DEFAULT_STRATEGY,
@@ -38,6 +42,7 @@ import {
 	fetchCodexUsageOnDemand,
 	getProvider,
 	getRankingUtilizationForProvider,
+	setProviderModelDefaultOverrides,
 	usageCache,
 } from "@better-ccflare/providers";
 import {
@@ -733,6 +738,12 @@ export default async function startServer(options?: {
 
 	// Initialize components
 	const config = container.resolve<Config>(SERVICE_KEYS.Config);
+	setProviderModelDefaultOverrides(
+		filterEnabledProviderModelDefaultOverrides(
+			config.getEnabledProviderModelDefaultProviders(),
+			config.getProviderModelDefaultOverrides(),
+		),
+	);
 	installOutboundProxy(() => config.getOutboundProxy());
 	const outboundProxyUrl = config.getOutboundProxy();
 	if (outboundProxyUrl) {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -61,6 +61,47 @@ export interface RuntimeConfig {
 	};
 }
 
+export type ProviderModelDefaultOverrides = Record<
+	string,
+	Record<string, string>
+>;
+
+/**
+ * Env var that expands which providers accept editable model-default
+ * overrides (via the config file, the API, and the dashboard tab).
+ * Absent or empty => only "codex" is editable. This gates only the
+ * override SURFACE (listing, accepting POSTs, showing a dashboard
+ * tab) — the built-in factory maps for every provider (xai, qwen,
+ * ...) keep translating models exactly as before; nothing here
+ * touches model resolution itself.
+ */
+export const PROVIDER_MODEL_DEFAULTS_ENV_VAR =
+	"CCFLARE_MODEL_DEFAULTS_PROVIDERS";
+
+const DEFAULT_PROVIDER_MODEL_DEFAULTS_PROVIDERS: readonly string[] = ["codex"];
+
+/**
+ * Drops overrides for providers outside `enabledProviders` without
+ * mutating the input. Callers pass in the full, persisted overrides
+ * map and push the filtered result into the in-memory registry (see
+ * setProviderModelDefaultOverrides in @better-ccflare/providers) at
+ * boot and after a successful POST. The persisted file always keeps
+ * the full map — a disabled provider's stored override is never
+ * erased, just excluded here, so it re-applies automatically once
+ * CCFLARE_MODEL_DEFAULTS_PROVIDERS re-enables that provider.
+ */
+export function filterEnabledProviderModelDefaultOverrides(
+	enabledProviders: Iterable<string>,
+	overrides: ProviderModelDefaultOverrides,
+): ProviderModelDefaultOverrides {
+	const enabled = new Set(enabledProviders);
+	const filtered: ProviderModelDefaultOverrides = {};
+	for (const [provider, families] of Object.entries(overrides)) {
+		if (enabled.has(provider)) filtered[provider] = families;
+	}
+	return filtered;
+}
+
 export interface ConfigData {
 	lb_strategy?: StrategyName;
 	client_id?: string;
@@ -80,6 +121,7 @@ export interface ConfigData {
 	usage_throttling_five_hour_enabled?: boolean;
 	usage_throttling_weekly_enabled?: boolean;
 	model_scoped_capacity_routing?: ModelScopedCapacityRoutingMode;
+	provider_model_default_overrides?: ProviderModelDefaultOverrides;
 	agent_frontmatter_model_fallback?: boolean;
 	model_catalog_oauth_refresh_enabled?: boolean;
 	health_detail_enabled?: boolean;
@@ -110,7 +152,12 @@ export interface ConfigData {
 	db_retry_delay_ms?: number;
 	db_retry_backoff?: number;
 	db_retry_max_delay_ms?: number;
-	[key: string]: string | number | boolean | undefined;
+	[key: string]:
+		| string
+		| number
+		| boolean
+		| ProviderModelDefaultOverrides
+		| undefined;
 }
 
 /**
@@ -250,7 +297,12 @@ export class Config extends EventEmitter {
 		defaultValue?: string | number | boolean,
 	): string | number | boolean | undefined {
 		if (key in this.data) {
-			return this.data[key];
+			const value = this.data[key];
+			// Settings with an object value (e.g.
+			// provider_model_default_overrides) have their own typed getter.
+			// This generic accessor serves scalars only — returning the object
+			// here would misrepresent the declared type.
+			return typeof value === "object" ? undefined : value;
 		}
 
 		if (defaultValue !== undefined) {
@@ -655,6 +707,53 @@ export class Config extends EventEmitter {
 		this.set("model_scoped_capacity_routing", mode);
 	}
 
+	getProviderModelDefaultOverrides(): ProviderModelDefaultOverrides {
+		const raw = this.data.provider_model_default_overrides;
+		if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+		const overrides: ProviderModelDefaultOverrides = {};
+		for (const [provider, families] of Object.entries(raw)) {
+			if (!families || typeof families !== "object" || Array.isArray(families))
+				continue;
+			const values: Record<string, string> = {};
+			for (const [family, model] of Object.entries(families)) {
+				if (typeof model === "string" && model.trim())
+					values[family] = model.trim();
+			}
+			if (Object.keys(values).length > 0) overrides[provider] = values;
+		}
+		return overrides;
+	}
+
+	setProviderModelDefaultOverrides(
+		overrides: ProviderModelDefaultOverrides,
+	): void {
+		this.data.provider_model_default_overrides = overrides;
+		this.saveConfig();
+		this.emit("change", {
+			key: "provider_model_default_overrides",
+			newValue: overrides,
+		});
+	}
+
+	/**
+	 * Providers currently allowed to edit their model-default overrides:
+	 * "codex" by default, or the exact CCFLARE_MODEL_DEFAULTS_PROVIDERS
+	 * list when that env var is set (comma-separated, trimmed). Never
+	 * affects which providers HAVE a built-in factory map — only which
+	 * of them expose that map for override via the API/dashboard.
+	 */
+	getEnabledProviderModelDefaultProviders(): string[] {
+		const fromEnv = process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS;
+		if (fromEnv) {
+			const parsed = fromEnv
+				.split(",")
+				.map((provider) => provider.trim())
+				.filter(Boolean);
+			if (parsed.length > 0) return parsed;
+		}
+		return [...DEFAULT_PROVIDER_MODEL_DEFAULTS_PROVIDERS];
+	}
+
 	getHealthDetailEnabled(): boolean {
 		const fromEnv = parseEnabledEnvFlag(process.env.HEALTH_DETAIL_ENABLED);
 		if (fromEnv !== undefined) {
@@ -805,7 +904,10 @@ export class Config extends EventEmitter {
 		this.set("alert_webhook_url", value);
 	}
 
-	getAllSettings(): Record<string, string | number | boolean | undefined> {
+	getAllSettings(): Record<
+		string,
+		string | number | boolean | ProviderModelDefaultOverrides | undefined
+	> {
 		// Include current strategy (which might come from env)
 		return {
 			...this.data,

--- a/packages/config/src/provider-model-default-overrides.test.ts
+++ b/packages/config/src/provider-model-default-overrides.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Config, filterEnabledProviderModelDefaultOverrides } from "./index";
+
+describe("provider model default overrides", () => {
+	it("keeps only non-empty provider-family overrides", () => {
+		const directory = mkdtempSync(join(tmpdir(), "ccflare-provider-defaults-"));
+		const path = join(directory, "config.json");
+		try {
+			writeFileSync(
+				path,
+				JSON.stringify({
+					provider_model_default_overrides: {
+						codex: { opus: "gpt-custom", haiku: "" },
+					},
+				}),
+			);
+			const config = new Config(path);
+			expect(config.getProviderModelDefaultOverrides()).toEqual({
+				codex: { opus: "gpt-custom" },
+			});
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("provider model default enabled providers (CCFLARE_MODEL_DEFAULTS_PROVIDERS)", () => {
+	const ORIGINAL_ENV = process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS;
+
+	afterEach(() => {
+		if (ORIGINAL_ENV === undefined) {
+			delete process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS;
+		} else {
+			process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS = ORIGINAL_ENV;
+		}
+	});
+
+	function makeConfig(initial: Record<string, Record<string, string>> = {}) {
+		const directory = mkdtempSync(
+			join(tmpdir(), "ccflare-provider-defaults-enabled-"),
+		);
+		const path = join(directory, "config.json");
+		writeFileSync(
+			path,
+			JSON.stringify({ provider_model_default_overrides: initial }),
+		);
+		return {
+			config: new Config(path),
+			cleanup: () => rmSync(directory, { recursive: true, force: true }),
+		};
+	}
+
+	it("defaults to only codex when the env var is absent or blank", () => {
+		delete process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS;
+		const { config, cleanup } = makeConfig();
+		try {
+			expect(config.getEnabledProviderModelDefaultProviders()).toEqual([
+				"codex",
+			]);
+		} finally {
+			cleanup();
+		}
+
+		process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS = "  ,  ";
+		const { config: blankConfig, cleanup: cleanupBlank } = makeConfig();
+		try {
+			expect(blankConfig.getEnabledProviderModelDefaultProviders()).toEqual([
+				"codex",
+			]);
+		} finally {
+			cleanupBlank();
+		}
+	});
+
+	it("parses a trimmed comma-separated list when the env var is set", () => {
+		process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS = "codex, xai ,qwen";
+		const { config, cleanup } = makeConfig();
+		try {
+			expect(config.getEnabledProviderModelDefaultProviders()).toEqual([
+				"codex",
+				"xai",
+				"qwen",
+			]);
+		} finally {
+			cleanup();
+		}
+	});
+});
+
+describe("filterEnabledProviderModelDefaultOverrides", () => {
+	it("drops overrides for providers outside the enabled set without mutating the input", () => {
+		const overrides = {
+			codex: { opus: "gpt-custom" },
+			xai: { sonnet: "grok-custom" },
+		};
+		const filtered = filterEnabledProviderModelDefaultOverrides(
+			["codex"],
+			overrides,
+		);
+		expect(filtered).toEqual({ codex: { opus: "gpt-custom" } });
+		// A entrada do provider desabilitado permanece no mapa original.
+		expect(overrides.xai).toEqual({ sonnet: "grok-custom" });
+	});
+
+	it("brings a previously-disabled provider back once it is enabled", () => {
+		const overrides = {
+			codex: { opus: "gpt-custom" },
+			xai: { sonnet: "grok-custom" },
+		};
+		expect(
+			filterEnabledProviderModelDefaultOverrides(["codex", "xai"], overrides),
+		).toEqual(overrides);
+	});
+});

--- a/packages/dashboard-web/src/components/SettingsTab.tsx
+++ b/packages/dashboard-web/src/components/SettingsTab.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { AdvancedSettingsCard } from "./overview/AdvancedSettingsCard";
 import { CacheKeepaliveCard } from "./overview/CacheKeepaliveCard";
 import { DataRetentionCard } from "./overview/DataRetentionCard";
 import { RoutingCard } from "./overview/RoutingCard";
@@ -15,6 +16,7 @@ export const SettingsTab = React.memo(() => {
 				<SystemCacheTtlCard />
 				<UsageThrottlingCard />
 				<DataRetentionCard />
+				<AdvancedSettingsCard />
 			</div>
 		</div>
 	);

--- a/packages/dashboard-web/src/components/accounts/AccountModelMappingsDialog.tsx
+++ b/packages/dashboard-web/src/components/accounts/AccountModelMappingsDialog.tsx
@@ -167,6 +167,7 @@ export function AccountModelMappingsDialog({
 										id="fable"
 										mode="list"
 										provider={account.provider}
+										accountId={account.id}
 										value={modelMappings.fable}
 										onChange={(value) => handleInputChange("fable", value)}
 										placeholder={`e.g., ${LATEST_FABLE_MODEL}`}
@@ -184,6 +185,7 @@ export function AccountModelMappingsDialog({
 										id="opus"
 										mode="list"
 										provider={account.provider}
+										accountId={account.id}
 										value={modelMappings.opus}
 										onChange={(value) => handleInputChange("opus", value)}
 										placeholder={`e.g., ${LATEST_OPUS_MODEL}`}
@@ -201,6 +203,7 @@ export function AccountModelMappingsDialog({
 										id="sonnet"
 										mode="list"
 										provider={account.provider}
+										accountId={account.id}
 										value={modelMappings.sonnet}
 										onChange={(value) => handleInputChange("sonnet", value)}
 										placeholder={`e.g., ${LATEST_SONNET_MODEL}`}
@@ -218,6 +221,7 @@ export function AccountModelMappingsDialog({
 										id="haiku"
 										mode="list"
 										provider={account.provider}
+										accountId={account.id}
 										value={modelMappings.haiku}
 										onChange={(value) => handleInputChange("haiku", value)}
 										placeholder={`e.g., ${LATEST_HAIKU_MODEL}`}

--- a/packages/dashboard-web/src/components/combos/ComboSlotBuilder.tsx
+++ b/packages/dashboard-web/src/components/combos/ComboSlotBuilder.tsx
@@ -274,6 +274,7 @@ export function ComboSlotBuilder({ combo }: ComboSlotBuilderProps) {
 							<div className="flex items-center gap-1.5">
 								<ModelCombobox
 									provider={selectedProvider}
+									accountId={newAccountId || null}
 									value={newModel}
 									onChange={setNewModel}
 									placeholder="Model id"

--- a/packages/dashboard-web/src/components/models/ModelCombobox.tsx
+++ b/packages/dashboard-web/src/components/models/ModelCombobox.tsx
@@ -45,6 +45,11 @@ export interface ModelComboboxProps {
 	 * not pass this prop, so their behavior remains unchanged.
 	 */
 	hideClientModelOption?: boolean;
+	/**
+	 * Account whose own model listing should drive the list. Optional: the
+	 * per-provider default-map screen has no account in context.
+	 */
+	accountId?: string | null;
 }
 
 interface ModelOptionProps {
@@ -125,10 +130,11 @@ export function ModelCombobox({
 	inputClassName,
 	disabled,
 	hideClientModelOption = false,
+	accountId,
 }: ModelComboboxProps) {
 	const [open, setOpen] = useState(false);
 	const [filter, setFilter] = useState("");
-	const query = useProviderModels(provider);
+	const query = useProviderModels(provider, accountId);
 
 	const selected = useMemo(() => parseModelList(value), [value]);
 	const usesClientModel = value.trim().length === 0;

--- a/packages/dashboard-web/src/components/models/ModelCombobox.tsx
+++ b/packages/dashboard-web/src/components/models/ModelCombobox.tsx
@@ -44,6 +44,7 @@ export interface ModelComboboxProps {
 	 * Defaults to false — ComboSlotBuilder and AccountModelMappingsDialog do
 	 * not pass this prop, so their behavior remains unchanged.
 	 */
+	hideClientModelOption?: boolean;
 }
 
 interface ModelOptionProps {
@@ -123,6 +124,7 @@ export function ModelCombobox({
 	className,
 	inputClassName,
 	disabled,
+	hideClientModelOption = false,
 }: ModelComboboxProps) {
 	const [open, setOpen] = useState(false);
 	const [filter, setFilter] = useState("");
@@ -240,36 +242,38 @@ export function ModelCombobox({
 					className="max-h-72 overflow-y-auto overscroll-contain p-1"
 					onWheelCapture={(e) => e.stopPropagation()}
 				>
-					<button
-						type="button"
-						onClick={handleUseClientModel}
-						disabled={clientModelDisabled}
-						className={cn(
-							"mb-1 flex w-full items-start gap-2 rounded-sm border border-dashed px-2 py-2 text-left hover:bg-accent hover:text-accent-foreground",
-							usesClientModel &&
-								!clientModelDisabled &&
-								"border-primary bg-accent/60",
-							clientModelDisabled &&
-								"cursor-not-allowed opacity-60 hover:bg-transparent hover:text-inherit",
-						)}
-					>
-						<Check
+					{!hideClientModelOption && (
+						<button
+							type="button"
+							onClick={handleUseClientModel}
+							disabled={clientModelDisabled}
 							className={cn(
-								"mt-0.5 h-3.5 w-3.5 shrink-0",
-								usesClientModel && !clientModelDisabled
-									? "opacity-100"
-									: "opacity-0",
+								"mb-1 flex w-full items-start gap-2 rounded-sm border border-dashed px-2 py-2 text-left hover:bg-accent hover:text-accent-foreground",
+								usesClientModel &&
+									!clientModelDisabled &&
+									"border-primary bg-accent/60",
+								clientModelDisabled &&
+									"cursor-not-allowed opacity-60 hover:bg-transparent hover:text-inherit",
 							)}
-						/>
-						<span className="min-w-0 flex-1">
-							<span className="block text-sm font-medium">
-								{clientModelTitle}
+						>
+							<Check
+								className={cn(
+									"mt-0.5 h-3.5 w-3.5 shrink-0",
+									usesClientModel && !clientModelDisabled
+										? "opacity-100"
+										: "opacity-0",
+								)}
+							/>
+							<span className="min-w-0 flex-1">
+								<span className="block text-sm font-medium">
+									{clientModelTitle}
+								</span>
+								<span className="block text-[11px] text-muted-foreground">
+									{clientModelHint(mode, provider, passthroughAllowed)}
+								</span>
 							</span>
-							<span className="block text-[11px] text-muted-foreground">
-								{clientModelHint(mode, provider, passthroughAllowed)}
-							</span>
-						</span>
-					</button>
+						</button>
+					)}
 
 					{query.isLoading && (
 						<div className="flex items-center gap-2 px-2 py-3 text-xs text-muted-foreground">

--- a/packages/dashboard-web/src/components/overview/AdvancedSettingsCard.tsx
+++ b/packages/dashboard-web/src/components/overview/AdvancedSettingsCard.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from "react";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "../ui/card";
+import { Separator } from "../ui/separator";
+import { ProviderModelDefaultsDialog } from "./ProviderModelDefaultsDialog";
+
+/**
+ * Advanced settings: rarely changed items, each behind its own modal so they
+ * do not compete for space with frequently used cards in the SettingsTab
+ * grid.
+ *
+ * To add an item: add an ADVANCED_SETTINGS_ITEMS entry with a title, one
+ * description line, and the dialog it opens (already with its own trigger
+ * button; see ProviderModelDefaultsDialog). The card itself knows nothing
+ * about the content of each item.
+ */
+interface AdvancedSettingItem {
+	id: string;
+	title: string;
+	description: string;
+	dialog: ReactNode;
+}
+
+const ADVANCED_SETTINGS_ITEMS: AdvancedSettingItem[] = [
+	{
+		id: "provider-model-defaults",
+		title: "Provider Model Defaults",
+		description:
+			"Built-in fallback model per provider and Claude family, used only as a last resort.",
+		dialog: <ProviderModelDefaultsDialog />,
+	},
+];
+
+export function AdvancedSettingsCard() {
+	return (
+		<Card className="card-hover">
+			<CardHeader>
+				<CardTitle>Advanced</CardTitle>
+				<CardDescription>
+					Settings you rarely need to touch, each behind its own dialog.
+				</CardDescription>
+			</CardHeader>
+			<CardContent className="space-y-3">
+				{ADVANCED_SETTINGS_ITEMS.map((item, index) => (
+					<div key={item.id}>
+						{index > 0 && <Separator className="mb-3" />}
+						<div className="flex items-center justify-between gap-3">
+							<div className="space-y-0.5">
+								<p className="text-sm font-medium">{item.title}</p>
+								<p className="text-xs text-muted-foreground">
+									{item.description}
+								</p>
+							</div>
+							{item.dialog}
+						</div>
+					</div>
+				))}
+			</CardContent>
+		</Card>
+	);
+}

--- a/packages/dashboard-web/src/components/overview/ProviderModelDefaultsDialog.tsx
+++ b/packages/dashboard-web/src/components/overview/ProviderModelDefaultsDialog.tsx
@@ -1,0 +1,296 @@
+import { AlertCircle, Info, Loader2, RefreshCw, Save } from "lucide-react";
+import { useEffect, useState } from "react";
+import {
+	useProviderModelDefaults,
+	useSaveProviderModelDefaults,
+} from "../../hooks/useProviderModelDefaults";
+import type { ProviderModelDefaultOverrideInput } from "../../lib/provider-model-defaults-api";
+import { ModelCombobox } from "../models/ModelCombobox";
+import { Button } from "../ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "../ui/dialog";
+import { Label } from "../ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
+
+// Display order for known families; any future family sent by the backend that
+// is unknown here goes last, alphabetically — it never disappears from the
+// screen merely because it is absent from this list.
+const FAMILY_ORDER = ["fable", "opus", "sonnet", "haiku"];
+
+function familyLabel(family: string): string {
+	return family.charAt(0).toUpperCase() + family.slice(1);
+}
+
+function fieldKey(provider: string, family: string): string {
+	return `${provider}:${family}`;
+}
+
+function domId(provider: string, family: string): string {
+	return `provider-model-default-${provider}-${family}`;
+}
+
+function sortFamilies<T extends { family: string }>(fields: T[]): T[] {
+	return [...fields].sort((a, b) => {
+		const ia = FAMILY_ORDER.indexOf(a.family);
+		const ib = FAMILY_ORDER.indexOf(b.family);
+		if (ia === -1 && ib === -1) return a.family.localeCompare(b.family);
+		if (ia === -1) return 1;
+		if (ib === -1) return -1;
+		return ia - ib;
+	});
+}
+
+/**
+ * Per-provider default model map: the LAST word in the resolution chain
+ * (combo slot -> account mapping -> this map embedded in code). It has a UI
+ * only because one hardcoded map sent a Codex/ChatGPT account to a model its
+ * subscription cannot use — and until now rebuilding was the only fix.
+ *
+ * Empty field == no override == use the factory value (shown in the
+ * placeholder and hint below the field). This is NOT the ModelCombobox "use
+ * the client model" (passthrough) option — that option is deliberately
+ * hidden here with `hideClientModelOption`: this field exists specifically
+ * for providers that do not speak Claude, so passthrough never makes sense
+ * on this screen.
+ *
+ * It lives in a modal (opened from the SettingsTab "Advanced" card) because
+ * it is rarely changed. One tab per provider deliberately keeps each tab
+ * short (at most 4 fields): ModelCombobox renders its popover without a
+ * portal (see ModelCombobox) because when portalized, Radix Dialog scroll
+ * locking swallows the mouse wheel inside modals — and an `overflow-y-auto`
+ * between the dialog and field would clip the dropdown list. Therefore this
+ * modal does not scroll: the tabs exist to guarantee that, not just to organize.
+ */
+export function ProviderModelDefaultsDialog() {
+	const query = useProviderModelDefaults();
+	const save = useSaveProviderModelDefaults();
+	// Local draft per field (key `${provider}:${family}`). It becomes a real
+	// override only when the user clicks Save — nothing here saves on every
+	// keystroke.
+	const [drafts, setDrafts] = useState<Record<string, string>>({});
+	const [activeTab, setActiveTab] = useState<string | undefined>(undefined);
+
+	// Resynchronizes the draft whenever the query brings a fresh server
+	// snapshot: on initial load and after Save invalidates the query. An empty
+	// override in the draft means "no customization; use the factory value".
+	useEffect(() => {
+		if (!query.data) return;
+		const next: Record<string, string> = {};
+		for (const provider of query.data) {
+			for (const field of provider.fields) {
+				next[fieldKey(provider.provider, field.family)] = field.override ?? "";
+			}
+		}
+		setDrafts(next);
+	}, [query.data]);
+
+	const providers = query.data ?? [];
+	const sortedProviders = [...providers].sort((a, b) =>
+		a.provider.localeCompare(b.provider),
+	);
+
+	// Keeps the active tab valid as providers arrive or change; selects the
+	// first one by default once the list arrives.
+	useEffect(() => {
+		if (sortedProviders.length === 0) return;
+		if (
+			activeTab &&
+			sortedProviders.some((provider) => provider.provider === activeTab)
+		) {
+			return;
+		}
+		setActiveTab(sortedProviders[0].provider);
+	}, [sortedProviders, activeTab]);
+
+	const handleChange = (provider: string, family: string, value: string) => {
+		setDrafts((prev) => ({ ...prev, [fieldKey(provider, family)]: value }));
+	};
+
+	const handleReset = (provider: string, family: string) => {
+		setDrafts((prev) => ({ ...prev, [fieldKey(provider, family)]: "" }));
+	};
+
+	// Derived on every render: fields whose drafts differ from what is saved
+	// now. It is also the Save payload — no parallel "dirty" state can drift
+	// from what will actually be sent. It runs over ALL providers, not only
+	// the active tab: Save applies to the entire modal.
+	const dirtyOverrides: ProviderModelDefaultOverrideInput[] = [];
+	for (const provider of providers) {
+		for (const field of provider.fields) {
+			const key = fieldKey(provider.provider, field.family);
+			const draft = (drafts[key] ?? "").trim();
+			const saved = field.override ?? "";
+			if (draft !== saved) {
+				dirtyOverrides.push({
+					provider: provider.provider,
+					family: field.family,
+					model: draft,
+				});
+			}
+		}
+	}
+
+	const handleSave = () => {
+		if (dirtyOverrides.length === 0) return;
+		save.mutate(dirtyOverrides);
+	};
+
+	const disableFields = query.isLoading || save.isPending;
+
+	return (
+		<Dialog>
+			<DialogTrigger asChild>
+				<Button variant="outline" size="sm">
+					Configure
+				</Button>
+			</DialogTrigger>
+			<DialogContent className="max-w-2xl">
+				<DialogHeader>
+					<DialogTitle>Provider Model Defaults</DialogTitle>
+					<DialogDescription>
+						The built-in model this proxy falls back to per provider and Claude
+						family, for providers that do not speak Claude model ids natively.
+					</DialogDescription>
+				</DialogHeader>
+
+				<p className="flex items-start gap-1.5 text-xs text-muted-foreground">
+					<Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+					Last resort in the routing chain: only used when the requested model
+					has no slot in the combo and no mapping on the account.
+				</p>
+
+				{query.isLoading && (
+					<div className="flex items-center gap-2 py-4 text-sm text-muted-foreground">
+						<Loader2 className="h-4 w-4 animate-spin" />
+						Loading provider defaults...
+					</div>
+				)}
+
+				{query.isError && (
+					<p className="flex items-center gap-2 py-2 text-sm text-destructive">
+						<AlertCircle className="h-4 w-4 shrink-0" />
+						Could not load provider defaults.{" "}
+						{query.error instanceof Error
+							? query.error.message
+							: "unknown error"}
+					</p>
+				)}
+
+				{!query.isLoading && !query.isError && sortedProviders.length === 0 && (
+					<p className="py-2 text-sm text-muted-foreground">
+						No provider has a built-in default map to configure.
+					</p>
+				)}
+
+				{sortedProviders.length > 0 && activeTab && (
+					<Tabs value={activeTab} onValueChange={setActiveTab}>
+						<TabsList>
+							{sortedProviders.map((provider) => (
+								<TabsTrigger key={provider.provider} value={provider.provider}>
+									{provider.provider}
+								</TabsTrigger>
+							))}
+						</TabsList>
+						{sortedProviders.map((provider) => (
+							<TabsContent
+								key={provider.provider}
+								value={provider.provider}
+								className="grid grid-cols-1 gap-3 sm:grid-cols-2"
+							>
+								{sortFamilies(provider.fields).map((field) => {
+									const key = fieldKey(provider.provider, field.family);
+									const id = domId(provider.provider, field.family);
+									const draft = drafts[key] ?? "";
+									const customized = draft.trim().length > 0;
+									return (
+										<div key={key} className="space-y-1">
+											<Label htmlFor={id} className="text-xs">
+												{familyLabel(field.family)}
+											</Label>
+											<div className="flex items-center gap-1.5">
+												<ModelCombobox
+													id={id}
+													provider={provider.provider}
+													value={draft}
+													onChange={(value) =>
+														handleChange(provider.provider, field.family, value)
+													}
+													placeholder={`${field.factory} (factory)`}
+													hideClientModelOption
+													className="flex-1"
+													inputClassName="h-8"
+													disabled={disableFields}
+												/>
+												{customized && (
+													<Button
+														type="button"
+														variant="ghost"
+														size="sm"
+														title={`Reset to factory: ${field.factory}`}
+														onClick={() =>
+															handleReset(provider.provider, field.family)
+														}
+														disabled={save.isPending}
+													>
+														<RefreshCw className="h-3.5 w-3.5" />
+													</Button>
+												)}
+											</div>
+											<p className="text-[11px] text-muted-foreground">
+												{customized
+													? `Customized. Factory: ${field.factory}`
+													: `Factory: ${field.factory}`}
+											</p>
+										</div>
+									);
+								})}
+							</TabsContent>
+						))}
+					</Tabs>
+				)}
+
+				<div className="flex items-center gap-2 pt-1">
+					<Button
+						size="sm"
+						onClick={handleSave}
+						disabled={
+							dirtyOverrides.length === 0 || save.isPending || query.isLoading
+						}
+					>
+						{save.isPending ? (
+							<>
+								<Loader2 className="h-3.5 w-3.5 animate-spin" />
+								Saving...
+							</>
+						) : (
+							<>
+								<Save className="h-3.5 w-3.5" />
+								Save
+							</>
+						)}
+					</Button>
+					{dirtyOverrides.length > 0 && !save.isPending && (
+						<span className="text-xs text-muted-foreground">
+							{dirtyOverrides.length} field
+							{dirtyOverrides.length === 1 ? "" : "s"} changed
+						</span>
+					)}
+				</div>
+
+				{save.isError && (
+					<p className="flex items-center gap-2 text-xs text-destructive">
+						<AlertCircle className="h-3.5 w-3.5 shrink-0" />
+						Could not save.{" "}
+						{save.error instanceof Error ? save.error.message : "unknown error"}
+					</p>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/packages/dashboard-web/src/hooks/useProviderModelDefaults.ts
+++ b/packages/dashboard-web/src/hooks/useProviderModelDefaults.ts
@@ -1,0 +1,36 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+	fetchProviderModelDefaults,
+	type ProviderModelDefaultOverrideInput,
+	saveProviderModelDefaultOverrides,
+} from "../lib/provider-model-defaults-api";
+import { queryKeys } from "../lib/query-keys";
+
+/**
+ * Per-provider-and-family default model map (the one embedded in code, the
+ * last word in the resolution chain). Few records: short staleTime only to
+ * avoid duplicate calls between re-renders, with no polling.
+ */
+export const useProviderModelDefaults = () =>
+	useQuery({
+		queryKey: queryKeys.providerModelDefaults(),
+		queryFn: fetchProviderModelDefaults,
+		staleTime: 30 * 1000,
+	});
+
+/**
+ * Saves the overrides edited on screen in one operation. Invalidates the query
+ * above to reload the effective value after saving.
+ */
+export const useSaveProviderModelDefaults = () => {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (overrides: ProviderModelDefaultOverrideInput[]) =>
+			saveProviderModelDefaultOverrides(overrides),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: queryKeys.providerModelDefaults(),
+			});
+		},
+	});
+};

--- a/packages/dashboard-web/src/hooks/useProviderModels.ts
+++ b/packages/dashboard-web/src/hooks/useProviderModels.ts
@@ -1,9 +1,5 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
-import {
-	fetchProviderModels,
-	type TestModelResult,
-	testAccountModel,
-} from "../lib/model-api";
+import { useQuery } from "@tanstack/react-query";
+import { fetchProviderModels } from "../lib/model-api";
 import { queryKeys } from "../lib/query-keys";
 
 /**
@@ -27,12 +23,3 @@ export const useProviderModels = (
 		retry: false,
 	});
 };
-
-/**
- * Makes ONE real request to the provider. Never call it implicitly: it consumes
- * quota from the tested account.
- */
-export const useTestAccountModel = () =>
-	useMutation<TestModelResult, Error, { accountId: string; model: string }>({
-		mutationFn: ({ accountId, model }) => testAccountModel(accountId, model),
-	});

--- a/packages/dashboard-web/src/hooks/useProviderModels.ts
+++ b/packages/dashboard-web/src/hooks/useProviderModels.ts
@@ -1,16 +1,24 @@
-import { useQuery } from "@tanstack/react-query";
-import { fetchProviderModels } from "../lib/model-api";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+	fetchProviderModels,
+	type TestModelResult,
+	testAccountModel,
+} from "../lib/model-api";
 import { queryKeys } from "../lib/query-keys";
 
 /**
  * Provider model list. Disabled while the provider is unknown (no selected
  * account), so the combobox never suggests the wrong provider list.
  */
-export const useProviderModels = (provider?: string | null) => {
+export const useProviderModels = (
+	provider?: string | null,
+	accountId?: string | null,
+) => {
 	const normalized = provider?.trim() ?? "";
+	const account = accountId?.trim() ?? "";
 	return useQuery({
-		queryKey: queryKeys.providerModels(normalized),
-		queryFn: () => fetchProviderModels(normalized),
+		queryKey: queryKeys.providerModels(normalized, account),
+		queryFn: () => fetchProviderModels(normalized, account),
 		enabled: normalized.length > 0,
 		staleTime: 5 * 60 * 1000,
 		gcTime: 30 * 60 * 1000,
@@ -19,3 +27,12 @@ export const useProviderModels = (provider?: string | null) => {
 		retry: false,
 	});
 };
+
+/**
+ * Makes ONE real request to the provider. Never call it implicitly: it consumes
+ * quota from the tested account.
+ */
+export const useTestAccountModel = () =>
+	useMutation<TestModelResult, Error, { accountId: string; model: string }>({
+		mutationFn: ({ accountId, model }) => testAccountModel(accountId, model),
+	});

--- a/packages/dashboard-web/src/lib/model-api.ts
+++ b/packages/dashboard-web/src/lib/model-api.ts
@@ -1,15 +1,13 @@
 import { api } from "../api";
 
 /**
- * Adapter for the two endpoints used by the model selector.
+ * Adapter for the endpoint used by the model selector.
  *
  * Everything the dashboard knows about these response shapes lives here: if
  * the backend changes the contract, this is the only file to update.
  *
  *   GET  /api/models?provider=<anthropic|codex|...>
  *     -> { provider, fetchedAt, source, models: [{ id, displayName, source }] }
- *   POST /api/accounts/:id/test-model    body { model }
- *     -> { ok, inconclusive?, status, error?, durationMs }
  *
  * Authentication comes for free from the shared `api` client, which injects
  * `x-api-key` into every request and opens the auth dialog on 401.
@@ -39,21 +37,6 @@ export interface ProviderModels {
 	fetchedAt: number | null;
 	source: string | null;
 	models: ProviderModel[];
-}
-
-export interface TestModelResult {
-	ok: boolean;
-	/**
-	 * true when the failure says NOTHING about the model: the account was
-	 * unavailable at that moment (429/503/529). It is not a verdict on the
-	 * model — treating it as rejection produces a false negative.
-	 */
-	inconclusive?: boolean;
-	/** Upstream HTTP status (0 when the request did not get that far). */
-	status: number;
-	/** Raw provider error text — the reason the test button exists. */
-	error?: string;
-	durationMs: number;
 }
 
 const MODEL_SOURCES: ProviderModelSource[] = [
@@ -128,47 +111,6 @@ export async function fetchProviderModels(
 		source: typeof body.source === "string" ? body.source : null,
 		models,
 	};
-}
-
-/**
- * Sends ONE real request to the provider using the supplied account.
- * It consumes quota — call it only on explicit user action.
- */
-export async function testAccountModel(
-	accountId: string,
-	model: string,
-): Promise<TestModelResult> {
-	const startedAt = Date.now();
-	try {
-		const body = asRecord(
-			await api.post<unknown>(
-				`/api/accounts/${encodeURIComponent(accountId)}/test-model`,
-				{ model },
-			),
-		);
-		const elapsed = Date.now() - startedAt;
-		const error =
-			typeof body.error === "string" && body.error.trim()
-				? body.error
-				: undefined;
-		return {
-			ok: body.ok === true,
-			inconclusive: body.inconclusive === true,
-			status: typeof body.status === "number" ? body.status : 0,
-			error,
-			durationMs:
-				typeof body.durationMs === "number" ? body.durationMs : elapsed,
-		};
-	} catch (err) {
-		// A transport failure is also a test result: the user asked "does this
-		// model work?", and the honest answer is the raw failure text.
-		return {
-			ok: false,
-			status: err instanceof HttpError ? err.status : 0,
-			error: err instanceof Error ? err.message : String(err),
-			durationMs: Date.now() - startedAt,
-		};
-	}
 }
 
 /** Mapping fields accept a comma-separated list (rotation on 429). */

--- a/packages/dashboard-web/src/lib/model-api.ts
+++ b/packages/dashboard-web/src/lib/model-api.ts
@@ -21,6 +21,12 @@ export interface ProviderModel {
 	id: string;
 	displayName: string;
 	/**
+	 * Model the provider says replaces this one. Present only when the
+	 * provider has announced the deprecation — picking a model on its way out
+	 * is a decision someone has to undo later.
+	 */
+	supersededBy?: string | null;
+	/**
 	 * "builtin"/"catalog": ccflare knows this model for the provider.
 	 * "reference": it exists in the provider public catalog — which is NOT a
 	 * promise that the account plan can call it.
@@ -33,6 +39,21 @@ export interface ProviderModels {
 	fetchedAt: number | null;
 	source: string | null;
 	models: ProviderModel[];
+}
+
+export interface TestModelResult {
+	ok: boolean;
+	/**
+	 * true when the failure says NOTHING about the model: the account was
+	 * unavailable at that moment (429/503/529). It is not a verdict on the
+	 * model — treating it as rejection produces a false negative.
+	 */
+	inconclusive?: boolean;
+	/** Upstream HTTP status (0 when the request did not get that far). */
+	status: number;
+	/** Raw provider error text — the reason the test button exists. */
+	error?: string;
+	durationMs: number;
 }
 
 const MODEL_SOURCES: ProviderModelSource[] = [
@@ -60,7 +81,16 @@ function normalizeModel(raw: unknown): ProviderModel | null {
 		typeof entry.displayName === "string" && entry.displayName.trim()
 			? entry.displayName.trim()
 			: id;
-	return { id, displayName, source: normalizeSource(entry.source) };
+	const supersededBy =
+		typeof entry.supersededBy === "string" && entry.supersededBy.trim()
+			? entry.supersededBy
+			: null;
+	return {
+		id,
+		displayName,
+		source: normalizeSource(entry.source),
+		supersededBy,
+	};
 }
 
 function asRecord(raw: unknown): Record<string, unknown> {
@@ -70,10 +100,17 @@ function asRecord(raw: unknown): Record<string, unknown> {
 /** Model list for a provider. Tolerant: malformed input becomes an empty list. */
 export async function fetchProviderModels(
 	provider: string,
+	accountId?: string | null,
 ): Promise<ProviderModels> {
+	// With an account the backend can ask the provider what THIS subscription
+	// may call; without one it can only offer the generic catalogue, which
+	// lists models a given plan may not reach.
+	const scope = accountId?.trim()
+		? `&accountId=${encodeURIComponent(accountId.trim())}`
+		: "";
 	const body = asRecord(
 		await api.get<unknown>(
-			`/api/models?provider=${encodeURIComponent(provider)}`,
+			`/api/models?provider=${encodeURIComponent(provider)}${scope}`,
 		),
 	);
 	const list: unknown[] = Array.isArray(body.models) ? body.models : [];
@@ -93,6 +130,48 @@ export async function fetchProviderModels(
 	};
 }
 
+/**
+ * Sends ONE real request to the provider using the supplied account.
+ * It consumes quota — call it only on explicit user action.
+ */
+export async function testAccountModel(
+	accountId: string,
+	model: string,
+): Promise<TestModelResult> {
+	const startedAt = Date.now();
+	try {
+		const body = asRecord(
+			await api.post<unknown>(
+				`/api/accounts/${encodeURIComponent(accountId)}/test-model`,
+				{ model },
+			),
+		);
+		const elapsed = Date.now() - startedAt;
+		const error =
+			typeof body.error === "string" && body.error.trim()
+				? body.error
+				: undefined;
+		return {
+			ok: body.ok === true,
+			inconclusive: body.inconclusive === true,
+			status: typeof body.status === "number" ? body.status : 0,
+			error,
+			durationMs:
+				typeof body.durationMs === "number" ? body.durationMs : elapsed,
+		};
+	} catch (err) {
+		// A transport failure is also a test result: the user asked "does this
+		// model work?", and the honest answer is the raw failure text.
+		return {
+			ok: false,
+			status: err instanceof HttpError ? err.status : 0,
+			error: err instanceof Error ? err.message : String(err),
+			durationMs: Date.now() - startedAt,
+		};
+	}
+}
+
+/** Mapping fields accept a comma-separated list (rotation on 429). */
 export function parseModelList(value: string): string[] {
 	return value
 		.split(",")

--- a/packages/dashboard-web/src/lib/provider-model-defaults-api.ts
+++ b/packages/dashboard-web/src/lib/provider-model-defaults-api.ts
@@ -1,0 +1,112 @@
+import { api } from "../api";
+
+/**
+ * Adapter for ONE endpoint: the per-provider-and-family default model map
+ * currently embedded in code (codex, xai, qwen, ...) and used as the LAST
+ * word when neither the combo slot nor account mapping supplies a model. One
+ * of these hardcoded maps caused the incident
+ * `400 The 'gpt-5.3-codex' model is not supported when using Codex with a
+ * ChatGPT account` — the account subscription cannot use that model, and
+ * until now rebuilding was the only possible fix.
+ *
+ * Everything the dashboard knows about these response shapes lives here: if
+ * the backend changes the contract, this is the only file to update.
+ *
+ *   GET  /api/config/provider-model-defaults
+ *     -> per provider and family: factory value, override (if any), and
+ *        effective value. Expected shape (tolerant of shape variation):
+ *        { providers: [ { provider, fields: [
+ *            { family, factory, override, effective },
+ *        ] } ] }
+ *   POST /api/config/provider-model-defaults   body { overrides: [{ provider, family, model }] }
+ *     -> saves overrides; model === "" removes the override for that
+ *        provider and family (returns to the factory value).
+ *
+ * Authentication comes for free from the shared `api` client, which injects
+ * `x-api-key` into every request and opens the auth dialog on 401.
+ */
+
+export interface ProviderModelDefaultField {
+	family: string;
+	/** Value embedded in code — what applies with no override. */
+	factory: string;
+	/** Override saved today; null when there is no customization. */
+	override: string | null;
+	/** What the proxy actually uses now (override if present, otherwise factory). */
+	effective: string;
+}
+
+export interface ProviderModelDefaults {
+	provider: string;
+	fields: ProviderModelDefaultField[];
+}
+
+export interface ProviderModelDefaultOverrideInput {
+	provider: string;
+	family: string;
+	/** An empty string removes the override (returns to the factory value). */
+	model: string;
+}
+
+function asRecord(raw: unknown): Record<string, unknown> {
+	return raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+}
+
+function asString(raw: unknown): string {
+	return typeof raw === "string" ? raw.trim() : "";
+}
+
+function normalizeField(raw: unknown): ProviderModelDefaultField | null {
+	const entry = asRecord(raw);
+	const family = asString(entry.family);
+	if (!family) return null;
+	const factory = asString(entry.factory);
+	const overrideRaw = entry.override;
+	const override =
+		typeof overrideRaw === "string" && overrideRaw.trim()
+			? overrideRaw.trim()
+			: null;
+	// effective tolerates being absent: falls back to override, then factory.
+	const effective = asString(entry.effective) || override || factory;
+	return { family, factory, override, effective };
+}
+
+function normalizeProvider(raw: unknown): ProviderModelDefaults | null {
+	const entry = asRecord(raw);
+	const provider = asString(entry.provider);
+	if (!provider) return null;
+	const list: unknown[] = Array.isArray(entry.fields) ? entry.fields : [];
+	const fields: ProviderModelDefaultField[] = [];
+	for (const item of list) {
+		const field = normalizeField(item);
+		if (field) fields.push(field);
+	}
+	return { provider, fields };
+}
+
+/** Default model map for all providers. Malformed input becomes an empty list. */
+export async function fetchProviderModelDefaults(): Promise<
+	ProviderModelDefaults[]
+> {
+	const body = asRecord(
+		await api.get<unknown>("/api/config/provider-model-defaults"),
+	);
+	const list: unknown[] = Array.isArray(body.providers) ? body.providers : [];
+	const providers: ProviderModelDefaults[] = [];
+	for (const item of list) {
+		const provider = normalizeProvider(item);
+		if (provider) providers.push(provider);
+	}
+	return providers;
+}
+
+/**
+ * Saves overrides in one operation, triggered by explicit action (the Save
+ * button): this card does not save on every keystroke. A field with
+ * model === "" removes that provider-and-family override (returns to factory).
+ */
+export async function saveProviderModelDefaultOverrides(
+	overrides: ProviderModelDefaultOverrideInput[],
+): Promise<void> {
+	await api.post("/api/config/provider-model-defaults", { overrides });
+}

--- a/packages/dashboard-web/src/lib/query-keys.ts
+++ b/packages/dashboard-web/src/lib/query-keys.ts
@@ -39,8 +39,19 @@ export const queryKeys = {
 	models: () => [...queryKeys.all, "models"] as const,
 	// Deliberately kept under the 'models' key: invalidating models() also
 	// invalidates the per-provider lists.
-	providerModels: (provider?: string | null) =>
-		[...queryKeys.all, "models", "provider", provider ?? ""] as const,
+	// The account is part of the key: two accounts of the same provider can be
+	// on different plans and get different lists.
+	// Server feature flags. One entry for the whole dashboard: they come from
+	// environment variables and only change when the process restarts.
+	features: () => [...queryKeys.all, "features"] as const,
+	providerModels: (provider?: string | null, accountId?: string | null) =>
+		[
+			...queryKeys.all,
+			"models",
+			"provider",
+			provider ?? "",
+			accountId ?? "",
+		] as const,
 	// Single record for the default-model map per provider+family (today the
 	// last word in the chain, hardcoded). No parameter: the screen reads
 	// and writes everything at once.

--- a/packages/http-api/src/handlers/__tests__/models-provider.test.ts
+++ b/packages/http-api/src/handlers/__tests__/models-provider.test.ts
@@ -1,33 +1,15 @@
-import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
-import { CODEX_KNOWN_MODELS } from "@better-ccflare/providers";
+import { afterAll, describe, expect, it, mock } from "bun:test";
 import type { APIContext } from "@better-ccflare/types";
 
-// listCatalogueModels is the seam to the shared models.dev catalogue, and the
-// real one performs network I/O. Stub it so these tests are offline and
-// deterministic.
-//
-// mock.module must run at top level and replaces the WHOLE module globally
-// and across file boundaries in Bun (no per-file isolation without
-// --isolate), so we capture the real @better-ccflare/core exports first,
-// spread them, and restore them in afterAll — same discipline as
-// oauth.test.ts. The handler is then imported dynamically, AFTER the mock is
-// registered, so its `listCatalogueModels` binding is the stub beyond any
-// doubt about import ordering.
+// The shared models.dev catalogue is the last-resort source for providers
+// ccflare cannot ask directly, and the real one performs network I/O. Stub it
+// so these tests are offline and deterministic — same discipline as the rest
+// of this suite. The handler is imported after the mock is registered.
 const actualCore = await import("@better-ccflare/core");
-
-/** What the stubbed catalogue returns; set per test. */
-let catalogueEntries: Array<{ id: string; name: string }> = [];
-/** Every models.dev section the handler asked for, in order. */
-let catalogueCalls: string[] = [];
-
-const stubListCatalogueModels = async (section: string) => {
-	catalogueCalls.push(section);
-	return catalogueEntries;
-};
 
 mock.module("@better-ccflare/core", () => ({
 	...actualCore,
-	listCatalogueModels: stubListCatalogueModels,
+	listCatalogueModels: async () => [],
 }));
 
 afterAll(() => {
@@ -36,192 +18,159 @@ afterAll(() => {
 
 const { createModelsHandler } = await import("../models");
 
+/**
+ * `GET /api/models` answers one question: which models can THIS account serve?
+ *
+ * It used to answer a wider one — built-in lists, the models.dev catalogue, the
+ * provider's documentation — and that width was the defect. Every model in a
+ * catalogue is one click away from being chosen, and choosing one the plan does
+ * not cover is what produced `400 The 'gpt-5.3-codex' model is not supported
+ * when using Codex with a ChatGPT account`. So the only source left is the
+ * account's own listing, and an empty answer is a real answer: nothing has been
+ * read yet.
+ */
+
 interface ListedModel {
 	id: string;
 	displayName: string;
 	source: string;
-	createdAt?: string | null;
 }
 
-interface ModelsBody {
-	models: ListedModel[];
-	fetchedAt: number;
-	source: string;
+interface Body {
 	provider: string;
-	referenceSection?: string;
+	models: ListedModel[];
+	source: string;
 	warning?: string;
 }
 
-const CATALOG_FETCHED_AT = 1_700_000_000_000;
-
-/** Context carrying a canned Anthropic catalog — the only dependency of the
- * no-provider / anthropic branch. */
-function makeContext(): APIContext {
+function makeContext(opts: {
+	codex?: {
+		models: Array<{
+			id: string;
+			displayName: string;
+			description?: string | null;
+			contextWindow?: number | null;
+			supersededBy?: string | null;
+		}>;
+	} | null;
+	anthropic?: {
+		models: Array<{ id: string; displayName: string }>;
+		source: string;
+	};
+}): APIContext {
 	return {
 		modelCatalog: {
+			codexModels: async () =>
+				opts.codex
+					? {
+							models: opts.codex.models.map((m) => ({
+								description: null,
+								contextWindow: null,
+								supersededBy: null,
+								...m,
+							})),
+							fetchedAt: 1_000,
+							source: "live" as const,
+						}
+					: null,
 			get: async () => ({
-				models: [
-					{
-						id: "claude-sonnet-4-5-20250929",
-						displayName: "Claude Sonnet 4.5",
-						createdAt: "2025-09-29T00:00:00Z",
-					},
-				],
-				fetchedAt: CATALOG_FETCHED_AT,
-				source: "live" as const,
+				models: (opts.anthropic?.models ?? []).map((m) => ({
+					...m,
+					createdAt: null,
+				})),
+				fetchedAt: 1_000,
+				source: (opts.anthropic?.source ?? "fallback") as "live" | "fallback",
 			}),
 			refresh: async () => ({ success: true }),
 		},
 	} as unknown as APIContext;
 }
 
-/** Find one listed model, failing loudly instead of returning undefined. */
-function listed(body: ModelsBody, id: string): ListedModel {
-	const found = body.models.find((model) => model.id === id);
-	if (!found) {
-		throw new Error(
-			`Expected model "${id}" in listing, got: ${body.models
-				.map((model) => model.id)
-				.join(", ")}`,
-		);
-	}
-	return found;
+async function ask(context: APIContext, query: string): Promise<Body> {
+	const handler = createModelsHandler(context);
+	const response = await handler(new URL(`http://local/api/models?${query}`));
+	return (await response.json()) as Body;
 }
 
 describe("GET /api/models", () => {
-	beforeEach(() => {
-		catalogueEntries = [];
-		catalogueCalls = [];
-	});
-
-	// Non-regression: the agents screen consumes this body. `provider` and the
-	// per-entry `source` are additive; nothing that was there may move.
-	it("without ?provider keeps the legacy Anthropic body shape", async () => {
-		const handler = createModelsHandler(makeContext());
-
-		const response = await handler(new URL("http://localhost/api/models"));
-		const body = (await response.json()) as ModelsBody;
-
-		expect(response.status).toBe(200);
-		expect(body.fetchedAt).toBe(CATALOG_FETCHED_AT);
-		expect(body.source).toBe("live");
-		expect(body.models).toHaveLength(1);
-		expect(body.models[0]).toMatchObject({
-			id: "claude-sonnet-4-5-20250929",
-			displayName: "Claude Sonnet 4.5",
-			createdAt: "2025-09-29T00:00:00Z",
-			source: "catalog",
+	it("returns what the codex account itself reported", async () => {
+		const context = makeContext({
+			codex: {
+				models: [
+					{ id: "gpt-5.6-sol", displayName: "GPT-5.6-Sol" },
+					{ id: "gpt-5.6-terra", displayName: "GPT-5.6-Terra" },
+				],
+			},
 		});
-		expect(body.provider).toBe("anthropic");
-		// The Anthropic branch must never consult the models.dev catalogue.
-		expect(catalogueCalls).toEqual([]);
 
-		// The URL argument is optional — calling with none behaves identically.
-		const bare = (await (await handler()).json()) as ModelsBody;
-		expect(bare.provider).toBe("anthropic");
-		expect(bare.models).toHaveLength(1);
-	});
+		const body = await ask(context, "provider=codex&accountId=acc-1");
 
-	it("?provider=codex lists the builtins first, in map order, tagged builtin", async () => {
-		catalogueEntries = [
-			{ id: "gpt-4.1", name: "GPT-4.1" },
-			{ id: "gpt-4o", name: "GPT-4o" },
-		];
-		const handler = createModelsHandler(makeContext());
-
-		const response = await handler(
-			new URL("http://localhost/api/models?provider=codex"),
-		);
-		const body = (await response.json()) as ModelsBody;
-
-		expect(response.status).toBe(200);
-		expect(body.provider).toBe("codex");
-		// codex is served by the "openai" section of models.dev.
-		expect(catalogueCalls).toEqual(["openai"]);
-		expect(body.referenceSection).toBe("openai");
-		expect(body.source).toBe("mixed");
-
-		const ids = body.models.map((model) => model.id);
-		// Builtins come first and in the declaration order of the provider's
-		// own context-window table.
-		expect(ids.slice(0, CODEX_KNOWN_MODELS.length)).toEqual([
-			...CODEX_KNOWN_MODELS,
+		expect(body.models.map((m) => m.id)).toEqual([
+			"gpt-5.6-sol",
+			"gpt-5.6-terra",
 		]);
-		// The model at the heart of the incident this endpoint exists for.
-		expect(ids).toContain("gpt-5.3-codex");
-		for (const id of CODEX_KNOWN_MODELS) {
-			expect(listed(body, id).source).toBe("builtin");
-		}
-		// Reference entries follow, alphabetically.
-		expect(ids.slice(CODEX_KNOWN_MODELS.length)).toEqual(["gpt-4.1", "gpt-4o"]);
-		expect(listed(body, "gpt-4.1").source).toBe("reference");
-		expect(listed(body, "gpt-4.1").displayName).toBe("GPT-4.1");
+		expect(body.models.every((m) => m.source === "account")).toBe(true);
+		expect(body.warning).toBeUndefined();
 	});
 
-	// listCatalogueModels is contractually non-throwing: it swallows fetch
-	// failures and an unknown section alike, and reports both as an empty
-	// list. That empty list is therefore the "catalogue unavailable" signal
-	// the handler has to survive — the endpoint must degrade, never fail.
-	it("?provider=codex degrades to builtins plus a warning when the catalogue is unavailable", async () => {
-		catalogueEntries = [];
-		const handler = createModelsHandler(makeContext());
-
-		const response = await handler(
-			new URL("http://localhost/api/models?provider=codex"),
+	// Nothing is substituted here on purpose. A catalogue would fill the gap with
+	// models this account may not be able to call, which is worse than an honest
+	// blank.
+	it("returns an empty list, not a catalogue, when nothing was read yet", async () => {
+		const body = await ask(
+			makeContext({ codex: null }),
+			"provider=codex&accountId=acc-1",
 		);
-		const body = (await response.json()) as ModelsBody;
 
-		expect(response.status).toBe(200);
-		expect(body.source).toBe("builtin");
-		expect(body.models).toHaveLength(CODEX_KNOWN_MODELS.length);
-		expect(body.models.every((model) => model.source === "builtin")).toBe(true);
-		expect(body.warning).toBeDefined();
-		expect(body.warning).toContain("openai");
-	});
-
-	it("deduplicates by id, keeping the stronger marking", async () => {
-		catalogueEntries = [
-			// Also a builtin: must survive once, as builtin.
-			{ id: "gpt-5.6-sol", name: "GPT-5.6 Sol (catalogue name)" },
-			{ id: "gpt-4.1", name: "GPT-4.1" },
-			// Repeated inside the reference list itself.
-			{ id: "gpt-4.1", name: "GPT-4.1 (again)" },
-		];
-		const handler = createModelsHandler(makeContext());
-
-		const response = await handler(
-			new URL("http://localhost/api/models?provider=codex"),
-		);
-		const body = (await response.json()) as ModelsBody;
-
-		const ids = body.models.map((model) => model.id);
-		expect(ids.filter((id) => id === "gpt-5.6-sol")).toHaveLength(1);
-		expect(ids.filter((id) => id === "gpt-4.1")).toHaveLength(1);
-
-		const sol = listed(body, "gpt-5.6-sol");
-		expect(sol.source).toBe("builtin");
-		// The builtin entry wins whole — the catalogue's display name must not
-		// leak in and make a builtin look like a catalogue find.
-		expect(sol.displayName).toBe("gpt-5.6-sol");
-		expect(listed(body, "gpt-4.1").source).toBe("reference");
-		expect(body.models).toHaveLength(CODEX_KNOWN_MODELS.length + 1);
-	});
-
-	it("an unknown provider yields an empty listing rather than an error", async () => {
-		catalogueEntries = [];
-		const handler = createModelsHandler(makeContext());
-
-		const response = await handler(
-			new URL("http://localhost/api/models?provider=nope"),
-		);
-		const body = (await response.json()) as ModelsBody;
-
-		expect(response.status).toBe(200);
-		expect(body.provider).toBe("nope");
-		// No override in the section map: the provider name is used verbatim.
-		expect(catalogueCalls).toEqual(["nope"]);
+		// The contract is the empty list: nothing is substituted for a listing
+		// that was not read. The wording of the warning is not the point.
 		expect(body.models).toEqual([]);
 		expect(body.source).toBe("unavailable");
-		expect(body.warning).toBeDefined();
+		expect(body.warning).toBeTruthy();
+	});
+
+	it("cannot answer for codex without an account", async () => {
+		const body = await ask(makeContext({ codex: null }), "provider=codex");
+
+		expect(body.models).toEqual([]);
+		expect(body.source).toBe("unavailable");
+	});
+
+	it("returns the Anthropic listing when it came from the provider", async () => {
+		const context = makeContext({
+			anthropic: {
+				models: [{ id: "claude-opus-5", displayName: "Claude Opus 5" }],
+				source: "live",
+			},
+		});
+
+		const body = await ask(context, "provider=anthropic");
+
+		expect(body.models.map((m) => m.id)).toEqual(["claude-opus-5"]);
+		expect(body.source).toBe("live");
+	});
+
+	// `fallback` means the bundled list or an on-disk copy answered — a catalogue
+	// wearing the listing's clothes. Same rule as everywhere else: it does not
+	// reach the field.
+	it("refuses to pass off the bundled Anthropic list as a listing", async () => {
+		const context = makeContext({
+			anthropic: {
+				models: [{ id: "claude-opus-5", displayName: "Claude Opus 5" }],
+				source: "fallback",
+			},
+		});
+
+		const body = await ask(context, "provider=anthropic");
+
+		expect(body.models).toEqual([]);
+		expect(body.source).toBe("unavailable");
+	});
+
+	it("says plainly that it cannot read a list from an unknown provider", async () => {
+		const body = await ask(makeContext({}), "provider=whatever");
+
+		expect(body.models).toEqual([]);
+		expect(body.warning).toContain("whatever");
 	});
 });

--- a/packages/http-api/src/handlers/__tests__/provider-model-defaults.test.ts
+++ b/packages/http-api/src/handlers/__tests__/provider-model-defaults.test.ts
@@ -1,7 +1,9 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { PROVIDER_MODEL_DEFAULTS_ENV_VAR } from "@better-ccflare/config";
 import {
+	clearDerivedProviderModelDefaults,
 	resolveProviderModelDefault,
+	setDerivedProviderModelDefaults,
 	setProviderModelDefaultOverrides,
 } from "@better-ccflare/providers";
 import { createConfigHandlers } from "../config";
@@ -51,6 +53,20 @@ afterEach(() => {
 });
 
 describe("provider model defaults", () => {
+	// The provider-wide default is no longer a constant: it is whatever the
+	// last listing read from an account of that provider implied. So the
+	// precondition every one of these cases needs is 'a listing was read',
+	// which is what this stands in for.
+	beforeEach(() => {
+		clearDerivedProviderModelDefaults();
+		setDerivedProviderModelDefaults("codex", "acc-seed", {
+			fable: "gpt-5.6-sol",
+			opus: "gpt-5.6-sol",
+			sonnet: "gpt-5.6-terra",
+			haiku: "gpt-5.6-luna",
+		});
+	});
+
 	it("merges one family override without erasing the provider factory map", async () => {
 		const handlers = createConfigHandlers(makeConfig());
 		const response = await handlers.setProviderModelDefaults(
@@ -71,7 +87,7 @@ describe("provider model defaults", () => {
 		).toBe("gpt-custom");
 		expect(
 			codex.fields.find((field) => field.family === "haiku")?.effective,
-		).toBe("gpt-5.4-mini");
+		).toBe("gpt-5.6-luna");
 	});
 
 	it("empty model removes an override and resolver returns factory", async () => {
@@ -83,7 +99,7 @@ describe("provider model defaults", () => {
 			request([{ provider: "codex", family: "opus", model: "" }]),
 		);
 		expect(response.status).toBe(200);
-		expect(resolveProviderModelDefault("codex", "opus")).toBe("gpt-5.3-codex");
+		expect(resolveProviderModelDefault("codex", "opus")).toBe("gpt-5.6-sol");
 	});
 
 	it("rejects unknown providers and families", async () => {
@@ -186,6 +202,6 @@ describe("provider model defaults", () => {
 			request([{ provider: "codex", family: "opus", model: "gpt-custom" }]),
 		);
 		expect(response.status).toBe(400);
-		expect(resolveProviderModelDefault("codex", "opus")).toBe("gpt-5.3-codex");
+		expect(resolveProviderModelDefault("codex", "opus")).toBe("gpt-5.6-sol");
 	});
 });

--- a/packages/http-api/src/handlers/__tests__/provider-model-defaults.test.ts
+++ b/packages/http-api/src/handlers/__tests__/provider-model-defaults.test.ts
@@ -53,6 +53,34 @@ afterEach(() => {
 });
 
 describe("provider model defaults", () => {
+	// The dialog draws its fields from this response. Enumerating it from the
+	// discovered map meant a provider with no compiled defaults and no listing
+	// yet had no rows at all — so the override was reachable by API and invisible
+	// in the only place it is documented.
+	it("still lists the fields when nothing has been discovered", async () => {
+		clearDerivedProviderModelDefaults();
+		const handlers = createConfigHandlers(makeConfig());
+
+		const response = await handlers.getProviderModelDefaults();
+		const body = (await response.json()) as {
+			providers: Array<{
+				provider: string;
+				fields: Array<{ family: string; factory: string | null }>;
+			}>;
+		};
+
+		const codex = body.providers.find((p) => p.provider === "codex");
+		expect(codex).toBeDefined();
+		expect(codex?.fields.map((f) => f.family).sort()).toEqual([
+			"fable",
+			"haiku",
+			"opus",
+			"sonnet",
+		]);
+		// Nothing read yet is a state to show, not a reason to hide the row.
+		expect(codex?.fields.every((f) => f.factory === null)).toBe(true);
+	});
+
 	// The override exists for the case where discovery has not answered — a cold
 	// start, or a listing endpoint that stopped responding. Validating it against
 	// the discovered map closed the escape hatch exactly then.

--- a/packages/http-api/src/handlers/__tests__/provider-model-defaults.test.ts
+++ b/packages/http-api/src/handlers/__tests__/provider-model-defaults.test.ts
@@ -53,6 +53,21 @@ afterEach(() => {
 });
 
 describe("provider model defaults", () => {
+	// The override exists for the case where discovery has not answered — a cold
+	// start, or a listing endpoint that stopped responding. Validating it against
+	// the discovered map closed the escape hatch exactly then.
+	it("accepts an override before any listing has been read", async () => {
+		clearDerivedProviderModelDefaults();
+		const handlers = createConfigHandlers(makeConfig());
+
+		const response = await handlers.setProviderModelDefaults(
+			request([{ provider: "codex", family: "opus", model: "gpt-5.6-sol" }]),
+		);
+
+		expect(response.status).toBe(200);
+		expect(resolveProviderModelDefault("codex", "opus")).toBe("gpt-5.6-sol");
+	});
+
 	// The provider-wide default is no longer a constant: it is whatever the
 	// last listing read from an account of that provider implied. So the
 	// precondition every one of these cases needs is 'a listing was read',

--- a/packages/http-api/src/handlers/__tests__/provider-model-defaults.test.ts
+++ b/packages/http-api/src/handlers/__tests__/provider-model-defaults.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { PROVIDER_MODEL_DEFAULTS_ENV_VAR } from "@better-ccflare/config";
+import {
+	resolveProviderModelDefault,
+	setProviderModelDefaultOverrides,
+} from "@better-ccflare/providers";
+import { createConfigHandlers } from "../config";
+
+function makeConfig(initial: Record<string, Record<string, string>> = {}) {
+	let saved = initial;
+	return {
+		getProviderModelDefaultOverrides: () => structuredClone(saved),
+		setProviderModelDefaultOverrides: (
+			value: Record<string, Record<string, string>>,
+		) => {
+			saved = structuredClone(value);
+		},
+		getEnabledProviderModelDefaultProviders: () => {
+			const fromEnv = process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS;
+			if (fromEnv) {
+				const parsed = fromEnv
+					.split(",")
+					.map((provider) => provider.trim())
+					.filter(Boolean);
+				if (parsed.length > 0) return parsed;
+			}
+			return ["codex"];
+		},
+	} as unknown as import("@better-ccflare/config").Config;
+}
+
+function request(overrides: unknown): Request {
+	return new Request("http://localhost/api/config/provider-model-defaults", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ overrides }),
+	});
+}
+
+const ORIGINAL_MODEL_DEFAULTS_PROVIDERS_ENV =
+	process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS;
+
+afterEach(() => {
+	setProviderModelDefaultOverrides({});
+	if (ORIGINAL_MODEL_DEFAULTS_PROVIDERS_ENV === undefined) {
+		delete process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS;
+	} else {
+		process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS =
+			ORIGINAL_MODEL_DEFAULTS_PROVIDERS_ENV;
+	}
+});
+
+describe("provider model defaults", () => {
+	it("merges one family override without erasing the provider factory map", async () => {
+		const handlers = createConfigHandlers(makeConfig());
+		const response = await handlers.setProviderModelDefaults(
+			request([{ provider: "codex", family: "opus", model: "gpt-custom" }]),
+		);
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as {
+			providers: Array<{
+				provider: string;
+				fields: Array<{ family: string; effective: string }>;
+			}>;
+		};
+		const codex = body.providers.find(
+			(provider) => provider.provider === "codex",
+		)!;
+		expect(
+			codex.fields.find((field) => field.family === "opus")?.effective,
+		).toBe("gpt-custom");
+		expect(
+			codex.fields.find((field) => field.family === "haiku")?.effective,
+		).toBe("gpt-5.4-mini");
+	});
+
+	it("empty model removes an override and resolver returns factory", async () => {
+		const handlers = createConfigHandlers(
+			makeConfig({ codex: { opus: "gpt-custom" } }),
+		);
+		setProviderModelDefaultOverrides({ codex: { opus: "gpt-custom" } });
+		const response = await handlers.setProviderModelDefaults(
+			request([{ provider: "codex", family: "opus", model: "" }]),
+		);
+		expect(response.status).toBe(200);
+		expect(resolveProviderModelDefault("codex", "opus")).toBe("gpt-5.3-codex");
+	});
+
+	it("rejects unknown providers and families", async () => {
+		const handlers = createConfigHandlers(makeConfig());
+		expect(
+			(
+				await handlers.setProviderModelDefaults(
+					request([{ provider: "nope", family: "opus", model: "x" }]),
+				)
+			).status,
+		).toBe(400);
+		// `fable` now exists in the codex map; the nonexistent family is
+		// now another one, and `fable` must be ACCEPTED.
+		expect(
+			(
+				await handlers.setProviderModelDefaults(
+					request([{ provider: "codex", family: "inexistente", model: "x" }]),
+				)
+			).status,
+		).toBe(400);
+		expect(
+			(
+				await handlers.setProviderModelDefaults(
+					request([
+						{ provider: "codex", family: "fable", model: "gpt-5.6-sol" },
+					]),
+				)
+			).status,
+		).toBe(200);
+	});
+
+	it("resolver returns factory when no override exists", () => {
+		expect(resolveProviderModelDefault("xai", "sonnet")).toBe("grok-4.3");
+	});
+
+	it("GET lists only codex by default (CCFLARE_MODEL_DEFAULTS_PROVIDERS unset)", async () => {
+		delete process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS;
+		const handlers = createConfigHandlers(makeConfig());
+		const response = handlers.getProviderModelDefaults();
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as {
+			providers: Array<{ provider: string }>;
+		};
+		expect(body.providers.map((provider) => provider.provider)).toEqual([
+			"codex",
+		]);
+	});
+
+	it("POST rejects a disabled provider with 400 citing the env var", async () => {
+		delete process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS;
+		const handlers = createConfigHandlers(makeConfig());
+		const response = await handlers.setProviderModelDefaults(
+			request([{ provider: "xai", family: "sonnet", model: "grok-x" }]),
+		);
+		expect(response.status).toBe(400);
+		const body = (await response.json()) as { error?: string };
+		expect(JSON.stringify(body)).toContain(PROVIDER_MODEL_DEFAULTS_ENV_VAR);
+		expect(JSON.stringify(body)).toContain("xai");
+	});
+
+	it("CCFLARE_MODEL_DEFAULTS_PROVIDERS=codex,xai lists and accepts xai again", async () => {
+		process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS = "codex,xai";
+		const handlers = createConfigHandlers(makeConfig());
+		const getBody = (await handlers.getProviderModelDefaults().json()) as {
+			providers: Array<{ provider: string }>;
+		};
+		expect(
+			getBody.providers.map((provider) => provider.provider).sort(),
+		).toEqual(["codex", "xai"]);
+
+		const response = await handlers.setProviderModelDefaults(
+			request([{ provider: "xai", family: "sonnet", model: "grok-x" }]),
+		);
+		expect(response.status).toBe(200);
+		expect(resolveProviderModelDefault("xai", "sonnet")).toBe("grok-x");
+	});
+
+	it("a disabled provider's stored override stays inert and does not affect resolution", async () => {
+		process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS = "codex,xai";
+		const config = makeConfig({ xai: { sonnet: "grok-custom" } });
+		const handlers = createConfigHandlers(config);
+		// A POST to codex already pushes the whole map (filtered by enabled
+		// providers) to the in-memory registry, just as boot does.
+		await handlers.setProviderModelDefaults(
+			request([{ provider: "codex", family: "opus", model: "gpt-custom" }]),
+		);
+		expect(resolveProviderModelDefault("xai", "sonnet")).toBe("grok-custom");
+
+		process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS = "codex";
+		await handlers.setProviderModelDefaults(
+			request([{ provider: "codex", family: "opus", model: "gpt-custom" }]),
+		);
+		expect(resolveProviderModelDefault("xai", "sonnet")).toBe("grok-4.3");
+	});
+
+	it("codex keeps translating even when left out of CCFLARE_MODEL_DEFAULTS_PROVIDERS", async () => {
+		process.env.CCFLARE_MODEL_DEFAULTS_PROVIDERS = "xai";
+		const handlers = createConfigHandlers(makeConfig());
+		const response = await handlers.setProviderModelDefaults(
+			request([{ provider: "codex", family: "opus", model: "gpt-custom" }]),
+		);
+		expect(response.status).toBe(400);
+		expect(resolveProviderModelDefault("codex", "opus")).toBe("gpt-5.3-codex");
+	});
+});

--- a/packages/http-api/src/handlers/config.ts
+++ b/packages/http-api/src/handlers/config.ts
@@ -1,4 +1,8 @@
-import type { Config } from "@better-ccflare/config";
+import {
+	type Config,
+	filterEnabledProviderModelDefaultOverrides,
+	PROVIDER_MODEL_DEFAULTS_ENV_VAR,
+} from "@better-ccflare/config";
 import {
 	DEFAULT_AGENT_MODEL,
 	NETWORK,
@@ -13,6 +17,11 @@ import {
 	errorResponse,
 	jsonResponse,
 } from "@better-ccflare/http-common";
+import {
+	getProviderModelDefaultFactories,
+	getProviderModelDefaultOverrides,
+	setProviderModelDefaultOverrides,
+} from "@better-ccflare/providers";
 import type { APIContext } from "@better-ccflare/types";
 import {
 	allowedModelErrorMessage,
@@ -248,6 +257,106 @@ export function createConfigHandlers(
 			config.setUsageThrottlingFiveHourEnabled(body.fiveHourEnabled);
 			config.setUsageThrottlingWeeklyEnabled(body.weeklyEnabled);
 			return new Response(null, { status: 204 });
+		},
+
+		getProviderModelDefaults: (): Response => {
+			const enabledProviders = new Set(
+				config.getEnabledProviderModelDefaultProviders(),
+			);
+			const factories = getProviderModelDefaultFactories();
+			const overrides = config.getProviderModelDefaultOverrides();
+			return jsonResponse({
+				providers: Object.entries(factories)
+					.filter(([provider]) => enabledProviders.has(provider))
+					.map(([provider, families]) => ({
+						provider,
+						fields: Object.entries(families).map(([family, factory]) => ({
+							family,
+							factory,
+							override: overrides[provider]?.[family] ?? null,
+							effective:
+								getProviderModelDefaultOverrides()[provider]?.[family] ??
+								factory,
+						})),
+					})),
+			});
+		},
+
+		setProviderModelDefaults: async (req: Request): Promise<Response> => {
+			let body: unknown;
+			try {
+				body = await req.json();
+			} catch {
+				return errorResponse(BadRequest("Body must be JSON"));
+			}
+			const entries = (body as { overrides?: unknown } | null)?.overrides;
+			if (!Array.isArray(entries)) {
+				return errorResponse(
+					BadRequest(
+						"Invalid provider model defaults payload: expected 'overrides' array",
+					),
+				);
+			}
+			const factories = getProviderModelDefaultFactories();
+			const enabledProviders = new Set(
+				config.getEnabledProviderModelDefaultProviders(),
+			);
+			const next = config.getProviderModelDefaultOverrides();
+			for (const entry of entries) {
+				const value = entry as {
+					provider?: unknown;
+					family?: unknown;
+					model?: unknown;
+				} | null;
+				const provider =
+					typeof value?.provider === "string" ? value.provider.trim() : "";
+				const family =
+					typeof value?.family === "string" ? value.family.trim() : "";
+				if (!factories[provider])
+					return errorResponse(
+						BadRequest(`Unknown provider: ${provider || "(empty)"}`),
+					);
+				if (!enabledProviders.has(provider))
+					return errorResponse(
+						BadRequest(
+							`Provider "${provider}" is not editable; set ${PROVIDER_MODEL_DEFAULTS_ENV_VAR} to enable it`,
+						),
+					);
+				if (!factories[provider][family])
+					return errorResponse(
+						BadRequest(
+							`Unknown family '${family || "(empty)"}' for provider '${provider}'`,
+						),
+					);
+				if (typeof value?.model !== "string")
+					return errorResponse(BadRequest("model must be a string"));
+				const model = value.model.trim();
+				if (model) {
+					next[provider] = { ...next[provider], [family]: model };
+				} else if (next[provider]) {
+					delete next[provider][family];
+					if (Object.keys(next[provider]).length === 0) delete next[provider];
+				}
+			}
+			config.setProviderModelDefaultOverrides(next);
+			setProviderModelDefaultOverrides(
+				filterEnabledProviderModelDefaultOverrides(enabledProviders, next),
+			);
+			return jsonResponse({
+				providers: Object.entries(factories)
+					.filter(([provider]) => enabledProviders.has(provider))
+					.map(([provider, families]) => ({
+						provider,
+						fields: Object.entries(families).map(([family, factory]) => ({
+							family,
+							factory,
+							override: next[provider]?.[family] ?? null,
+							effective:
+								getProviderModelDefaultOverrides()[provider]?.[family] ??
+								factory,
+						})),
+					})),
+			});
 		},
 
 		getModelCapacityRouting: (): Response => {

--- a/packages/http-api/src/handlers/config.ts
+++ b/packages/http-api/src/handlers/config.ts
@@ -5,6 +5,7 @@ import {
 } from "@better-ccflare/config";
 import {
 	DEFAULT_AGENT_MODEL,
+	KNOWN_PATTERNS,
 	NETWORK,
 	STRATEGIES,
 	type StrategyName,
@@ -301,6 +302,12 @@ export function createConfigHandlers(
 			const enabledProviders = new Set(
 				config.getEnabledProviderModelDefaultProviders(),
 			);
+			// What may be configured is not a function of what has been
+			// discovered. A provider whose defaults come from a live listing has
+			// no compiled map, so validating against one would reject the manual
+			// override exactly when it is needed: before the first successful
+			// listing, or after one stops answering.
+			const knownFamilies = new Set<string>(KNOWN_PATTERNS);
 			const next = config.getProviderModelDefaultOverrides();
 			for (const entry of entries) {
 				const value = entry as {
@@ -312,17 +319,18 @@ export function createConfigHandlers(
 					typeof value?.provider === "string" ? value.provider.trim() : "";
 				const family =
 					typeof value?.family === "string" ? value.family.trim() : "";
-				if (!factories[provider])
-					return errorResponse(
-						BadRequest(`Unknown provider: ${provider || "(empty)"}`),
-					);
+				if (!provider)
+					return errorResponse(BadRequest("Unknown provider: (empty)"));
 				if (!enabledProviders.has(provider))
 					return errorResponse(
 						BadRequest(
 							`Provider "${provider}" is not editable; set ${PROVIDER_MODEL_DEFAULTS_ENV_VAR} to enable it`,
 						),
 					);
-				if (!factories[provider][family])
+				// A family this provider already maps is obviously valid; one it does
+				// not is still valid if ccflare knows the family at all, because the
+				// map may simply not have been read yet.
+				if (!factories[provider]?.[family] && !knownFamilies.has(family))
 					return errorResponse(
 						BadRequest(
 							`Unknown family '${family || "(empty)"}' for provider '${provider}'`,

--- a/packages/http-api/src/handlers/config.ts
+++ b/packages/http-api/src/handlers/config.ts
@@ -266,20 +266,29 @@ export function createConfigHandlers(
 			);
 			const factories = getProviderModelDefaultFactories();
 			const overrides = config.getProviderModelDefaultOverrides();
+			// Enumerated from the configurable surface, not from what has been
+			// discovered. A provider whose defaults come from a live listing has no
+			// compiled map, and driving the screen off that map hid its fields
+			// entirely — leaving the override reachable by API but not by anyone
+			// using the dashboard, which is the only place it is documented.
+			//
+			// `factory` may therefore be null: nothing has been read yet. That is a
+			// state worth showing, not a reason to hide the row.
 			return jsonResponse({
-				providers: Object.entries(factories)
-					.filter(([provider]) => enabledProviders.has(provider))
-					.map(([provider, families]) => ({
-						provider,
-						fields: Object.entries(families).map(([family, factory]) => ({
+				providers: [...enabledProviders].map((provider) => ({
+					provider,
+					fields: KNOWN_PATTERNS.map((family) => {
+						const factory = factories[provider]?.[family] ?? null;
+						return {
 							family,
 							factory,
 							override: overrides[provider]?.[family] ?? null,
 							effective:
 								getProviderModelDefaultOverrides()[provider]?.[family] ??
 								factory,
-						})),
-					})),
+						};
+					}),
+				})),
 			});
 		},
 

--- a/packages/http-api/src/handlers/models.ts
+++ b/packages/http-api/src/handlers/models.ts
@@ -1,6 +1,5 @@
 import { listCatalogueModels } from "@better-ccflare/core";
 import { errorResponse, jsonResponse } from "@better-ccflare/http-common";
-import { CODEX_KNOWN_MODELS } from "@better-ccflare/providers";
 import type { APIContext } from "../types";
 
 /**
@@ -16,7 +15,16 @@ import type { APIContext } from "../types";
  *                gpt-5.3-codex with HTTP 400 while OpenAI lists it happily.
  *                Never collapse this into the other two.
  */
-export type ModelListingSource = "builtin" | "catalog" | "reference";
+export type ModelListingSource =
+	| "builtin"
+	| "catalog"
+	| "reference"
+	/**
+	 * The provider's own listing for THIS account. The only source that can
+	 * tell an entitled model from one the plan does not reach — which is the
+	 * distinction that matters when the choice ends up in a request.
+	 */
+	| "account";
 
 export interface ProviderModelEntry {
 	id: string;
@@ -31,13 +39,20 @@ export interface ProviderModelEntry {
  * and friends.
  */
 const MODELS_DEV_SECTION_BY_PROVIDER: Record<string, string> = {
-	codex: "openai",
+	// Intentionally empty for providers that answer with a listing of their
+	// own. Add an entry only for a provider whose models ccflare cannot ask
+	// for — the catalogue is the fallback of last resort, not a second opinion.
 };
 
-/** Model ids ccflare ships knowledge of, per provider. */
-const BUILTIN_MODELS_BY_PROVIDER: Record<string, readonly string[]> = {
-	codex: CODEX_KNOWN_MODELS,
-};
+/**
+ * Model ids ccflare ships knowledge of, per provider.
+ *
+ * Empty for codex on purpose: the account's own listing supersedes anything
+ * compiled in, and the compiled list contained `gpt-5.3-codex`, which a
+ * ChatGPT-subscription account refuses. A built-in list is a guess about
+ * entitlement, and a guess is exactly what fails silently.
+ */
+const BUILTIN_MODELS_BY_PROVIDER: Record<string, readonly string[]> = {};
 
 /**
  * Providers served by the live Anthropic catalog. Both auth modes (OAuth and
@@ -65,19 +80,63 @@ function isAnthropicProvider(provider: string): boolean {
 export function createModelsHandler(context: APIContext) {
 	return async (url?: URL): Promise<Response> => {
 		const requested = url?.searchParams.get("provider")?.trim() || "";
+		const accountId = url?.searchParams.get("accountId")?.trim() || "";
+
+		// An account's own listing beats every catalogue: it is the only one
+		// that knows what this subscription may call. Providers without such a
+		// listing fall through to the generic path below, unchanged.
+		if (accountId && context.modelCatalog?.codexModels) {
+			const listing = await context.modelCatalog.codexModels(accountId);
+			if (listing) {
+				return jsonResponse({
+					provider: requested,
+					models: listing.models.map((model) => ({
+						id: model.id,
+						displayName: model.displayName,
+						source: "account" as const,
+						description: model.description,
+						contextWindow: model.contextWindow,
+						supersededBy: model.supersededBy,
+					})),
+					fetchedAt: listing.fetchedAt,
+					source: listing.source,
+					...(listing.source === "shared"
+						? {
+								warning:
+									"This account cannot read its own model list, so this is " +
+									"another account of the same provider. Accounts on " +
+									"different plans can differ.",
+							}
+						: {}),
+				});
+			}
+		}
 
 		if (requested === "" || isAnthropicProvider(requested)) {
 			if (!context.modelCatalog) {
 				return errorResponse("Model catalog is not available");
 			}
 			const catalog = await context.modelCatalog.get();
+			// `fallback` means an on-disk copy or the list bundled into the binary
+			// answered — not the provider. After a restart that would make the
+			// field look answered when nothing has been read.
+			const live = catalog.source === "live";
 			return jsonResponse({
-				...catalog,
 				provider: requested || "anthropic",
-				models: catalog.models.map((model) => ({
-					...model,
-					source: "catalog" as const,
-				})),
+				models: live
+					? catalog.models.map((model) => ({
+							...model,
+							source: "catalog" as const,
+						}))
+					: [],
+				fetchedAt: catalog.fetchedAt,
+				source: live ? "live" : "unavailable",
+				...(live
+					? {}
+					: {
+							warning:
+								"No listing read from the provider yet. The field takes any model id meanwhile.",
+						}),
 			});
 		}
 

--- a/packages/http-api/src/router.ts
+++ b/packages/http-api/src/router.ts
@@ -399,6 +399,12 @@ export class APIRouter {
 		this.handlers.set("POST:/api/config/usage-throttling", (req) =>
 			configHandlers.setUsageThrottling(req),
 		);
+		this.handlers.set("GET:/api/config/provider-model-defaults", () =>
+			configHandlers.getProviderModelDefaults(),
+		);
+		this.handlers.set("POST:/api/config/provider-model-defaults", (req) =>
+			configHandlers.setProviderModelDefaults(req),
+		);
 		this.handlers.set("GET:/api/config/model-capacity-routing", () =>
 			configHandlers.getModelCapacityRouting(),
 		);
@@ -715,6 +721,7 @@ export class APIRouter {
 					modelFallbacksHandler(req, accountId),
 				)(req, url);
 			}
+
 
 			// Account removal
 			if (parts.length === 4 && method === "DELETE") {

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -12,6 +12,7 @@ export * from "./minimax-usage-fetcher";
 export * from "./nanogpt-usage-fetcher";
 // Export OAuth utilities
 export * from "./oauth";
+export * from "./provider-model-defaults";
 // Factory functions for creating providers
 export {
 	type AnthropicCompatibleConfig,

--- a/packages/providers/src/provider-model-defaults.ts
+++ b/packages/providers/src/provider-model-defaults.ts
@@ -1,0 +1,53 @@
+export type ProviderModelDefaultOverrides = Record<
+	string,
+	Record<string, string>
+>;
+
+const factoryDefaults: ProviderModelDefaultOverrides = {};
+let overrides: ProviderModelDefaultOverrides = {};
+
+function copyMappings(
+	mappings: ProviderModelDefaultOverrides,
+): ProviderModelDefaultOverrides {
+	const copied: ProviderModelDefaultOverrides = {};
+	for (const [provider, families] of Object.entries(mappings)) {
+		const values: Record<string, string> = {};
+		for (const [family, model] of Object.entries(families)) {
+			if (typeof model === "string" && model.trim())
+				values[family] = model.trim();
+		}
+		if (Object.keys(values).length > 0) copied[provider] = values;
+	}
+	return copied;
+}
+
+/** Register a provider-owned built-in map without coupling providers to config. */
+export function registerProviderModelDefaultFactory(
+	provider: string,
+	mappings: Record<string, string>,
+): void {
+	factoryDefaults[provider] = { ...mappings };
+}
+
+/** Replace the process-wide overrides after config load or a successful POST. */
+export function setProviderModelDefaultOverrides(
+	value: ProviderModelDefaultOverrides | undefined,
+): void {
+	overrides = copyMappings(value ?? {});
+}
+
+/** Factory first, then a configured override when that exact family has one. */
+export function resolveProviderModelDefault(
+	provider: string,
+	family: string,
+): string | undefined {
+	return overrides[provider]?.[family] ?? factoryDefaults[provider]?.[family];
+}
+
+export function getProviderModelDefaultFactories(): ProviderModelDefaultOverrides {
+	return copyMappings(factoryDefaults);
+}
+
+export function getProviderModelDefaultOverrides(): ProviderModelDefaultOverrides {
+	return copyMappings(overrides);
+}

--- a/packages/providers/src/provider-model-defaults.ts
+++ b/packages/providers/src/provider-model-defaults.ts
@@ -36,16 +36,104 @@ export function setProviderModelDefaultOverrides(
 	overrides = copyMappings(value ?? {});
 }
 
-/** Factory first, then a configured override when that exact family has one. */
+/**
+ * Defaults derived from what an account itself reported it can serve.
+ *
+ * Keyed by account because two accounts of the same provider can be on
+ * different plans, and the whole point is to stop guessing on their behalf. In
+ * memory only: it is a projection of a listing already cached on disk, so
+ * persisting it again would create a second thing to invalidate.
+ */
+const derivedByAccount = new Map<string, Record<string, string>>();
+
+/** Same, but for the provider as a whole — see setDerived… below. */
+const derivedByProvider: ProviderModelDefaultOverrides = {};
+
+function derivedKey(provider: string, accountId: string): string {
+	return `${provider}\0${accountId}`;
+}
+
+/**
+ * Record the family -> model map that an account's own listing implies. Called
+ * whenever that listing is read, which is what keeps the defaults current
+ * without anyone maintaining a table.
+ */
+export function setDerivedProviderModelDefaults(
+	provider: string,
+	accountId: string,
+	families: Record<string, string>,
+): void {
+	derivedByAccount.set(derivedKey(provider, accountId), { ...families });
+	// The same listing also refreshes the provider-wide default: what the
+	// settings screen shows, and what an account without its own listing falls
+	// back to. Safe because the models this resolves to — the provider's top
+	// priorities — are the ones its own payload marks as available in every
+	// plan; the ones that vary by plan sit far below and are never picked.
+	//
+	// Kept apart from `factoryDefaults` on purpose: providers with no dynamic
+	// source of their own (xai, qwen) still rely on their compiled map, and
+	// overwriting that would break them.
+	derivedByProvider[provider] = { ...families };
+}
+
+/** True when this account already has a derived map — no listing needed. */
+export function hasDerivedProviderModelDefaults(
+	provider: string,
+	accountId: string,
+): boolean {
+	return derivedByAccount.has(derivedKey(provider, accountId));
+}
+
+/** Test seam: both derived maps are process-wide and leak between cases. */
+export function clearDerivedProviderModelDefaults(): void {
+	derivedByAccount.clear();
+	for (const provider of Object.keys(derivedByProvider)) {
+		delete derivedByProvider[provider];
+	}
+}
+
+/**
+ * Order of authority, most specific first:
+ *
+ *   1. an operator's explicit override for that family
+ *   2. what THIS account's own listing implies
+ *   3. the provider's built-in map
+ *
+ * The built-in map is last for a reason: it is a guess frozen at build time, and
+ * a guess about which models an account may call is exactly the thing that fails
+ * silently when a plan does not include one.
+ */
 export function resolveProviderModelDefault(
 	provider: string,
 	family: string,
+	accountId?: string | null,
 ): string | undefined {
-	return overrides[provider]?.[family] ?? factoryDefaults[provider]?.[family];
+	const derived = accountId
+		? derivedByAccount.get(derivedKey(provider, accountId))?.[family]
+		: undefined;
+	return (
+		overrides[provider]?.[family] ??
+		derived ??
+		derivedByProvider[provider]?.[family] ??
+		factoryDefaults[provider]?.[family]
+	);
 }
 
+/**
+ * What the settings screen calls the default. For a provider whose models
+ * are discovered, that is the derived map; for one with only a compiled map,
+ * it is that map. A provider can have both, and the discovered one wins,
+ * because it is the one that reflects reality.
+ */
 export function getProviderModelDefaultFactories(): ProviderModelDefaultOverrides {
-	return copyMappings(factoryDefaults);
+	const merged: ProviderModelDefaultOverrides = {};
+	for (const [provider, families] of Object.entries(factoryDefaults)) {
+		merged[provider] = { ...families };
+	}
+	for (const [provider, families] of Object.entries(derivedByProvider)) {
+		merged[provider] = { ...(merged[provider] ?? {}), ...families };
+	}
+	return copyMappings(merged);
 }
 
 export function getProviderModelDefaultOverrides(): ProviderModelDefaultOverrides {

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import type { Account } from "@better-ccflare/types";
+import {
+	clearDerivedProviderModelDefaults,
+	setDerivedProviderModelDefaults,
+} from "../../provider-model-defaults";
 import { fetchCodexUsageOnDemand } from "./on-demand-fetch";
 import {
 	CODEX_CACHE_KEY_MODE_ENV,
@@ -2271,7 +2275,14 @@ describe("CodexProvider.transformRequestBody", () => {
 		});
 	});
 
-	it("maps sonnet-family models to the default Codex model", async () => {
+	// The compiled default map is gone: it could not know what a subscription
+	// is entitled to, and pointing sonnet at a model the plan refuses is how a
+	// routine request came back 400. With no account — hence no listing — the
+	// family is left alone rather than guessed at.
+	it("leaves a sonnet-family model alone when nothing knows better", async () => {
+		// The derived map is process-wide: without this, a case that seeded it
+		// earlier would make this one pass or fail for the wrong reason.
+		clearDerivedProviderModelDefaults();
 		const provider = new CodexProvider();
 		const request = new Request("https://example.com/v1/messages", {
 			method: "POST",
@@ -2286,14 +2297,13 @@ describe("CodexProvider.transformRequestBody", () => {
 		const transformed = await provider.transformRequestBody(request, undefined);
 		const body = await transformed.json();
 
-		expect(body.model).toBe("gpt-5.3-codex");
+		expect(body.model).toBe("claude-3-7-sonnet");
 	});
 
-	// Regression: the fable entry alone is not enough for codex. mapModel
-	// resolves by substring and had no fable branch, so the map entry would
-	// never be looked up and the Claude model id would reach the upstream
-	// verbatim.
-	it("maps fable-family models to the codex default", async () => {
+	// Regression: mapModel translates by substring and had no branch for
+	// `fable`, so the family was not resolvable at all. It is resolvable now —
+	// what it resolves TO comes from the account, not from a constant.
+	it("resolves a fable-family model from the account listing", async () => {
 		const provider = new CodexProvider();
 		const request = new Request("https://example.com/v1/messages", {
 			method: "POST",
@@ -2305,10 +2315,22 @@ describe("CodexProvider.transformRequestBody", () => {
 			}),
 		});
 
-		const transformed = await provider.transformRequestBody(request, undefined);
+		// What the account's own listing implied, recorded when it was read.
+		setDerivedProviderModelDefaults("codex", "acc-1", {
+			fable: "gpt-5.6-sol",
+			opus: "gpt-5.6-sol",
+			sonnet: "gpt-5.6-terra",
+			haiku: "gpt-5.6-luna",
+		});
+		const account = {
+			id: "acc-1",
+			provider: "codex",
+		} as Parameters<typeof provider.transformRequestBody>[1];
+
+		const transformed = await provider.transformRequestBody(request, account);
 		const body = await transformed.json();
 
-		expect(body.model).toBe("gpt-5.3-codex");
+		expect(body.model).toBe("gpt-5.6-sol");
 	});
 
 	it("uses account sonnet mapping for sonnet-family models", async () => {
@@ -2355,9 +2377,21 @@ describe("CodexProvider.transformRequestBody", () => {
 		expect(body.model).toBe("gpt-5.3-codex");
 	});
 
-	it("uses default Codex mapping for families missing from account mappings", async () => {
+	// Before, this asserted the compiled fallback. Now the fallback IS the
+	// account's listing, so the test says which model that listing implied.
+	it("fills families missing from the account mappings from its listing", async () => {
+		setDerivedProviderModelDefaults("codex", "acc-1", {
+			fable: "gpt-5.6-sol",
+			opus: "gpt-5.6-sol",
+			sonnet: "gpt-5.6-terra",
+			haiku: "gpt-5.6-luna",
+		});
 		const provider = new CodexProvider();
 		const account = {
+			// The derived map is keyed by account: two accounts of the same
+			// provider can be on different plans, so there is nothing to look up
+			// without an id.
+			id: "acc-1",
 			model_mappings: JSON.stringify({ sonnet: "gpt-5.3-codex" }),
 		} as Parameters<typeof provider.transformRequestBody>[1];
 		const request = new Request("https://example.com/v1/messages", {
@@ -2373,7 +2407,9 @@ describe("CodexProvider.transformRequestBody", () => {
 		const transformed = await provider.transformRequestBody(request, account);
 		const body = await transformed.json();
 
-		expect(body.model).toBe("gpt-5.4-mini");
+		// The account maps some families explicitly; the ones it does not are
+		// filled from its own listing, never from a constant.
+		expect(body.model).toBe("gpt-5.6-luna");
 	});
 
 	it("passes through unknown model names unchanged", async () => {

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -113,7 +113,14 @@ const DEFAULT_MODEL_MAP: Record<string, string> = {
 	haiku: "gpt-5.4-mini",
 };
 
-registerProviderModelDefaultFactory("codex", DEFAULT_MODEL_MAP);
+// Deliberately NOT registered as a factory default any more.
+//
+// A map compiled at build time cannot know what a subscription is entitled
+// to: this one pointed `opus` and `sonnet` at `gpt-5.3-codex`, which a
+// ChatGPT-plan account refuses with HTTP 400 — the incident this whole line
+// of work came from. The account's own listing knows, so it decides; the map
+// below survives only as documentation of the shape and for the tests that
+// exercise family resolution.
 
 // Synced from the Codex CLI model cache (~/.codex/models_cache.json,
 // codex-cli 0.144.1). Missing entries mean no context_window block is
@@ -718,14 +725,23 @@ export class CodexProvider extends BaseProvider {
 
 		const lower = anthropicModel.toLowerCase();
 		// Precedence: combo slot -> account.model_mappings -> global override -> factory map.
+		// Resolved per account: the account's own listing is what decides, and
+		// two accounts of this provider can be on different plans.
+		const id = account?.id;
 		if (lower.includes("fable"))
-			return resolveProviderModelDefault("codex", "fable") ?? anthropicModel;
+			return (
+				resolveProviderModelDefault("codex", "fable", id) ?? anthropicModel
+			);
 		if (lower.includes("haiku"))
-			return resolveProviderModelDefault("codex", "haiku") ?? anthropicModel;
+			return (
+				resolveProviderModelDefault("codex", "haiku", id) ?? anthropicModel
+			);
 		if (lower.includes("sonnet"))
-			return resolveProviderModelDefault("codex", "sonnet") ?? anthropicModel;
+			return (
+				resolveProviderModelDefault("codex", "sonnet", id) ?? anthropicModel
+			);
 		if (lower.includes("opus"))
-			return resolveProviderModelDefault("codex", "opus") ?? anthropicModel;
+			return resolveProviderModelDefault("codex", "opus", id) ?? anthropicModel;
 		return anthropicModel;
 	}
 

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -12,6 +12,10 @@ import {
 } from "@better-ccflare/openai-formats";
 import type { Account } from "@better-ccflare/types";
 import { BaseProvider } from "../../base";
+import {
+	registerProviderModelDefaultFactory,
+	resolveProviderModelDefault,
+} from "../../provider-model-defaults";
 import type { RateLimitInfo, TokenRefreshResult } from "../../types";
 import { normalizeCodexInputUsage } from "./usage";
 
@@ -108,6 +112,8 @@ const DEFAULT_MODEL_MAP: Record<string, string> = {
 	sonnet: "gpt-5.3-codex",
 	haiku: "gpt-5.4-mini",
 };
+
+registerProviderModelDefaultFactory("codex", DEFAULT_MODEL_MAP);
 
 // Synced from the Codex CLI model cache (~/.codex/models_cache.json,
 // codex-cli 0.144.1). Missing entries mean no context_window block is
@@ -712,10 +718,14 @@ export class CodexProvider extends BaseProvider {
 
 		const lower = anthropicModel.toLowerCase();
 		// Precedence: combo slot -> account.model_mappings -> global override -> factory map.
-		if (lower.includes("fable")) return DEFAULT_MODEL_MAP.fable;
-		if (lower.includes("haiku")) return DEFAULT_MODEL_MAP.haiku;
-		if (lower.includes("sonnet")) return DEFAULT_MODEL_MAP.sonnet;
-		if (lower.includes("opus")) return DEFAULT_MODEL_MAP.opus;
+		if (lower.includes("fable"))
+			return resolveProviderModelDefault("codex", "fable") ?? anthropicModel;
+		if (lower.includes("haiku"))
+			return resolveProviderModelDefault("codex", "haiku") ?? anthropicModel;
+		if (lower.includes("sonnet"))
+			return resolveProviderModelDefault("codex", "sonnet") ?? anthropicModel;
+		if (lower.includes("opus"))
+			return resolveProviderModelDefault("codex", "opus") ?? anthropicModel;
 		return anthropicModel;
 	}
 

--- a/packages/providers/src/providers/index.ts
+++ b/packages/providers/src/providers/index.ts
@@ -17,6 +17,7 @@ export {
 	CODEX_DEFAULT_ENDPOINT,
 	CODEX_KNOWN_MODELS,
 	CODEX_MODEL_CONTEXT_WINDOWS,
+	CODEX_VERSION,
 	CodexOAuthProvider,
 	CodexProvider,
 	fetchCodexUsageOnDemand,

--- a/packages/providers/src/providers/qwen/provider.ts
+++ b/packages/providers/src/providers/qwen/provider.ts
@@ -1,6 +1,10 @@
 import { Logger } from "@better-ccflare/logger";
 import type { OpenAIRequest } from "@better-ccflare/openai-formats";
 import type { Account } from "@better-ccflare/types";
+import {
+	registerProviderModelDefaultFactory,
+	resolveProviderModelDefault,
+} from "../../provider-model-defaults";
 import type { RateLimitInfo } from "../../types";
 import { OpenAICompatibleProvider } from "../openai/provider";
 
@@ -28,6 +32,17 @@ const QWEN_MODEL_MAPPINGS = {
 	sonnet: "coder-model",
 	haiku: "coder-model",
 };
+
+registerProviderModelDefaultFactory("qwen", QWEN_MODEL_MAPPINGS);
+
+function resolvedQwenModelMappings(): Record<string, string> {
+	return Object.fromEntries(
+		Object.entries(QWEN_MODEL_MAPPINGS).map(([family, factory]) => [
+			family,
+			resolveProviderModelDefault("qwen", family) ?? factory,
+		]),
+	);
+}
 
 // Lines in the Claude Code system prompt that are environment/model-specific
 // and should be dropped entirely when proxying to Qwen.
@@ -155,7 +170,7 @@ export class QwenProvider extends OpenAICompatibleProvider {
 		return {
 			...account,
 			model_mappings:
-				account.model_mappings ?? JSON.stringify(QWEN_MODEL_MAPPINGS),
+				account.model_mappings ?? JSON.stringify(resolvedQwenModelMappings()),
 		};
 	}
 

--- a/packages/providers/src/providers/xai/provider.ts
+++ b/packages/providers/src/providers/xai/provider.ts
@@ -2,6 +2,10 @@ import { getEndpointUrl, validateEndpointUrl } from "@better-ccflare/core";
 import { Logger } from "@better-ccflare/logger";
 import type { OpenAIRequest } from "@better-ccflare/openai-formats";
 import type { Account } from "@better-ccflare/types";
+import {
+	registerProviderModelDefaultFactory,
+	resolveProviderModelDefault,
+} from "../../provider-model-defaults";
 import type { TokenRefreshResult } from "../../types";
 import { OpenAICompatibleProvider } from "../openai/provider";
 
@@ -17,6 +21,17 @@ export const XAI_MODEL_MAPPINGS = {
 	haiku: "grok-4.3",
 	fable: "grok-4.3",
 };
+
+registerProviderModelDefaultFactory("xai", XAI_MODEL_MAPPINGS);
+
+function resolvedXaiModelMappings(): Record<string, string> {
+	return Object.fromEntries(
+		Object.entries(XAI_MODEL_MAPPINGS).map(([family, factory]) => [
+			family,
+			resolveProviderModelDefault("xai", family) ?? factory,
+		]),
+	);
+}
 
 export class XaiProvider extends OpenAICompatibleProvider {
 	override name = "xai";
@@ -128,7 +143,7 @@ export class XaiProvider extends OpenAICompatibleProvider {
 			...account,
 			custom_endpoint: account.custom_endpoint ?? XAI_DEFAULT_ENDPOINT,
 			model_mappings:
-				account.model_mappings ?? JSON.stringify(XAI_MODEL_MAPPINGS),
+				account.model_mappings ?? JSON.stringify(resolvedXaiModelMappings()),
 		};
 	}
 

--- a/packages/proxy/src/__tests__/codex-model-catalog.test.ts
+++ b/packages/proxy/src/__tests__/codex-model-catalog.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import type { Account } from "@better-ccflare/types";
+import {
+	clearCodexModelCacheForTests,
+	getCodexModels,
+} from "../codex-model-catalog";
+import type { ProxyContext } from "../handlers/proxy-types";
+
+/**
+ * The per-subscription model list, and what happens when OpenAI stops
+ * answering.
+ *
+ * This endpoint is not part of OpenAI's public REST reference — it is what the
+ * Codex CLI itself calls — so the interesting case is not the happy path. It is
+ * the day it changes shape or goes away: the answer must then be the last list
+ * OpenAI gave for that account, not a generic catalogue that lists models the
+ * subscription cannot call.
+ */
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "acc-codex",
+		name: "codex-account",
+		provider: "codex",
+		api_key: null,
+		refresh_token: "rt",
+		access_token: "at",
+		expires_at: Date.now() + 3_600_000,
+		created_at: Date.now(),
+		...overrides,
+	} as Account;
+}
+
+function makeCtx(account: Account | null): ProxyContext {
+	return {
+		dbOps: {
+			getAccount: async () => account,
+		},
+		refreshInFlight: new Map(),
+	} as unknown as ProxyContext;
+}
+
+// Shaped after what a real subscription account returned on 2026-08-09,
+// including the two entries OpenAI marks `hide` and the deprecation notices.
+const LIVE_BODY = {
+	models: [
+		{
+			slug: "gpt-5.6-sol",
+			display_name: "GPT-5.6-Sol",
+			description: "Latest frontier agentic coding model.",
+			context_window: 272_000,
+			visibility: "list",
+			priority: 1,
+		},
+		{
+			slug: "gpt-5.6-sol-wm",
+			display_name: "GPT-5.6-Sol-WM",
+			description: "Work Mode routing alias for GPT-5.6 Sol.",
+			visibility: "hide",
+			priority: 1,
+		},
+		{
+			slug: "gpt-5.4-mini",
+			display_name: "GPT-5.4-Mini",
+			visibility: "list",
+			priority: 23,
+			upgrade: { model: "gpt-5.6-luna" },
+		},
+		{
+			slug: "codex-auto-review",
+			display_name: "Codex Auto Review",
+			visibility: "hide",
+			priority: 43,
+		},
+		// Duplicated and empty ids do not become entries.
+		{ slug: "gpt-5.6-sol", visibility: "list" },
+		{ slug: "  ", visibility: "list" },
+	],
+};
+
+let originalFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+	originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+describe("getCodexModels", () => {
+	it("reads the subscription's own list and keeps the useful fields", async () => {
+		globalThis.fetch = (async () =>
+			new Response(JSON.stringify(LIVE_BODY), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			})) as typeof globalThis.fetch;
+
+		const listing = await getCodexModels("acc-codex", makeCtx(makeAccount()));
+
+		expect(listing?.source).toBe("live");
+		expect(listing?.models.map((m) => m.id)).toEqual([
+			"gpt-5.6-sol",
+			"gpt-5.4-mini",
+		]);
+		expect(listing?.models[0].contextWindow).toBe(272_000);
+		// OpenAI's own ordering, not alphabetical — which would have opened the
+		// list with the mini model.
+		expect(listing?.models[0].id).toBe("gpt-5.6-sol");
+		expect(listing?.models[0].description).toContain("frontier");
+		expect(listing?.models[1].displayName).toBe("GPT-5.4-Mini");
+	});
+
+	// The payload marks routing aliases and internal models as `hide`. Reading
+	// the flag beats matching on the name: the next alias OpenAI ships is
+	// excluded without anyone having to learn its suffix.
+	it("leaves out the entries OpenAI marks as hidden", async () => {
+		globalThis.fetch = (async () =>
+			new Response(JSON.stringify(LIVE_BODY), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			})) as typeof globalThis.fetch;
+
+		const listing = await getCodexModels("acc-codex", makeCtx(makeAccount()));
+		const ids = listing?.models.map((m) => m.id) ?? [];
+
+		expect(ids).not.toContain("gpt-5.6-sol-wm");
+		expect(ids).not.toContain("codex-auto-review");
+		expect(ids).toEqual(["gpt-5.6-sol", "gpt-5.4-mini"]);
+	});
+
+	// A model on its way out is a choice someone will have to undo later.
+	it("carries the replacement OpenAI names for a deprecated model", async () => {
+		globalThis.fetch = (async () =>
+			new Response(JSON.stringify(LIVE_BODY), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			})) as typeof globalThis.fetch;
+
+		const listing = await getCodexModels("acc-codex", makeCtx(makeAccount()));
+		const mini = listing?.models.find((m) => m.id === "gpt-5.4-mini");
+
+		expect(mini?.supersededBy).toBe("gpt-5.6-luna");
+		expect(listing?.models[0].supersededBy).toBeNull();
+	});
+
+	// The reason the cache exists.
+	it("serves the last successful list when OpenAI stops answering", async () => {
+		globalThis.fetch = (async () =>
+			new Response(JSON.stringify(LIVE_BODY), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			})) as typeof globalThis.fetch;
+		await getCodexModels("acc-codex", makeCtx(makeAccount()));
+
+		globalThis.fetch = (async () =>
+			new Response("nope", { status: 500 })) as typeof globalThis.fetch;
+		const listing = await getCodexModels("acc-codex", makeCtx(makeAccount()));
+
+		expect(listing?.source).toBe("cached");
+		expect(listing?.models.map((m) => m.id)).toEqual([
+			"gpt-5.6-sol",
+			"gpt-5.4-mini",
+		]);
+	});
+
+	// Measured on real accounts: two of three answer HTTP 401 here while serving
+	// traffic perfectly. Their own list will never exist, and an empty field
+	// forever is worse than another account's list plainly labelled as such.
+	it("inherits from another account of the provider when it cannot read", async () => {
+		globalThis.fetch = (async () =>
+			new Response(JSON.stringify(LIVE_BODY), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			})) as typeof globalThis.fetch;
+		await getCodexModels("acc-codex", makeCtx(makeAccount()));
+
+		globalThis.fetch = (async () =>
+			new Response("nope", { status: 401 })) as typeof globalThis.fetch;
+		const listing = await getCodexModels(
+			"acc-blind",
+			makeCtx(makeAccount({ id: "acc-blind" })),
+		);
+
+		expect(listing?.source).toBe("shared");
+		expect(listing?.borrowedFrom).toBe("acc-codex");
+		expect(listing?.models.map((m) => m.id)).toEqual([
+			"gpt-5.6-sol",
+			"gpt-5.4-mini",
+		]);
+	});
+
+	it("returns nothing when no account of the provider has ever read", async () => {
+		clearCodexModelCacheForTests();
+		globalThis.fetch = (async () =>
+			new Response("nope", { status: 401 })) as typeof globalThis.fetch;
+
+		expect(
+			await getCodexModels(
+				"acc-never-read",
+				makeCtx(makeAccount({ id: "acc-never-read" })),
+			),
+		).toBeNull();
+	});
+
+	it("refuses an account that is not a Codex account", async () => {
+		const listing = await getCodexModels(
+			"acc-codex",
+			makeCtx(makeAccount({ provider: "anthropic" })),
+		);
+
+		expect(listing).toBeNull();
+	});
+
+	it("returns nothing for an account that does not exist", async () => {
+		expect(await getCodexModels("ghost", makeCtx(null))).toBeNull();
+	});
+});

--- a/packages/proxy/src/__tests__/codex-model-catalog.test.ts
+++ b/packages/proxy/src/__tests__/codex-model-catalog.test.ts
@@ -190,6 +190,38 @@ describe("getCodexModels", () => {
 		]);
 	});
 
+	// A 200 carrying nothing usable is not an answer. Recording it would mark the
+	// account as resolved and stop every later attempt, freezing it with no
+	// defaults because of one odd response.
+	it("treats a listing with no usable models as a failure", async () => {
+		clearCodexModelCacheForTests();
+		globalThis.fetch = (async () =>
+			new Response(JSON.stringify({ models: [] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			})) as typeof globalThis.fetch;
+
+		expect(
+			await getCodexModels(
+				"acc-empty",
+				makeCtx(makeAccount({ id: "acc-empty" })),
+			),
+		).toBeNull();
+
+		// And the account is not stuck: a later real answer still lands.
+		globalThis.fetch = (async () =>
+			new Response(JSON.stringify(LIVE_BODY), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			})) as typeof globalThis.fetch;
+		const listing = await getCodexModels(
+			"acc-empty",
+			makeCtx(makeAccount({ id: "acc-empty" })),
+		);
+
+		expect(listing?.source).toBe("live");
+	});
+
 	it("returns nothing when no account of the provider has ever read", async () => {
 		clearCodexModelCacheForTests();
 		globalThis.fetch = (async () =>

--- a/packages/proxy/src/codex-model-catalog.ts
+++ b/packages/proxy/src/codex-model-catalog.ts
@@ -262,6 +262,12 @@ export async function getCodexModels(
 
 	try {
 		const models = await fetchLive(account, ctx);
+		// An answer with nothing usable in it is not an answer. Recording it
+		// would mark the account as resolved and stop every later attempt, so a
+		// single odd response would freeze the account with no defaults at all.
+		if (models.length === 0) {
+			throw new Error("the listing came back with no usable models");
+		}
 		const listing: CodexModelListing = {
 			accountId,
 			models,

--- a/packages/proxy/src/codex-model-catalog.ts
+++ b/packages/proxy/src/codex-model-catalog.ts
@@ -1,0 +1,298 @@
+import { Logger } from "@better-ccflare/logger";
+import {
+	CODEX_VERSION,
+	hasDerivedProviderModelDefaults,
+	setDerivedProviderModelDefaults,
+} from "@better-ccflare/providers";
+import type { Account } from "@better-ccflare/types";
+import type { ProxyContext } from "./handlers/proxy-types";
+import { getValidAccessToken } from "./handlers/token-manager";
+
+const log = new Logger("CodexModelCatalog");
+
+/**
+ * Models a Codex account can actually call, straight from OpenAI.
+ *
+ * `api.openai.com/v1/models` is the documented listing, and it is the WRONG
+ * question here: it answers for API-key organisations and returns HTTP 403
+ * (`Missing scopes: api.model.read`) for a ChatGPT-subscription token. The
+ * endpoint below is what the Codex CLI itself calls, and it answers per
+ * subscription — measured against a real account, `gpt-5.3-codex` is absent
+ * from it, which is exactly the model whose refusal started this whole line of
+ * work.
+ *
+ * It is not part of OpenAI's public REST reference, so it is treated as
+ * best-effort: every success is written to disk, and a later failure serves the
+ * last known-good list rather than a generic catalogue that would happily list
+ * models this plan cannot call.
+ */
+export interface CodexModelEntry {
+	id: string;
+	displayName: string;
+	description: string | null;
+	contextWindow: number | null;
+	/**
+	 * Model OpenAI says will replace this one, when it has announced a
+	 * deprecation. Worth surfacing: picking a model that is on its way out is
+	 * a decision someone will have to undo.
+	 */
+	supersededBy: string | null;
+}
+
+export interface CodexModelListing {
+	accountId: string;
+	models: CodexModelEntry[];
+	fetchedAt: number;
+	/**
+	 * "live" straight from OpenAI, "cached" this account's own earlier read,
+	 * "shared" another account of the same provider — see the note on
+	 * providerWide below.
+	 */
+	source: "live" | "cached" | "shared";
+	/** Account the list actually came from, when it was not this one. */
+	borrowedFrom?: string;
+}
+
+const FETCH_TIMEOUT_MS = 15_000;
+
+/**
+ * Last good listing per account, for this process only.
+ *
+ * Deliberately not written to disk: a snapshot that outlives the process is a
+ * second place where the truth can quietly go stale. A failed refresh keeps
+ * serving what is already here; a restart starts empty and stays empty until
+ * a read succeeds, which is honest about what is actually known.
+ */
+const lastGood = new Map<string, CodexModelListing>();
+
+/**
+ * The last listing any account of this provider managed to read.
+ *
+ * Two of three measured accounts answer HTTP 401 on the models endpoint while
+ * serving traffic perfectly — for them, their own list will never exist. Login
+ * accounts of one provider generally see the same models, so one account's
+ * read is a far better answer than nothing.
+ *
+ * "Generally" is doing work in that sentence: the provider's payload carries
+ * `available_in_plans`, so different plans can differ. A borrowed list is
+ * therefore labelled as borrowed rather than passed off as this account's own.
+ */
+let providerWide: CodexModelListing | null = null;
+
+/** Test seam: both registries are process-wide and leak between cases. */
+export function clearCodexModelCacheForTests(): void {
+	lastGood.clear();
+	providerWide = null;
+}
+
+function readCache(accountId: string): CodexModelListing | null {
+	const own = lastGood.get(accountId);
+	if (own) return { ...own, source: "cached" };
+	// Nothing of this account's own: fall back to whatever another account of
+	// the same provider read, labelled so nobody mistakes it for this one's.
+	if (providerWide) {
+		return {
+			...providerWide,
+			accountId,
+			source: "shared",
+			borrowedFrom: providerWide.accountId,
+		};
+	}
+	return null;
+}
+
+function writeCache(listing: CodexModelListing): void {
+	lastGood.set(listing.accountId, listing);
+	providerWide = listing;
+}
+
+interface CodexModelsResponse {
+	models?: Array<{
+		slug?: string;
+		display_name?: string;
+		description?: string;
+		context_window?: number;
+		/** "list" to be offered; "hide" for routing aliases and internal models. */
+		visibility?: string;
+		/** OpenAI's own ordering, frontier first. */
+		priority?: number;
+		upgrade?: { model?: string } | null;
+	}>;
+}
+
+function normalize(body: CodexModelsResponse): CodexModelEntry[] {
+	const seen = new Set<string>();
+	const entries: Array<CodexModelEntry & { priority: number }> = [];
+	for (const raw of body.models ?? []) {
+		const id = typeof raw.slug === "string" ? raw.slug.trim() : "";
+		if (!id || seen.has(id)) continue;
+
+		// OpenAI marks what is meant to be offered. Two of the eight entries a
+		// live account returns are `hide`: a Work Mode routing alias and the
+		// automatic review model — neither is something to pick in a mapping.
+		// Reading the flag rather than matching on the name means the next alias
+		// OpenAI ships is excluded without anyone learning its suffix.
+		if (raw.visibility && raw.visibility !== "list") continue;
+
+		seen.add(id);
+		entries.push({
+			id,
+			priority: typeof raw.priority === "number" ? raw.priority : 1_000,
+			supersededBy:
+				typeof raw.upgrade?.model === "string" ? raw.upgrade.model : null,
+			displayName:
+				typeof raw.display_name === "string" && raw.display_name.trim()
+					? raw.display_name
+					: id,
+			description:
+				typeof raw.description === "string" && raw.description.trim()
+					? raw.description
+					: null,
+			contextWindow:
+				typeof raw.context_window === "number" ? raw.context_window : null,
+		});
+	}
+
+	// OpenAI's own ordering puts the frontier models first; alphabetical would
+	// open the list with `codex-auto-review` and `gpt-5.4-mini`.
+	return entries
+		.sort((a, b) => a.priority - b.priority)
+		.map(({ priority: _priority, ...entry }) => entry);
+}
+
+/**
+ * One live call for one account. The token comes from the normal refresh path,
+ * because a stored access token is routinely stale — measured: two of three
+ * accounts answered 401 with the token as stored, and 200 once refreshed.
+ */
+async function fetchLive(
+	account: Account,
+	ctx: ProxyContext,
+): Promise<CodexModelEntry[]> {
+	const accessToken = await getValidAccessToken(account, ctx);
+	if (!accessToken) throw new Error("no access token for this account");
+
+	const url = `https://chatgpt.com/backend-api/codex/models?client_version=${encodeURIComponent(CODEX_VERSION)}`;
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+	try {
+		const response = await fetch(url, {
+			method: "GET",
+			headers: {
+				authorization: `Bearer ${accessToken}`,
+				accept: "application/json",
+				// The endpoint rejects the request without a client version, and
+				// identifies the caller by originator — mirroring the CLI keeps us
+				// on the path OpenAI actually serves.
+				originator: "codex_cli_rs",
+				"user-agent": `codex_cli_rs/${CODEX_VERSION}`,
+			},
+			signal: controller.signal,
+		});
+
+		if (!response.ok) {
+			throw new Error(`HTTP ${response.status}`);
+		}
+		return normalize((await response.json()) as CodexModelsResponse);
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+/**
+ * Make sure this account has a derived default map before anything tries to
+ * map a Claude family onto one of the provider's models.
+ *
+ * A no-op for every other provider, and for a codex account that already has
+ * one — which, after the first request, is all of them.
+ */
+export async function ensureCodexModelDefaults(
+	account: Account | null | undefined,
+	ctx: ProxyContext,
+): Promise<void> {
+	if (account?.provider !== "codex") return;
+	if (hasDerivedProviderModelDefaults("codex", account.id)) return;
+	try {
+		await getCodexModels(account.id, ctx);
+	} catch (err) {
+		// Never blocks the request: without a map the family falls through and
+		// the provider gets to say what it thinks, which the record then learns.
+		log.debug(`Could not load the model list for ${account.name}: ${err}`);
+	}
+}
+
+/**
+ * The family -> model map an account's own listing implies.
+ *
+ * The listing arrives ordered by the provider's `priority`, so position IS
+ * the tier and there is no table of ours to keep current: whatever OpenAI
+ * promotes to the top becomes the frontier default by itself.
+ *
+ * `opus` and `fable` take the frontier model, `sonnet` the next one and
+ * `haiku` the one after — matching what each Anthropic family is for. A
+ * shorter list degrades to the last available model rather than leaving a
+ * family unmapped, because an unmapped family falls through to the Claude
+ * name and the provider answers 400.
+ */
+export function deriveFamilyDefaults(
+	models: CodexModelEntry[],
+): Record<string, string> {
+	if (models.length === 0) return {};
+	const at = (index: number): string =>
+		models[Math.min(index, models.length - 1)].id;
+	return {
+		fable: at(0),
+		opus: at(0),
+		sonnet: at(1),
+		haiku: at(2),
+	};
+}
+
+/**
+ * The model list for one Codex account: live when OpenAI answers, otherwise the
+ * last list it gave us. Returns null only when both are unavailable — a brand
+ * new account whose first fetch failed.
+ */
+export async function getCodexModels(
+	accountId: string,
+	ctx: ProxyContext,
+): Promise<CodexModelListing | null> {
+	const account = await ctx.dbOps.getAccount(accountId);
+	if (!account || account.provider !== "codex") return null;
+
+	try {
+		const models = await fetchLive(account, ctx);
+		const listing: CodexModelListing = {
+			accountId,
+			models,
+			fetchedAt: Date.now(),
+			source: "live",
+		};
+		// Kept before returning, so a later failure still has something to serve.
+		writeCache(listing);
+		setDerivedProviderModelDefaults(
+			"codex",
+			accountId,
+			deriveFamilyDefaults(models),
+		);
+		return listing;
+	} catch (error) {
+		const cached = readCache(accountId);
+		// The cached listing is still this account's own answer, just an older
+		// one — far better than a map compiled months ago.
+		if (cached) {
+			setDerivedProviderModelDefaults(
+				"codex",
+				accountId,
+				deriveFamilyDefaults(cached.models),
+			);
+		}
+		log.warn(
+			`Live Codex model list failed for ${account.name} (${error}); ` +
+				(cached
+					? `serving the list from ${new Date(cached.fetchedAt).toISOString()}`
+					: "and there is no cached list to fall back to"),
+		);
+		return cached;
+	}
+}

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -25,6 +25,7 @@ import type {
 	RequestMeta,
 } from "@better-ccflare/types";
 import { cacheBodyStore } from "../cache-body-store";
+import { ensureCodexModelDefaults } from "../codex-model-catalog";
 import { RequestBodyContext } from "../request-body-context";
 import { forwardToClient } from "../response-handler";
 import { isModelRewrite } from "../worker-messages";
@@ -703,6 +704,12 @@ export async function proxyWithAccount(
 		}
 
 		const providerRequest = new Request(targetUrl, requestInit);
+
+		// The provider is about to translate the Claude family into one of its
+		// own models, and only this account's listing knows which. Loading it
+		// here costs one await on the account's first request in this process;
+		// after that it is memory.
+		await ensureCodexModelDefaults(account, ctx);
 
 		let transformedRequest = provider.transformRequestBody
 			? await provider.transformRequestBody(providerRequest, account)

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -24,6 +24,11 @@ export {
 	resetDefaultCircuitBreaker as resetDefaultCircuitBreakerProxy,
 	shouldCountAsCircuitFailure,
 } from "./circuit-breaker";
+export type {
+	CodexModelEntry,
+	CodexModelListing,
+} from "./codex-model-catalog";
+export { getCodexModels } from "./codex-model-catalog";
 export {
 	type CodexUsageRefreshOutcome,
 	checkAllAccountsHealth,

--- a/packages/types/src/context.ts
+++ b/packages/types/src/context.ts
@@ -73,6 +73,24 @@ export interface APIContext {
 			source: "live" | "fallback";
 		}>;
 		refresh: () => Promise<{ success: boolean; error?: string }>;
+		/**
+		 * Models one account can actually call, from the provider's own
+		 * per-account listing. Null when the account is unknown, is not of a
+		 * provider with such a listing, or none has ever been read.
+		 */
+		codexModels?: (accountId: string) => Promise<{
+			models: Array<{
+				id: string;
+				displayName: string;
+				description: string | null;
+				contextWindow: number | null;
+				supersededBy: string | null;
+			}>;
+			fetchedAt: number;
+			/** "shared" = read from another account of the same provider. */
+			source: "live" | "cached" | "shared";
+			borrowedFrom?: string;
+		} | null>;
 	};
 	/**
 	 * Process-local secret gating internal-probe requests (auto-refresh /


### PR DESCRIPTION
Replaces #402, which tried to solve the same problem the other way round.

## The problem

`DEFAULT_MODEL_MAP` in the Codex provider is a guess, compiled at build time, about which models an account may call. That guess is what breaks:

```
400 The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.
```

It maps `opus` and `sonnet` to `gpt-5.3-codex`, and a ChatGPT-subscription account refuses that model. No table baked into the binary can know what a subscription is entitled to — that fact lives with the account.

#402 made the map editable, so an operator could correct it by hand. That works, but it treats the symptom: someone still has to notice, diagnose and type the right value, per install.

## What this does instead

The account is asked. `chatgpt.com/backend-api/codex/models` is the listing the Codex CLI itself reads; it answers per subscription. On a real subscription account it returns six models, and `gpt-5.3-codex` is **not** among them.

Resolution order becomes:

```
operator override  ->  this account's listing  ->  provider-wide listing
```

with no compiled map underneath for codex. The editable override from #402 is kept — it is the escape hatch, not the default.

The tiering needs no table either. The listing arrives ordered by the provider's own `priority`, so position **is** the tier:

| Family | Takes | Today resolves to |
|---|---|---|
| opus, fable | 1st | `gpt-5.6-sol` |
| sonnet | 2nd | `gpt-5.6-terra` |
| haiku | 3rd | `gpt-5.6-luna` |

If OpenAI promotes a different model to the top, the default follows on its own.

## Details that came from the payload, not from us

- **`visibility: "hide"` entries are left out.** Two of the eight a live account returns are not models to choose: a Work Mode routing alias (`gpt-5.6-sol-wm`, also `supported_in_api: false`) and `codex-auto-review`. Reading the flag beats matching on the name — the next alias is excluded without anyone learning its suffix.
- **`upgrade` carries a deprecation notice** naming the replacement (`gpt-5.4` → `gpt-5.6-terra`), which reaches the picker.
- **Using one account's listing for another is safe** where it matters: `available_in_plans` shows the priority 1/2/3 models present in all 22 plans the endpoint lists. The models that vary by plan sit far below and the rule never reaches them.

## Behaviour worth calling out

- **An account that cannot read its own listing inherits another account's**, labelled `shared`. Measured on real accounts: two of three answer HTTP 401 on this endpoint while serving traffic perfectly — without inheritance their field is empty forever. It is labelled rather than passed off as their own, because plans *can* differ.
- **The listing is cached in memory only.** A failed refresh keeps serving what is there; a restart starts empty and stays empty until a read succeeds. That is honest about what is actually known.
- **`models.ts` no longer carries codex data** — neither the built-in list nor a models.dev section. A provider that answers with a listing of its own needs no catalogue, and a catalogue that lists what a plan cannot call is the thing this change exists to remove. **Providers ccflare cannot ask are untouched** and keep the catalogue.
- **The Anthropic branch stops serving the bundled list as if it were a listing.** Without a live read the field is empty and says so, instead of looking answered from a snapshot frozen at build time.

## Testing

- Listing parser and its guards; the tiering; inheritance between accounts; the settings screen against a derived default; codex family resolution.
- The three cases that pinned the compiled map were **rewritten, not deleted** — they described a real decision, and now they describe the new one.
- Full suite on this branch: **3058 pass**, with the same 17 failures as the branch point (network/abort tests that do not run in my container). Compared as failure *sets*, not counts.
- Running in production on my own instance since today, serving real traffic.

## Review

This is stacked on #399; the commit to review is `2e134c2`.
