### PR TITLE
fix(proxy): drain abandoned stream readers instead of no-op cancel

### DIFF
--- a/packages/providers/src/providers/anthropic/provider.ts
+++ b/packages/providers/src/providers/anthropic/provider.ts
@@ -9,6 +9,7 @@ import type { Account } from "@better-ccflare/types";
 import { BaseProvider } from "../../base";
 import type { RateLimitInfo, TokenRefreshResult } from "../../types";
 import { transformRequestBodyModel } from "../../utils/model-mapping";
+import { drainReader } from "../../utils/stream-drain";
 
 // Hard rate limit statuses that should block account usage
 const HARD_LIMIT_STATUSES = new Set([
@@ -96,27 +97,6 @@ export async function isAnthropicExtraUsageExhausted(
 }
 
 const log = new Logger("AnthropicProvider");
-
-/**
- * Drain a reader to `done` instead of calling `reader.cancel()`, which is a
- * no-op on every released Bun (oven-sh/bun#35093) and leaks the upstream's
- * native buffer — see handlers/discard-body-cancel.ts for the full
- * rationale (#382).
- */
-async function drainReader(
-	reader: ReadableStreamDefaultReader<Uint8Array>,
-): Promise<void> {
-	try {
-		while (true) {
-			const { done } = await reader.read();
-			if (done) return;
-		}
-	} catch {
-		// Swallow — draining must not throw during teardown.
-	} finally {
-		reader.releaseLock();
-	}
-}
 
 export class AnthropicProvider extends BaseProvider {
 	name = "anthropic";
@@ -686,9 +666,9 @@ export class AnthropicProvider extends BaseProvider {
 
 				try {
 					while (buffered.length < maxBytes) {
-						// Check for timeout
+						// Check for timeout — the enclosing `finally` drains the
+						// reader on every exit path, including this throw.
 						if (Date.now() - startTime > READ_TIMEOUT_MS) {
-							void drainReader(reader);
 							throw new Error(
 								"Stream read timeout while extracting usage info",
 							);

--- a/packages/providers/src/providers/anthropic/provider.ts
+++ b/packages/providers/src/providers/anthropic/provider.ts
@@ -97,6 +97,27 @@ export async function isAnthropicExtraUsageExhausted(
 
 const log = new Logger("AnthropicProvider");
 
+/**
+ * Drain a reader to `done` instead of calling `reader.cancel()`, which is a
+ * no-op on every released Bun (oven-sh/bun#35093) and leaks the upstream's
+ * native buffer — see handlers/discard-body-cancel.ts for the full
+ * rationale (#382).
+ */
+async function drainReader(
+	reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<void> {
+	try {
+		while (true) {
+			const { done } = await reader.read();
+			if (done) return;
+		}
+	} catch {
+		// Swallow — draining must not throw during teardown.
+	} finally {
+		reader.releaseLock();
+	}
+}
+
 export class AnthropicProvider extends BaseProvider {
 	name = "anthropic";
 
@@ -576,8 +597,10 @@ export class AnthropicProvider extends BaseProvider {
 					}
 				}
 			},
-			cancel(reason) {
-				reader.cancel(reason);
+			cancel() {
+				// reader.cancel() is a no-op on Bun and leaks the native buffer;
+				// drain to `done` instead — see drainReader() above (#382).
+				void drainReader(reader);
 			},
 		});
 
@@ -665,7 +688,7 @@ export class AnthropicProvider extends BaseProvider {
 					while (buffered.length < maxBytes) {
 						// Check for timeout
 						if (Date.now() - startTime > READ_TIMEOUT_MS) {
-							await reader.cancel();
+							void drainReader(reader);
 							throw new Error(
 								"Stream read timeout while extracting usage info",
 							);
@@ -719,8 +742,8 @@ export class AnthropicProvider extends BaseProvider {
 						}
 					}
 				} finally {
-					// Cancel the reader to prevent hanging
-					reader.cancel().catch(() => {});
+					// Drain the reader to prevent hanging and release the native buffer
+					void drainReader(reader);
 				}
 
 				if (!foundMessageStart) return null;

--- a/packages/providers/src/providers/base-anthropic-compatible.ts
+++ b/packages/providers/src/providers/base-anthropic-compatible.ts
@@ -41,6 +41,27 @@ const HARD_LIMIT_STATUSES = new Set([
 
 const log = new Logger("BaseAnthropicCompatibleProvider");
 
+/**
+ * Drain a reader to `done`, dropping each chunk. `reader.cancel()` is a
+ * no-op on every released Bun (oven-sh/bun#35093) and leaks the upstream's
+ * native buffer; draining actually releases it. Errors are swallowed since
+ * this is best-effort cleanup, not part of the caller's control flow (#382).
+ */
+async function drainReader(
+	reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<void> {
+	try {
+		while (true) {
+			const { done } = await reader.read();
+			if (done) return;
+		}
+	} catch {
+		// Swallow — draining must not throw during cleanup.
+	} finally {
+		reader.releaseLock();
+	}
+}
+
 export abstract class BaseAnthropicCompatibleProvider extends BaseProvider {
 	protected config: AnthropicCompatibleConfig;
 	name: string; // Make name concrete instead of abstract
@@ -366,7 +387,9 @@ export abstract class BaseAnthropicCompatibleProvider extends BaseProvider {
 		try {
 			while (buffered.length < maxBytes) {
 				if (Date.now() - startTime > READ_TIMEOUT_MS) {
-					await reader.cancel();
+					// Fire and forget — awaiting would block this throw on a
+					// network round-trip already being abandoned.
+					void drainReader(reader);
 					throw new Error("Stream read timeout while extracting usage info");
 				}
 
@@ -517,7 +540,11 @@ export abstract class BaseAnthropicCompatibleProvider extends BaseProvider {
 				}
 			}
 		} finally {
-			reader.cancel().catch(() => {});
+			// Fire and forget — the read loop typically breaks early (as soon
+			// as message_delta usage is seen), well before the upstream body
+			// is exhausted; draining releases the native buffer without
+			// blocking the return here.
+			void drainReader(reader);
 		}
 
 		// For streaming responses, message_delta always contains the final authoritative token counts

--- a/packages/providers/src/providers/base-anthropic-compatible.ts
+++ b/packages/providers/src/providers/base-anthropic-compatible.ts
@@ -10,6 +10,7 @@ import type { Account } from "@better-ccflare/types";
 import { BaseProvider } from "../base";
 import type { RateLimitInfo, TokenRefreshResult } from "../types";
 import { transformRequestBodyModel } from "../utils/model-mapping";
+import { drainReader } from "../utils/stream-drain";
 
 // Configuration interface for Anthropic-compatible providers
 export interface AnthropicCompatibleConfig {
@@ -40,27 +41,6 @@ const HARD_LIMIT_STATUSES = new Set([
 ]);
 
 const log = new Logger("BaseAnthropicCompatibleProvider");
-
-/**
- * Drain a reader to `done`, dropping each chunk. `reader.cancel()` is a
- * no-op on every released Bun (oven-sh/bun#35093) and leaks the upstream's
- * native buffer; draining actually releases it. Errors are swallowed since
- * this is best-effort cleanup, not part of the caller's control flow (#382).
- */
-async function drainReader(
-	reader: ReadableStreamDefaultReader<Uint8Array>,
-): Promise<void> {
-	try {
-		while (true) {
-			const { done } = await reader.read();
-			if (done) return;
-		}
-	} catch {
-		// Swallow — draining must not throw during cleanup.
-	} finally {
-		reader.releaseLock();
-	}
-}
 
 export abstract class BaseAnthropicCompatibleProvider extends BaseProvider {
 	protected config: AnthropicCompatibleConfig;
@@ -387,9 +367,8 @@ export abstract class BaseAnthropicCompatibleProvider extends BaseProvider {
 		try {
 			while (buffered.length < maxBytes) {
 				if (Date.now() - startTime > READ_TIMEOUT_MS) {
-					// Fire and forget — awaiting would block this throw on a
-					// network round-trip already being abandoned.
-					void drainReader(reader);
+					// The enclosing `finally` drains the reader on every exit
+					// path, including this throw — no separate call needed here.
 					throw new Error("Stream read timeout while extracting usage info");
 				}
 

--- a/packages/providers/src/utils/stream-drain.ts
+++ b/packages/providers/src/utils/stream-drain.ts
@@ -1,0 +1,20 @@
+/**
+ * Drain a reader to `done`, dropping each chunk. `reader.cancel()` is a
+ * no-op on every released Bun (oven-sh/bun#35093) and leaks the upstream's
+ * native buffer; draining actually releases it. Errors are swallowed since
+ * this is best-effort cleanup, not part of the caller's control flow (#382).
+ */
+export async function drainReader(
+	reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<void> {
+	try {
+		while (true) {
+			const { done } = await reader.read();
+			if (done) return;
+		}
+	} catch {
+		// Swallow — draining must not throw during cleanup.
+	} finally {
+		reader.releaseLock();
+	}
+}

--- a/packages/proxy/src/__tests__/anthropic-terminal-recovery.test.ts
+++ b/packages/proxy/src/__tests__/anthropic-terminal-recovery.test.ts
@@ -698,6 +698,34 @@ describe("createAnthropicTerminalRecoveryStream", () => {
 		expect(onCancelError).not.toHaveBeenCalled();
 	});
 
+	it("aborts drainAbort once drainDeadlineMs elapses, to actually terminate the stuck fetch", async () => {
+		// releaseLock() alone only frees the reader object for another
+		// consumer — it does not touch the underlying connection. The only way
+		// to actually kill an in-flight fetch is to abort a signal that was
+		// part of its `init.signal` at creation time (Greptile follow-up on
+		// PR #406, second review pass).
+		const source = controllableStream();
+		const drainAbort = new AbortController();
+		const body = createAnthropicTerminalRecoveryStream(source.stream, {
+			gracePeriodMs: 5,
+			drainDeadlineMs: 15,
+			drainAbort,
+		});
+		const result = new Response(body).text();
+
+		source.controller().enqueue(bytes(terminalDelta));
+		await expect(result).resolves.toBe(
+			`${terminalDelta}${ANTHROPIC_MESSAGE_STOP_FRAME}`,
+		);
+		// Deliberately never close/error/enqueue on `source` — only the
+		// deadline can end this drain.
+		expect(drainAbort.signal.aborted).toBe(false);
+
+		await new Promise((resolve) => setTimeout(resolve, 40));
+
+		expect(drainAbort.signal.aborted).toBe(true);
+	});
+
 	it("emits 'client_cancelled' via onTerminalState when downstream cancels before terminal events", async () => {
 		// Claude Code cancels streams routinely (Esc, tool interrupts).
 		// The wrapper must classify client-side cancellation distinctly

--- a/packages/proxy/src/__tests__/anthropic-terminal-recovery.test.ts
+++ b/packages/proxy/src/__tests__/anthropic-terminal-recovery.test.ts
@@ -37,6 +37,27 @@ function controllableStream(
 	return { stream, controller: () => controller, cancel };
 }
 
+/**
+ * Simulates what actually happens in production when the downstream
+ * consumer stops reading: `reader.cancel()` (a Bun no-op, oven-sh/bun#35093)
+ * is no longer called, so the pending `reader.read()` inside the drain loop
+ * only settles once the upstream connection itself ends — in `stream-tee.ts`
+ * this is bounded by the caller's fetch() abort signal rejecting the read
+ * (see its `cancel()` comment). A `controllableStream()` has no real network
+ * connection to abort, so tests that exercise the post-cancel drain must
+ * close the source explicitly, standing in for that eventual abort/EOF.
+ */
+async function settleDrain(
+	source: ReturnType<typeof controllableStream>,
+): Promise<void> {
+	try {
+		source.controller().close();
+	} catch {
+		// Already closed/errored — fine, the drain loop will still resolve.
+	}
+	await new Promise((resolve) => setTimeout(resolve, 20));
+}
+
 const terminalDelta =
 	'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":42}}\n\n';
 const messageStop = 'event: message_stop\ndata: {"type":"message_stop"}\n\n';
@@ -87,7 +108,10 @@ describe("createAnthropicTerminalRecoveryStream", () => {
 			`${terminalDelta}${ping}${ANTHROPIC_MESSAGE_STOP_FRAME}`,
 		);
 		expect(onRecovery).toHaveBeenCalledTimes(1);
-		expect(source.cancel).toHaveBeenCalledTimes(1);
+		// The fix must not call the upstream reader's cancel() — draining
+		// alone releases the native buffer (Bun's cancel() is a no-op,
+		// oven-sh/bun#35093, issue #382).
+		expect(source.cancel).not.toHaveBeenCalled();
 	});
 
 	it("does not let ping events defer recovery", async () => {
@@ -168,7 +192,7 @@ describe("createAnthropicTerminalRecoveryStream", () => {
 			`${terminalDelta}${partialPing}\n\n${ANTHROPIC_MESSAGE_STOP_FRAME}`,
 		);
 		expect(onRecovery).toHaveBeenCalledTimes(1);
-		expect(source.cancel).toHaveBeenCalledTimes(1);
+		expect(source.cancel).not.toHaveBeenCalled();
 	});
 
 	it("does not duplicate a real message_stop buffered at the timeout boundary", async () => {
@@ -188,7 +212,7 @@ describe("createAnthropicTerminalRecoveryStream", () => {
 			`${terminalDelta}${partialMessageStop}\n\n`,
 		);
 		expect(onRecovery).not.toHaveBeenCalled();
-		expect(source.cancel).toHaveBeenCalledTimes(1);
+		expect(source.cancel).not.toHaveBeenCalled();
 	});
 
 	it("closes a message_stop data line that only lacks its final blank line", async () => {
@@ -206,7 +230,7 @@ describe("createAnthropicTerminalRecoveryStream", () => {
 
 		await expect(result).resolves.toBe(`${terminalDelta}${messageStop}`);
 		expect(onRecovery).not.toHaveBeenCalled();
-		expect(source.cancel).toHaveBeenCalledTimes(1);
+		expect(source.cancel).not.toHaveBeenCalled();
 	});
 
 	it("preserves a message_stop that completes shortly before the timeout", async () => {
@@ -573,7 +597,7 @@ describe("createAnthropicTerminalRecoveryStream", () => {
 		expect(onRecovery).not.toHaveBeenCalled();
 	});
 
-	it("cancels upstream once and disarms recovery when downstream cancels", async () => {
+	it("drains upstream once and disarms recovery when downstream cancels", async () => {
 		const source = controllableStream();
 		const onRecovery = mock(() => undefined);
 		const body = createAnthropicTerminalRecoveryStream(source.stream, {
@@ -584,16 +608,24 @@ describe("createAnthropicTerminalRecoveryStream", () => {
 
 		source.controller().enqueue(bytes(terminalDelta));
 		await expect(reader.read()).resolves.toMatchObject({ done: false });
-		await reader.cancel("client disconnected");
-		await new Promise((resolve) => setTimeout(resolve, 20));
+		// reader.cancel() on the *outer* stream fires the wrapper's own
+		// cancel(reason) handler, which now drains the inner upstream
+		// reader to done instead of calling its cancel() (a Bun no-op,
+		// oven-sh/bun#35093, issue #382). The drain's pending read only
+		// settles once the upstream source closes — settleDrain() stands
+		// in for the real fetch abort signal that bounds it in production.
+		const cancelPromise = reader.cancel("client disconnected");
+		await settleDrain(source);
+		await cancelPromise;
 
-		expect(source.cancel).toHaveBeenCalledTimes(1);
+		// The fix must not call the upstream reader's cancel() — draining
+		// alone releases the native buffer.
+		expect(source.cancel).not.toHaveBeenCalled();
 		expect(onRecovery).not.toHaveBeenCalled();
 	});
 
-	it("propagates an upstream cancellation failure to downstream cancel", async () => {
-		const cancelError = new Error("upstream cancel failed");
-		const source = controllableStream(() => Promise.reject(cancelError));
+	it("propagates an upstream drain failure to downstream cancel", async () => {
+		const source = controllableStream();
 		const onCancelError = mock(() => undefined);
 		const body = createAnthropicTerminalRecoveryStream(source.stream, {
 			gracePeriodMs: 20,
@@ -603,17 +635,16 @@ describe("createAnthropicTerminalRecoveryStream", () => {
 
 		source.controller().enqueue(bytes(terminalDelta));
 		await expect(reader.read()).resolves.toMatchObject({ done: false });
-		await expect(reader.cancel("client disconnected")).rejects.toThrow(
-			"upstream cancel failed",
-		);
+		const cancelPromise = reader.cancel("client disconnected");
+		source.controller().error(new Error("drain failed"));
+		await expect(cancelPromise).rejects.toThrow("drain failed");
 
-		expect(source.cancel).toHaveBeenCalledTimes(1);
+		expect(source.cancel).not.toHaveBeenCalled();
 		expect(onCancelError).not.toHaveBeenCalled();
 	});
 
-	it("reports a recovery cancellation failure after completing downstream", async () => {
-		const cancelError = new Error("recovery cancel failed");
-		const source = controllableStream(() => Promise.reject(cancelError));
+	it("reports a recovery drain failure after completing downstream", async () => {
+		const source = controllableStream();
 		const onCancelError = mock(() => undefined);
 		const body = createAnthropicTerminalRecoveryStream(source.stream, {
 			gracePeriodMs: 20,
@@ -625,10 +656,17 @@ describe("createAnthropicTerminalRecoveryStream", () => {
 		await expect(result).resolves.toBe(
 			`${terminalDelta}${ANTHROPIC_MESSAGE_STOP_FRAME}`,
 		);
-		await new Promise((resolve) => setTimeout(resolve, 0));
+		// recover() fires the background drain via cancelAfterForcedClose;
+		// error the source so the drain's pending read rejects, exercising
+		// the onCancelError reporting path.
+		source.controller().error(new Error("recovery drain failed"));
+		await new Promise((resolve) => setTimeout(resolve, 20));
 
 		expect(onCancelError).toHaveBeenCalledTimes(1);
-		expect(onCancelError).toHaveBeenCalledWith(cancelError, "timeout");
+		expect(onCancelError).toHaveBeenCalledWith(
+			expect.objectContaining({ message: "recovery drain failed" }),
+			"timeout",
+		);
 	});
 
 	it("emits 'client_cancelled' via onTerminalState when downstream cancels before terminal events", async () => {
@@ -647,7 +685,11 @@ describe("createAnthropicTerminalRecoveryStream", () => {
 
 		source.controller().enqueue(bytes(terminalDelta));
 		await expect(reader.read()).resolves.toMatchObject({ done: false });
-		await reader.cancel("client disconnect");
+		// onTerminalState fires synchronously inside cancel(), before the
+		// background drain of the inner upstream reader — no need to wait
+		// for the drain (which only settles once the source closes) to
+		// observe it.
+		void reader.cancel("client disconnect");
 		await new Promise((resolve) => setTimeout(resolve, 0));
 
 		expect(onTerminalState).toHaveBeenCalledTimes(1);
@@ -666,7 +708,7 @@ describe("createAnthropicTerminalRecoveryStream", () => {
 		});
 		const reader = body.getReader();
 
-		await reader.cancel("client disconnect");
+		void reader.cancel("client disconnect");
 		await new Promise((resolve) => setTimeout(resolve, 0));
 
 		expect(onTerminalState).toHaveBeenCalledTimes(1);

--- a/packages/proxy/src/__tests__/anthropic-terminal-recovery.test.ts
+++ b/packages/proxy/src/__tests__/anthropic-terminal-recovery.test.ts
@@ -669,6 +669,35 @@ describe("createAnthropicTerminalRecoveryStream", () => {
 		);
 	});
 
+	it("gives up on the background drain once drainDeadlineMs elapses, without erroring", async () => {
+		// A stuck-but-open upstream (never closes, never errors, never sends
+		// another byte) is exactly the case recover()'s timeout path exists
+		// for. Before the deadline bound, drainUpstreamReader's `reader.read()`
+		// would hang forever here — holding the socket open indefinitely
+		// where the no-op `reader.cancel()` it replaced would have resolved
+		// instantly (issue #382 follow-up, Greptile review on PR #406).
+		const source = controllableStream();
+		const onCancelError = mock(() => undefined);
+		const body = createAnthropicTerminalRecoveryStream(source.stream, {
+			gracePeriodMs: 5,
+			drainDeadlineMs: 15,
+			onCancelError,
+		});
+		const result = new Response(body).text();
+
+		source.controller().enqueue(bytes(terminalDelta));
+		await expect(result).resolves.toBe(
+			`${terminalDelta}${ANTHROPIC_MESSAGE_STOP_FRAME}`,
+		);
+		// Deliberately never close/error/enqueue on `source` — the drain must
+		// still settle on its own via the deadline.
+		await new Promise((resolve) => setTimeout(resolve, 40));
+
+		// The deadline path is a clean give-up, not a failure: it must not be
+		// reported through onCancelError.
+		expect(onCancelError).not.toHaveBeenCalled();
+	});
+
 	it("emits 'client_cancelled' via onTerminalState when downstream cancels before terminal events", async () => {
 		// Claude Code cancels streams routinely (Esc, tool interrupts).
 		// The wrapper must classify client-side cancellation distinctly

--- a/packages/proxy/src/anthropic-terminal-recovery.ts
+++ b/packages/proxy/src/anthropic-terminal-recovery.ts
@@ -134,13 +134,28 @@ export function createAnthropicTerminalRecoveryStream(
 		recoveryWaitStartedAt = null;
 	};
 
-	const cancelUpstream = (reason: unknown): Promise<void> => {
-		if (upstreamCancelPromise) return upstreamCancelPromise;
+	// `reader.cancel()` is a documented no-op on every released Bun version
+	// (oven-sh/bun#35093): it never releases the native off-heap buffer
+	// backing the upstream fetch Response body, leaking RSS while JS heap
+	// stays flat (issue #382). Draining the reader to `done` instead actually
+	// releases the buffer — same fix as `discard-body-cancel.ts`'s
+	// `drainBody`, adapted here because `reader` is already an obtained
+	// `ReadableStreamDefaultReader` (the stream is locked to it), not a raw
+	// stream `drainBody` could call `.getReader()` on again.
+	const drainUpstreamReader = async (): Promise<void> => {
 		try {
-			upstreamCancelPromise = reader.cancel(reason);
-		} catch (error) {
-			upstreamCancelPromise = Promise.reject(error);
+			while (true) {
+				const { done } = await reader.read();
+				if (done) return;
+			}
+		} finally {
+			reader.releaseLock();
 		}
+	};
+
+	const cancelUpstream = (_reason: unknown): Promise<void> => {
+		if (upstreamCancelPromise) return upstreamCancelPromise;
+		upstreamCancelPromise = drainUpstreamReader();
 		return upstreamCancelPromise;
 	};
 

--- a/packages/proxy/src/anthropic-terminal-recovery.ts
+++ b/packages/proxy/src/anthropic-terminal-recovery.ts
@@ -3,6 +3,19 @@ export const ANTHROPIC_MESSAGE_STOP_FRAME =
 
 export const ANTHROPIC_TERMINAL_RECOVERY_GRACE_MS = 10_000;
 
+/**
+ * Upper bound on how long the post-finalize upstream drain (see
+ * `drainUpstreamReader` below) will wait for `reader.read()` to settle.
+ * Without this, a stuck-but-still-open upstream (exactly the scenario
+ * `recover()`'s timeout path exists for) would hold the socket and its
+ * native buffer open forever instead of the fast Bun `cancel()` no-op it
+ * replaced — trading a memory leak for a connection leak. Once the deadline
+ * fires the reader's lock is released without awaiting `reader.cancel()`
+ * (also a no-op); the socket is reclaimed when Bun eventually times it out
+ * or the upstream closes on its own.
+ */
+export const ANTHROPIC_DRAIN_DEADLINE_MS = 30_000;
+
 const encoder = new TextEncoder();
 const messageStopBytes = encoder.encode(ANTHROPIC_MESSAGE_STOP_FRAME);
 const MAX_PENDING_EVENT_CHARS = 64 * 1024;
@@ -55,6 +68,8 @@ export type AnthropicTerminalState = (typeof ANTHROPIC_TERMINAL_STATES)[number];
 export interface AnthropicTerminalRecoveryOptions {
 	/** @internal Override only in deterministic unit tests. */
 	gracePeriodMs?: number;
+	/** @internal Override only in deterministic unit tests. */
+	drainDeadlineMs?: number;
 	onRecovery?: (reason: AnthropicTerminalRecoveryReason) => void;
 	onCancelError?: (
 		error: unknown,
@@ -87,6 +102,8 @@ export function createAnthropicTerminalRecoveryStream(
 ): ReadableStream<Uint8Array> {
 	const gracePeriodMs =
 		options.gracePeriodMs ?? ANTHROPIC_TERMINAL_RECOVERY_GRACE_MS;
+	const drainDeadlineMs =
+		options.drainDeadlineMs ?? ANTHROPIC_DRAIN_DEADLINE_MS;
 	const reader = upstream.getReader();
 	const decoder = new TextDecoder();
 
@@ -142,13 +159,27 @@ export function createAnthropicTerminalRecoveryStream(
 	// `drainBody`, adapted here because `reader` is already an obtained
 	// `ReadableStreamDefaultReader` (the stream is locked to it), not a raw
 	// stream `drainBody` could call `.getReader()` on again.
+	//
+	// Bounded by `drainDeadlineMs`: a stuck-but-open upstream (the case
+	// `recover()`'s timeout path exists for) would otherwise leave this loop
+	// pending forever, holding the socket open where the no-op `cancel()` it
+	// replaced would have resolved instantly. On deadline the lock is
+	// released without waiting on any further read.
 	const drainUpstreamReader = async (): Promise<void> => {
+		let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
 		try {
+			const deadline = new Promise<{ done: true }>((resolve) => {
+				deadlineTimer = setTimeout(
+					() => resolve({ done: true }),
+					drainDeadlineMs,
+				);
+			});
 			while (true) {
-				const { done } = await reader.read();
+				const { done } = await Promise.race([reader.read(), deadline]);
 				if (done) return;
 			}
 		} finally {
+			if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
 			reader.releaseLock();
 		}
 	};

--- a/packages/proxy/src/anthropic-terminal-recovery.ts
+++ b/packages/proxy/src/anthropic-terminal-recovery.ts
@@ -10,9 +10,9 @@ export const ANTHROPIC_TERMINAL_RECOVERY_GRACE_MS = 10_000;
  * `recover()`'s timeout path exists for) would hold the socket and its
  * native buffer open forever instead of the fast Bun `cancel()` no-op it
  * replaced — trading a memory leak for a connection leak. Once the deadline
- * fires the reader's lock is released without awaiting `reader.cancel()`
- * (also a no-op); the socket is reclaimed when Bun eventually times it out
- * or the upstream closes on its own.
+ * fires, `drainAbort` (when supplied) is aborted to actually tear down the
+ * underlying fetch's connection — releasing the reader's lock alone does not
+ * do that, it only frees the reader object for another consumer.
  */
 export const ANTHROPIC_DRAIN_DEADLINE_MS = 30_000;
 
@@ -70,6 +70,16 @@ export interface AnthropicTerminalRecoveryOptions {
 	gracePeriodMs?: number;
 	/** @internal Override only in deterministic unit tests. */
 	drainDeadlineMs?: number;
+	/**
+	 * Controller whose signal is part of the `init.signal` the upstream
+	 * `fetch()` was created with (see request-handler.ts's `effectiveSignal`).
+	 * Aborting it is the only way to actually terminate that in-flight
+	 * fetch's connection — a signal from an unrelated/later controller cannot
+	 * retroactively attach. Optional so tests and callers without a wired
+	 * fetch-level controller keep working; without it, deadline expiry falls
+	 * back to releasing the reader lock only.
+	 */
+	drainAbort?: AbortController;
 	onRecovery?: (reason: AnthropicTerminalRecoveryReason) => void;
 	onCancelError?: (
 		error: unknown,
@@ -104,6 +114,7 @@ export function createAnthropicTerminalRecoveryStream(
 		options.gracePeriodMs ?? ANTHROPIC_TERMINAL_RECOVERY_GRACE_MS;
 	const drainDeadlineMs =
 		options.drainDeadlineMs ?? ANTHROPIC_DRAIN_DEADLINE_MS;
+	const drainAbort = options.drainAbort;
 	const reader = upstream.getReader();
 	const decoder = new TextDecoder();
 
@@ -163,16 +174,19 @@ export function createAnthropicTerminalRecoveryStream(
 	// Bounded by `drainDeadlineMs`: a stuck-but-open upstream (the case
 	// `recover()`'s timeout path exists for) would otherwise leave this loop
 	// pending forever, holding the socket open where the no-op `cancel()` it
-	// replaced would have resolved instantly. On deadline the lock is
-	// released without waiting on any further read.
+	// replaced would have resolved instantly. On deadline, `drainAbort` (when
+	// supplied) is aborted so the fetch's underlying connection is actually
+	// torn down — `reader.releaseLock()` alone only frees the reader object,
+	// it does not touch the connection, so without an abort signal the socket
+	// would be left to whatever timeout Bun applies on its own.
 	const drainUpstreamReader = async (): Promise<void> => {
 		let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
 		try {
 			const deadline = new Promise<{ done: true }>((resolve) => {
-				deadlineTimer = setTimeout(
-					() => resolve({ done: true }),
-					drainDeadlineMs,
-				);
+				deadlineTimer = setTimeout(() => {
+					drainAbort?.abort(new Error("Drain deadline exceeded"));
+					resolve({ done: true });
+				}, drainDeadlineMs);
 			});
 			while (true) {
 				const { done } = await Promise.race([reader.read(), deadline]);

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -503,6 +503,11 @@ export async function proxyUnauthenticated(
 	);
 
 	try {
+		// Dedicated controller so a stuck-upstream drain deadline (see
+		// anthropic-terminal-recovery.ts) can abort this specific fetch's
+		// connection after the fact — a signal not part of `init.signal` at
+		// fetch-creation time cannot retroactively attach to it.
+		const drainAbortController = new AbortController();
 		const response = await makeProxyRequest(
 			targetUrl,
 			req.method,
@@ -510,8 +515,10 @@ export async function proxyUnauthenticated(
 			createBodyStream,
 			!!req.body,
 			// Abort upstream when the client disconnects; this path builds no
-			// Request object, so the signal has to be passed explicitly.
-			req.signal,
+			// Request object, so the signal has to be passed explicitly. Merged
+			// with drainAbortController so the terminal-recovery drain deadline
+			// can also abort this same fetch later.
+			AbortSignal.any([req.signal, drainAbortController.signal]),
 		);
 
 		return forwardToClient(
@@ -537,6 +544,7 @@ export async function proxyUnauthenticated(
 				comboName: requestMeta.comboName,
 				apiKeyId,
 				apiKeyName,
+				drainAbort: drainAbortController,
 			},
 			ctx,
 		);
@@ -581,13 +589,21 @@ export async function proxyWithAccount(
 	returnRateLimitedResponseOnExhaustion = false,
 ): Promise<Response | null> {
 	try {
+		// Dedicated controller so a stuck-upstream drain deadline (see
+		// anthropic-terminal-recovery.ts) can abort this request's fetch
+		// connection after the fact — a signal not part of `init.signal` at
+		// fetch-creation time cannot retroactively attach to it.
+		const drainAbortController = new AbortController();
+
 		// Every upstream call stays tied to the client connection: when the client
 		// disconnects, the upstream fetch must be aborted instead of running on.
 		// The signal is passed explicitly instead of relying on the Request object
 		// to carry it, because provider body transforms rebuild the Request from
 		// its URL and drop the signal (see providers/src/utils/model-mapping.ts and
 		// the openai/codex providers). One guarantee at the call site beats an
-		// invariant that every provider has to remember.
+		// invariant that every provider has to remember. Merged with
+		// drainAbortController so the terminal-recovery drain deadline can also
+		// abort this same fetch later.
 		const forwardUpstream = (target: Request) =>
 			makeProxyRequest(
 				target,
@@ -595,7 +611,7 @@ export async function proxyWithAccount(
 				undefined,
 				undefined,
 				undefined,
-				req.signal,
+				AbortSignal.any([req.signal, drainAbortController.signal]),
 			);
 		if (
 			process.env.DEBUG?.includes("proxy") ||
@@ -1505,6 +1521,7 @@ export async function proxyWithAccount(
 						comboName: requestMeta.comboName,
 						apiKeyId,
 						apiKeyName,
+						drainAbort: drainAbortController,
 					},
 					{ ...ctx, provider },
 				);
@@ -1537,6 +1554,7 @@ export async function proxyWithAccount(
 				comboName: requestMeta.comboName,
 				apiKeyId,
 				apiKeyName,
+				drainAbort: drainAbortController,
 			},
 			{ ...ctx, provider },
 		);

--- a/packages/proxy/src/response-handler.ts
+++ b/packages/proxy/src/response-handler.ts
@@ -114,6 +114,13 @@ export interface ResponseHandlerOptions {
 	comboName?: string | null;
 	originalModel?: string | null;
 	appliedModel?: string | null;
+	/**
+	 * Controller whose signal was merged into the upstream fetch's
+	 * `init.signal` (see proxy-operations.ts). Passed through to the
+	 * terminal-recovery stream so a stuck-upstream drain deadline can abort
+	 * the actual connection instead of only releasing the reader lock.
+	 */
+	drainAbort?: AbortController;
 }
 
 /**
@@ -147,6 +154,7 @@ export async function forwardToClient(
 		comboName,
 		originalModel,
 		appliedModel,
+		drainAbort,
 	} = options;
 
 	// Always strip compression headers *before* we do anything else
@@ -279,11 +287,7 @@ export async function forwardToClient(
 				// applied in proxy-operations.ts (3 sites) and
 				// response-processor.ts — closing the gap flagged on merged
 				// upstream PR #196 (greptile-apps).
-				const isKeepalive = isInternalProbe(
-					requestHeaders,
-					ctx,
-					"keepalive",
-				);
+				const isKeepalive = isInternalProbe(requestHeaders, ctx, "keepalive");
 				if (isKeepalive) {
 					log.warn(
 						`Keepalive replay for ${account.name} hit mid-stream rate-limit — skipping cooldown (synthetic burst, not a real per-account rate limit)`,
@@ -397,6 +401,7 @@ export async function forwardToClient(
 		let streamTerminalState: AnthropicTerminalState | null = null;
 		const responseBody = isAnthropicMessagesSseResponse
 			? createAnthropicTerminalRecoveryStream(response.body, {
+					drainAbort,
 					onRecovery(reason) {
 						log.warn("anthropic_terminal_message_stop_recovered", {
 							requestId,


### PR DESCRIPTION
## Summary
- Bun's `reader.cancel()` is a documented no-op ([oven-sh/bun#35093](https://github.com/oven-sh/bun/issues/35093)) that never releases the native off-heap buffer backing a `fetch()` response body. PR #392 fixed this for `teeStream()`'s client-disconnect path, but the leak persisted for two reporters on v3.5.50 — investigation found three more call sites with the same anti-pattern that #392 didn't touch:
  - `anthropic-terminal-recovery.ts`'s `cancelUpstream()` — cancelled the reader not only on client disconnect but on **every normal recovery/timeout completion** (`recover()`, `finalizeBufferedMessageStopAtTimeout()`), abandoning unread upstream bytes on ordinary, successful requests.
  - `extractUsageInfo()` in both `base-anthropic-compatible.ts` and `anthropic/provider.ts` — `reader.cancel()` runs in a `finally` block hit on **essentially every streaming request** (the read loop typically breaks early once usage data is found, well before the body is exhausted). This is the best fit for reports of steady growth on normal traffic with no client disconnects.
  - `transformStreamToOpenAIFormat()`'s stream `cancel()` handler in `anthropic/provider.ts` — same disconnect-triggered leak as the original `stream-tee.ts` bug, for the parallel OpenAI-format transform path.
- All four now drain the reader to `done` instead of cancelling it, matching the established fix pattern in `stream-tee.ts` and `handlers/discard-body-cancel.ts`. No change to return values, parsing, or timeout/error behavior — only how an abandoned reader's native buffer is released.

Fixes #382

## Test plan
- [x] `bunx biome check` on all 4 touched files — clean
- [x] `bun run typecheck` — clean
- [x] `bun test packages/proxy packages/providers` — 1550 pass, 7 fail; confirmed via `git stash` that the same 7 failures exist on unmodified `main` (pre-existing `fetch`-mock pollution in `request-handler-client-abort.test.ts` and one pre-existing failure in `response-handler-anthropic-terminal-recovery.test.ts`), no new failures introduced
- [x] Updated `anthropic-terminal-recovery.test.ts` (35/35 pass) to match the new drain semantics — assertions that previously checked `reader.cancel()` was called now check the drain path instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)