### PR TITLE
fix: don't let a spent extra_usage pool bench an otherwise-routable account

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -37,7 +37,7 @@ import {
 	extractWeeklyResetTime,
 	fetchCodexUsageOnDemand,
 	getProvider,
-	getRepresentativeUtilizationForProvider,
+	getRankingUtilizationForProvider,
 	usageCache,
 } from "@better-ccflare/providers";
 import {
@@ -1080,7 +1080,10 @@ export default async function startServer(options?: {
 		getAccountUtilization(accountId: string, provider: string): number | null {
 			const data = usageCache.get(accountId);
 			if (!data) return null;
-			return getRepresentativeUtilizationForProvider(data, provider);
+			// Ranking, not gating: this feeds SessionStrategy's water-filling sort
+			// across same-priority accounts, where a spent extra_usage pool is a
+			// legitimate reason to prefer another account.
+			return getRankingUtilizationForProvider(data, provider);
 		},
 		getAccountWeeklyReset(accountId: string, provider: string): number | null {
 			const data = usageCache.get(accountId);

--- a/packages/http-api/src/handlers/accounts.ts
+++ b/packages/http-api/src/handlers/accounts.ts
@@ -26,6 +26,7 @@ import {
 	type AnyUsageData,
 	fetchUsageData,
 	getRepresentativeUtilization,
+	getRepresentativeUtilizationForProvider,
 	getRepresentativeWindow,
 	parseCodexUsageHeaders,
 	type UsageData,
@@ -511,7 +512,19 @@ export function createAccountsListHandler(
 						rate_limited_until: account.rate_limited_until
 							? Number(account.rate_limited_until)
 							: null,
-						usageUtilization,
+						// The STATUS LABEL must be derived from the same signal that
+						// gates admission, not from the display utilization: the
+						// latter includes extra_usage, so a routable account whose
+						// overage pool is spent would be labelled usage_exhausted
+						// while it happily serves traffic. usageUtilization /
+						// usageWindow below still report the pool for display.
+						usageUtilization:
+							getRepresentativeUtilizationForProvider(
+								// FullUsageData is the http-api display shape (nullable
+								// utilization); the provider helpers read the same fields.
+								fullUsageData as AnyUsageData | null,
+								account.provider ?? "anthropic",
+							) ?? usageUtilization,
 						// Shared provider-aware derivation (same as /health) — a plain
 						// extractUsageResetMs(fullUsageData, usageWindow) silently loses
 						// the zai reset because usageWindow is the display label

--- a/packages/providers/src/__tests__/usage-fetcher-extra-usage.test.ts
+++ b/packages/providers/src/__tests__/usage-fetcher-extra-usage.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test";
+import { isUsageExhausted } from "@better-ccflare/core";
+import type { UsageData } from "../usage-fetcher";
+import {
+	getRankingUtilizationForProvider,
+	getRepresentativeUsageResetMs,
+	getRepresentativeUtilization,
+	getRepresentativeUtilizationForProvider,
+	getRepresentativeWindow,
+} from "../usage-fetcher";
+
+// The real shape of an account whose monthly overage credits are spent while
+// its plan quota is nearly untouched: five_hour 5%, seven_day 1%, but
+// extra_usage 100% (used_credits 1123 of a 1000 monthly_limit). Anthropic
+// still serves these requests — it reports spend_limit_reached: false and the
+// plan windows have headroom.
+const overageSpent = {
+	five_hour: { utilization: 5, resets_at: "2030-01-01T00:00:00.000Z" },
+	seven_day: { utilization: 1, resets_at: "2030-01-07T00:00:00.000Z" },
+	extra_usage: {
+		is_enabled: true,
+		monthly_limit: 1000,
+		used_credits: 1123,
+		utilization: 100,
+		spend_limit_reached: false,
+	},
+} as unknown as UsageData;
+
+describe("extra_usage is a billing pool, not a hard limit", () => {
+	it("is excluded from the admission utilization", () => {
+		expect(
+			getRepresentativeUtilizationForProvider(overageSpent, "anthropic"),
+		).toBe(5);
+	});
+
+	it("does not bench an account whose plan quota has headroom", () => {
+		const utilization = getRepresentativeUtilizationForProvider(
+			overageSpent,
+			"anthropic",
+		);
+		const resetMs = getRepresentativeUsageResetMs(overageSpent, "anthropic");
+		expect(isUsageExhausted(utilization, resetMs, Date.now())).toBe(false);
+	});
+
+	it("pairs the admission utilization with the reset of the same window", () => {
+		// extra_usage has no resets_at; drawing the reset from it yields null,
+		// which makes isUsageExhausted's staleness guard unclearable forever.
+		expect(getRepresentativeUsageResetMs(overageSpent, "anthropic")).toBe(
+			new Date("2030-01-01T00:00:00.000Z").getTime(),
+		);
+	});
+
+	it("still benches an account whose real hard-limit window is exhausted", () => {
+		const planExhausted = {
+			five_hour: { utilization: 100, resets_at: "2030-01-01T00:00:00.000Z" },
+			seven_day: { utilization: 20, resets_at: "2030-01-07T00:00:00.000Z" },
+		} as unknown as UsageData;
+		const utilization = getRepresentativeUtilizationForProvider(
+			planExhausted,
+			"anthropic",
+		);
+		expect(utilization).toBe(100);
+		expect(
+			isUsageExhausted(
+				utilization,
+				getRepresentativeUsageResetMs(planExhausted, "anthropic"),
+				Date.now(),
+			),
+		).toBe(true);
+	});
+
+	it("still counts toward ranking, where less headroom should sort later", () => {
+		expect(getRankingUtilizationForProvider(overageSpent, "anthropic")).toBe(
+			100,
+		);
+	});
+
+	it("remains visible on the display surfaces", () => {
+		expect(getRepresentativeUtilization(overageSpent)).toBe(100);
+		expect(getRepresentativeWindow(overageSpent)).toBe("extra_usage");
+	});
+});

--- a/packages/providers/src/usage-fetcher.ts
+++ b/packages/providers/src/usage-fetcher.ts
@@ -412,10 +412,14 @@ export function getRepresentativeWindow(
 }
 
 function utilizationForProvider(
-	data: AnyUsageData,
+	data: AnyUsageData | null | undefined,
 	provider: string,
 	includeExtraUsage: boolean,
 ): number | null {
+	// Same defensive guard as getRepresentativeUsageResetMs — callers that
+	// derive a display label may hold a null payload for providers that expose
+	// no usage surface.
+	if (!data || typeof data !== "object") return null;
 	switch (provider) {
 		case "anthropic":
 		case "codex": {
@@ -495,7 +499,7 @@ function utilizationForProvider(
  * a spent overage pool legitimately makes an account the less attractive pick.
  */
 export function getRepresentativeUtilizationForProvider(
-	data: AnyUsageData,
+	data: AnyUsageData | null | undefined,
 	provider: string,
 ): number | null {
 	return utilizationForProvider(data, provider, false);
@@ -509,7 +513,7 @@ export function getRepresentativeUtilizationForProvider(
  * Ordering only — this value must never gate admission.
  */
 export function getRankingUtilizationForProvider(
-	data: AnyUsageData,
+	data: AnyUsageData | null | undefined,
 	provider: string,
 ): number | null {
 	return utilizationForProvider(data, provider, true);

--- a/packages/providers/src/usage-fetcher.ts
+++ b/packages/providers/src/usage-fetcher.ts
@@ -351,12 +351,9 @@ export function getRepresentativeUtilization(
 	return utilizations.length > 0 ? Math.max(...utilizations) : null;
 }
 
-/**
- * Determine which window is the most restrictive (highest utilization)
- * Dynamically handles any usage window fields in the response
- */
-export function getRepresentativeWindow(
+function representativeWindow(
 	usage: UsageData | null,
+	includeExtraUsage: boolean,
 ): string | null {
 	if (!usage) return null;
 
@@ -364,6 +361,7 @@ export function getRepresentativeWindow(
 
 	// Iterate through all properties to find UsageWindow objects
 	for (const [key, value] of Object.entries(usage)) {
+		if (key === "extra_usage" && !includeExtraUsage) continue;
 		// Check if this is a UsageWindow object
 		if (
 			value &&
@@ -399,12 +397,24 @@ export function getRepresentativeWindow(
 }
 
 /**
- * Get the representative utilization for any supported provider type.
- * Returns null if the provider is not supported or data is unavailable.
+ * Determine which window is the most restrictive (highest utilization)
+ * Dynamically handles any usage window fields in the response.
+ *
+ * Display surface — `extra_usage` is included, because a dashboard showing a
+ * 100%-spent overage pool is telling the truth. Reset derivation for the
+ * admission path deliberately uses the hard-limit-only variant instead, so the
+ * reset it reports belongs to a window that actually has one.
  */
-export function getRepresentativeUtilizationForProvider(
+export function getRepresentativeWindow(
+	usage: UsageData | null,
+): string | null {
+	return representativeWindow(usage, true);
+}
+
+function utilizationForProvider(
 	data: AnyUsageData,
 	provider: string,
+	includeExtraUsage: boolean,
 ): number | null {
 	switch (provider) {
 		case "anthropic":
@@ -422,8 +432,9 @@ export function getRepresentativeUtilizationForProvider(
 				const w = d[key] as UsageWindow | undefined;
 				if (w?.utilization != null) utils.push(w.utilization);
 			}
-			// extra_usage has utilization: number | null
-			if (d.extra_usage?.utilization != null)
+			// extra_usage has utilization: number | null. Ranking only — see the
+			// exported wrappers below for why it must never gate admission.
+			if (includeExtraUsage && d.extra_usage?.utilization != null)
 				utils.push(d.extra_usage.utilization);
 			// Account-level limits[] caps (session / weekly_all) for limits-only payloads.
 			for (const { util } of accountLevelLimitWindows(d)) utils.push(util);
@@ -457,6 +468,51 @@ export function getRepresentativeUtilizationForProvider(
 		default:
 			return null;
 	}
+}
+
+/**
+ * Representative utilization for admission decisions: the max across the
+ * account's **hard-limit** windows only. Returns null if the provider is not
+ * supported or data is unavailable.
+ *
+ * `extra_usage` is deliberately NOT folded in. It is a *billing* pool
+ * (monthly overage credits), not a rate-limit window:
+ *
+ * - It has no `resets_at`, so a 100% reading pairs with `resetMs = null` and
+ *   `isUsageExhausted()`'s staleness guard can never clear it — the account
+ *   would be benched permanently, with no recovery path, while its real
+ *   five_hour/seven_day quota sits idle.
+ * - Upstream keeps serving from plan quota when the overage pool is spent, so
+ *   excluding a maxed-out `extra_usage` account is a false exclusion that
+ *   removes a working account. `isAccountExhaustedForModel` already encodes
+ *   exactly that trade-off ("a false exclusion removes a working account, a
+ *   false pass costs one reactive 429 round-trip") and fails open here.
+ * - Genuine overage rejection is a billing-policy 400 handled reactively as
+ *   `extra_usage_exhausted` (issue #293), not something to predict from
+ *   telemetry.
+ *
+ * Use {@link getRankingUtilizationForProvider} for load-balancing order, where
+ * a spent overage pool legitimately makes an account the less attractive pick.
+ */
+export function getRepresentativeUtilizationForProvider(
+	data: AnyUsageData,
+	provider: string,
+): number | null {
+	return utilizationForProvider(data, provider, false);
+}
+
+/**
+ * Utilization for **ranking** same-priority accounts (the water-filling sort in
+ * SessionStrategy). Identical to {@link getRepresentativeUtilizationForProvider}
+ * except that `extra_usage` counts: an account whose overage pool is spent has
+ * genuinely less headroom than one with credits left, so it should sort later.
+ * Ordering only — this value must never gate admission.
+ */
+export function getRankingUtilizationForProvider(
+	data: AnyUsageData,
+	provider: string,
+): number | null {
+	return utilizationForProvider(data, provider, true);
 }
 
 /**
@@ -532,13 +588,19 @@ export function getRepresentativeUsageResetMs(
 		switch (provider) {
 			case "anthropic":
 			case "codex": {
-				const windowName = getRepresentativeWindow(data as UsageData);
+				// Hard-limit windows only — must stay in lockstep with
+				// getRepresentativeUtilizationForProvider, which also excludes
+				// extra_usage. Pairing a utilization drawn from the hard-limit
+				// set with a reset drawn from a set that includes extra_usage
+				// would report the wrong window's recovery time (and extra_usage
+				// has no resets_at at all, so it would report none).
+				const windowName = representativeWindow(data as UsageData, false);
 				// Flat legacy shape: the window name is an actual property
 				// (five_hour/seven_day/...) carrying its own resets_at.
 				const flatReset = extractUsageResetMs(data, windowName);
 				if (flatReset !== null) return flatReset;
 				// limits[]-only payloads (2026 API): five_hour/seven_day are
-				// absent as properties — getRepresentativeWindow derives those
+				// absent as properties — representativeWindow derives those
 				// same names synthetically from limits[] kind "session" /
 				// "weekly_all". Fall back to the matching limits[] entry's own
 				// resets_at so the staleness guard still has a real reset time.


### PR DESCRIPTION
Fixes #404.

`extra_usage` — the monthly overage **billing** pool — was folded into the representative
utilization that `isUsageExhausted()` thresholds at 100%, so it gated admission. An account
at `five_hour: 5` / `seven_day: 1` / `extra_usage: 100` was dropped from the candidate pool
and every request 503'd with `pool_exhausted`, while upstream kept serving that same account
happily from plan quota (`spend_limit_reached: false`; a direct, non-proxied request to the
same token succeeded seconds later).

It also could not self-heal. The representative window resolved to `extra_usage`, which has
no `resets_at`, so the snapshot paired `utilization: 100` with `resetMs: null` — and `null`
takes the left branch of the staleness guard's `(resetMs == null || resetMs > now)`, which
is permanently true. The guard's own comment says its intent is "a known resetMs in the past
means the snapshot predates the window reset and MUST NOT count as exhausted", i.e. it
assumes the window *has* a reset. My account was hard-down for ~14 hours.

## Approach

The `extra_usage` term entered `getRepresentativeUtilizationForProvider()` in `513eea1e`
purely as a **ranking** signal for the water-filling session sort, where it is correct — an
account whose overage pool is spent genuinely has less headroom and should sort later. The
harm came from that same value later being reused as an **admission gate**.

So this splits the two uses rather than deleting the term:

| function | includes `extra_usage` | used for |
| --- | --- | --- |
| `getRepresentativeUtilizationForProvider` | no | admission (account-selector, `/health`, 503 body) |
| `getRankingUtilizationForProvider` *(new)* | yes | `SessionStrategy` water-filling sort |

Reset derivation follows the gate (`representativeWindow(d, false)`), so utilization and
reset always come from the same window set — otherwise a hard-limit utilization would be
paired with a reset belonging to a different window.

The second commit fixes a display inconsistency the first one exposes: the accounts list fed
`computeRateLimitStatusDisplay` the *display* utilization (which includes `extra_usage`)
while the reset now comes from the hard-limit window, so a routable account was labelled
`usage_exhausted (267m)` — promising a recovery that was never pending. The label now derives
from the same signal as the gate. `usageUtilization` / `usageWindow` in the response are
untouched, so the dashboard still shows the spent pool.

## Why this direction

It realigns the gate with how the rest of the codebase already treats `extra_usage`:

- `isAccountExhaustedForModel()` fails open on available overage — "a false exclusion removes
  a working account, a false pass costs one reactive 429 round-trip."
- `UsageHistoryRepository` excludes it — "extra_usage has no resets_at → not a window."
- Real overage rejection is handled reactively as `extra_usage_exhausted` (#293), commented
  "billing-policy rejection, NOT a rate limit."

## Tests

New `packages/providers/src/__tests__/usage-fetcher-extra-usage.test.ts` (6 cases) pins the
reported payload shape: excluded from admission, not benched, utilization/reset paired from
the same window, a genuinely exhausted plan window *still* benches, ranking still counts the
pool, and the display surfaces still report it.

I verified these actually catch the bug — flipping the flag back to the old behavior fails
two of them, so they are not written to fit the current output.

- `bun test`: 3035 pass / 12 fail — the same 12 failures are present on unmodified `main`
  (agent-registry persistence, `makeProxyRequest` abort). None are usage-related.
- `bun run typecheck`: clean.
- `biome check`: clean.

Also added a null guard to the shared utilization helper, matching
`getRepresentativeUsageResetMs` — display callers can hold a null payload.

## Verified live

Running on my proxy against v3.5.50: requests that had 503'd for ~14 hours now return 200
with the account attributed, and `rateLimitStatus` reads `allowed` instead of
`usage_exhausted`, with the dashboard still showing the pool at 100%.
