### PR TITLE
fix: refresh-token rotation races could permanently flag healthy accounts as requiring re-auth

### DIFF
--- a/packages/database/src/database-operations.ts
+++ b/packages/database/src/database-operations.ts
@@ -820,6 +820,30 @@ OAuth tokens will need to be re-authenticated.
 	}
 
 	/**
+	 * Compare-and-set variant of {@link updateAccountTokens} guarded on the
+	 * account currently having no refresh token — see
+	 * {@link AccountRepository.updateTokensIfRefreshTokenAbsent}.
+	 */
+	async updateAccountTokensIfRefreshTokenAbsent(
+		accountId: string,
+		accessToken: string,
+		expiresAt: number,
+		refreshToken?: string,
+	): Promise<boolean> {
+		return withDatabaseRetry(
+			() =>
+				this.accounts.updateTokensIfRefreshTokenAbsent(
+					accountId,
+					accessToken,
+					expiresAt,
+					refreshToken,
+				),
+			this.retryConfig,
+			"updateAccountTokensIfRefreshTokenAbsent",
+		);
+	}
+
+	/**
 	 * Compare-and-set variant of {@link setRequiresReauth}(accountId, true)
 	 * guarded on the expected refresh token — see
 	 * {@link AccountRepository.flagRequiresReauthIfTokenMatches}.

--- a/packages/database/src/database-operations.ts
+++ b/packages/database/src/database-operations.ts
@@ -793,6 +793,52 @@ OAuth tokens will need to be re-authenticated.
 		);
 	}
 
+	/**
+	 * Compare-and-set variant of {@link updateAccountTokens} guarded on the
+	 * expected refresh token — see
+	 * {@link AccountRepository.updateTokensIfRefreshTokenMatches}.
+	 */
+	async updateAccountTokensIfRefreshTokenMatches(
+		accountId: string,
+		expectedRefreshToken: string,
+		accessToken: string,
+		expiresAt: number,
+		refreshToken?: string,
+	): Promise<boolean> {
+		return withDatabaseRetry(
+			() =>
+				this.accounts.updateTokensIfRefreshTokenMatches(
+					accountId,
+					expectedRefreshToken,
+					accessToken,
+					expiresAt,
+					refreshToken,
+				),
+			this.retryConfig,
+			"updateAccountTokensIfRefreshTokenMatches",
+		);
+	}
+
+	/**
+	 * Compare-and-set variant of {@link setRequiresReauth}(accountId, true)
+	 * guarded on the expected refresh token — see
+	 * {@link AccountRepository.flagRequiresReauthIfTokenMatches}.
+	 */
+	async flagRequiresReauthIfTokenMatches(
+		accountId: string,
+		expectedRefreshToken: string,
+	): Promise<boolean> {
+		return withDatabaseRetry(
+			() =>
+				this.accounts.flagRequiresReauthIfTokenMatches(
+					accountId,
+					expectedRefreshToken,
+				),
+			this.retryConfig,
+			"flagRequiresReauthIfTokenMatches",
+		);
+	}
+
 	async updateAccountUsage(accountId: string): Promise<void> {
 		const sessionDuration =
 			this.runtime?.sessionDurationMs || 5 * 60 * 60 * 1000;

--- a/packages/database/src/repositories/__tests__/account-cas-writes.test.ts
+++ b/packages/database/src/repositories/__tests__/account-cas-writes.test.ts
@@ -132,6 +132,122 @@ describe("AccountRepository — compare-and-set token/requires_reauth writes (ro
 		});
 	});
 
+	describe("updateTokensIfRefreshTokenAbsent", () => {
+		it("applies the write and returns true when refresh_token is NULL", async () => {
+			db.run(
+				`INSERT INTO accounts (id, name, provider, refresh_token, access_token, expires_at, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				[
+					"account-null-rt",
+					"Account Null RT",
+					"anthropic",
+					null,
+					"at-old",
+					1,
+					1,
+				],
+			);
+
+			const result = await repository.updateTokensIfRefreshTokenAbsent(
+				"account-null-rt",
+				"at-new",
+				999,
+				"rt-issued",
+			);
+
+			expect(result).toBe(true);
+			const row = getRaw("account-null-rt");
+			expect(row.access_token).toBe("at-new");
+			expect(row.expires_at).toBe(999);
+			expect(row.refresh_token).toBe("rt-issued");
+			expect(row.refresh_token_issued_at).not.toBeNull();
+			expect(row.requires_reauth).toBe(0);
+		});
+
+		it("applies the write and returns true when refresh_token is an empty string", async () => {
+			db.run(
+				`INSERT INTO accounts (id, name, provider, refresh_token, access_token, expires_at, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				[
+					"account-empty-rt",
+					"Account Empty RT",
+					"anthropic",
+					"",
+					"at-old",
+					1,
+					1,
+				],
+			);
+
+			const result = await repository.updateTokensIfRefreshTokenAbsent(
+				"account-empty-rt",
+				"at-new",
+				999,
+				"rt-issued",
+			);
+
+			expect(result).toBe(true);
+			const row = getRaw("account-empty-rt");
+			expect(row.access_token).toBe("at-new");
+			expect(row.expires_at).toBe(999);
+			expect(row.refresh_token).toBe("rt-issued");
+			expect(row.requires_reauth).toBe(0);
+		});
+
+		it("updates access_token/expires_at and resets requires_reauth without touching refresh_token when no new refresh token is passed", async () => {
+			db.run(
+				`INSERT INTO accounts (id, name, provider, refresh_token, access_token, expires_at, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				[
+					"account-null-rt-2",
+					"Account Null RT 2",
+					"anthropic",
+					null,
+					"at-old",
+					1,
+					1,
+				],
+			);
+
+			const result = await repository.updateTokensIfRefreshTokenAbsent(
+				"account-null-rt-2",
+				"at-new",
+				999,
+			);
+
+			expect(result).toBe(true);
+			const row = getRaw("account-null-rt-2");
+			expect(row.access_token).toBe("at-new");
+			expect(row.expires_at).toBe(999);
+			expect(row.refresh_token).toBeNull();
+			expect(row.requires_reauth).toBe(0);
+		});
+
+		it("returns false and leaves the row unchanged when the account already has a real refresh token", async () => {
+			const result = await repository.updateTokensIfRefreshTokenAbsent(
+				"account-1",
+				"at-new",
+				999,
+				"rt-issued",
+			);
+
+			expect(result).toBe(false);
+			const row = getRaw("account-1");
+			expect(row.access_token).toBe("at-old");
+			expect(row.expires_at).toBe(1);
+			expect(row.refresh_token).toBe("rt-original");
+			expect(row.requires_reauth).toBe(0);
+		});
+
+		it("returns false when the account id does not exist", async () => {
+			const result = await repository.updateTokensIfRefreshTokenAbsent(
+				"missing-account",
+				"at-new",
+				999,
+				"rt-issued",
+			);
+
+			expect(result).toBe(false);
+		});
+	});
+
 	describe("flagRequiresReauthIfTokenMatches", () => {
 		it("sets requires_reauth = 1 and returns true when expectedRefreshToken matches", async () => {
 			const result = await repository.flagRequiresReauthIfTokenMatches(

--- a/packages/database/src/repositories/__tests__/account-cas-writes.test.ts
+++ b/packages/database/src/repositories/__tests__/account-cas-writes.test.ts
@@ -1,0 +1,165 @@
+import "@better-ccflare/core";
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { BunSqlAdapter } from "../../adapters/bun-sql-adapter";
+import { AccountRepository } from "../account.repository";
+
+interface RawAccountRow {
+	access_token: string | null;
+	expires_at: number | null;
+	refresh_token: string | null;
+	refresh_token_issued_at: number | null;
+	requires_reauth: number;
+}
+
+describe("AccountRepository — compare-and-set token/requires_reauth writes (rotation-race hardening)", () => {
+	let db: Database;
+	let repository: AccountRepository;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		db.run(`
+			CREATE TABLE accounts (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				provider TEXT DEFAULT 'anthropic',
+				api_key TEXT,
+				refresh_token TEXT DEFAULT '',
+				access_token TEXT,
+				expires_at INTEGER,
+				created_at INTEGER NOT NULL,
+				last_used INTEGER,
+				request_count INTEGER DEFAULT 0,
+				total_requests INTEGER DEFAULT 0,
+				rate_limited_until INTEGER,
+				rate_limited_reason TEXT,
+				rate_limited_at INTEGER,
+				session_start INTEGER,
+				session_request_count INTEGER DEFAULT 0,
+				paused INTEGER DEFAULT 0,
+				requires_reauth INTEGER DEFAULT 0,
+				rate_limit_reset INTEGER,
+				rate_limit_status TEXT,
+				rate_limit_remaining INTEGER,
+				priority INTEGER DEFAULT 0,
+				auto_fallback_enabled INTEGER DEFAULT 0,
+				auto_refresh_enabled INTEGER DEFAULT 0,
+				auto_pause_on_overage_enabled INTEGER DEFAULT 0,
+				peak_hours_pause_enabled INTEGER DEFAULT 0,
+				custom_endpoint TEXT,
+				model_mappings TEXT,
+				cross_region_mode TEXT,
+				model_fallbacks TEXT,
+				billing_type TEXT,
+				pause_reason TEXT,
+				refresh_token_issued_at INTEGER,
+				consecutive_rate_limits INTEGER DEFAULT 0
+			)
+		`);
+		db.run(
+			`INSERT INTO accounts (id, name, provider, refresh_token, access_token, expires_at, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			["account-1", "Account 1", "anthropic", "rt-original", "at-old", 1, 1],
+		);
+		repository = new AccountRepository(new BunSqlAdapter(db));
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	function getRaw(id: string): RawAccountRow {
+		return db
+			.query<RawAccountRow, [string]>(
+				"SELECT access_token, expires_at, refresh_token, refresh_token_issued_at, requires_reauth FROM accounts WHERE id = ?",
+			)
+			.get(id) as RawAccountRow;
+	}
+
+	describe("updateTokensIfRefreshTokenMatches", () => {
+		it("applies the write and returns true when expectedRefreshToken matches, resetting requires_reauth and rotating the refresh token when one is passed", async () => {
+			await repository.setRequiresReauth("account-1", true);
+
+			const result = await repository.updateTokensIfRefreshTokenMatches(
+				"account-1",
+				"rt-original",
+				"at-new",
+				999,
+				"rt-rotated",
+			);
+
+			expect(result).toBe(true);
+			const row = getRaw("account-1");
+			expect(row.access_token).toBe("at-new");
+			expect(row.expires_at).toBe(999);
+			expect(row.refresh_token).toBe("rt-rotated");
+			expect(row.refresh_token_issued_at).not.toBeNull();
+			expect(row.requires_reauth).toBe(0);
+		});
+
+		it("updates access_token/expires_at and resets requires_reauth without touching refresh_token when no new refresh token is passed", async () => {
+			await repository.setRequiresReauth("account-1", true);
+
+			const result = await repository.updateTokensIfRefreshTokenMatches(
+				"account-1",
+				"rt-original",
+				"at-new",
+				999,
+			);
+
+			expect(result).toBe(true);
+			const row = getRaw("account-1");
+			expect(row.access_token).toBe("at-new");
+			expect(row.expires_at).toBe(999);
+			expect(row.refresh_token).toBe("rt-original");
+			expect(row.requires_reauth).toBe(0);
+		});
+
+		it("returns false and leaves the row unchanged when expectedRefreshToken no longer matches (rotated concurrently)", async () => {
+			const result = await repository.updateTokensIfRefreshTokenMatches(
+				"account-1",
+				"rt-stale",
+				"at-new",
+				999,
+				"rt-rotated",
+			);
+
+			expect(result).toBe(false);
+			const row = getRaw("account-1");
+			expect(row.access_token).toBe("at-old");
+			expect(row.expires_at).toBe(1);
+			expect(row.refresh_token).toBe("rt-original");
+			expect(row.requires_reauth).toBe(0);
+		});
+	});
+
+	describe("flagRequiresReauthIfTokenMatches", () => {
+		it("sets requires_reauth = 1 and returns true when expectedRefreshToken matches", async () => {
+			const result = await repository.flagRequiresReauthIfTokenMatches(
+				"account-1",
+				"rt-original",
+			);
+
+			expect(result).toBe(true);
+			expect(getRaw("account-1").requires_reauth).toBe(1);
+		});
+
+		it("returns false and leaves requires_reauth at 0 when the refresh token was rotated concurrently", async () => {
+			const result = await repository.flagRequiresReauthIfTokenMatches(
+				"account-1",
+				"rt-rotated-elsewhere",
+			);
+
+			expect(result).toBe(false);
+			expect(getRaw("account-1").requires_reauth).toBe(0);
+		});
+
+		it("returns false when the account id does not exist", async () => {
+			const result = await repository.flagRequiresReauthIfTokenMatches(
+				"missing-account",
+				"rt-original",
+			);
+
+			expect(result).toBe(false);
+		});
+	});
+});

--- a/packages/database/src/repositories/account.repository.ts
+++ b/packages/database/src/repositories/account.repository.ts
@@ -120,6 +120,66 @@ export class AccountRepository extends BaseRepository<Account> {
 		]);
 	}
 
+	/**
+	 * Compare-and-set variant of {@link updateTokens}, guarded on the caller's
+	 * expected `refresh_token`. If a rotation lands between the caller's read
+	 * and this write (e.g. a concurrent refresh cycle already rotated the
+	 * token), the WHERE clause matches no row and the write becomes a no-op
+	 * instead of overwriting the newer token with a stale one. See the
+	 * rotation-race hardening design.
+	 *
+	 * @returns `true` if a row was updated, `false` if the refresh token no
+	 * longer matched (or the account doesn't exist).
+	 */
+	async updateTokensIfRefreshTokenMatches(
+		accountId: string,
+		expectedRefreshToken: string,
+		accessToken: string,
+		expiresAt: number,
+		refreshToken?: string,
+	): Promise<boolean> {
+		const now = Date.now();
+		if (refreshToken) {
+			const changes = await this.runWithChanges(
+				`UPDATE accounts SET access_token = ?, expires_at = ?, refresh_token = ?, refresh_token_issued_at = ?, requires_reauth = 0 WHERE id = ? AND refresh_token = ?`,
+				[
+					accessToken,
+					expiresAt,
+					refreshToken,
+					now,
+					accountId,
+					expectedRefreshToken,
+				],
+			);
+			return changes > 0;
+		}
+		const changes = await this.runWithChanges(
+			`UPDATE accounts SET access_token = ?, expires_at = ?, requires_reauth = 0 WHERE id = ? AND refresh_token = ?`,
+			[accessToken, expiresAt, accountId, expectedRefreshToken],
+		);
+		return changes > 0;
+	}
+
+	/**
+	 * Compare-and-set variant of {@link setRequiresReauth}(accountId, true),
+	 * guarded on the caller's expected `refresh_token`. Prevents condemning a
+	 * healthy account whose refresh token was rotated by a concurrent refresh
+	 * cycle between the failed-refresh read and this flagging write.
+	 *
+	 * @returns `true` if a row was flagged, `false` if the refresh token no
+	 * longer matched (or the account doesn't exist).
+	 */
+	async flagRequiresReauthIfTokenMatches(
+		accountId: string,
+		expectedRefreshToken: string,
+	): Promise<boolean> {
+		const changes = await this.runWithChanges(
+			`UPDATE accounts SET requires_reauth = 1 WHERE id = ? AND refresh_token = ?`,
+			[accountId, expectedRefreshToken],
+		);
+		return changes > 0;
+	}
+
 	async incrementUsage(
 		accountId: string,
 		sessionDurationMs: number,

--- a/packages/database/src/repositories/account.repository.ts
+++ b/packages/database/src/repositories/account.repository.ts
@@ -161,6 +161,38 @@ export class AccountRepository extends BaseRepository<Account> {
 	}
 
 	/**
+	 * Compare-and-set variant of {@link updateTokens}, guarded on the account
+	 * currently having no refresh token (`NULL` or `''`). Used when a token
+	 * refresh cycle started from an account that had no refresh token to
+	 * begin with — if a concurrent rotation has since given the account a
+	 * real refresh token, the WHERE clause matches no row and this write
+	 * becomes a no-op instead of clobbering the newer token.
+	 *
+	 * @returns `true` if a row was updated, `false` if the account already
+	 * has a refresh token (or the account doesn't exist).
+	 */
+	async updateTokensIfRefreshTokenAbsent(
+		accountId: string,
+		accessToken: string,
+		expiresAt: number,
+		refreshToken?: string,
+	): Promise<boolean> {
+		const now = Date.now();
+		if (refreshToken) {
+			const changes = await this.runWithChanges(
+				`UPDATE accounts SET access_token = ?, expires_at = ?, refresh_token = ?, refresh_token_issued_at = ?, requires_reauth = 0 WHERE id = ? AND (refresh_token IS NULL OR refresh_token = '')`,
+				[accessToken, expiresAt, refreshToken, now, accountId],
+			);
+			return changes > 0;
+		}
+		const changes = await this.runWithChanges(
+			`UPDATE accounts SET access_token = ?, expires_at = ?, requires_reauth = 0 WHERE id = ? AND (refresh_token IS NULL OR refresh_token = '')`,
+			[accessToken, expiresAt, accountId],
+		);
+		return changes > 0;
+	}
+
+	/**
 	 * Compare-and-set variant of {@link setRequiresReauth}(accountId, true),
 	 * guarded on the caller's expected `refresh_token`. Prevents condemning a
 	 * healthy account whose refresh token was rotated by a concurrent refresh

--- a/packages/proxy/src/__tests__/auto-refresh-proactive-requires-reauth.test.ts
+++ b/packages/proxy/src/__tests__/auto-refresh-proactive-requires-reauth.test.ts
@@ -18,17 +18,26 @@ interface ProactiveRow {
 
 function makeDb(queryRows: ProactiveRow[]) {
 	const runCalls: Array<[string, unknown[]]> = [];
+	const runWithChangesCalls: Array<[string, unknown[]]> = [];
 	const queries: string[] = [];
 	const db = {
 		run: mock(async (sql: string, params: unknown[]) => {
 			runCalls.push([sql, params]);
+		}),
+		// flagIfDefinitiveAuthFailure persists requires_reauth via the CAS
+		// helper (runWithChanges), not run — return 1 so the mocked write
+		// reports as "landed" (matches the real UPDATE ... WHERE refresh_token
+		// = ? matching the row's current token in these fixtures).
+		runWithChanges: mock(async (sql: string, params: unknown[]) => {
+			runWithChangesCalls.push([sql, params]);
+			return 1;
 		}),
 		query: mock(async (sql: string) => {
 			queries.push(sql);
 			return queryRows;
 		}),
 	};
-	return { db, runCalls, queries };
+	return { db, runCalls, runWithChangesCalls, queries };
 }
 
 function makeScheduler(db: unknown) {
@@ -75,7 +84,7 @@ describe("AutoRefreshScheduler proactive refresh — requires_reauth guard", () 
 
 describe("AutoRefreshScheduler proactive refresh — definitive auth failure", () => {
 	it("flags an xAI account whose proactive refresh returns invalid_grant and emits the event", async () => {
-		const { db, runCalls } = makeDb([
+		const { db, runWithChangesCalls } = makeDb([
 			{
 				id: "xai-dead",
 				name: "xai-dead",
@@ -102,9 +111,11 @@ describe("AutoRefreshScheduler proactive refresh — definitive auth failure", (
 		const scheduler = makeScheduler(db);
 		await scheduler.checkAndRefreshOpenAICompatibleOAuthTokens();
 
-		const flagWrite = runCalls.find(([sql]) => sql.includes("requires_reauth"));
+		const flagWrite = runWithChangesCalls.find(([sql]) =>
+			sql.includes("requires_reauth"),
+		);
 		expect(flagWrite).toBeDefined();
-		expect(flagWrite?.[1]).toEqual(["xai-dead"]);
+		expect(flagWrite?.[1]).toEqual(["xai-dead", "rt"]);
 		expect(emitted).toHaveLength(1);
 		expect(emitted[0]).toMatchObject({
 			accountId: "xai-dead",
@@ -114,7 +125,7 @@ describe("AutoRefreshScheduler proactive refresh — definitive auth failure", (
 	});
 
 	it("flags a Codex account whose proactive refresh returns refresh_token_reused", async () => {
-		const { db, runCalls } = makeDb([
+		const { db, runWithChangesCalls } = makeDb([
 			{
 				id: "codex-dead",
 				name: "codex-dead",
@@ -138,9 +149,11 @@ describe("AutoRefreshScheduler proactive refresh — definitive auth failure", (
 		const scheduler = makeScheduler(db);
 		await scheduler.checkAndRefreshCodexTokens();
 
-		const flagWrite = runCalls.find(([sql]) => sql.includes("requires_reauth"));
+		const flagWrite = runWithChangesCalls.find(([sql]) =>
+			sql.includes("requires_reauth"),
+		);
 		expect(flagWrite).toBeDefined();
-		expect(flagWrite?.[1]).toEqual(["codex-dead"]);
+		expect(flagWrite?.[1]).toEqual(["codex-dead", "rt"]);
 		expect(emitted).toHaveLength(1);
 		expect(emitted[0]?.reason).toBe("refresh_token_reused");
 	});

--- a/packages/proxy/src/__tests__/auto-refresh-proactive-requires-reauth.test.ts
+++ b/packages/proxy/src/__tests__/auto-refresh-proactive-requires-reauth.test.ts
@@ -18,34 +18,65 @@ interface ProactiveRow {
 
 function makeDb(queryRows: ProactiveRow[]) {
 	const runCalls: Array<[string, unknown[]]> = [];
-	const runWithChangesCalls: Array<[string, unknown[]]> = [];
 	const queries: string[] = [];
+	const flagCalls: Array<[string, string]> = [];
+	const persistCalls: Array<
+		[string, string, string, number, string | undefined]
+	> = [];
 	const db = {
 		run: mock(async (sql: string, params: unknown[]) => {
 			runCalls.push([sql, params]);
-		}),
-		// flagIfDefinitiveAuthFailure persists requires_reauth via the CAS
-		// helper (runWithChanges), not run — return 1 so the mocked write
-		// reports as "landed" (matches the real UPDATE ... WHERE refresh_token
-		// = ? matching the row's current token in these fixtures).
-		runWithChanges: mock(async (sql: string, params: unknown[]) => {
-			runWithChangesCalls.push([sql, params]);
-			return 1;
 		}),
 		query: mock(async (sql: string) => {
 			queries.push(sql);
 			return queryRows;
 		}),
 	};
-	return { db, runCalls, runWithChangesCalls, queries };
+	const dbOps = {
+		// flagIfDefinitiveAuthFailure persists requires_reauth via this CAS
+		// helper — return true so the write reports as "landed" (matches the
+		// real UPDATE ... WHERE refresh_token = ? matching the row's current
+		// token in these fixtures).
+		flagRequiresReauthIfTokenMatches: mock(
+			async (accountId: string, expectedRefreshToken: string) => {
+				flagCalls.push([accountId, expectedRefreshToken]);
+				return true;
+			},
+		),
+		// The proactive persist paths route their token-rotation CAS write
+		// through this helper too — return true so it reports as "landed"
+		// (these tests only exercise the failure path, so it's never asserted
+		// on directly, but must resolve for the success branch to log cleanly).
+		updateAccountTokensIfRefreshTokenMatches: mock(
+			async (
+				accountId: string,
+				expectedRefreshToken: string,
+				accessToken: string,
+				expiresAt: number,
+				refreshToken?: string,
+			) => {
+				persistCalls.push([
+					accountId,
+					expectedRefreshToken,
+					accessToken,
+					expiresAt,
+					refreshToken,
+				]);
+				return true;
+			},
+		),
+		updateAccountTokensIfRefreshTokenAbsent: mock(async () => true),
+	};
+	return { db, dbOps, runCalls, flagCalls, persistCalls, queries };
 }
 
-function makeScheduler(db: unknown) {
+function makeScheduler(db: unknown, dbOps: unknown) {
 	return new AutoRefreshScheduler(
 		db as never,
 		{
 			runtime: { port: 8080, clientId: "test-client" },
 			refreshInFlight: new Map(),
+			dbOps,
 		} as never,
 	) as unknown as {
 		checkAndRefreshOpenAICompatibleOAuthTokens(): Promise<void>;
@@ -60,8 +91,8 @@ afterEach(() => {
 
 describe("AutoRefreshScheduler proactive refresh — requires_reauth guard", () => {
 	it("excludes flagged accounts from the OpenAI-compatible eligibility query", async () => {
-		const { db, queries } = makeDb([]);
-		const scheduler = makeScheduler(db);
+		const { db, dbOps, queries } = makeDb([]);
+		const scheduler = makeScheduler(db, dbOps);
 
 		await scheduler.checkAndRefreshOpenAICompatibleOAuthTokens();
 
@@ -71,8 +102,8 @@ describe("AutoRefreshScheduler proactive refresh — requires_reauth guard", () 
 	});
 
 	it("excludes flagged accounts from the Codex eligibility query", async () => {
-		const { db, queries } = makeDb([]);
-		const scheduler = makeScheduler(db);
+		const { db, dbOps, queries } = makeDb([]);
+		const scheduler = makeScheduler(db, dbOps);
 
 		await scheduler.checkAndRefreshCodexTokens();
 
@@ -84,7 +115,7 @@ describe("AutoRefreshScheduler proactive refresh — requires_reauth guard", () 
 
 describe("AutoRefreshScheduler proactive refresh — definitive auth failure", () => {
 	it("flags an xAI account whose proactive refresh returns invalid_grant and emits the event", async () => {
-		const { db, runWithChangesCalls } = makeDb([
+		const { db, dbOps, flagCalls } = makeDb([
 			{
 				id: "xai-dead",
 				name: "xai-dead",
@@ -108,14 +139,10 @@ describe("AutoRefreshScheduler proactive refresh — definitive auth failure", (
 		const emitted: AuthFailureEvt[] = [];
 		authFailureEvents.once("event", (event) => emitted.push(event));
 
-		const scheduler = makeScheduler(db);
+		const scheduler = makeScheduler(db, dbOps);
 		await scheduler.checkAndRefreshOpenAICompatibleOAuthTokens();
 
-		const flagWrite = runWithChangesCalls.find(([sql]) =>
-			sql.includes("requires_reauth"),
-		);
-		expect(flagWrite).toBeDefined();
-		expect(flagWrite?.[1]).toEqual(["xai-dead", "rt"]);
+		expect(flagCalls).toEqual([["xai-dead", "rt"]]);
 		expect(emitted).toHaveLength(1);
 		expect(emitted[0]).toMatchObject({
 			accountId: "xai-dead",
@@ -125,7 +152,7 @@ describe("AutoRefreshScheduler proactive refresh — definitive auth failure", (
 	});
 
 	it("flags a Codex account whose proactive refresh returns refresh_token_reused", async () => {
-		const { db, runWithChangesCalls } = makeDb([
+		const { db, dbOps, flagCalls } = makeDb([
 			{
 				id: "codex-dead",
 				name: "codex-dead",
@@ -146,20 +173,16 @@ describe("AutoRefreshScheduler proactive refresh — definitive auth failure", (
 		const emitted: AuthFailureEvt[] = [];
 		authFailureEvents.once("event", (event) => emitted.push(event));
 
-		const scheduler = makeScheduler(db);
+		const scheduler = makeScheduler(db, dbOps);
 		await scheduler.checkAndRefreshCodexTokens();
 
-		const flagWrite = runWithChangesCalls.find(([sql]) =>
-			sql.includes("requires_reauth"),
-		);
-		expect(flagWrite).toBeDefined();
-		expect(flagWrite?.[1]).toEqual(["codex-dead", "rt"]);
+		expect(flagCalls).toEqual([["codex-dead", "rt"]]);
 		expect(emitted).toHaveLength(1);
 		expect(emitted[0]?.reason).toBe("refresh_token_reused");
 	});
 
 	it("does NOT flag a proactive refresh that fails with a transient network error", async () => {
-		const { db, runWithChangesCalls } = makeDb([
+		const { db, dbOps, flagCalls } = makeDb([
 			{
 				id: "codex-net",
 				name: "codex-net",
@@ -181,14 +204,13 @@ describe("AutoRefreshScheduler proactive refresh — definitive auth failure", (
 		authFailureEvents.on("event", listener);
 
 		try {
-			const scheduler = makeScheduler(db);
+			const scheduler = makeScheduler(db, dbOps);
 			await scheduler.checkAndRefreshCodexTokens();
 		} finally {
 			authFailureEvents.off("event", listener);
 		}
 
-		const flagWrite = runWithChangesCalls.find(([sql]) => sql.includes("requires_reauth"));
-		expect(flagWrite).toBeUndefined();
+		expect(flagCalls).toHaveLength(0);
 		expect(emittedCount).toBe(0);
 	});
 });

--- a/packages/proxy/src/__tests__/auto-refresh-proactive-requires-reauth.test.ts
+++ b/packages/proxy/src/__tests__/auto-refresh-proactive-requires-reauth.test.ts
@@ -159,7 +159,7 @@ describe("AutoRefreshScheduler proactive refresh — definitive auth failure", (
 	});
 
 	it("does NOT flag a proactive refresh that fails with a transient network error", async () => {
-		const { db, runCalls } = makeDb([
+		const { db, runWithChangesCalls } = makeDb([
 			{
 				id: "codex-net",
 				name: "codex-net",
@@ -187,7 +187,7 @@ describe("AutoRefreshScheduler proactive refresh — definitive auth failure", (
 			authFailureEvents.off("event", listener);
 		}
 
-		const flagWrite = runCalls.find(([sql]) => sql.includes("requires_reauth"));
+		const flagWrite = runWithChangesCalls.find(([sql]) => sql.includes("requires_reauth"));
 		expect(flagWrite).toBeUndefined();
 		expect(emittedCount).toBe(0);
 	});

--- a/packages/proxy/src/__tests__/auto-refresh-rotation-race-guard.test.ts
+++ b/packages/proxy/src/__tests__/auto-refresh-rotation-race-guard.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for the rotation-race guard in AutoRefreshScheduler.flagIfDefinitiveAuthFailure.
+ *
+ * The proactive refresh paths (qwen/xai, codex) call provider.refreshToken()
+ * directly, bypassing the token-manager funnel fixed in Tasks 1-2. If another
+ * consumer rotated the refresh token between the scheduler's loop-start
+ * snapshot and this refresh attempt, a definitive-looking rejection
+ * (invalid_grant, etc.) condemns a superseded token, not the account itself.
+ * The guard re-reads the current DB refresh token before flagging
+ * requires_reauth and skips the flag when it no longer matches the one this
+ * attempt used.
+ */
+import { describe, expect, it, mock } from "bun:test";
+import { type AuthFailureEvt, authFailureEvents } from "@better-ccflare/core";
+import type { AutoRefreshScheduler } from "../auto-refresh-scheduler";
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/** Build a minimal mock DB adapter with a spy on `run` and a canned `query` result. */
+function makeDb(queryResult: unknown[] = []) {
+	const runCalls: Array<[string, unknown[]]> = [];
+	return {
+		run: mock(async (sql: string, params: unknown[]) => {
+			runCalls.push([sql, params]);
+		}),
+		query: mock(async () => queryResult),
+		runCalls,
+	};
+}
+
+/** Build a minimal mock ProxyContext. */
+function makeProxyContext() {
+	return {
+		runtime: { port: 8080, clientId: "test-client" },
+		refreshInFlight: new Map(),
+	};
+}
+
+/** Instantiate the scheduler without starting the interval. */
+async function makeScheduler(db: ReturnType<typeof makeDb>) {
+	const { AutoRefreshScheduler } = await import("../auto-refresh-scheduler");
+	return new AutoRefreshScheduler(
+		db as never,
+		makeProxyContext() as never,
+	) as AutoRefreshScheduler & {
+		flagIfDefinitiveAuthFailure(
+			error: unknown,
+			row: {
+				id: string;
+				name: string;
+				provider: string;
+				refresh_token: string;
+			},
+		): Promise<void>;
+	};
+}
+
+const row = {
+	id: "acc-1",
+	name: "test-account",
+	provider: "qwen",
+	refresh_token: "RT1-consumed",
+};
+const invalidGrant = new Error(
+	"Failed to refresh token for account test-account: invalid_grant: token expired",
+);
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe("AutoRefreshScheduler — rotation-race guard before requires_reauth", () => {
+	it("skips flagging when the DB refresh token differs from the attempted one", async () => {
+		const db = makeDb([{ refresh_token: "RT2-current" }]);
+		const scheduler = await makeScheduler(db);
+
+		const events: AuthFailureEvt[] = [];
+		const listener = (e: AuthFailureEvt) => events.push(e);
+		authFailureEvents.on("event", listener);
+		try {
+			await scheduler.flagIfDefinitiveAuthFailure(invalidGrant, row);
+		} finally {
+			authFailureEvents.off("event", listener);
+		}
+
+		const flagCall = db.runCalls.find(([sql]) =>
+			sql.includes("requires_reauth = 1"),
+		);
+		expect(flagCall).toBeUndefined();
+		expect(events).toHaveLength(0);
+	});
+
+	it("flags when the DB refresh token equals the attempted one", async () => {
+		const db = makeDb([{ refresh_token: "RT1-consumed" }]);
+		const scheduler = await makeScheduler(db);
+
+		await scheduler.flagIfDefinitiveAuthFailure(invalidGrant, row);
+
+		const flagCall = db.runCalls.find(
+			([sql, params]) =>
+				sql.includes("requires_reauth = 1") &&
+				Array.isArray(params) &&
+				params[0] === "acc-1",
+		);
+		expect(flagCall).toBeDefined();
+	});
+
+	it("flags when the DB row cannot be read (fail-safe to previous behavior)", async () => {
+		const db = makeDb([]);
+		db.query = mock(async () => {
+			throw new Error("db unavailable");
+		});
+		const scheduler = await makeScheduler(db);
+
+		await scheduler.flagIfDefinitiveAuthFailure(invalidGrant, row);
+
+		const flagCall = db.runCalls.find(([sql]) =>
+			sql.includes("requires_reauth = 1"),
+		);
+		expect(flagCall).toBeDefined();
+	});
+
+	it("does nothing for non-definitive errors", async () => {
+		const db = makeDb([{ refresh_token: "RT1-consumed" }]);
+		const scheduler = await makeScheduler(db);
+
+		await scheduler.flagIfDefinitiveAuthFailure(
+			new Error("upstream 503 timeout"),
+			row,
+		);
+
+		expect(db.runCalls).toHaveLength(0);
+	});
+});

--- a/packages/proxy/src/__tests__/auto-refresh-rotation-race-guard.test.ts
+++ b/packages/proxy/src/__tests__/auto-refresh-rotation-race-guard.test.ts
@@ -6,52 +6,76 @@
  * consumer rotated the refresh token between the scheduler's loop-start
  * snapshot and this refresh attempt, a definitive-looking rejection
  * (invalid_grant, etc.) condemns a superseded token, not the account itself.
- * The guard uses a single compare-and-set UPDATE — condemning the account
- * only if it still holds the exact refresh token this attempt used — instead
- * of a separate read-then-write, closing the race window between them.
+ * The guard uses a single compare-and-set write — condemning the account only
+ * if it still holds the exact refresh token this attempt used — instead of a
+ * separate read-then-write, closing the race window between them. That CAS
+ * write goes through proxyContext.dbOps.flagRequiresReauthIfTokenMatches (a
+ * retry-wrapped method shared with the token-manager funnel), not raw SQL.
+ *
+ * A pending rotation registered by the proactive persist paths (this file's
+ * sibling, auto-refresh-proactive-requires-reauth) takes priority over the
+ * CAS write entirely: it means a rotation already succeeded at the provider
+ * moments ago and is merely waiting to be persisted, so the "failure" being
+ * handled here is just a replay of the now-consumed token.
  */
-import { describe, expect, it, mock } from "bun:test";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
 import { type AuthFailureEvt, authFailureEvents } from "@better-ccflare/core";
 import type { AutoRefreshScheduler } from "../auto-refresh-scheduler";
+import {
+	clearAllPendingRotationsForTests,
+	recordPendingRotation,
+} from "../handlers/pending-rotation-registry";
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
-/**
- * Build a minimal mock DB adapter with spies on `run` and `runWithChanges`.
- * `runWithChangesReturn` configures the number of affected rows the CAS
- * UPDATE reports back (0 = no row matched, i.e. rotation race lost).
- */
-function makeDb(runWithChangesReturn = 0) {
+/** Build a minimal mock DB adapter with a spy on `run` (used for non-CAS writes). */
+function makeDb() {
 	const runCalls: Array<[string, unknown[]]> = [];
-	const runWithChangesCalls: Array<[string, unknown[]]> = [];
 	return {
 		run: mock(async (sql: string, params: unknown[]) => {
 			runCalls.push([sql, params]);
 		}),
 		query: mock(async () => []),
-		runWithChanges: mock(async (sql: string, params: unknown[]) => {
-			runWithChangesCalls.push([sql, params]);
-			return runWithChangesReturn;
-		}),
 		runCalls,
-		runWithChangesCalls,
 	};
 }
 
-/** Build a minimal mock ProxyContext. */
-function makeProxyContext() {
+/**
+ * Build a minimal mock ProxyContext with a mockable
+ * dbOps.flagRequiresReauthIfTokenMatches.
+ *
+ * `flagOutcome` controls what the CAS flag write reports back:
+ * - `true` — the row still held the expected refresh token; flagged.
+ * - `false` — the row's refresh token had already changed; not flagged.
+ * - an `Error` — the write rejects (DB unavailable).
+ */
+function makeProxyContext(flagOutcome: boolean | Error = true) {
+	const flagCalls: Array<[string, string]> = [];
 	return {
 		runtime: { port: 8080, clientId: "test-client" },
 		refreshInFlight: new Map(),
+		dbOps: {
+			flagRequiresReauthIfTokenMatches: mock(
+				async (accountId: string, expectedRefreshToken: string) => {
+					flagCalls.push([accountId, expectedRefreshToken]);
+					if (flagOutcome instanceof Error) throw flagOutcome;
+					return flagOutcome;
+				},
+			),
+		},
+		flagCalls,
 	};
 }
 
 /** Instantiate the scheduler without starting the interval. */
-async function makeScheduler(db: ReturnType<typeof makeDb>) {
+async function makeScheduler(
+	db: ReturnType<typeof makeDb>,
+	proxyContext: ReturnType<typeof makeProxyContext>,
+) {
 	const { AutoRefreshScheduler } = await import("../auto-refresh-scheduler");
 	return new AutoRefreshScheduler(
 		db as never,
-		makeProxyContext() as never,
+		proxyContext as never,
 	) as AutoRefreshScheduler & {
 		flagIfDefinitiveAuthFailure(
 			error: unknown,
@@ -90,39 +114,39 @@ async function collectEvents(
 	return events;
 }
 
+beforeEach(() => {
+	clearAllPendingRotationsForTests();
+});
+
 // ── tests ─────────────────────────────────────────────────────────────────────
 
 describe("AutoRefreshScheduler — rotation-race guard before requires_reauth", () => {
-	it("skips flagging when the CAS UPDATE matches no row (refresh token rotated underneath)", async () => {
-		const db = makeDb(0);
-		const scheduler = await makeScheduler(db);
+	it("skips flagging when the CAS write matches no row (refresh token rotated underneath)", async () => {
+		const db = makeDb();
+		const proxyContext = makeProxyContext(false);
+		const scheduler = await makeScheduler(db, proxyContext);
 
 		const events = await collectEvents(() =>
 			scheduler.flagIfDefinitiveAuthFailure(invalidGrant, row),
 		);
 
-		const casCall = db.runWithChangesCalls.find(([sql]) =>
-			sql.includes("requires_reauth = 1"),
-		);
-		expect(casCall).toBeDefined();
+		expect(proxyContext.flagCalls).toEqual([["acc-1", "RT1-consumed"]]);
 		expect(
-			db.runCalls.find(([sql]) => sql.includes("requires_reauth = 1")),
+			db.runCalls.find(([sql]) => sql.includes("requires_reauth")),
 		).toBeUndefined();
 		expect(events).toHaveLength(0);
 	});
 
-	it("flags when the CAS UPDATE matches the row (refresh token still current)", async () => {
-		const db = makeDb(1);
-		const scheduler = await makeScheduler(db);
+	it("flags when the CAS write matches the row (refresh token still current)", async () => {
+		const db = makeDb();
+		const proxyContext = makeProxyContext(true);
+		const scheduler = await makeScheduler(db, proxyContext);
 
 		const events = await collectEvents(() =>
 			scheduler.flagIfDefinitiveAuthFailure(invalidGrant, row),
 		);
 
-		expect(db.runWithChangesCalls).toHaveLength(1);
-		const [sql, params] = db.runWithChangesCalls[0];
-		expect(sql).toContain("requires_reauth = 1");
-		expect(params).toEqual(["acc-1", "RT1-consumed"]);
+		expect(proxyContext.flagCalls).toEqual([["acc-1", "RT1-consumed"]]);
 		expect(events).toHaveLength(1);
 		expect(events[0]).toMatchObject({
 			accountId: "acc-1",
@@ -134,10 +158,8 @@ describe("AutoRefreshScheduler — rotation-race guard before requires_reauth", 
 
 	it("does NOT flag when the DB cannot be written/read", async () => {
 		const db = makeDb();
-		db.runWithChanges = mock(async () => {
-			throw new Error("db unavailable");
-		});
-		const scheduler = await makeScheduler(db);
+		const proxyContext = makeProxyContext(new Error("db unavailable"));
+		const scheduler = await makeScheduler(db, proxyContext);
 
 		const events = await collectEvents(() =>
 			scheduler.flagIfDefinitiveAuthFailure(invalidGrant, row),
@@ -145,13 +167,14 @@ describe("AutoRefreshScheduler — rotation-race guard before requires_reauth", 
 
 		expect(events).toHaveLength(0);
 		expect(
-			db.runCalls.find(([sql]) => sql.includes("requires_reauth = 1")),
+			db.runCalls.find(([sql]) => sql.includes("requires_reauth")),
 		).toBeUndefined();
 	});
 
 	it("does nothing for non-definitive errors", async () => {
-		const db = makeDb(1);
-		const scheduler = await makeScheduler(db);
+		const db = makeDb();
+		const proxyContext = makeProxyContext(true);
+		const scheduler = await makeScheduler(db, proxyContext);
 
 		await scheduler.flagIfDefinitiveAuthFailure(
 			new Error("upstream 503 timeout"),
@@ -159,6 +182,25 @@ describe("AutoRefreshScheduler — rotation-race guard before requires_reauth", 
 		);
 
 		expect(db.runCalls).toHaveLength(0);
-		expect(db.runWithChangesCalls).toHaveLength(0);
+		expect(proxyContext.flagCalls).toHaveLength(0);
+	});
+
+	it("skips flagging when a pending rotation exists for the row", async () => {
+		const db = makeDb();
+		const proxyContext = makeProxyContext(true);
+		recordPendingRotation(row.id, {
+			accessToken: "at-new",
+			expiresAt: Date.now() + 60_000,
+			refreshToken: "rt-new",
+			attemptedRefreshToken: row.refresh_token,
+		});
+		const scheduler = await makeScheduler(db, proxyContext);
+
+		const events = await collectEvents(() =>
+			scheduler.flagIfDefinitiveAuthFailure(invalidGrant, row),
+		);
+
+		expect(proxyContext.flagCalls).toHaveLength(0);
+		expect(events).toHaveLength(0);
 	});
 });

--- a/packages/proxy/src/__tests__/auto-refresh-rotation-race-guard.test.ts
+++ b/packages/proxy/src/__tests__/auto-refresh-rotation-race-guard.test.ts
@@ -6,9 +6,9 @@
  * consumer rotated the refresh token between the scheduler's loop-start
  * snapshot and this refresh attempt, a definitive-looking rejection
  * (invalid_grant, etc.) condemns a superseded token, not the account itself.
- * The guard re-reads the current DB refresh token before flagging
- * requires_reauth and skips the flag when it no longer matches the one this
- * attempt used.
+ * The guard uses a single compare-and-set UPDATE — condemning the account
+ * only if it still holds the exact refresh token this attempt used — instead
+ * of a separate read-then-write, closing the race window between them.
  */
 import { describe, expect, it, mock } from "bun:test";
 import { type AuthFailureEvt, authFailureEvents } from "@better-ccflare/core";
@@ -16,15 +16,25 @@ import type { AutoRefreshScheduler } from "../auto-refresh-scheduler";
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
-/** Build a minimal mock DB adapter with a spy on `run` and a canned `query` result. */
-function makeDb(queryResult: unknown[] = []) {
+/**
+ * Build a minimal mock DB adapter with spies on `run` and `runWithChanges`.
+ * `runWithChangesReturn` configures the number of affected rows the CAS
+ * UPDATE reports back (0 = no row matched, i.e. rotation race lost).
+ */
+function makeDb(runWithChangesReturn = 0) {
 	const runCalls: Array<[string, unknown[]]> = [];
+	const runWithChangesCalls: Array<[string, unknown[]]> = [];
 	return {
 		run: mock(async (sql: string, params: unknown[]) => {
 			runCalls.push([sql, params]);
 		}),
-		query: mock(async () => queryResult),
+		query: mock(async () => []),
+		runWithChanges: mock(async (sql: string, params: unknown[]) => {
+			runWithChangesCalls.push([sql, params]);
+			return runWithChangesReturn;
+		}),
 		runCalls,
+		runWithChangesCalls,
 	};
 }
 
@@ -65,61 +75,82 @@ const invalidGrant = new Error(
 	"Failed to refresh token for account test-account: invalid_grant: token expired",
 );
 
+/** Collect authFailureEvents emitted while running `fn`. */
+async function collectEvents(
+	fn: () => Promise<void>,
+): Promise<AuthFailureEvt[]> {
+	const events: AuthFailureEvt[] = [];
+	const listener = (e: AuthFailureEvt) => events.push(e);
+	authFailureEvents.on("event", listener);
+	try {
+		await fn();
+	} finally {
+		authFailureEvents.off("event", listener);
+	}
+	return events;
+}
+
 // ── tests ─────────────────────────────────────────────────────────────────────
 
 describe("AutoRefreshScheduler — rotation-race guard before requires_reauth", () => {
-	it("skips flagging when the DB refresh token differs from the attempted one", async () => {
-		const db = makeDb([{ refresh_token: "RT2-current" }]);
+	it("skips flagging when the CAS UPDATE matches no row (refresh token rotated underneath)", async () => {
+		const db = makeDb(0);
 		const scheduler = await makeScheduler(db);
 
-		const events: AuthFailureEvt[] = [];
-		const listener = (e: AuthFailureEvt) => events.push(e);
-		authFailureEvents.on("event", listener);
-		try {
-			await scheduler.flagIfDefinitiveAuthFailure(invalidGrant, row);
-		} finally {
-			authFailureEvents.off("event", listener);
-		}
+		const events = await collectEvents(() =>
+			scheduler.flagIfDefinitiveAuthFailure(invalidGrant, row),
+		);
 
-		const flagCall = db.runCalls.find(([sql]) =>
+		const casCall = db.runWithChangesCalls.find(([sql]) =>
 			sql.includes("requires_reauth = 1"),
 		);
-		expect(flagCall).toBeUndefined();
+		expect(casCall).toBeDefined();
+		expect(
+			db.runCalls.find(([sql]) => sql.includes("requires_reauth = 1")),
+		).toBeUndefined();
 		expect(events).toHaveLength(0);
 	});
 
-	it("flags when the DB refresh token equals the attempted one", async () => {
-		const db = makeDb([{ refresh_token: "RT1-consumed" }]);
+	it("flags when the CAS UPDATE matches the row (refresh token still current)", async () => {
+		const db = makeDb(1);
 		const scheduler = await makeScheduler(db);
 
-		await scheduler.flagIfDefinitiveAuthFailure(invalidGrant, row);
-
-		const flagCall = db.runCalls.find(
-			([sql, params]) =>
-				sql.includes("requires_reauth = 1") &&
-				Array.isArray(params) &&
-				params[0] === "acc-1",
+		const events = await collectEvents(() =>
+			scheduler.flagIfDefinitiveAuthFailure(invalidGrant, row),
 		);
-		expect(flagCall).toBeDefined();
+
+		expect(db.runWithChangesCalls).toHaveLength(1);
+		const [sql, params] = db.runWithChangesCalls[0];
+		expect(sql).toContain("requires_reauth = 1");
+		expect(params).toEqual(["acc-1", "RT1-consumed"]);
+		expect(events).toHaveLength(1);
+		expect(events[0]).toMatchObject({
+			accountId: "acc-1",
+			accountName: "test-account",
+			provider: "qwen",
+			reason: "invalid_grant",
+		});
 	});
 
-	it("flags when the DB row cannot be read (fail-safe to previous behavior)", async () => {
-		const db = makeDb([]);
-		db.query = mock(async () => {
+	it("does NOT flag when the DB cannot be written/read", async () => {
+		const db = makeDb();
+		db.runWithChanges = mock(async () => {
 			throw new Error("db unavailable");
 		});
 		const scheduler = await makeScheduler(db);
 
-		await scheduler.flagIfDefinitiveAuthFailure(invalidGrant, row);
-
-		const flagCall = db.runCalls.find(([sql]) =>
-			sql.includes("requires_reauth = 1"),
+		const events = await collectEvents(() =>
+			scheduler.flagIfDefinitiveAuthFailure(invalidGrant, row),
 		);
-		expect(flagCall).toBeDefined();
+
+		expect(events).toHaveLength(0);
+		expect(
+			db.runCalls.find(([sql]) => sql.includes("requires_reauth = 1")),
+		).toBeUndefined();
 	});
 
 	it("does nothing for non-definitive errors", async () => {
-		const db = makeDb([{ refresh_token: "RT1-consumed" }]);
+		const db = makeDb(1);
 		const scheduler = await makeScheduler(db);
 
 		await scheduler.flagIfDefinitiveAuthFailure(
@@ -128,5 +159,6 @@ describe("AutoRefreshScheduler — rotation-race guard before requires_reauth", 
 		);
 
 		expect(db.runCalls).toHaveLength(0);
+		expect(db.runWithChangesCalls).toHaveLength(0);
 	});
 });

--- a/packages/proxy/src/auto-refresh-scheduler.ts
+++ b/packages/proxy/src/auto-refresh-scheduler.ts
@@ -1045,11 +1045,34 @@ export class AutoRefreshScheduler {
 	 */
 	private async flagIfDefinitiveAuthFailure(
 		error: unknown,
-		row: { id: string; name: string; provider: string },
+		row: { id: string; name: string; provider: string; refresh_token: string },
 	): Promise<void> {
 		const message = error instanceof Error ? error.message : String(error);
 		const reason = extractAuthFailureReason(message, row.name);
 		if (!reason) return;
+
+		// Rotation-race guard: if the account's current refresh token is no
+		// longer the one this attempt used, another consumer rotated it after our
+		// loop-start snapshot — the rejection condemned a superseded token, not
+		// the account. Skip flagging; the next scheduler pass uses the live row.
+		try {
+			const rows = await this.db.query<{ refresh_token: string | null }>(
+				`SELECT refresh_token FROM accounts WHERE id = ?`,
+				[row.id],
+			);
+			const currentRefreshToken = rows[0]?.refresh_token ?? null;
+			if (currentRefreshToken && currentRefreshToken !== row.refresh_token) {
+				log.warn(
+					`Skipping requires_reauth for ${row.name}: the failed ${row.provider} refresh used a superseded refresh token (rotation race)`,
+				);
+				return;
+			}
+		} catch (readError) {
+			log.warn(
+				`Could not verify current refresh token for ${row.name} — treating ${reason} as definitive`,
+				readError,
+			);
+		}
 
 		try {
 			await this.db.run(

--- a/packages/proxy/src/auto-refresh-scheduler.ts
+++ b/packages/proxy/src/auto-refresh-scheduler.ts
@@ -15,6 +15,11 @@ import {
 	getValidAccessToken,
 	INTERNAL_PROBE_SECRET_HEADER,
 } from "./handlers";
+import {
+	flushPendingRotation,
+	getPendingRotation,
+	recordPendingRotation,
+} from "./handlers/pending-rotation-registry";
 import type { ProxyContext } from "./proxy";
 
 const log = new Logger("AutoRefreshScheduler");
@@ -804,6 +809,19 @@ export class AutoRefreshScheduler {
 		);
 
 		for (const row of accounts) {
+			// (round-3 item 2) Flush any rotation from an earlier cycle that
+			// succeeded at the provider but failed to persist, before touching
+			// this row again. A still-failing flush means the account's live
+			// credentials are the ones sitting in the registry, not the row we
+			// just read — refreshing again this cycle would race the retry.
+			const flush = await flushPendingRotation(row.id, this.proxyContext.dbOps);
+			if (flush === "failed") {
+				log.warn(
+					`Skipping proactive ${row.provider} refresh for ${row.name} this cycle — a pending rotation is still awaiting persist`,
+				);
+				continue;
+			}
+
 			// Skip if a refresh is already in-flight for this account (deduplication)
 			if (this.proxyContext.refreshInFlight.has(row.id)) {
 				log.debug(
@@ -869,24 +887,43 @@ export class AutoRefreshScheduler {
 						// attempt used — a rotation that landed underneath (manual re-auth,
 						// or a request-triggered refresh joining the same account) must not
 						// be overwritten with the tokens from this now-superseded attempt.
-						const changes = await this.db.runWithChanges(
-							`UPDATE accounts SET access_token = ?, expires_at = ?, refresh_token = ?, refresh_token_issued_at = ? WHERE id = ? AND refresh_token = ?`,
-							[
-								result.accessToken,
-								result.expiresAt,
-								newRefreshToken,
-								Date.now(),
-								row.id,
-								row.refresh_token,
-							],
-						);
-						if (changes === 0) {
-							log.warn(
-								`Skipped persisting refreshed ${row.provider} token for ${row.name}: refresh token changed underneath (superseded by a newer rotation or manual re-auth)`,
-							);
-						} else {
-							log.info(
-								`${row.provider} token refreshed for ${row.name}, expires at ${new Date(result.expiresAt).toISOString()}`,
+						// Routed through the retry-wrapped dbOps helper instead of raw SQL
+						// so this write benefits from the same transient-failure retries on
+						// Postgres as the token-manager funnel.
+						try {
+							const persisted =
+								await this.proxyContext.dbOps.updateAccountTokensIfRefreshTokenMatches(
+									row.id,
+									row.refresh_token,
+									result.accessToken,
+									result.expiresAt,
+									newRefreshToken,
+								);
+							if (!persisted) {
+								log.warn(
+									`Skipped persisting refreshed ${row.provider} token for ${row.name}: refresh token changed underneath (superseded by a newer rotation or manual re-auth)`,
+								);
+							} else {
+								log.info(
+									`${row.provider} token refreshed for ${row.name}, expires at ${new Date(result.expiresAt).toISOString()}`,
+								);
+							}
+						} catch (persistError) {
+							// (round-3 item 2) A rotation the provider has already
+							// committed must never be silently dropped: the DB still
+							// holds the consumed token, and a later stale consumer would
+							// replay it, get invalid_grant, and CAS-flag a healthy
+							// account. Record it so every subsequent touchpoint retries
+							// the persist and suppresses flagging meanwhile.
+							recordPendingRotation(row.id, {
+								accessToken: result.accessToken,
+								expiresAt: result.expiresAt,
+								refreshToken: newRefreshToken,
+								attemptedRefreshToken: row.refresh_token,
+							});
+							log.error(
+								`Failed to persist refreshed ${row.provider} token for ${row.name} — rotation queued for re-persist`,
+								persistError,
 							);
 						}
 						return result.accessToken;
@@ -959,6 +996,19 @@ export class AutoRefreshScheduler {
 		);
 
 		for (const row of accounts) {
+			// (round-3 item 2) Flush any rotation from an earlier cycle that
+			// succeeded at the provider but failed to persist, before touching
+			// this row again. A still-failing flush means the account's live
+			// credentials are the ones sitting in the registry, not the row we
+			// just read — refreshing again this cycle would race the retry.
+			const flush = await flushPendingRotation(row.id, this.proxyContext.dbOps);
+			if (flush === "failed") {
+				log.warn(
+					`Skipping proactive Codex refresh for ${row.name} this cycle — a pending rotation is still awaiting persist`,
+				);
+				continue;
+			}
+
 			// Skip if a refresh is already in-flight for this account (deduplication)
 			if (this.proxyContext.refreshInFlight.has(row.id)) {
 				log.debug(
@@ -1022,24 +1072,43 @@ export class AutoRefreshScheduler {
 						// attempt used — a rotation that landed underneath (manual re-auth,
 						// or a request-triggered refresh joining the same account) must not
 						// be overwritten with the tokens from this now-superseded attempt.
-						const changes = await this.db.runWithChanges(
-							`UPDATE accounts SET access_token = ?, expires_at = ?, refresh_token = ?, refresh_token_issued_at = ? WHERE id = ? AND refresh_token = ?`,
-							[
-								result.accessToken,
-								result.expiresAt,
-								newRefreshToken,
-								Date.now(),
-								row.id,
-								row.refresh_token,
-							],
-						);
-						if (changes === 0) {
-							log.warn(
-								`Skipped persisting refreshed Codex token for ${row.name}: refresh token changed underneath (superseded by a newer rotation or manual re-auth)`,
-							);
-						} else {
-							log.info(
-								`Codex token refreshed for ${row.name}, expires at ${new Date(result.expiresAt).toISOString()}`,
+						// Routed through the retry-wrapped dbOps helper instead of raw SQL
+						// so this write benefits from the same transient-failure retries on
+						// Postgres as the token-manager funnel.
+						try {
+							const persisted =
+								await this.proxyContext.dbOps.updateAccountTokensIfRefreshTokenMatches(
+									row.id,
+									row.refresh_token,
+									result.accessToken,
+									result.expiresAt,
+									newRefreshToken,
+								);
+							if (!persisted) {
+								log.warn(
+									`Skipped persisting refreshed Codex token for ${row.name}: refresh token changed underneath (superseded by a newer rotation or manual re-auth)`,
+								);
+							} else {
+								log.info(
+									`Codex token refreshed for ${row.name}, expires at ${new Date(result.expiresAt).toISOString()}`,
+								);
+							}
+						} catch (persistError) {
+							// (round-3 item 2) A rotation the provider has already
+							// committed must never be silently dropped: the DB still
+							// holds the consumed token, and a later stale consumer would
+							// replay it, get invalid_grant, and CAS-flag a healthy
+							// account. Record it so every subsequent touchpoint retries
+							// the persist and suppresses flagging meanwhile.
+							recordPendingRotation(row.id, {
+								accessToken: result.accessToken,
+								expiresAt: result.expiresAt,
+								refreshToken: newRefreshToken,
+								attemptedRefreshToken: row.refresh_token,
+							});
+							log.error(
+								`Failed to persist refreshed Codex token for ${row.name} — rotation queued for re-persist`,
+								persistError,
 							);
 						}
 						return result.accessToken;
@@ -1087,18 +1156,30 @@ export class AutoRefreshScheduler {
 		const reason = extractAuthFailureReason(message, row.name);
 		if (!reason) return;
 
+		// (round-3 item 2) A pending unpersisted rotation means WE rotated
+		// successfully moments ago — this failure is a replay of the consumed
+		// token, not a dead account.
+		if (getPendingRotation(row.id)) {
+			log.warn(
+				`Skipping requires_reauth for ${row.name}: a successful rotation is awaiting persist (replayed a consumed token)`,
+			);
+			return;
+		}
+
 		// Atomic rotation-race guard (CAS): condemn the account only if it still
 		// holds the exact refresh token this attempt used. A rotation that landed
-		// after our snapshot makes the UPDATE a no-op — no flag, no alert. A DB
+		// after our snapshot makes the write a no-op — no flag, no alert. A DB
 		// error leaves the flag unset: "unable to verify" is not evidence of a
-		// dead token; the next scheduler pass retries with the live row.
+		// dead token; the next scheduler pass retries with the live row. Routed
+		// through the retry-wrapped dbOps helper (shared with the token-manager
+		// funnel) instead of raw SQL so this write benefits from the same
+		// transient-failure retries on Postgres.
 		let flagged = false;
 		try {
-			const changes = await this.db.runWithChanges(
-				`UPDATE accounts SET requires_reauth = 1 WHERE id = ? AND refresh_token = ?`,
-				[row.id, row.refresh_token],
+			flagged = await this.proxyContext.dbOps.flagRequiresReauthIfTokenMatches(
+				row.id,
+				row.refresh_token,
 			);
-			flagged = changes > 0;
 		} catch (writeError) {
 			log.warn(
 				`Could not verify-and-flag requires_reauth for ${row.name} — leaving unset (unverified ${reason})`,

--- a/packages/proxy/src/auto-refresh-scheduler.ts
+++ b/packages/proxy/src/auto-refresh-scheduler.ts
@@ -865,23 +865,41 @@ export class AutoRefreshScheduler {
 					.refreshToken(account, this.proxyContext.runtime.clientId)
 					.then(async (result) => {
 						const newRefreshToken = result.refreshToken ?? row.refresh_token;
-						await this.db.run(
-							`UPDATE accounts SET access_token = ?, expires_at = ?, refresh_token = ?, refresh_token_issued_at = ? WHERE id = ?`,
+						// CAS: only persist if the row still holds the refresh token this
+						// attempt used — a rotation that landed underneath (manual re-auth,
+						// or a request-triggered refresh joining the same account) must not
+						// be overwritten with the tokens from this now-superseded attempt.
+						const changes = await this.db.runWithChanges(
+							`UPDATE accounts SET access_token = ?, expires_at = ?, refresh_token = ?, refresh_token_issued_at = ? WHERE id = ? AND refresh_token = ?`,
 							[
 								result.accessToken,
 								result.expiresAt,
 								newRefreshToken,
 								Date.now(),
 								row.id,
+								row.refresh_token,
 							],
 						);
-						log.info(
-							`${row.provider} token refreshed for ${row.name}, expires at ${new Date(result.expiresAt).toISOString()}`,
-						);
+						if (changes === 0) {
+							log.warn(
+								`Skipped persisting refreshed ${row.provider} token for ${row.name}: refresh token changed underneath (superseded by a newer rotation or manual re-auth)`,
+							);
+						} else {
+							log.info(
+								`${row.provider} token refreshed for ${row.name}, expires at ${new Date(result.expiresAt).toISOString()}`,
+							);
+						}
 						return result.accessToken;
 					})
 					.finally(() => {
-						this.proxyContext.refreshInFlight.delete(row.id);
+						// Identity-safe: never delete a newer entry installed by a manual
+						// reauth or a concurrent request-triggered refresh that ran while
+						// this promise was still settling.
+						if (
+							this.proxyContext.refreshInFlight.get(row.id) === refreshPromise
+						) {
+							this.proxyContext.refreshInFlight.delete(row.id);
+						}
 					});
 
 				this.proxyContext.refreshInFlight.set(row.id, refreshPromise);
@@ -1000,23 +1018,41 @@ export class AutoRefreshScheduler {
 					.refreshToken(account, this.proxyContext.runtime.clientId)
 					.then(async (result) => {
 						const newRefreshToken = result.refreshToken ?? row.refresh_token;
-						await this.db.run(
-							`UPDATE accounts SET access_token = ?, expires_at = ?, refresh_token = ?, refresh_token_issued_at = ? WHERE id = ?`,
+						// CAS: only persist if the row still holds the refresh token this
+						// attempt used — a rotation that landed underneath (manual re-auth,
+						// or a request-triggered refresh joining the same account) must not
+						// be overwritten with the tokens from this now-superseded attempt.
+						const changes = await this.db.runWithChanges(
+							`UPDATE accounts SET access_token = ?, expires_at = ?, refresh_token = ?, refresh_token_issued_at = ? WHERE id = ? AND refresh_token = ?`,
 							[
 								result.accessToken,
 								result.expiresAt,
 								newRefreshToken,
 								Date.now(),
 								row.id,
+								row.refresh_token,
 							],
 						);
-						log.info(
-							`Codex token refreshed for ${row.name}, expires at ${new Date(result.expiresAt).toISOString()}`,
-						);
+						if (changes === 0) {
+							log.warn(
+								`Skipped persisting refreshed Codex token for ${row.name}: refresh token changed underneath (superseded by a newer rotation or manual re-auth)`,
+							);
+						} else {
+							log.info(
+								`Codex token refreshed for ${row.name}, expires at ${new Date(result.expiresAt).toISOString()}`,
+							);
+						}
 						return result.accessToken;
 					})
 					.finally(() => {
-						this.proxyContext.refreshInFlight.delete(row.id);
+						// Identity-safe: never delete a newer entry installed by a manual
+						// reauth or a concurrent request-triggered refresh that ran while
+						// this promise was still settling.
+						if (
+							this.proxyContext.refreshInFlight.get(row.id) === refreshPromise
+						) {
+							this.proxyContext.refreshInFlight.delete(row.id);
+						}
 					});
 
 				this.proxyContext.refreshInFlight.set(row.id, refreshPromise);
@@ -1051,46 +1087,34 @@ export class AutoRefreshScheduler {
 		const reason = extractAuthFailureReason(message, row.name);
 		if (!reason) return;
 
-		// Rotation-race guard: if the account's current refresh token is no
-		// longer the one this attempt used, another consumer rotated it after our
-		// loop-start snapshot — the rejection condemned a superseded token, not
-		// the account. Skip flagging; the next scheduler pass uses the live row.
+		// Atomic rotation-race guard (CAS): condemn the account only if it still
+		// holds the exact refresh token this attempt used. A rotation that landed
+		// after our snapshot makes the UPDATE a no-op — no flag, no alert. A DB
+		// error leaves the flag unset: "unable to verify" is not evidence of a
+		// dead token; the next scheduler pass retries with the live row.
+		let flagged = false;
 		try {
-			const rows = await this.db.query<{ refresh_token: string | null }>(
-				`SELECT refresh_token FROM accounts WHERE id = ?`,
-				[row.id],
+			const changes = await this.db.runWithChanges(
+				`UPDATE accounts SET requires_reauth = 1 WHERE id = ? AND refresh_token = ?`,
+				[row.id, row.refresh_token],
 			);
-			const currentRefreshToken = rows[0]?.refresh_token ?? null;
-			if (currentRefreshToken && currentRefreshToken !== row.refresh_token) {
-				log.warn(
-					`Skipping requires_reauth for ${row.name}: the failed ${row.provider} refresh used a superseded refresh token (rotation race)`,
-				);
-				return;
-			}
-		} catch (readError) {
-			log.warn(
-				`Could not verify current refresh token for ${row.name} — treating ${reason} as definitive`,
-				readError,
-			);
-		}
-
-		try {
-			await this.db.run(
-				`UPDATE accounts SET requires_reauth = 1 WHERE id = ?`,
-				[row.id],
-			);
-			log.error(
-				`Account ${row.name} requires re-authentication — proactive ${row.provider} refresh returned ${reason}`,
-			);
+			flagged = changes > 0;
 		} catch (writeError) {
-			log.error(
-				`Failed to persist requires_reauth for ${row.name}:`,
+			log.warn(
+				`Could not verify-and-flag requires_reauth for ${row.name} — leaving unset (unverified ${reason})`,
 				writeError,
 			);
+			return;
 		}
-
-		// Emit regardless of the write outcome — the alert is the operator's only
-		// signal that the account is dead, and it is fire-and-forget.
+		if (!flagged) {
+			log.warn(
+				`Skipping requires_reauth for ${row.name}: the failed ${row.provider} refresh used a superseded refresh token (rotation race)`,
+			);
+			return;
+		}
+		log.error(
+			`Account ${row.name} requires re-authentication — proactive ${row.provider} refresh returned ${reason}`,
+		);
 		authFailureEvents.emit("event", {
 			accountId: row.id,
 			accountName: row.name,

--- a/packages/proxy/src/auto-refresh-scheduler.ts
+++ b/packages/proxy/src/auto-refresh-scheduler.ts
@@ -809,15 +809,19 @@ export class AutoRefreshScheduler {
 		);
 
 		for (const row of accounts) {
-			// (round-3 item 2) Flush any rotation from an earlier cycle that
-			// succeeded at the provider but failed to persist, before touching
-			// this row again. A still-failing flush means the account's live
-			// credentials are the ones sitting in the registry, not the row we
-			// just read — refreshing again this cycle would race the retry.
+			// (round-3 item 2; hardened in round-3 final review, I1) Flush any
+			// rotation from an earlier cycle before touching this row again. Any
+			// outcome other than "none" means this row's snapshot predates that
+			// flush: "failed" means the registry's unpersisted rotation is still
+			// the account's live credentials; "persisted"/"superseded" both mean
+			// the refresh_token this row shows was just consumed (by the flush
+			// itself or by whatever superseded it) — refreshing with it now
+			// would replay an already-consumed token. Skip this row for this
+			// cycle either way; the next cycle re-reads it fresh.
 			const flush = await flushPendingRotation(row.id, this.proxyContext.dbOps);
-			if (flush === "failed") {
+			if (flush !== "none") {
 				log.warn(
-					`Skipping proactive ${row.provider} refresh for ${row.name} this cycle — a pending rotation is still awaiting persist`,
+					`Skipping proactive ${row.provider} refresh for ${row.name} this cycle: row snapshot predates a pending-rotation flush (${flush})`,
 				);
 				continue;
 			}
@@ -996,15 +1000,20 @@ export class AutoRefreshScheduler {
 		);
 
 		for (const row of accounts) {
-			// (round-3 item 2) Flush any rotation from an earlier cycle that
-			// succeeded at the provider but failed to persist, before touching
-			// this row again. A still-failing flush means the account's live
-			// credentials are the ones sitting in the registry, not the row we
-			// just read — refreshing again this cycle would race the retry.
+			// (round-3 item 2; hardened in round-3 final review, I1) Flush any
+			// rotation from an earlier cycle before touching this row again. Any
+			// outcome other than "none" means this row's snapshot predates that
+			// flush: "failed" means the registry's unpersisted rotation is still
+			// the account's live credentials; "persisted"/"superseded" both mean
+			// the refresh_token this row shows was just consumed (by the flush
+			// itself or by whatever superseded it) — refreshing with it now
+			// would replay an already-consumed token, and on Codex specifically
+			// reuse-detection can invalidate the whole token family. Skip this
+			// row for this cycle either way; the next cycle re-reads it fresh.
 			const flush = await flushPendingRotation(row.id, this.proxyContext.dbOps);
-			if (flush === "failed") {
+			if (flush !== "none") {
 				log.warn(
-					`Skipping proactive Codex refresh for ${row.name} this cycle — a pending rotation is still awaiting persist`,
+					`Skipping proactive Codex refresh for ${row.name} this cycle: row snapshot predates a pending-rotation flush (${flush})`,
 				);
 				continue;
 			}

--- a/packages/proxy/src/handlers/__tests__/pending-rotation-registry.test.ts
+++ b/packages/proxy/src/handlers/__tests__/pending-rotation-registry.test.ts
@@ -137,9 +137,69 @@ describe("flushPendingRotation — identity-guarded delete (round-3 final review
 		expect(entry).toBeDefined();
 		expect(entry?.accessToken).toBe("access-2");
 		expect(entry?.refreshToken).toBe("RT3");
-		// Anchor compression applies here too: the newer entry was recorded
-		// while the original (RT1-anchored) entry was still present.
-		expect(entry?.attemptedRefreshToken).toBe("RT1");
+		// Anchor compression at record time set this to "RT1" — but the CAS
+		// that just landed moved the DB from "RT1" to "RT2", so the survivor's
+		// anchor is rebased onto that (round-3, Codex concurrent flush/
+		// re-record race) instead of staying at "RT1", which the DB no longer
+		// holds.
+		expect(entry?.attemptedRefreshToken).toBe("RT2");
+	});
+});
+
+describe("flushPendingRotation — rebases the survivor's anchor after a concurrent flush lands", () => {
+	it("rebases the anchor onto the just-persisted refresh token instead of misreading the DB as superseded on the next flush", async () => {
+		let resolveCas: (value: boolean) => void = () => {};
+		const casPromise = new Promise<boolean>((resolve) => {
+			resolveCas = resolve;
+		});
+		const dbOps = makeDbOps({
+			updateAccountTokensIfRefreshTokenMatches: mock(() => casPromise),
+		});
+
+		recordPendingRotation("acc-1", {
+			accessToken: "access-1",
+			expiresAt: 1,
+			refreshToken: "RT2",
+			attemptedRefreshToken: "RT1",
+		});
+
+		const flushPromise = flushPendingRotation("acc-1", dbOps);
+
+		// A newer rotation is recorded while the flush above's CAS write is
+		// still in flight. Anchor compression sets its attemptedRefreshToken
+		// to "RT1" (the existing entry's anchor) — that's the bug's
+		// precondition: E2's anchor still points at a token the DB is about
+		// to move past.
+		recordPendingRotation("acc-1", {
+			accessToken: "access-2",
+			expiresAt: 2,
+			refreshToken: "RT3",
+			attemptedRefreshToken: "RT2",
+		});
+
+		resolveCas(true);
+		const outcome = await flushPromise;
+
+		expect(outcome).toBe("persisted");
+		const survivor = getPendingRotation("acc-1");
+		expect(survivor).toBeDefined();
+		// The CAS that just landed moved the DB's refresh token from "RT1" to
+		// "RT2" — the survivor's anchor must be rebased onto that instead of
+		// staying at "RT1", which the DB no longer holds.
+		expect(survivor?.attemptedRefreshToken).toBe("RT2");
+		expect(survivor?.refreshToken).toBe("RT3");
+		expect(survivor?.accessToken).toBe("access-2");
+
+		const secondDbOps = makeDbOps({
+			updateAccountTokensIfRefreshTokenMatches: mock(async () => true),
+		});
+		const secondOutcome = await flushPendingRotation("acc-1", secondDbOps);
+
+		expect(secondOutcome).toBe("persisted");
+		expect(
+			secondDbOps.updateAccountTokensIfRefreshTokenMatches,
+		).toHaveBeenCalledWith("acc-1", "RT2", "access-2", 2, "RT3");
+		expect(getPendingRotation("acc-1")).toBeUndefined();
 	});
 });
 

--- a/packages/proxy/src/handlers/__tests__/pending-rotation-registry.test.ts
+++ b/packages/proxy/src/handlers/__tests__/pending-rotation-registry.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+	clearAllPendingRotationsForTests,
+	clearPendingRotation,
+	flushPendingRotation,
+	getPendingRotation,
+	type PendingRotationDbOps,
+	recordPendingRotation,
+} from "../pending-rotation-registry";
+
+function makeDbOps(overrides: Partial<PendingRotationDbOps> = {}) {
+	return {
+		updateAccountTokensIfRefreshTokenMatches: mock(async () => true),
+		updateAccountTokensIfRefreshTokenAbsent: mock(async () => true),
+		...overrides,
+	} satisfies PendingRotationDbOps;
+}
+
+beforeEach(() => {
+	clearAllPendingRotationsForTests();
+});
+
+describe("recordPendingRotation / getPendingRotation", () => {
+	it("roundtrips a recorded rotation", () => {
+		recordPendingRotation("acc-1", {
+			accessToken: "access-1",
+			expiresAt: 12345,
+			refreshToken: "refresh-1",
+			attemptedRefreshToken: "old-refresh-1",
+		});
+
+		const entry = getPendingRotation("acc-1");
+		expect(entry).toBeDefined();
+		expect(entry?.accessToken).toBe("access-1");
+		expect(entry?.expiresAt).toBe(12345);
+		expect(entry?.refreshToken).toBe("refresh-1");
+		expect(entry?.attemptedRefreshToken).toBe("old-refresh-1");
+		expect(typeof entry?.recordedAt).toBe("number");
+	});
+
+	it("returns undefined when no entry exists for the account", () => {
+		expect(getPendingRotation("missing-acc")).toBeUndefined();
+	});
+
+	it("replaces an existing entry for the same account id", () => {
+		recordPendingRotation("acc-1", {
+			accessToken: "access-1",
+			expiresAt: 1,
+			attemptedRefreshToken: "old-1",
+		});
+		recordPendingRotation("acc-1", {
+			accessToken: "access-2",
+			expiresAt: 2,
+			attemptedRefreshToken: "old-2",
+		});
+
+		const entry = getPendingRotation("acc-1");
+		expect(entry?.accessToken).toBe("access-2");
+		expect(entry?.expiresAt).toBe(2);
+		expect(entry?.attemptedRefreshToken).toBe("old-2");
+	});
+});
+
+describe("clearPendingRotation", () => {
+	it("removes the entry for the given account", () => {
+		recordPendingRotation("acc-1", {
+			accessToken: "access-1",
+			expiresAt: 1,
+			attemptedRefreshToken: "old-1",
+		});
+		clearPendingRotation("acc-1");
+		expect(getPendingRotation("acc-1")).toBeUndefined();
+	});
+
+	it("is a no-op when there is no entry for the account", () => {
+		expect(() => clearPendingRotation("no-such-acc")).not.toThrow();
+	});
+});
+
+describe("flushPendingRotation", () => {
+	it('returns "none" when there is no pending entry for the account', async () => {
+		const dbOps = makeDbOps();
+		const outcome = await flushPendingRotation("acc-1", dbOps);
+		expect(outcome).toBe("none");
+		expect(
+			dbOps.updateAccountTokensIfRefreshTokenMatches,
+		).not.toHaveBeenCalled();
+		expect(
+			dbOps.updateAccountTokensIfRefreshTokenAbsent,
+		).not.toHaveBeenCalled();
+	});
+
+	it('returns "persisted" and clears the entry when attemptedRefreshToken is truthy and CAS lands', async () => {
+		const dbOps = makeDbOps({
+			updateAccountTokensIfRefreshTokenMatches: mock(async () => true),
+		});
+		recordPendingRotation("acc-1", {
+			accessToken: "access-1",
+			expiresAt: 999,
+			refreshToken: "refresh-new",
+			attemptedRefreshToken: "refresh-old",
+		});
+
+		const outcome = await flushPendingRotation("acc-1", dbOps);
+
+		expect(outcome).toBe("persisted");
+		expect(dbOps.updateAccountTokensIfRefreshTokenMatches).toHaveBeenCalledWith(
+			"acc-1",
+			"refresh-old",
+			"access-1",
+			999,
+			"refresh-new",
+		);
+		expect(
+			dbOps.updateAccountTokensIfRefreshTokenAbsent,
+		).not.toHaveBeenCalled();
+		expect(getPendingRotation("acc-1")).toBeUndefined();
+	});
+
+	it('uses updateAccountTokensIfRefreshTokenAbsent when attemptedRefreshToken is empty, and returns "persisted"', async () => {
+		const dbOps = makeDbOps({
+			updateAccountTokensIfRefreshTokenAbsent: mock(async () => true),
+		});
+		recordPendingRotation("acc-1", {
+			accessToken: "access-1",
+			expiresAt: 999,
+			refreshToken: "refresh-new",
+			attemptedRefreshToken: "",
+		});
+
+		const outcome = await flushPendingRotation("acc-1", dbOps);
+
+		expect(outcome).toBe("persisted");
+		expect(dbOps.updateAccountTokensIfRefreshTokenAbsent).toHaveBeenCalledWith(
+			"acc-1",
+			"access-1",
+			999,
+			"refresh-new",
+		);
+		expect(
+			dbOps.updateAccountTokensIfRefreshTokenMatches,
+		).not.toHaveBeenCalled();
+		expect(getPendingRotation("acc-1")).toBeUndefined();
+	});
+
+	it('returns "superseded" and clears the entry when the CAS matches 0 rows', async () => {
+		const dbOps = makeDbOps({
+			updateAccountTokensIfRefreshTokenMatches: mock(async () => false),
+		});
+		recordPendingRotation("acc-1", {
+			accessToken: "access-1",
+			expiresAt: 999,
+			attemptedRefreshToken: "refresh-old",
+		});
+
+		const outcome = await flushPendingRotation("acc-1", dbOps);
+
+		expect(outcome).toBe("superseded");
+		expect(getPendingRotation("acc-1")).toBeUndefined();
+	});
+
+	it('returns "failed" and keeps the entry when the write throws', async () => {
+		const dbOps = makeDbOps({
+			updateAccountTokensIfRefreshTokenMatches: mock(async () => {
+				throw new Error("db unavailable");
+			}),
+		});
+		recordPendingRotation("acc-1", {
+			accessToken: "access-1",
+			expiresAt: 999,
+			attemptedRefreshToken: "refresh-old",
+		});
+
+		const outcome = await flushPendingRotation("acc-1", dbOps);
+
+		expect(outcome).toBe("failed");
+		expect(getPendingRotation("acc-1")).toBeDefined();
+	});
+});
+
+describe("size cap", () => {
+	it("evicts the oldest entry once more than 100 entries are recorded", () => {
+		for (let i = 0; i < 100; i++) {
+			recordPendingRotation(`acc-${i}`, {
+				accessToken: `access-${i}`,
+				expiresAt: i,
+				attemptedRefreshToken: `old-${i}`,
+			});
+		}
+		expect(getPendingRotation("acc-0")).toBeDefined();
+
+		recordPendingRotation("acc-100", {
+			accessToken: "access-100",
+			expiresAt: 100,
+			attemptedRefreshToken: "old-100",
+		});
+
+		expect(getPendingRotation("acc-0")).toBeUndefined();
+		expect(getPendingRotation("acc-1")).toBeDefined();
+		expect(getPendingRotation("acc-100")).toBeDefined();
+	});
+});

--- a/packages/proxy/src/handlers/__tests__/pending-rotation-registry.test.ts
+++ b/packages/proxy/src/handlers/__tests__/pending-rotation-registry.test.ts
@@ -42,7 +42,7 @@ describe("recordPendingRotation / getPendingRotation", () => {
 		expect(getPendingRotation("missing-acc")).toBeUndefined();
 	});
 
-	it("replaces an existing entry for the same account id", () => {
+	it("replaces accessToken/expiresAt but preserves the original attemptedRefreshToken anchor", () => {
 		recordPendingRotation("acc-1", {
 			accessToken: "access-1",
 			expiresAt: 1,
@@ -57,7 +57,89 @@ describe("recordPendingRotation / getPendingRotation", () => {
 		const entry = getPendingRotation("acc-1");
 		expect(entry?.accessToken).toBe("access-2");
 		expect(entry?.expiresAt).toBe(2);
-		expect(entry?.attemptedRefreshToken).toBe("old-2");
+		// (round-3 final review, C1) The anchor stays "old-1" — the token the
+		// DB actually still holds — not "old-2", which the second rotation
+		// only ever consumed in-memory.
+		expect(entry?.attemptedRefreshToken).toBe("old-1");
+	});
+});
+
+describe("recordPendingRotation — anchor compression across chained rotations (round-3 final review, C1)", () => {
+	it("keeps the original anchor through a 3-link chain and flushes against it", async () => {
+		recordPendingRotation("acc-1", {
+			accessToken: "access-2",
+			expiresAt: 2,
+			refreshToken: "RT2",
+			attemptedRefreshToken: "RT1",
+		});
+		recordPendingRotation("acc-1", {
+			accessToken: "access-3",
+			expiresAt: 3,
+			refreshToken: "RT3",
+			attemptedRefreshToken: "RT2",
+		});
+
+		const entry = getPendingRotation("acc-1");
+		expect(entry?.attemptedRefreshToken).toBe("RT1");
+		expect(entry?.refreshToken).toBe("RT3");
+		expect(entry?.accessToken).toBe("access-3");
+		expect(entry?.expiresAt).toBe(3);
+
+		const dbOps = makeDbOps({
+			updateAccountTokensIfRefreshTokenMatches: mock(async () => true),
+		});
+		const outcome = await flushPendingRotation("acc-1", dbOps);
+
+		expect(outcome).toBe("persisted");
+		expect(dbOps.updateAccountTokensIfRefreshTokenMatches).toHaveBeenCalledWith(
+			"acc-1",
+			"RT1",
+			"access-3",
+			3,
+			"RT3",
+		);
+	});
+});
+
+describe("flushPendingRotation — identity-guarded delete (round-3 final review, I2)", () => {
+	it("does not delete a newer entry re-recorded while the CAS write is still in flight", async () => {
+		let resolveCas: (value: boolean) => void = () => {};
+		const casPromise = new Promise<boolean>((resolve) => {
+			resolveCas = resolve;
+		});
+		const dbOps = makeDbOps({
+			updateAccountTokensIfRefreshTokenMatches: mock(() => casPromise),
+		});
+		recordPendingRotation("acc-1", {
+			accessToken: "access-1",
+			expiresAt: 1,
+			refreshToken: "RT2",
+			attemptedRefreshToken: "RT1",
+		});
+
+		const flushPromise = flushPendingRotation("acc-1", dbOps);
+
+		// A newer rotation lands in the registry while the CAS write above is
+		// still awaiting resolution (e.g. a concurrent request-triggered
+		// refresh's own failed persist).
+		recordPendingRotation("acc-1", {
+			accessToken: "access-2",
+			expiresAt: 2,
+			refreshToken: "RT3",
+			attemptedRefreshToken: "RT2",
+		});
+
+		resolveCas(true);
+		const outcome = await flushPromise;
+
+		expect(outcome).toBe("persisted");
+		const entry = getPendingRotation("acc-1");
+		expect(entry).toBeDefined();
+		expect(entry?.accessToken).toBe("access-2");
+		expect(entry?.refreshToken).toBe("RT3");
+		// Anchor compression applies here too: the newer entry was recorded
+		// while the original (RT1-anchored) entry was still present.
+		expect(entry?.attemptedRefreshToken).toBe("RT1");
 	});
 });
 

--- a/packages/proxy/src/handlers/__tests__/pending-rotation-registry.test.ts
+++ b/packages/proxy/src/handlers/__tests__/pending-rotation-registry.test.ts
@@ -321,8 +321,8 @@ describe("flushPendingRotation", () => {
 });
 
 describe("size cap", () => {
-	it("evicts the oldest entry once more than 100 entries are recorded", () => {
-		for (let i = 0; i < 100; i++) {
+	it("evicts the oldest entry once more than 1000 entries are recorded", () => {
+		for (let i = 0; i < 1000; i++) {
 			recordPendingRotation(`acc-${i}`, {
 				accessToken: `access-${i}`,
 				expiresAt: i,
@@ -331,14 +331,14 @@ describe("size cap", () => {
 		}
 		expect(getPendingRotation("acc-0")).toBeDefined();
 
-		recordPendingRotation("acc-100", {
-			accessToken: "access-100",
-			expiresAt: 100,
-			attemptedRefreshToken: "old-100",
+		recordPendingRotation("acc-1000", {
+			accessToken: "access-1000",
+			expiresAt: 1000,
+			attemptedRefreshToken: "old-1000",
 		});
 
 		expect(getPendingRotation("acc-0")).toBeUndefined();
 		expect(getPendingRotation("acc-1")).toBeDefined();
-		expect(getPendingRotation("acc-100")).toBeDefined();
+		expect(getPendingRotation("acc-1000")).toBeDefined();
 	});
 });

--- a/packages/proxy/src/handlers/__tests__/token-manager-requires-reauth.test.ts
+++ b/packages/proxy/src/handlers/__tests__/token-manager-requires-reauth.test.ts
@@ -60,6 +60,8 @@ function makeContext(refreshError: Error) {
 			dbOps: {
 				getAccount: mock(async () => null),
 				setRequiresReauth,
+				updateAccountTokensIfRefreshTokenMatches: mock(async () => true),
+				flagRequiresReauthIfTokenMatches: mock(async () => true),
 			},
 			runtime: { clientId: "test-client" },
 			refreshInFlight: new Map(),
@@ -136,8 +138,8 @@ describe("extractAuthFailureReason / isDefinitiveAuthFailure", () => {
 });
 
 describe("refreshAccessTokenSafe requires_reauth detection", () => {
-	it("enqueues the flag for a realistic invalid_grant refresh error and propagates it", async () => {
-		const { ctx, queuedJobs, setRequiresReauth } = makeContext(
+	it("flags requires_reauth via the direct CAS write for a realistic invalid_grant refresh error and propagates it", async () => {
+		const { ctx } = makeContext(
 			new Error(
 				"Failed to refresh token for account test-account: invalid_grant: Refresh token is invalid or has been revoked.",
 			),
@@ -149,9 +151,10 @@ describe("refreshAccessTokenSafe requires_reauth detection", () => {
 			refreshAccessTokenSafe(makeAccount("invalid-grant"), ctx as never),
 		).rejects.toThrow("Failed to refresh access token");
 
-		expect(queuedJobs).toHaveLength(1);
-		await queuedJobs[0]();
-		expect(setRequiresReauth).toHaveBeenCalledWith("invalid-grant", true);
+		expect(ctx.dbOps.flagRequiresReauthIfTokenMatches).toHaveBeenCalledWith(
+			"invalid-grant",
+			"refresh-token",
+		);
 		expect(emitted).toHaveLength(1);
 		expect(emitted[0]).toMatchObject({
 			accountId: "invalid-grant",
@@ -175,6 +178,7 @@ describe("refreshAccessTokenSafe requires_reauth detection", () => {
 
 		expect(queuedJobs).toHaveLength(0);
 		expect(setRequiresReauth).not.toHaveBeenCalled();
+		expect(ctx.dbOps.flagRequiresReauthIfTokenMatches).not.toHaveBeenCalled();
 	});
 
 	it("ignores invalid_grant in the account name when the provider error is harmless", async () => {
@@ -193,5 +197,6 @@ describe("refreshAccessTokenSafe requires_reauth detection", () => {
 
 		expect(queuedJobs).toHaveLength(0);
 		expect(setRequiresReauth).not.toHaveBeenCalled();
+		expect(ctx.dbOps.flagRequiresReauthIfTokenMatches).not.toHaveBeenCalled();
 	});
 });

--- a/packages/proxy/src/handlers/__tests__/token-manager-rotation-race.test.ts
+++ b/packages/proxy/src/handlers/__tests__/token-manager-rotation-race.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock } from "bun:test";
+import { type AuthFailureEvt, authFailureEvents } from "@better-ccflare/core";
 import type { Account } from "@better-ccflare/types";
 import { refreshAccessTokenSafe } from "../token-manager";
 
@@ -179,5 +180,114 @@ describe("refreshAccessTokenSafe — rotation-race pre-refresh guard", () => {
 
 		expect(token).toBe("brand-new");
 		expect(refreshToken).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("refreshAccessTokenSafe — benign race on invalid_grant", () => {
+	const invalidGrant = new Error(
+		"Status 400, Error: invalid_grant: Refresh token not found or invalid",
+	);
+
+	it("recovers with DB tokens instead of flagging when the RT was rotated meanwhile", async () => {
+		const account = makeAccount("race-catch-recover-1", {
+			refresh_token: "RT1-consumed",
+			access_token: "stale",
+			expires_at: 1,
+		});
+		const dbAccount = makeAccount("race-catch-recover-1", {
+			refresh_token: "RT2-current",
+			access_token: "fresh-access",
+			expires_at: Date.now() + 3_600_000,
+		});
+		// getAccount: first call (pre-refresh guard) must NOT short-circuit, so
+		// return the stale state first, then the rotated state for the catch.
+		const staleDb = makeAccount("race-catch-recover-1", {
+			refresh_token: "RT1-consumed",
+			access_token: "stale",
+			expires_at: 1,
+		});
+		const { ctx, setRequiresReauth, queuedJobs } = makeContext({
+			refreshError: invalidGrant,
+		});
+		let call = 0;
+		ctx.dbOps.getAccount = mock(async () =>
+			call++ === 0 ? staleDb : dbAccount,
+		);
+
+		const events: AuthFailureEvt[] = [];
+		const listener = (e: AuthFailureEvt) => events.push(e);
+		authFailureEvents.on("event", listener);
+		try {
+			const token = await refreshAccessTokenSafe(
+				account as never,
+				ctx as never,
+			);
+			expect(token).toBe("fresh-access");
+		} finally {
+			authFailureEvents.off("event", listener);
+		}
+
+		for (const job of queuedJobs) await job();
+		expect(setRequiresReauth).not.toHaveBeenCalled();
+		expect(events).toHaveLength(0);
+		expect(account.refresh_token).toBe("RT2-current");
+	});
+
+	it("does not flag when the RT was rotated but no valid access token exists yet (throws, retries later)", async () => {
+		const account = makeAccount("race-catch-noflag-1", {
+			refresh_token: "RT1-consumed",
+			access_token: "stale",
+			expires_at: 1,
+		});
+		const staleDb = makeAccount("race-catch-noflag-1", {
+			refresh_token: "RT1-consumed",
+			access_token: "stale",
+			expires_at: 1,
+		});
+		const rotatedDb = makeAccount("race-catch-noflag-1", {
+			refresh_token: "RT2-current",
+			access_token: "also-expired",
+			expires_at: 2,
+		});
+		const { ctx, setRequiresReauth, queuedJobs } = makeContext({
+			refreshError: invalidGrant,
+		});
+		let call = 0;
+		ctx.dbOps.getAccount = mock(async () =>
+			call++ === 0 ? staleDb : rotatedDb,
+		);
+
+		await expect(
+			refreshAccessTokenSafe(account as never, ctx as never),
+		).rejects.toThrow();
+
+		for (const job of queuedJobs) await job();
+		expect(setRequiresReauth).not.toHaveBeenCalled();
+		expect(account.refresh_token).toBe("RT2-current");
+	});
+
+	it("still flags requires_reauth when the rejected RT is the account's current one", async () => {
+		const account = makeAccount("race-catch-flag-1", {
+			refresh_token: "RT1-dead",
+			access_token: "stale",
+			expires_at: 1,
+		});
+		const sameDb = makeAccount("race-catch-flag-1", {
+			refresh_token: "RT1-dead",
+			access_token: "stale",
+			expires_at: 1,
+		});
+		const { ctx, setRequiresReauth, queuedJobs } = makeContext({
+			refreshError: invalidGrant,
+		});
+		ctx.dbOps.getAccount = mock(async () => sameDb);
+
+		await expect(
+			refreshAccessTokenSafe(account as never, ctx as never),
+		).rejects.toThrow();
+
+		for (const job of queuedJobs) await job();
+		expect(setRequiresReauth).toHaveBeenCalledTimes(1);
+		expect(setRequiresReauth).toHaveBeenCalledWith("race-catch-flag-1", true);
 	});
 });

--- a/packages/proxy/src/handlers/__tests__/token-manager-rotation-race.test.ts
+++ b/packages/proxy/src/handlers/__tests__/token-manager-rotation-race.test.ts
@@ -1,7 +1,15 @@
-import { describe, expect, it, mock } from "bun:test";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
 import { type AuthFailureEvt, authFailureEvents } from "@better-ccflare/core";
 import type { Account } from "@better-ccflare/types";
+import {
+	clearAllPendingRotationsForTests,
+	getPendingRotation,
+} from "../pending-rotation-registry";
 import { refreshAccessTokenSafe } from "../token-manager";
+
+beforeEach(() => {
+	clearAllPendingRotationsForTests();
+});
 
 function makeAccount(id: string, overrides: Partial<Account> = {}): Account {
 	return {
@@ -73,6 +81,7 @@ function makeContext(opts: {
 				setRequiresReauth,
 				updateAccountTokens: mock(async () => {}),
 				updateAccountTokensIfRefreshTokenMatches: mock(async () => true),
+				updateAccountTokensIfRefreshTokenAbsent: mock(async () => true),
 				flagRequiresReauthIfTokenMatches: mock(async () => true),
 			},
 			runtime: { clientId: "test-client" },
@@ -616,7 +625,7 @@ describe("refreshAccessTokenSafe — accounts with no refresh token to CAS again
 	// refresh token" shape in this codebase is an empty string, not null. This
 	// still exercises the exact `!attemptedRefreshToken` falsy branch.
 
-	it("falls back to the plain updateAccountTokens write on success (no CAS possible)", async () => {
+	it("P5: uses the null-safe CAS write on success instead of the plain updateAccountTokens (round-3 item 4)", async () => {
 		const account = makeAccount("no-rt-success-1", {
 			refresh_token: "",
 			access_token: "stale-access",
@@ -633,15 +642,38 @@ describe("refreshAccessTokenSafe — accounts with no refresh token to CAS again
 		const token = await refreshAccessTokenSafe(account as never, ctx as never);
 
 		expect(token).toBe("brand-new");
-		expect(ctx.dbOps.updateAccountTokens).toHaveBeenCalledWith(
+		expect(
+			ctx.dbOps.updateAccountTokensIfRefreshTokenAbsent,
+		).toHaveBeenCalledWith(
 			"no-rt-success-1",
 			"brand-new",
 			expect.any(Number),
 			undefined,
 		);
+		expect(ctx.dbOps.updateAccountTokens).not.toHaveBeenCalled();
 		expect(
 			ctx.dbOps.updateAccountTokensIfRefreshTokenMatches,
 		).not.toHaveBeenCalled();
+	});
+
+	it("P5b: warns and skips without throwing when the null-safe CAS write is superseded", async () => {
+		const account = makeAccount("no-rt-cas-false-1", {
+			refresh_token: "",
+			access_token: "stale-access",
+			expires_at: 1,
+		});
+		const { ctx } = makeContext({
+			dbAccount: null,
+			refreshResult: {
+				accessToken: "brand-new",
+				expiresAt: Date.now() + 3_600_000,
+			},
+		});
+		ctx.dbOps.updateAccountTokensIfRefreshTokenAbsent = mock(async () => false);
+
+		const token = await refreshAccessTokenSafe(account as never, ctx as never);
+
+		expect(token).toBe("brand-new");
 	});
 
 	it("does not flag or emit on invalid_grant failure — unverifiable without a refresh token to CAS against", async () => {
@@ -668,5 +700,171 @@ describe("refreshAccessTokenSafe — accounts with no refresh token to CAS again
 
 		expect(ctx.dbOps.flagRequiresReauthIfTokenMatches).not.toHaveBeenCalled();
 		expect(events).toHaveLength(0);
+	});
+});
+
+describe("refreshAccessTokenSafe — pending-rotation registry (round 3, item 1) and RT-regression guard (item 3)", () => {
+	it("P1: records a pending rotation when the persist write rejects and serves the rotated token", async () => {
+		const account = makeAccount("pending-persist-fail-1", {
+			refresh_token: "RT1",
+			access_token: "stale-access",
+			expires_at: 1,
+		});
+		const { ctx } = makeContext({
+			dbAccount: null,
+			refreshResult: {
+				accessToken: "new-access",
+				expiresAt: Date.now() + 3_600_000,
+				refreshToken: "RT2",
+			},
+		});
+		ctx.dbOps.updateAccountTokensIfRefreshTokenMatches = mock(async () => {
+			throw new Error("disk full");
+		});
+
+		const token = await refreshAccessTokenSafe(account as never, ctx as never);
+
+		expect(token).toBe("new-access");
+		const pending = getPendingRotation("pending-persist-fail-1");
+		expect(pending).toBeTruthy();
+		expect(pending?.attemptedRefreshToken).toBe("RT1");
+		expect(pending?.refreshToken).toBe("RT2");
+		expect(pending?.accessToken).toBe("new-access");
+	});
+
+	it("P2: flushes the pending rotation before the next refresh and skips the replay", async () => {
+		const accountId = "pending-flush-skip-replay-1";
+		// Seed a pending rotation the same way P1 does: a successful provider
+		// refresh whose persist write rejects.
+		const seedAccount = makeAccount(accountId, {
+			refresh_token: "RT1",
+			access_token: "stale-access",
+			expires_at: 1,
+		});
+		const seed = makeContext({
+			dbAccount: null,
+			refreshResult: {
+				accessToken: "rotated-access",
+				expiresAt: Date.now() + 3_600_000,
+				refreshToken: "RT2",
+			},
+		});
+		seed.ctx.dbOps.updateAccountTokensIfRefreshTokenMatches = mock(async () => {
+			throw new Error("disk full");
+		});
+		await refreshAccessTokenSafe(seedAccount as never, seed.ctx as never);
+		expect(getPendingRotation(accountId)).toBeTruthy();
+
+		// A fresh caller shows up with a STALE snapshot (still RT1, still
+		// expired) and its own ctx/refreshInFlight map. getAccount is rigged to
+		// return the same STALE row regardless of the flush's outcome, so any
+		// skip of the refresh below can only be explained by the new
+		// pending-rotation short-circuit, not the pre-existing DB-adoption path.
+		const staleAccount = makeAccount(accountId, {
+			refresh_token: "RT1",
+			access_token: "stale-access",
+			expires_at: 1,
+		});
+		const staleDbRow = makeAccount(accountId, {
+			refresh_token: "RT1",
+			access_token: "stale-access",
+			expires_at: 1,
+		});
+		const { ctx, refreshToken } = makeContext({ dbAccount: staleDbRow });
+		// This time the CAS write underlying the flush succeeds.
+		ctx.dbOps.updateAccountTokensIfRefreshTokenMatches = mock(async () => true);
+
+		const token = await refreshAccessTokenSafe(
+			staleAccount as never,
+			ctx as never,
+		);
+
+		expect(token).toBe("rotated-access");
+		expect(refreshToken).not.toHaveBeenCalled();
+		expect(getPendingRotation(accountId)).toBeUndefined();
+	});
+
+	it("P3: does not flag when a definitive failure hits an account with a pending rotation", async () => {
+		const accountId = "pending-blocks-flag-1";
+		// Seed a pending rotation with NO rotated refresh token and an
+		// already-expired pending access token, so the flush-serve
+		// short-circuit falls through to a real refresh attempt using the
+		// still-unrotated RT1 — exactly what a replayed consumed token looks
+		// like from the caller's perspective.
+		const seedAccount = makeAccount(accountId, {
+			refresh_token: "RT1",
+			access_token: "stale-access",
+			expires_at: 1,
+		});
+		const seed = makeContext({
+			dbAccount: null,
+			refreshResult: {
+				accessToken: "rotated-access-expired",
+				expiresAt: 2,
+			},
+		});
+		seed.ctx.dbOps.updateAccountTokensIfRefreshTokenMatches = mock(async () => {
+			throw new Error("disk full");
+		});
+		await refreshAccessTokenSafe(seedAccount as never, seed.ctx as never);
+		expect(getPendingRotation(accountId)).toBeTruthy();
+
+		const account = makeAccount(accountId, {
+			refresh_token: "RT1",
+			access_token: "stale-access",
+			expires_at: 1,
+		});
+		const staleDbRow = makeAccount(accountId, {
+			refresh_token: "RT1",
+			access_token: "stale-access",
+			expires_at: 1,
+		});
+		const invalidGrant = new Error(
+			"Status 400, Error: invalid_grant: Refresh token not found or invalid",
+		);
+		const { ctx } = makeContext({
+			dbAccount: staleDbRow,
+			refreshError: invalidGrant,
+		});
+		// The flush keeps failing.
+		ctx.dbOps.updateAccountTokensIfRefreshTokenMatches = mock(async () => {
+			throw new Error("disk still full");
+		});
+
+		const events: AuthFailureEvt[] = [];
+		const listener = (e: AuthFailureEvt) => events.push(e);
+		authFailureEvents.on("event", listener);
+		try {
+			await expect(
+				refreshAccessTokenSafe(account as never, ctx as never),
+			).rejects.toThrow();
+		} finally {
+			authFailureEvents.off("event", listener);
+		}
+
+		expect(ctx.dbOps.flagRequiresReauthIfTokenMatches).not.toHaveBeenCalled();
+		expect(events).toHaveLength(0);
+	});
+
+	it("P4: does not regress the refresh token when adopting a newer access token (round-3 item 3)", async () => {
+		const account = makeAccount("no-regress-rt-1", {
+			refresh_token: "RT2",
+			refresh_token_issued_at: 2000,
+			access_token: "expired-mem",
+			expires_at: 1,
+		});
+		const dbAccount = makeAccount("no-regress-rt-1", {
+			refresh_token: "RT1",
+			refresh_token_issued_at: 1000,
+			access_token: "fresh-access-from-db",
+			expires_at: Date.now() + 3_600_000,
+		});
+		const { ctx, refreshToken } = makeContext({ dbAccount });
+
+		const token = await refreshAccessTokenSafe(account as never, ctx as never);
+
+		expect(token).toBe("fresh-access-from-db");
+		expect(refreshToken).not.toHaveBeenCalled();
+		expect(account.refresh_token).toBe("RT2");
 	});
 });

--- a/packages/proxy/src/handlers/__tests__/token-manager-rotation-race.test.ts
+++ b/packages/proxy/src/handlers/__tests__/token-manager-rotation-race.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { Account } from "@better-ccflare/types";
+import { refreshAccessTokenSafe } from "../token-manager";
+
+function makeAccount(id: string, overrides: Partial<Account> = {}): Account {
+	return {
+		id,
+		name: "test-account",
+		provider: "fake-refresh-provider",
+		api_key: null,
+		refresh_token: "refresh-token",
+		access_token: "expired-access-token",
+		expires_at: 1,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: 1,
+		rate_limited_until: null,
+		rate_limited_reason: null,
+		rate_limited_at: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		requires_reauth: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		peak_hours_pause_enabled: false,
+		custom_endpoint: null,
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		billing_type: null,
+		pause_reason: null,
+		refresh_token_issued_at: null,
+		consecutive_rate_limits: 0,
+		...overrides,
+	};
+}
+
+function makeContext(opts: {
+	dbAccount?: Account | null;
+	refreshResult?: {
+		accessToken: string;
+		expiresAt: number;
+		refreshToken?: string;
+	};
+	refreshError?: Error;
+}) {
+	const queuedJobs: Array<() => Promise<void>> = [];
+	const setRequiresReauth = mock(async () => {});
+	const refreshCalls: Array<{ refreshTokenAtCall: string | null }> = [];
+	const refreshToken = mock(async (account: Account) => {
+		refreshCalls.push({ refreshTokenAtCall: account.refresh_token });
+		if (opts.refreshError) throw opts.refreshError;
+		return (
+			opts.refreshResult ?? {
+				accessToken: "new-access-token",
+				expiresAt: Date.now() + 3_600_000,
+			}
+		);
+	});
+	return {
+		ctx: {
+			provider: { name: "fake-refresh-provider", refreshToken },
+			dbOps: {
+				getAccount: mock(async () => opts.dbAccount ?? null),
+				setRequiresReauth,
+				updateAccountTokens: mock(async () => {}),
+			},
+			runtime: { clientId: "test-client" },
+			refreshInFlight: new Map(),
+			asyncWriter: {
+				enqueue: mock((job: () => Promise<void>) => queuedJobs.push(job)),
+			},
+		},
+		queuedJobs,
+		setRequiresReauth,
+		refreshToken,
+		refreshCalls,
+	};
+}
+
+describe("refreshAccessTokenSafe — rotation-race pre-refresh guard", () => {
+	it("adopts a fresher valid token from the DB and skips the provider refresh", async () => {
+		const account = makeAccount("race-adopt-1", {
+			refresh_token: "RT1-stale",
+			access_token: "stale-access",
+			expires_at: 1,
+		});
+		const dbAccount = makeAccount("race-adopt-1", {
+			refresh_token: "RT2-current",
+			access_token: "fresh-access",
+			expires_at: Date.now() + 3_600_000,
+			refresh_token_issued_at: Date.now(),
+		});
+		const { ctx, refreshToken } = makeContext({ dbAccount });
+
+		const token = await refreshAccessTokenSafe(account as never, ctx as never);
+
+		expect(token).toBe("fresh-access");
+		expect(refreshToken).not.toHaveBeenCalled();
+		// in-memory snapshot healed
+		expect(account.access_token).toBe("fresh-access");
+		expect(account.refresh_token).toBe("RT2-current");
+	});
+
+	it("still refreshes when the DB row matches the snapshot (no race)", async () => {
+		const account = makeAccount("race-norace-1", {
+			refresh_token: "RT1",
+			access_token: "stale-access",
+			expires_at: 1,
+		});
+		const dbAccount = makeAccount("race-norace-1", {
+			refresh_token: "RT1",
+			access_token: "stale-access",
+			expires_at: 1,
+		});
+		const { ctx, refreshToken } = makeContext({
+			dbAccount,
+			refreshResult: {
+				accessToken: "brand-new",
+				expiresAt: Date.now() + 3_600_000,
+			},
+		});
+
+		const token = await refreshAccessTokenSafe(account as never, ctx as never);
+
+		expect(token).toBe("brand-new");
+		expect(refreshToken).toHaveBeenCalledTimes(1);
+	});
+
+	it("uses the DB's rotated refresh token when a refresh is still needed", async () => {
+		// DB has a newer RT but its access token is also expired → refresh must
+		// run, but with RT2, not the snapshot's consumed RT1.
+		const account = makeAccount("race-rt-sync-1", {
+			refresh_token: "RT1-consumed",
+			access_token: "stale-access",
+			expires_at: 1,
+		});
+		const dbAccount = makeAccount("race-rt-sync-1", {
+			refresh_token: "RT2-current",
+			access_token: "also-expired",
+			expires_at: 2,
+			refresh_token_issued_at: Date.now(),
+		});
+		const { ctx, refreshCalls } = makeContext({
+			dbAccount,
+			refreshResult: {
+				accessToken: "brand-new",
+				expiresAt: Date.now() + 3_600_000,
+			},
+		});
+
+		await refreshAccessTokenSafe(account as never, ctx as never);
+
+		expect(refreshCalls[0]?.refreshTokenAtCall).toBe("RT2-current");
+	});
+
+	it("proceeds to refresh when the account is missing from the DB", async () => {
+		const account = makeAccount("race-nodb-1", {
+			refresh_token: "RT1",
+			access_token: "stale",
+			expires_at: 1,
+		});
+		const { ctx, refreshToken } = makeContext({
+			dbAccount: null,
+			refreshResult: {
+				accessToken: "brand-new",
+				expiresAt: Date.now() + 3_600_000,
+			},
+		});
+
+		const token = await refreshAccessTokenSafe(account as never, ctx as never);
+
+		expect(token).toBe("brand-new");
+		expect(refreshToken).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/proxy/src/handlers/__tests__/token-manager-rotation-race.test.ts
+++ b/packages/proxy/src/handlers/__tests__/token-manager-rotation-race.test.ts
@@ -418,6 +418,44 @@ describe("refreshAccessTokenSafe — benign race on invalid_grant", () => {
 		expect(ctx.dbOps.flagRequiresReauthIfTokenMatches).not.toHaveBeenCalled();
 		expect(events).toHaveLength(0);
 	});
+
+	it("does not flag and rejects with TokenRefreshError when the CAS flag write itself rejects", async () => {
+		const account = makeAccount("flag-cas-rejects-1", {
+			refresh_token: "RT1-dead",
+			access_token: "stale",
+			expires_at: 1,
+		});
+		const sameDb = makeAccount("flag-cas-rejects-1", {
+			refresh_token: "RT1-dead",
+			access_token: "stale",
+			expires_at: 1,
+		});
+		const { ctx } = makeContext({ refreshError: invalidGrant });
+		ctx.dbOps.getAccount = mock(async () => sameDb);
+		// The CAS write itself throws (e.g. a transient DB error), not merely
+		// resolving false — the surrounding try/catch must swallow it and leave
+		// requires_reauth unset rather than letting it propagate unexpectedly.
+		ctx.dbOps.flagRequiresReauthIfTokenMatches = mock(async () => {
+			throw new Error("db write failed");
+		});
+
+		const events: AuthFailureEvt[] = [];
+		const listener = (e: AuthFailureEvt) => events.push(e);
+		authFailureEvents.on("event", listener);
+		try {
+			await expect(
+				refreshAccessTokenSafe(account as never, ctx as never),
+			).rejects.toThrow("Failed to refresh access token");
+		} finally {
+			authFailureEvents.off("event", listener);
+		}
+
+		expect(ctx.dbOps.flagRequiresReauthIfTokenMatches).toHaveBeenCalledWith(
+			"flag-cas-rejects-1",
+			"RT1-dead",
+		);
+		expect(events).toHaveLength(0);
+	});
 });
 
 describe("refreshAccessTokenSafe — persist-in-promise and identity-safe cleanup", () => {
@@ -460,6 +498,34 @@ describe("refreshAccessTokenSafe — persist-in-promise and identity-safe cleanu
 		);
 		// The lossy asyncWriter queue must never be used for the token write.
 		expect(queuedJobs).toHaveLength(0);
+	});
+
+	it("calls the CAS write with undefined as the 5th arg when the provider returns no rotated refresh token", async () => {
+		const account = makeAccount("undefined-rt-arg-1", {
+			refresh_token: "RT1",
+			access_token: "stale-access",
+			expires_at: 1,
+		});
+		const { ctx } = makeContext({
+			dbAccount: null,
+			refreshResult: {
+				accessToken: "brand-new",
+				expiresAt: Date.now() + 3_600_000,
+				// no refreshToken key: the provider did not rotate this time.
+			},
+		});
+
+		await refreshAccessTokenSafe(account as never, ctx as never);
+
+		expect(
+			ctx.dbOps.updateAccountTokensIfRefreshTokenMatches,
+		).toHaveBeenCalledWith(
+			"undefined-rt-arg-1",
+			"RT1",
+			"brand-new",
+			expect.any(Number),
+			undefined,
+		);
 	});
 
 	it("finally does not delete a newer in-flight entry installed while it was still settling (finding 4, test D)", async () => {
@@ -542,5 +608,65 @@ describe("refreshAccessTokenSafe — join in-flight before backoff", () => {
 		expect(refreshToken).toHaveBeenCalledTimes(1);
 		// ...and the joiner did not start a second refresh of its own either.
 		expect(joinedRefresh).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("refreshAccessTokenSafe — accounts with no refresh token to CAS against", () => {
+	// Account.refresh_token is typed as `string` (not nullable) — the "no
+	// refresh token" shape in this codebase is an empty string, not null. This
+	// still exercises the exact `!attemptedRefreshToken` falsy branch.
+
+	it("falls back to the plain updateAccountTokens write on success (no CAS possible)", async () => {
+		const account = makeAccount("no-rt-success-1", {
+			refresh_token: "",
+			access_token: "stale-access",
+			expires_at: 1,
+		});
+		const { ctx } = makeContext({
+			dbAccount: null,
+			refreshResult: {
+				accessToken: "brand-new",
+				expiresAt: Date.now() + 3_600_000,
+			},
+		});
+
+		const token = await refreshAccessTokenSafe(account as never, ctx as never);
+
+		expect(token).toBe("brand-new");
+		expect(ctx.dbOps.updateAccountTokens).toHaveBeenCalledWith(
+			"no-rt-success-1",
+			"brand-new",
+			expect.any(Number),
+			undefined,
+		);
+		expect(
+			ctx.dbOps.updateAccountTokensIfRefreshTokenMatches,
+		).not.toHaveBeenCalled();
+	});
+
+	it("does not flag or emit on invalid_grant failure — unverifiable without a refresh token to CAS against", async () => {
+		const account = makeAccount("no-rt-failure-1", {
+			refresh_token: "",
+			access_token: "stale",
+			expires_at: 1,
+		});
+		const noRtInvalidGrant = new Error(
+			"Status 400, Error: invalid_grant: Refresh token not found or invalid",
+		);
+		const { ctx } = makeContext({ refreshError: noRtInvalidGrant });
+
+		const events: AuthFailureEvt[] = [];
+		const listener = (e: AuthFailureEvt) => events.push(e);
+		authFailureEvents.on("event", listener);
+		try {
+			await expect(
+				refreshAccessTokenSafe(account as never, ctx as never),
+			).rejects.toThrow("Failed to refresh access token");
+		} finally {
+			authFailureEvents.off("event", listener);
+		}
+
+		expect(ctx.dbOps.flagRequiresReauthIfTokenMatches).not.toHaveBeenCalled();
+		expect(events).toHaveLength(0);
 	});
 });

--- a/packages/proxy/src/handlers/__tests__/token-manager-rotation-race.test.ts
+++ b/packages/proxy/src/handlers/__tests__/token-manager-rotation-race.test.ts
@@ -846,6 +846,62 @@ describe("refreshAccessTokenSafe — pending-rotation registry (round 3, item 1)
 		expect(events).toHaveLength(0);
 	});
 
+	it("P1b: preserves the original anchor across a second failed-persist rotation while the first is still pending (round-3 final review, C1)", async () => {
+		const accountId = "pending-chain-anchor-1";
+		// Seed exactly like P1: a successful provider refresh (RT1 -> RT2)
+		// whose persist rejects. Use an already-expired pending access token
+		// (like P3) so the second call below falls through to a REAL second
+		// refresh instead of just serving the seeded credentials.
+		const seedAccount = makeAccount(accountId, {
+			refresh_token: "RT1",
+			access_token: "stale-access",
+			expires_at: 1,
+		});
+		const seed = makeContext({
+			dbAccount: null,
+			refreshResult: {
+				accessToken: "access-2-expired",
+				expiresAt: 2,
+				refreshToken: "RT2",
+			},
+		});
+		seed.ctx.dbOps.updateAccountTokensIfRefreshTokenMatches = mock(async () => {
+			throw new Error("disk full");
+		});
+		await refreshAccessTokenSafe(seedAccount as never, seed.ctx as never);
+		const seeded = getPendingRotation(accountId);
+		expect(seeded?.attemptedRefreshToken).toBe("RT1");
+		expect(seeded?.refreshToken).toBe("RT2");
+
+		// A second caller shows up with a stale (still-RT1) snapshot. Its own
+		// provider call rotates RT2 -> RT3 (via the pending-rotation fallthrough
+		// adopting RT2 first), and its persist ALSO rejects.
+		const secondAccount = makeAccount(accountId, {
+			refresh_token: "RT1",
+			access_token: "stale-access",
+			expires_at: 1,
+		});
+		const second = makeContext({
+			dbAccount: null,
+			refreshResult: {
+				accessToken: "access-3",
+				expiresAt: Date.now() + 3_600_000,
+				refreshToken: "RT3",
+			},
+		});
+		second.ctx.dbOps.updateAccountTokensIfRefreshTokenMatches = mock(
+			async () => {
+				throw new Error("disk still full");
+			},
+		);
+
+		await refreshAccessTokenSafe(secondAccount as never, second.ctx as never);
+
+		const chained = getPendingRotation(accountId);
+		expect(chained?.attemptedRefreshToken).toBe("RT1");
+		expect(chained?.refreshToken).toBe("RT3");
+	});
+
 	it("P4: does not regress the refresh token when adopting a newer access token (round-3 item 3)", async () => {
 		const account = makeAccount("no-regress-rt-1", {
 			refresh_token: "RT2",

--- a/packages/proxy/src/handlers/__tests__/token-manager-rotation-race.test.ts
+++ b/packages/proxy/src/handlers/__tests__/token-manager-rotation-race.test.ts
@@ -967,10 +967,12 @@ describe("refreshAccessTokenSafe — adopts authoritative DB credentials when th
 
 		const token = await refreshAccessTokenSafe(account as never, ctx as never);
 
-		// The current request still gets the provider-valid access token it
-		// just minted.
-		expect(token).toBe("new-access-from-provider");
-		// But the live `account` object adopts the DB's authoritative
+		// The adopted DB row's access token is still comfortably valid, so the
+		// caller must be served THAT token — not the losing rotated one, which
+		// may already be dead if the winning manual re-auth revoked its session
+		// family.
+		expect(token).toBe("manual-access");
+		// The live `account` object also adopts the DB's authoritative
 		// credentials rather than the losing rotated ones.
 		expect(account.refresh_token).toBe("RT_manual");
 		expect(account.access_token).toBe("manual-access");
@@ -978,6 +980,53 @@ describe("refreshAccessTokenSafe — adopts authoritative DB credentials when th
 		expect(account.refresh_token_issued_at).toBe(
 			manualReauthDb.refresh_token_issued_at,
 		);
+	});
+
+	it("falls back to the losing rotated access token when the adopted DB row's access token is already expired", async () => {
+		const accountId = "adopt-authoritative-expired-1";
+		const account = makeAccount(accountId, {
+			refresh_token: "RT1",
+			access_token: "stale-access",
+			expires_at: 1,
+		});
+		const preRefreshDb = makeAccount(accountId, {
+			refresh_token: "RT1",
+			access_token: "stale-access",
+			expires_at: 1,
+		});
+		// Post-persist read: the winning writer's row is authoritative for the
+		// refresh token, but its access token is already expired (e.g. a manual
+		// re-auth that hasn't refreshed yet) — not servable to this caller.
+		const expiredManualReauthDb = makeAccount(accountId, {
+			refresh_token: "RT_manual",
+			access_token: "manual-access-expired",
+			expires_at: Date.now() - 1000,
+			refresh_token_issued_at: Date.now(),
+		});
+		const { ctx } = makeContext({
+			refreshResult: {
+				accessToken: "new-access-from-provider",
+				expiresAt: Date.now() + 3_600_000,
+				refreshToken: "RT2-losing",
+			},
+		});
+		let call = 0;
+		ctx.dbOps.getAccount = mock(async () =>
+			call++ === 0 ? preRefreshDb : expiredManualReauthDb,
+		);
+		ctx.dbOps.updateAccountTokensIfRefreshTokenMatches = mock(
+			async () => false,
+		);
+
+		const token = await refreshAccessTokenSafe(account as never, ctx as never);
+
+		// The adopted access token is not servable, so the caller still gets
+		// the token this refresh just minted.
+		expect(token).toBe("new-access-from-provider");
+		// But the refresh token (and other DB-authoritative fields) are still
+		// adopted into the live `account` object.
+		expect(account.refresh_token).toBe("RT_manual");
+		expect(account.access_token).toBe("manual-access-expired");
 	});
 
 	it("falls back to the losing in-memory update when the post-persist re-read fails", async () => {

--- a/packages/proxy/src/handlers/__tests__/token-manager-rotation-race.test.ts
+++ b/packages/proxy/src/handlers/__tests__/token-manager-rotation-race.test.ts
@@ -4,6 +4,7 @@ import type { Account } from "@better-ccflare/types";
 import {
 	clearAllPendingRotationsForTests,
 	getPendingRotation,
+	recordPendingRotation,
 } from "../pending-rotation-registry";
 import { refreshAccessTokenSafe } from "../token-manager";
 
@@ -922,5 +923,150 @@ describe("refreshAccessTokenSafe — pending-rotation registry (round 3, item 1)
 		expect(token).toBe("fresh-access-from-db");
 		expect(refreshToken).not.toHaveBeenCalled();
 		expect(account.refresh_token).toBe("RT2");
+	});
+});
+
+describe("refreshAccessTokenSafe — adopts authoritative DB credentials when the persist CAS loses", () => {
+	it("adopts the DB row's newer credentials into `account` instead of the losing rotated ones when the persist CAS returns false", async () => {
+		const accountId = "adopt-authoritative-lost-cas-1";
+		const account = makeAccount(accountId, {
+			refresh_token: "RT1",
+			access_token: "stale-access",
+			expires_at: 1,
+		});
+		// Pre-refresh guard read: identical to the in-memory snapshot, so it
+		// does not short-circuit the refresh below.
+		const preRefreshDb = makeAccount(accountId, {
+			refresh_token: "RT1",
+			access_token: "stale-access",
+			expires_at: 1,
+		});
+		// Post-persist read: a manual re-auth (or a newer rotation) landed
+		// between the refresh attempt and the persist write, so the CAS below
+		// matches 0 rows and this is what the DB now authoritatively holds.
+		const manualReauthDb = makeAccount(accountId, {
+			refresh_token: "RT_manual",
+			access_token: "manual-access",
+			expires_at: Date.now() + 7_200_000,
+			refresh_token_issued_at: Date.now(),
+		});
+		const { ctx } = makeContext({
+			refreshResult: {
+				accessToken: "new-access-from-provider",
+				expiresAt: Date.now() + 3_600_000,
+				refreshToken: "RT2-losing",
+			},
+		});
+		let call = 0;
+		ctx.dbOps.getAccount = mock(async () =>
+			call++ === 0 ? preRefreshDb : manualReauthDb,
+		);
+		ctx.dbOps.updateAccountTokensIfRefreshTokenMatches = mock(
+			async () => false,
+		);
+
+		const token = await refreshAccessTokenSafe(account as never, ctx as never);
+
+		// The current request still gets the provider-valid access token it
+		// just minted.
+		expect(token).toBe("new-access-from-provider");
+		// But the live `account` object adopts the DB's authoritative
+		// credentials rather than the losing rotated ones.
+		expect(account.refresh_token).toBe("RT_manual");
+		expect(account.access_token).toBe("manual-access");
+		expect(account.expires_at).toBe(manualReauthDb.expires_at);
+		expect(account.refresh_token_issued_at).toBe(
+			manualReauthDb.refresh_token_issued_at,
+		);
+	});
+
+	it("falls back to the losing in-memory update when the post-persist re-read fails", async () => {
+		const accountId = "adopt-authoritative-readfail-1";
+		const account = makeAccount(accountId, {
+			refresh_token: "RT1",
+			access_token: "stale-access",
+			expires_at: 1,
+		});
+		const preRefreshDb = makeAccount(accountId, {
+			refresh_token: "RT1",
+			access_token: "stale-access",
+			expires_at: 1,
+		});
+		const { ctx } = makeContext({
+			refreshResult: {
+				accessToken: "new-access-from-provider",
+				expiresAt: Date.now() + 3_600_000,
+				refreshToken: "RT2-losing",
+			},
+		});
+		let call = 0;
+		ctx.dbOps.getAccount = mock(async () => {
+			if (call++ === 0) return preRefreshDb;
+			throw new Error("db unavailable");
+		});
+		ctx.dbOps.updateAccountTokensIfRefreshTokenMatches = mock(
+			async () => false,
+		);
+
+		const token = await refreshAccessTokenSafe(account as never, ctx as never);
+
+		expect(token).toBe("new-access-from-provider");
+		// Re-read failed — falls back to the pre-existing behavior of
+		// installing the (losing) result values in-memory.
+		expect(account.refresh_token).toBe("RT2-losing");
+		expect(account.access_token).toBe("new-access-from-provider");
+	});
+});
+
+describe("refreshAccessTokenSafe — serves the newest pending entry recorded during a flush", () => {
+	it("serves the entry re-recorded while the flush's CAS write was still in flight, not the pre-flush snapshot", async () => {
+		const accountId = "flush-serves-newest-1";
+		// Seed E1 (RT1 -> RT2) via a successful provider refresh whose persist
+		// write rejects, exactly like the P1 pending-registry seeding pattern.
+		const seedAccount = makeAccount(accountId, {
+			refresh_token: "RT1",
+			access_token: "stale-access",
+			expires_at: 1,
+		});
+		const seed = makeContext({
+			dbAccount: null,
+			refreshResult: {
+				accessToken: "access-1",
+				expiresAt: Date.now() + 3_600_000,
+				refreshToken: "RT2",
+			},
+		});
+		seed.ctx.dbOps.updateAccountTokensIfRefreshTokenMatches = mock(async () => {
+			throw new Error("disk full");
+		});
+		await refreshAccessTokenSafe(seedAccount as never, seed.ctx as never);
+		expect(getPendingRotation(accountId)?.accessToken).toBe("access-1");
+
+		// A second caller triggers a flush whose CAS write, before resolving,
+		// simulates a concurrent request-triggered refresh recording a newer
+		// rotation (E2: access-2 / RT3) for the same account.
+		const account = makeAccount(accountId, {
+			refresh_token: "RT1",
+			access_token: "stale-access",
+			expires_at: 1,
+		});
+		const { ctx, refreshToken } = makeContext({ dbAccount: null });
+		ctx.dbOps.updateAccountTokensIfRefreshTokenMatches = mock(
+			async (id: string) => {
+				recordPendingRotation(id, {
+					accessToken: "access-2",
+					expiresAt: Date.now() + 3_600_000,
+					refreshToken: "RT3",
+					attemptedRefreshToken: "RT2",
+				});
+				return true;
+			},
+		);
+
+		const token = await refreshAccessTokenSafe(account as never, ctx as never);
+
+		expect(token).toBe("access-2");
+		expect(refreshToken).not.toHaveBeenCalled();
+		expect(getPendingRotation(accountId)?.accessToken).toBe("access-2");
 	});
 });

--- a/packages/proxy/src/handlers/__tests__/token-manager-rotation-race.test.ts
+++ b/packages/proxy/src/handlers/__tests__/token-manager-rotation-race.test.ts
@@ -72,6 +72,8 @@ function makeContext(opts: {
 				getAccount: mock(async () => opts.dbAccount ?? null),
 				setRequiresReauth,
 				updateAccountTokens: mock(async () => {}),
+				updateAccountTokensIfRefreshTokenMatches: mock(async () => true),
+				flagRequiresReauthIfTokenMatches: mock(async () => true),
 			},
 			runtime: { clientId: "test-client" },
 			refreshInFlight: new Map(),
@@ -181,6 +183,59 @@ describe("refreshAccessTokenSafe — rotation-race pre-refresh guard", () => {
 		expect(token).toBe("brand-new");
 		expect(refreshToken).toHaveBeenCalledTimes(1);
 	});
+
+	it("does not adopt an older refresh token from a delayed DB state (finding 6, test F)", async () => {
+		// account (memory) already rotated to RT2 at t=2000; the DB row is a
+		// delayed snapshot still showing RT1 issued at t=1000. A DB read that
+		// merely differs from memory must never be treated as "fresher" —
+		// only a strictly newer issued_at may override the in-memory RT.
+		const account = makeAccount("no-adopt-older-rt-1", {
+			refresh_token: "RT2",
+			refresh_token_issued_at: 2000,
+			access_token: "expired-mem",
+			expires_at: 1,
+		});
+		const dbAccount = makeAccount("no-adopt-older-rt-1", {
+			refresh_token: "RT1",
+			refresh_token_issued_at: 1000,
+			access_token: "also-expired-db",
+			expires_at: 2,
+		});
+		const { ctx, refreshCalls } = makeContext({
+			dbAccount,
+			refreshResult: {
+				accessToken: "brand-new",
+				expiresAt: Date.now() + 3_600_000,
+			},
+		});
+
+		await refreshAccessTokenSafe(account as never, ctx as never);
+
+		expect(refreshCalls[0]?.refreshTokenAtCall).toBe("RT2");
+		expect(account.refresh_token).toBe("RT2");
+	});
+
+	it("adopts when DB expiry is strictly newer even if access token string equal (finding 6, test G)", async () => {
+		const sharedAccessToken = "same-access-token-string";
+		const account = makeAccount("adopt-newer-expiry-1", {
+			refresh_token: "RT1",
+			access_token: sharedAccessToken,
+			expires_at: 1,
+		});
+		const dbAccount = makeAccount("adopt-newer-expiry-1", {
+			refresh_token: "RT1",
+			access_token: sharedAccessToken,
+			expires_at: Date.now() + 2 * 60 * 60 * 1000,
+			refresh_token_issued_at: Date.now(),
+		});
+		const { ctx, refreshToken } = makeContext({ dbAccount });
+
+		const token = await refreshAccessTokenSafe(account as never, ctx as never);
+
+		expect(token).toBe(sharedAccessToken);
+		expect(refreshToken).not.toHaveBeenCalled();
+		expect(account.expires_at).toBe(dbAccount.expires_at);
+	});
 });
 
 describe("refreshAccessTokenSafe — benign race on invalid_grant", () => {
@@ -266,7 +321,7 @@ describe("refreshAccessTokenSafe — benign race on invalid_grant", () => {
 		expect(account.refresh_token).toBe("RT2-current");
 	});
 
-	it("still flags requires_reauth when the rejected RT is the account's current one", async () => {
+	it("still flags requires_reauth via the CAS write when the rejected RT is the account's current one", async () => {
 		const account = makeAccount("race-catch-flag-1", {
 			refresh_token: "RT1-dead",
 			access_token: "stale",
@@ -277,17 +332,215 @@ describe("refreshAccessTokenSafe — benign race on invalid_grant", () => {
 			access_token: "stale",
 			expires_at: 1,
 		});
-		const { ctx, setRequiresReauth, queuedJobs } = makeContext({
+		const { ctx } = makeContext({
 			refreshError: invalidGrant,
 		});
 		ctx.dbOps.getAccount = mock(async () => sameDb);
 
+		const events: AuthFailureEvt[] = [];
+		const listener = (e: AuthFailureEvt) => events.push(e);
+		authFailureEvents.on("event", listener);
+		try {
+			await expect(
+				refreshAccessTokenSafe(account as never, ctx as never),
+			).rejects.toThrow();
+		} finally {
+			authFailureEvents.off("event", listener);
+		}
+
+		expect(ctx.dbOps.flagRequiresReauthIfTokenMatches).toHaveBeenCalledWith(
+			"race-catch-flag-1",
+			"RT1-dead",
+		);
+		expect(events).toHaveLength(1);
+	});
+
+	it("emits the auth-failure event only when the CAS flag write actually succeeds (finding 2, test B)", async () => {
+		const account = makeAccount("flag-cas-fail-1", {
+			refresh_token: "RT1-dead",
+			access_token: "stale",
+			expires_at: 1,
+		});
+		const sameDb = makeAccount("flag-cas-fail-1", {
+			refresh_token: "RT1-dead",
+			access_token: "stale",
+			expires_at: 1,
+		});
+		const { ctx } = makeContext({ refreshError: invalidGrant });
+		ctx.dbOps.getAccount = mock(async () => sameDb);
+		// Someone rotated the token between our verification read and the flag
+		// write — the CAS write is a no-op and must not be treated as success.
+		ctx.dbOps.flagRequiresReauthIfTokenMatches = mock(async () => false);
+
+		const events: AuthFailureEvt[] = [];
+		const listener = (e: AuthFailureEvt) => events.push(e);
+		authFailureEvents.on("event", listener);
+		try {
+			await expect(
+				refreshAccessTokenSafe(account as never, ctx as never),
+			).rejects.toThrow();
+		} finally {
+			authFailureEvents.off("event", listener);
+		}
+
+		expect(ctx.dbOps.flagRequiresReauthIfTokenMatches).toHaveBeenCalledWith(
+			"flag-cas-fail-1",
+			"RT1-dead",
+		);
+		expect(events).toHaveLength(0);
+	});
+
+	it("does not flag when the recovery DB read fails (finding 3, test C)", async () => {
+		const account = makeAccount("no-flag-db-read-fail-1", {
+			refresh_token: "RT1-dead",
+			access_token: "stale",
+			expires_at: 1,
+		});
+		const { ctx } = makeContext({ refreshError: invalidGrant });
+		// Every getAccount call fails: the pre-refresh guard swallows its own
+		// failure internally and proceeds; the post-failure recovery read is
+		// the one that matters here and must leave requires_reauth unverified.
+		ctx.dbOps.getAccount = mock(async () => {
+			throw new Error("db unavailable");
+		});
+
+		const events: AuthFailureEvt[] = [];
+		const listener = (e: AuthFailureEvt) => events.push(e);
+		authFailureEvents.on("event", listener);
+		try {
+			await expect(
+				refreshAccessTokenSafe(account as never, ctx as never),
+			).rejects.toThrow();
+		} finally {
+			authFailureEvents.off("event", listener);
+		}
+
+		expect(ctx.dbOps.flagRequiresReauthIfTokenMatches).not.toHaveBeenCalled();
+		expect(events).toHaveLength(0);
+	});
+});
+
+describe("refreshAccessTokenSafe — persist-in-promise and identity-safe cleanup", () => {
+	it("persists rotated tokens via the awaited CAS write before the refresh promise resolves (finding 1, test A)", async () => {
+		const account = makeAccount("persist-order-1", {
+			refresh_token: "RT1",
+			access_token: "stale-access",
+			expires_at: 1,
+		});
+		const { ctx, queuedJobs } = makeContext({
+			dbAccount: null,
+			refreshResult: {
+				accessToken: "brand-new",
+				expiresAt: Date.now() + 3_600_000,
+				refreshToken: "RT2",
+			},
+		});
+		let persisted = false;
+		ctx.dbOps.updateAccountTokensIfRefreshTokenMatches = mock(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			persisted = true;
+			return true;
+		});
+
+		const token = await refreshAccessTokenSafe(account as never, ctx as never);
+
+		expect(token).toBe("brand-new");
+		// The CAS write's tick-delayed resolution must have already happened by
+		// the time refreshAccessTokenSafe itself resolves — proving the write
+		// is awaited INSIDE the shared promise, not fired-and-forgotten.
+		expect(persisted).toBe(true);
+		expect(
+			ctx.dbOps.updateAccountTokensIfRefreshTokenMatches,
+		).toHaveBeenCalledWith(
+			"persist-order-1",
+			"RT1",
+			"brand-new",
+			expect.any(Number),
+			"RT2",
+		);
+		// The lossy asyncWriter queue must never be used for the token write.
+		expect(queuedJobs).toHaveLength(0);
+	});
+
+	it("finally does not delete a newer in-flight entry installed while it was still settling (finding 4, test D)", async () => {
+		const account = makeAccount("finally-identity-1", {
+			refresh_token: "RT1",
+			access_token: "stale",
+			expires_at: 1,
+		});
+		const { ctx } = makeContext({ dbAccount: null });
+		ctx.provider.refreshToken = mock(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			return {
+				accessToken: "brand-new",
+				expiresAt: Date.now() + 3_600_000,
+			};
+		});
+
+		const pending = refreshAccessTokenSafe(account as never, ctx as never);
+
+		// Let the synchronous setup (adoption guard's await + refreshInFlight
+		// install) run to completion before mutating the map — both are
+		// microtask-only, so they finish before this real timer fires.
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		const sentinel = Promise.resolve("sentinel-token");
+		ctx.refreshInFlight.delete(account.id);
+		ctx.refreshInFlight.set(account.id, sentinel);
+
+		await pending;
+
+		expect(ctx.refreshInFlight.get(account.id)).toBe(sentinel);
+	});
+});
+
+describe("refreshAccessTokenSafe — join in-flight before backoff", () => {
+	it("lets a concurrent caller join an in-flight refresh even while the account is in backoff (finding 5, test E)", async () => {
+		const account = makeAccount("join-inflight-backoff-1", {
+			refresh_token: "RT1",
+			access_token: "stale",
+			expires_at: 1,
+		});
+		const networkError = new Error("upstream 503 timeout");
+		const { ctx, refreshToken } = makeContext({
+			dbAccount: null,
+			refreshError: networkError,
+		});
+
+		// Seed a recent (transient, non-auth) failure so the account is now in
+		// its backoff window.
 		await expect(
 			refreshAccessTokenSafe(account as never, ctx as never),
 		).rejects.toThrow();
+		expect(ctx.refreshInFlight.has(account.id)).toBe(false);
+		expect(refreshToken).toHaveBeenCalledTimes(1);
 
-		for (const job of queuedJobs) await job();
-		expect(setRequiresReauth).toHaveBeenCalledTimes(1);
-		expect(setRequiresReauth).toHaveBeenCalledWith("race-catch-flag-1", true);
+		// Simulate a refresh already in flight via another path that shares
+		// this same ctx.refreshInFlight map — e.g. the auto-refresh scheduler,
+		// which registers its own promise directly into the map
+		// (auto-refresh-scheduler.ts) so concurrent request-triggered
+		// refreshes can join it.
+		const joinedRefresh = mock(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			return {
+				accessToken: "refresh-1-token",
+				expiresAt: Date.now() + 3_600_000,
+			};
+		});
+		ctx.provider.refreshToken = joinedRefresh;
+		const inFlightPromise = joinedRefresh().then(
+			(result: { accessToken: string }) => result.accessToken,
+		);
+		ctx.refreshInFlight.set(account.id, inFlightPromise);
+
+		// Still well within the backoff window — a fresh caller with no
+		// in-flight entry would be blocked here; this caller must instead join
+		// the in-flight promise rather than throw ServiceUnavailableError.
+		const joined = await refreshAccessTokenSafe(account as never, ctx as never);
+
+		expect(joined).toBe("refresh-1-token");
+		// The original seeding mock was never called again by the joiner...
+		expect(refreshToken).toHaveBeenCalledTimes(1);
+		// ...and the joiner did not start a second refresh of its own either.
+		expect(joinedRefresh).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/proxy/src/handlers/pending-rotation-registry.ts
+++ b/packages/proxy/src/handlers/pending-rotation-registry.ts
@@ -46,6 +46,22 @@ const pending = new Map<string, PendingRotation>();
  * Records a rotation that a provider call completed but that has not (yet)
  * been durably persisted. Replaces any existing entry for the account.
  *
+ * Anchor compression (round-3 final review, C1): if an entry already exists
+ * for this account, the new rotation's `attemptedRefreshToken` is discarded
+ * in favor of the existing entry's, and `recordedAt` is likewise carried
+ * over instead of reset. An entry can only still be present here because
+ * every flush attempt since it was recorded has failed — the DB never moved,
+ * so its `attemptedRefreshToken` is still the token the DB actually holds.
+ * A chain of rotations recorded while the DB is down (RT1→RT2, then RT2→RT3,
+ * …) must keep CASing against RT1: RT2 was only ever consumed in-memory by
+ * the provider call that produced the second (also-unpersisted) rotation,
+ * and a flush keyed on RT2 would match 0 rows, get misread as "superseded",
+ * and abandon the still-live RT1 anchor. (If the DB truly moved — a manual
+ * re-auth — the anchored CAS simply returns 0 rows on the next flush and is
+ * correctly classified "superseded" then.) Preserving `recordedAt` keeps
+ * this replace's FIFO-eviction position consistent with a plain replace
+ * instead of jumping the entry to the back of the eviction queue.
+ *
  * Bounded to MAX_PENDING_ROTATIONS entries: if recording this rotation would
  * exceed the cap, the oldest entry (by insertion order) is evicted first. An
  * eviction means a rotation is durably lost — the account will lose its
@@ -65,7 +81,14 @@ export function recordPendingRotation(
 			);
 		}
 	}
-	pending.set(accountId, { ...rotation, recordedAt: Date.now() });
+	const existing = pending.get(accountId);
+	pending.set(accountId, {
+		...rotation,
+		attemptedRefreshToken: existing
+			? existing.attemptedRefreshToken
+			: rotation.attemptedRefreshToken,
+		recordedAt: existing ? existing.recordedAt : Date.now(),
+	});
 }
 
 /** Returns the pending rotation for the account, if any. */
@@ -93,6 +116,15 @@ export function clearAllPendingRotationsForTests(): void {
  *   (manual re-auth or a newer rotation persisted); entry cleared, the DB is
  *   the source of truth now.
  * - "failed": the write threw; entry kept for the next flush attempt.
+ *
+ * Identity-guarded delete (round-3 final review, I2): both the "persisted"
+ * and "superseded" branches only delete the entry that was actually flushed
+ * — captured up front as `entry` — not whatever `pending.get(accountId)`
+ * happens to return by the time the awaited CAS settles. A caller can
+ * `recordPendingRotation` a newer rotation for this account while this
+ * flush's CAS write is still in flight (a flapping DB, or a concurrent
+ * request-triggered refresh); an unguarded delete would silently discard
+ * that newer entry even though it was never flushed.
  */
 export async function flushPendingRotation(
 	accountId: string,
@@ -118,10 +150,10 @@ export async function flushPendingRotation(
 				);
 
 		if (persisted) {
-			pending.delete(accountId);
+			if (pending.get(accountId) === entry) pending.delete(accountId);
 			return "persisted";
 		}
-		pending.delete(accountId);
+		if (pending.get(accountId) === entry) pending.delete(accountId);
 		log.warn(
 			`Pending rotation for account ${accountId} was superseded — the DB moved past the consumed token (manual re-auth or a newer rotation)`,
 		);

--- a/packages/proxy/src/handlers/pending-rotation-registry.ts
+++ b/packages/proxy/src/handlers/pending-rotation-registry.ts
@@ -1,0 +1,136 @@
+import { Logger } from "@better-ccflare/logger";
+
+const log = new Logger("PendingRotationRegistry");
+
+/**
+ * A refresh-token rotation that a provider call completed successfully but
+ * whose DB persist failed (or hasn't been attempted yet). Kept in-process so
+ * later touchpoints — the next refresh attempt, a request handler, a
+ * background flush — can retry the persist, serve the rotated credentials in
+ * the meantime, and avoid falsely flagging the account for re-auth.
+ */
+export type PendingRotation = {
+	accessToken: string;
+	expiresAt: number;
+	refreshToken?: string;
+	/** The refresh token the successful provider call consumed ("" when none). */
+	attemptedRefreshToken: string;
+	recordedAt: number;
+};
+
+/**
+ * Narrow structural view of the DatabaseOperations CAS methods this registry
+ * needs to flush a pending rotation. Declared here (not imported from the
+ * class) so this module has no runtime dependency on @better-ccflare/database.
+ */
+export type PendingRotationDbOps = {
+	updateAccountTokensIfRefreshTokenMatches(
+		accountId: string,
+		expectedRefreshToken: string,
+		accessToken: string,
+		expiresAt: number,
+		refreshToken?: string,
+	): Promise<boolean>;
+	updateAccountTokensIfRefreshTokenAbsent(
+		accountId: string,
+		accessToken: string,
+		expiresAt: number,
+		refreshToken?: string,
+	): Promise<boolean>;
+};
+
+const MAX_PENDING_ROTATIONS = 100;
+const pending = new Map<string, PendingRotation>();
+
+/**
+ * Records a rotation that a provider call completed but that has not (yet)
+ * been durably persisted. Replaces any existing entry for the account.
+ *
+ * Bounded to MAX_PENDING_ROTATIONS entries: if recording this rotation would
+ * exceed the cap, the oldest entry (by insertion order) is evicted first. An
+ * eviction means a rotation is durably lost — the account will lose its
+ * refresh token entirely once the in-memory copy also ages out — so it is
+ * logged as an error rather than silently dropped.
+ */
+export function recordPendingRotation(
+	accountId: string,
+	rotation: Omit<PendingRotation, "recordedAt">,
+): void {
+	if (!pending.has(accountId) && pending.size >= MAX_PENDING_ROTATIONS) {
+		const oldestId = pending.keys().next().value;
+		if (oldestId !== undefined) {
+			pending.delete(oldestId);
+			log.error(
+				`Evicted pending rotation for account ${oldestId}: registry exceeded ${MAX_PENDING_ROTATIONS} entries — that rotation is now durably lost`,
+			);
+		}
+	}
+	pending.set(accountId, { ...rotation, recordedAt: Date.now() });
+}
+
+/** Returns the pending rotation for the account, if any. */
+export function getPendingRotation(
+	accountId: string,
+): PendingRotation | undefined {
+	return pending.get(accountId);
+}
+
+/** Removes any pending rotation for the account. No-op if none exists. */
+export function clearPendingRotation(accountId: string): void {
+	pending.delete(accountId);
+}
+
+/** Test-only: clears the entire registry so tests don't leak state between runs. */
+export function clearAllPendingRotationsForTests(): void {
+	pending.clear();
+}
+
+/**
+ * Attempts to persist a pending rotation for the account.
+ * - "none": no entry for this account.
+ * - "persisted": CAS landed; entry cleared.
+ * - "superseded": CAS matched 0 rows — the DB moved past the consumed token
+ *   (manual re-auth or a newer rotation persisted); entry cleared, the DB is
+ *   the source of truth now.
+ * - "failed": the write threw; entry kept for the next flush attempt.
+ */
+export async function flushPendingRotation(
+	accountId: string,
+	dbOps: PendingRotationDbOps,
+): Promise<"none" | "persisted" | "superseded" | "failed"> {
+	const entry = pending.get(accountId);
+	if (!entry) return "none";
+
+	try {
+		const persisted = entry.attemptedRefreshToken
+			? await dbOps.updateAccountTokensIfRefreshTokenMatches(
+					accountId,
+					entry.attemptedRefreshToken,
+					entry.accessToken,
+					entry.expiresAt,
+					entry.refreshToken,
+				)
+			: await dbOps.updateAccountTokensIfRefreshTokenAbsent(
+					accountId,
+					entry.accessToken,
+					entry.expiresAt,
+					entry.refreshToken,
+				);
+
+		if (persisted) {
+			pending.delete(accountId);
+			return "persisted";
+		}
+		pending.delete(accountId);
+		log.warn(
+			`Pending rotation for account ${accountId} was superseded — the DB moved past the consumed token (manual re-auth or a newer rotation)`,
+		);
+		return "superseded";
+	} catch (error) {
+		log.error(
+			`Failed to flush pending rotation for account ${accountId} — keeping it for the next attempt`,
+			error,
+		);
+		return "failed";
+	}
+}

--- a/packages/proxy/src/handlers/pending-rotation-registry.ts
+++ b/packages/proxy/src/handlers/pending-rotation-registry.ts
@@ -111,7 +111,10 @@ export function clearAllPendingRotationsForTests(): void {
 /**
  * Attempts to persist a pending rotation for the account.
  * - "none": no entry for this account.
- * - "persisted": CAS landed; entry cleared.
+ * - "persisted": CAS landed; entry cleared — unless a newer rotation was
+ *   recorded for this account while the CAS write was in flight, in which
+ *   case that survivor is kept and its anchor is rebased onto the refresh
+ *   token this flush just persisted (see below).
  * - "superseded": CAS matched 0 rows — the DB moved past the consumed token
  *   (manual re-auth or a newer rotation persisted); entry cleared, the DB is
  *   the source of truth now.
@@ -125,6 +128,16 @@ export function clearAllPendingRotationsForTests(): void {
  * flush's CAS write is still in flight (a flapping DB, or a concurrent
  * request-triggered refresh); an unguarded delete would silently discard
  * that newer entry even though it was never flushed.
+ *
+ * Anchor rebase on a surviving entry (round-3, Codex concurrent
+ * flush/re-record race): when the CAS lands but a newer entry survived the
+ * identity guard above, that survivor's `attemptedRefreshToken` anchor was
+ * compressed against the *pre-flush* DB state and no longer matches what the
+ * DB now holds. Left alone, the survivor's own next flush would CAS against
+ * a stale anchor, match 0 rows, get misread as "superseded", and be
+ * discarded — even though it's the only in-memory copy of its refresh token.
+ * Rebasing the anchor onto `entry.refreshToken` (what this CAS just wrote)
+ * keeps the survivor's next flush aligned with reality.
  */
 export async function flushPendingRotation(
 	accountId: string,
@@ -150,7 +163,20 @@ export async function flushPendingRotation(
 				);
 
 		if (persisted) {
-			if (pending.get(accountId) === entry) pending.delete(accountId);
+			const current = pending.get(accountId);
+			if (current === entry) {
+				pending.delete(accountId);
+			} else if (current) {
+				// A newer rotation was recorded while this flush's CAS write was
+				// still in flight. The CAS we just landed moved the DB's refresh
+				// token to entry.refreshToken (or left it at the anchor when the
+				// rotation carried no new one) — rebase the survivor's anchor
+				// onto that, so its own flush matches the DB instead of reading
+				// 0 rows, getting misclassified "superseded", and discarding the
+				// newest credentials.
+				current.attemptedRefreshToken =
+					entry.refreshToken ?? entry.attemptedRefreshToken;
+			}
 			return "persisted";
 		}
 		if (pending.get(accountId) === entry) pending.delete(accountId);

--- a/packages/proxy/src/handlers/pending-rotation-registry.ts
+++ b/packages/proxy/src/handlers/pending-rotation-registry.ts
@@ -39,7 +39,14 @@ export type PendingRotationDbOps = {
 	): Promise<boolean>;
 };
 
-const MAX_PENDING_ROTATIONS = 100;
+// Safety valve against unbounded growth if persisting rotations stays broken
+// for a long time — not a limit expected to matter in practice. Entries are
+// small (~200 bytes each), so the cap can afford to be generous, and it
+// should be: eviction here durably loses a provider-committed rotation (see
+// the log.error below), so hitting this cap means 1000 accounts are
+// simultaneously mid-rotation during a DB outage, which should be
+// effectively unreachable.
+const MAX_PENDING_ROTATIONS = 1000;
 const pending = new Map<string, PendingRotation>();
 
 /**

--- a/packages/proxy/src/handlers/token-manager.ts
+++ b/packages/proxy/src/handlers/token-manager.ts
@@ -258,8 +258,8 @@ async function adoptDbTokensIfFresher(
 		account.expires_at = dbAccount.expires_at;
 		if (dbAccount.refresh_token) {
 			account.refresh_token = dbAccount.refresh_token;
+			account.refresh_token_issued_at = dbAccount.refresh_token_issued_at;
 		}
-		account.refresh_token_issued_at = dbAccount.refresh_token_issued_at;
 		refreshFailures.delete(account.id);
 		backoffCounters.delete(account.id);
 		log.info(
@@ -491,7 +491,7 @@ export async function refreshAccessTokenSafe(
 							return dbAccount.access_token;
 						}
 						log.warn(
-							`Refresh for ${account.name} used a superseded refresh token (${authFailureReason}) — not flagging re-auth; will retry with the rotated token`,
+							`Refresh for ${account.name} used a superseded refresh token (${authFailureReason}) — not flagging re-auth; the rotated token will be used after the refresh backoff`,
 						);
 						throw new TokenRefreshError(account.id, new Error(enhancedMessage));
 					}

--- a/packages/proxy/src/handlers/token-manager.ts
+++ b/packages/proxy/src/handlers/token-manager.ts
@@ -257,10 +257,7 @@ async function adoptDbTokensIfFresher(
 	// inequality — a delayed DB read must never look "different, therefore
 	// fresher": two access tokens minted moments apart can differ as strings
 	// while the DB's is actually the OLDER of the two.
-	if (
-		dbTokenValid &&
-		(dbAccount.expires_at ?? 0) > (account.expires_at ?? 0)
-	) {
+	if (dbTokenValid && (dbAccount.expires_at ?? 0) > (account.expires_at ?? 0)) {
 		account.access_token = dbAccount.access_token;
 		account.expires_at = dbAccount.expires_at;
 		if (dbAccount.refresh_token) {
@@ -285,8 +282,7 @@ async function adoptDbTokensIfFresher(
 	if (
 		dbAccount.refresh_token &&
 		dbAccount.refresh_token !== account.refresh_token &&
-		(memIssuedAt === null ||
-			(dbIssuedAt !== null && dbIssuedAt >= memIssuedAt))
+		(memIssuedAt === null || (dbIssuedAt !== null && dbIssuedAt >= memIssuedAt))
 	) {
 		account.refresh_token = dbAccount.refresh_token;
 		account.refresh_token_issued_at = dbAccount.refresh_token_issued_at;

--- a/packages/proxy/src/handlers/token-manager.ts
+++ b/packages/proxy/src/handlers/token-manager.ts
@@ -253,13 +253,19 @@ async function adoptDbTokensIfFresher(
 	// longer authoritative, so it is deliberately NOT served in that case.
 	const pendingRotation = getPendingRotation(account.id);
 	const flush = await flushPendingRotation(account.id, ctx.dbOps);
-	if (pendingRotation && (flush === "failed" || flush === "persisted")) {
-		account.access_token = pendingRotation.accessToken;
-		account.expires_at = pendingRotation.expiresAt;
-		if (pendingRotation.refreshToken) {
-			account.refresh_token = pendingRotation.refreshToken;
+	// An entry re-recorded for this account while the flush above was still
+	// awaiting its CAS write (e.g. a concurrent request-triggered refresh
+	// whose own persist also failed) outranks the pre-flush snapshot — it is
+	// strictly newer, so serve/adopt it instead of the stale `pendingRotation`
+	// captured before the flush.
+	const effectivePending = getPendingRotation(account.id) ?? pendingRotation;
+	if (effectivePending && (flush === "failed" || flush === "persisted")) {
+		account.access_token = effectivePending.accessToken;
+		account.expires_at = effectivePending.expiresAt;
+		if (effectivePending.refreshToken) {
+			account.refresh_token = effectivePending.refreshToken;
 		}
-		if (pendingRotation.expiresAt - Date.now() > TOKEN_SAFETY_WINDOW_MS) {
+		if (effectivePending.expiresAt - Date.now() > TOKEN_SAFETY_WINDOW_MS) {
 			log.warn(
 				`Serving rotated token for account ${account.name} from the pending-rotation registry (flush=${flush})`,
 			);
@@ -474,6 +480,11 @@ export async function refreshAccessTokenSafe(
 				// (finding 4) CAS on the attempted refresh token so a refresh
 				// that lost a race to a manual re-auth cannot overwrite newer
 				// credentials with the stale ones it started with.
+				// Set when the persist CAS loses to a manual re-auth or a newer
+				// rotation and the authoritative DB row is adopted below — skips
+				// the general in-memory update further down so the live
+				// `account` object never installs the losing credentials.
+				let adoptAuthoritative = false;
 				try {
 					let persisted: boolean;
 					if (attemptedRefreshToken) {
@@ -501,8 +512,26 @@ export async function refreshAccessTokenSafe(
 						clearPendingRotation(account.id);
 					} else {
 						log.warn(
-							`Skipped persisting refreshed tokens for ${account.name}: refresh token changed underneath (superseded by a newer rotation or manual re-auth)`,
+							`Skipped persisting refreshed tokens for ${account.name}: refresh token changed underneath (superseded by a newer rotation or manual re-auth) — adopting the authoritative DB credentials instead`,
 						);
+						try {
+							const dbAccount = await ctx.dbOps.getAccount(account.id);
+							if (dbAccount) {
+								account.access_token = dbAccount.access_token;
+								account.expires_at = dbAccount.expires_at;
+								if (dbAccount.refresh_token) {
+									account.refresh_token = dbAccount.refresh_token;
+									account.refresh_token_issued_at =
+										dbAccount.refresh_token_issued_at;
+								}
+								adoptAuthoritative = true;
+							}
+						} catch (readError) {
+							log.warn(
+								`Failed to re-read account ${account.name} after a lost persist CAS — falling back to the in-memory update`,
+								readError,
+							);
+						}
 					}
 				} catch (persistError) {
 					// (round-3 item 1) A rotation the provider has already
@@ -526,10 +555,15 @@ export async function refreshAccessTokenSafe(
 
 				// Update the live in-memory account object immediately
 				// This prevents subsequent requests from seeing stale token data
-				account.access_token = result.accessToken;
-				account.expires_at = result.expiresAt;
-				if (result.refreshToken) {
-					account.refresh_token = result.refreshToken;
+				// — unless the persist-CAS-loss branch above already adopted the
+				// authoritative DB row, in which case installing these (losing)
+				// result values would overwrite it right back.
+				if (!adoptAuthoritative) {
+					account.access_token = result.accessToken;
+					account.expires_at = result.expiresAt;
+					if (result.refreshToken) {
+						account.refresh_token = result.refreshToken;
+					}
 				}
 				account.last_used = Date.now();
 

--- a/packages/proxy/src/handlers/token-manager.ts
+++ b/packages/proxy/src/handlers/token-manager.ts
@@ -253,7 +253,14 @@ async function adoptDbTokensIfFresher(
 		typeof dbAccount.expires_at === "number" &&
 		dbAccount.expires_at - Date.now() > TOKEN_SAFETY_WINDOW_MS;
 
-	if (dbTokenValid && dbAccount.access_token !== account.access_token) {
+	// (finding 6) Adopt on strictly-newer expiry (monotonic), not on string
+	// inequality — a delayed DB read must never look "different, therefore
+	// fresher": two access tokens minted moments apart can differ as strings
+	// while the DB's is actually the OLDER of the two.
+	if (
+		dbTokenValid &&
+		(dbAccount.expires_at ?? 0) > (account.expires_at ?? 0)
+	) {
 		account.access_token = dbAccount.access_token;
 		account.expires_at = dbAccount.expires_at;
 		if (dbAccount.refresh_token) {
@@ -268,9 +275,18 @@ async function adoptDbTokensIfFresher(
 		return dbAccount.access_token;
 	}
 
+	// (finding 6) Sync a rotated refresh token only when the DB's is not
+	// provably older than the in-memory snapshot's. A DB row that predates
+	// issued-at tracking (dbIssuedAt === null) is never trusted over a
+	// snapshot that DOES have an issued-at, since we cannot tell whether the
+	// untracked DB write happened before or after it.
+	const dbIssuedAt = dbAccount.refresh_token_issued_at ?? null;
+	const memIssuedAt = account.refresh_token_issued_at ?? null;
 	if (
 		dbAccount.refresh_token &&
-		dbAccount.refresh_token !== account.refresh_token
+		dbAccount.refresh_token !== account.refresh_token &&
+		(memIssuedAt === null ||
+			(dbIssuedAt !== null && dbIssuedAt >= memIssuedAt))
 	) {
 		account.refresh_token = dbAccount.refresh_token;
 		account.refresh_token_issued_at = dbAccount.refresh_token_issued_at;
@@ -293,6 +309,15 @@ export async function refreshAccessTokenSafe(
 	account: Account,
 	ctx: ProxyContext,
 ): Promise<string> {
+	// (finding 5) Join an in-flight refresh FIRST — before backoff — so a
+	// concurrent caller shares the outcome instead of failing on a backoff
+	// seeded by an earlier, unrelated failure (e.g. the auto-refresh
+	// scheduler registers its own in-flight promise into this same map;
+	// a request-triggered caller must join that refresh, not bounce off a
+	// stale backoff record for the account).
+	const inFlight = ctx.refreshInFlight.get(account.id);
+	if (inFlight) return inFlight;
+
 	// Proactively clean expired entries before checking
 	cleanupExpiredFailures();
 
@@ -403,18 +428,47 @@ export async function refreshAccessTokenSafe(
 		// Create a new refresh promise and store it
 		const refreshPromise = provider
 			.refreshToken(account, ctx.runtime.clientId)
-			.then((result: TokenRefreshResult) => {
-				// 1. Persist to database asynchronously
-				ctx.asyncWriter.enqueue(() =>
-					ctx.dbOps.updateAccountTokens(
-						account.id,
-						result.accessToken,
-						result.expiresAt,
-						result.refreshToken,
-					),
-				);
+			.then(async (result: TokenRefreshResult) => {
+				// (finding 1) Persist INSIDE the shared promise so refreshInFlight
+				// stays installed until the write commits, and never via the
+				// lossy asyncWriter queue (a queued write's failure was
+				// previously unobservable to anyone awaiting this refresh).
+				// (finding 4) CAS on the attempted refresh token so a refresh
+				// that lost a race to a manual re-auth cannot overwrite newer
+				// credentials with the stale ones it started with.
+				try {
+					let persisted: boolean;
+					if (attemptedRefreshToken) {
+						persisted =
+							await ctx.dbOps.updateAccountTokensIfRefreshTokenMatches(
+								account.id,
+								attemptedRefreshToken,
+								result.accessToken,
+								result.expiresAt,
+								result.refreshToken,
+							);
+					} else {
+						await ctx.dbOps.updateAccountTokens(
+							account.id,
+							result.accessToken,
+							result.expiresAt,
+							result.refreshToken,
+						);
+						persisted = true;
+					}
+					if (!persisted) {
+						log.warn(
+							`Skipped persisting refreshed tokens for ${account.name}: refresh token changed underneath (superseded by a newer rotation or manual re-auth)`,
+						);
+					}
+				} catch (persistError) {
+					log.error(
+						`Failed to persist refreshed tokens for ${account.name} — continuing with in-memory tokens`,
+						persistError,
+					);
+				}
 
-				// 2. Update the live in-memory account object immediately
+				// Update the live in-memory account object immediately
 				// This prevents subsequent requests from seeing stale token data
 				account.access_token = result.accessToken;
 				account.expires_at = result.expiresAt;
@@ -462,11 +516,13 @@ export async function refreshAccessTokenSafe(
 					// consumer rotated successfully after our snapshot was taken.
 					// Recover from the DB instead of condemning a healthy account.
 					let dbAccount: Account | null = null;
+					let dbReadFailed = false;
 					try {
 						dbAccount = await ctx.dbOps.getAccount(account.id);
 					} catch (readError) {
+						dbReadFailed = true;
 						log.warn(
-							`Could not re-read account ${account.name} after ${authFailureReason} — treating failure as definitive`,
+							`Could not re-read account ${account.name} after ${authFailureReason} — leaving requires_reauth unset (unverified)`,
 							readError,
 						);
 					}
@@ -495,21 +551,38 @@ export async function refreshAccessTokenSafe(
 						);
 						throw new TokenRefreshError(account.id, new Error(enhancedMessage));
 					}
-					// Accepted race (documented, not synchronized): a manual re-auth that
-					// clears the flag via a direct DB write could be overtaken by this
-					// still-queued set(true) under a pathologically backlogged async
-					// writer. Likelihood is negligible — a human OAuth round-trip versus a
-					// millisecond queue drain — and recovery is simply to re-authenticate
-					// again, so building synchronization here is not worth the complexity.
-					ctx.asyncWriter.enqueue(() =>
-						ctx.dbOps.setRequiresReauth(account.id, true),
-					);
-					authFailureEvents.emit("event", {
-						accountId: account.id,
-						accountName: account.name,
-						provider: account.provider,
-						reason: authFailureReason,
-					});
+					// (finding 3) Unverifiable → do NOT flag; the backoff entry recorded
+					// above already keeps this account out of routing for a while.
+					if (dbReadFailed || !attemptedRefreshToken) {
+						throw new TokenRefreshError(account.id, new Error(enhancedMessage));
+					}
+					// (finding 2) Atomic flag: only condemn the account if the DB still
+					// holds the exact refresh token the provider just rejected — a CAS
+					// write closes the gap between this read and the flag write itself.
+					// Emit the auth-failure event only when the flag actually lands.
+					try {
+						const flagged = await ctx.dbOps.flagRequiresReauthIfTokenMatches(
+							account.id,
+							attemptedRefreshToken,
+						);
+						if (flagged) {
+							authFailureEvents.emit("event", {
+								accountId: account.id,
+								accountName: account.name,
+								provider: account.provider,
+								reason: authFailureReason,
+							});
+						} else {
+							log.warn(
+								`Skipped requires_reauth for ${account.name}: refresh token rotated between verification and flag write (rotation race)`,
+							);
+						}
+					} catch (flagError) {
+						log.warn(
+							`Could not persist requires_reauth for ${account.name} — leaving unset (unverified)`,
+							flagError,
+						);
+					}
 				}
 				log.error(
 					`Token refresh failed for account ${account.name}: ${enhancedMessage}`,
@@ -518,8 +591,12 @@ export async function refreshAccessTokenSafe(
 				throw new TokenRefreshError(account.id, new Error(enhancedMessage));
 			})
 			.finally(() => {
-				// Clean up the map when done (success or failure)
-				ctx.refreshInFlight.delete(account.id);
+				// (finding 4) Identity-safe: never delete a newer entry installed by
+				// a manual reauth or cache-clear that ran while this promise was
+				// still settling.
+				if (ctx.refreshInFlight.get(account.id) === refreshPromise) {
+					ctx.refreshInFlight.delete(account.id);
+				}
 			});
 		ctx.refreshInFlight.set(account.id, refreshPromise);
 	}

--- a/packages/proxy/src/handlers/token-manager.ts
+++ b/packages/proxy/src/handlers/token-manager.ts
@@ -395,6 +395,11 @@ export async function refreshAccessTokenSafe(
 		// Get the provider for this account
 		const provider = getProvider(account.provider) || ctx.provider;
 
+		// Captured for the rotation-race guard in the catch handler: if the DB's
+		// refresh token differs from this one by the time the refresh fails, the
+		// failure condemned a superseded token, not the account.
+		const attemptedRefreshToken = account.refresh_token;
+
 		// Create a new refresh promise and store it
 		const refreshPromise = provider
 			.refreshToken(account, ctx.runtime.clientId)
@@ -430,7 +435,7 @@ export async function refreshAccessTokenSafe(
 				});
 				return result.accessToken;
 			})
-			.catch((error) => {
+			.catch(async (error) => {
 				// Record the failure timestamp for backoff
 				refreshFailures.set(account.id, Date.now());
 				// Enforce size limit after adding a new entry
@@ -452,6 +457,44 @@ export async function refreshAccessTokenSafe(
 					account.name,
 				);
 				if (authFailureReason) {
+					// Rotation-race guard: a definitive rejection of a refresh token
+					// that is no longer the account's current one means another
+					// consumer rotated successfully after our snapshot was taken.
+					// Recover from the DB instead of condemning a healthy account.
+					let dbAccount: Account | null = null;
+					try {
+						dbAccount = await ctx.dbOps.getAccount(account.id);
+					} catch (readError) {
+						log.warn(
+							`Could not re-read account ${account.name} after ${authFailureReason} — treating failure as definitive`,
+							readError,
+						);
+					}
+					if (
+						dbAccount?.refresh_token &&
+						dbAccount.refresh_token !== attemptedRefreshToken
+					) {
+						account.refresh_token = dbAccount.refresh_token;
+						account.refresh_token_issued_at = dbAccount.refresh_token_issued_at;
+						const dbTokenValid =
+							typeof dbAccount.access_token === "string" &&
+							typeof dbAccount.expires_at === "number" &&
+							dbAccount.expires_at - Date.now() > TOKEN_SAFETY_WINDOW_MS;
+						if (dbTokenValid && dbAccount.access_token) {
+							account.access_token = dbAccount.access_token;
+							account.expires_at = dbAccount.expires_at;
+							refreshFailures.delete(account.id);
+							backoffCounters.delete(account.id);
+							log.warn(
+								`Refresh for ${account.name} lost a rotation race (${authFailureReason} on a superseded token) — adopted current tokens from DB`,
+							);
+							return dbAccount.access_token;
+						}
+						log.warn(
+							`Refresh for ${account.name} used a superseded refresh token (${authFailureReason}) — not flagging re-auth; will retry with the rotated token`,
+						);
+						throw new TokenRefreshError(account.id, new Error(enhancedMessage));
+					}
 					// Accepted race (documented, not synchronized): a manual re-auth that
 					// clears the flag via a direct DB write could be overtaken by this
 					// still-queued set(true) under a pathologically backlogged async

--- a/packages/proxy/src/handlers/token-manager.ts
+++ b/packages/proxy/src/handlers/token-manager.ts
@@ -11,6 +11,12 @@ import {
 } from "@better-ccflare/providers";
 import type { Account } from "@better-ccflare/types";
 import { TOKEN_REFRESH_BACKOFF_MS, TOKEN_SAFETY_WINDOW_MS } from "../constants";
+import {
+	clearPendingRotation,
+	flushPendingRotation,
+	getPendingRotation,
+	recordPendingRotation,
+} from "./pending-rotation-registry";
 import { ERROR_MESSAGES, type ProxyContext } from "./proxy-types";
 import {
 	checkRefreshTokenHealth,
@@ -236,6 +242,33 @@ async function adoptDbTokensIfFresher(
 	account: Account,
 	ctx: ProxyContext,
 ): Promise<string | null> {
+	// (round-3 item 1) A pending unpersisted rotation outranks anything the DB
+	// says: flush it first, and — if the flush landed ("persisted") or is
+	// still failing ("failed") — serve/use its credentials rather than
+	// replaying the consumed token from a stale row. Captured BEFORE the
+	// flush call: a successful flush clears the registry entry immediately,
+	// so the data must be read out while it still exists. A "superseded"
+	// flush means the DB already moved past the attempted token (a manual
+	// re-auth or a newer rotation landed first) — that pending data is no
+	// longer authoritative, so it is deliberately NOT served in that case.
+	const pendingRotation = getPendingRotation(account.id);
+	const flush = await flushPendingRotation(account.id, ctx.dbOps);
+	if (pendingRotation && (flush === "failed" || flush === "persisted")) {
+		account.access_token = pendingRotation.accessToken;
+		account.expires_at = pendingRotation.expiresAt;
+		if (pendingRotation.refreshToken) {
+			account.refresh_token = pendingRotation.refreshToken;
+		}
+		if (pendingRotation.expiresAt - Date.now() > TOKEN_SAFETY_WINDOW_MS) {
+			log.warn(
+				`Serving rotated token for account ${account.name} from the pending-rotation registry (flush=${flush})`,
+			);
+			return account.access_token;
+		}
+		// expired pending: fall through — the refresh below now uses the
+		// rotated refresh token instead of the consumed one.
+	}
+
 	let dbAccount: Account | null = null;
 	try {
 		dbAccount = await ctx.dbOps.getAccount(account.id);
@@ -253,6 +286,16 @@ async function adoptDbTokensIfFresher(
 		typeof dbAccount.expires_at === "number" &&
 		dbAccount.expires_at - Date.now() > TOKEN_SAFETY_WINDOW_MS;
 
+	// (round-3 item 3) Hoisted so the adoption branch below and the
+	// standalone RT-sync branch share the SAME staleness guard. A DB row
+	// that predates issued-at tracking (dbIssuedAt === null) is never
+	// trusted over a snapshot that DOES have an issued-at, since we cannot
+	// tell whether the untracked DB write happened before or after it.
+	const dbIssuedAt = dbAccount.refresh_token_issued_at ?? null;
+	const memIssuedAt = account.refresh_token_issued_at ?? null;
+	const dbRefreshTokenNotOlder =
+		memIssuedAt === null || (dbIssuedAt !== null && dbIssuedAt >= memIssuedAt);
+
 	// (finding 6) Adopt on strictly-newer expiry (monotonic), not on string
 	// inequality — a delayed DB read must never look "different, therefore
 	// fresher": two access tokens minted moments apart can differ as strings
@@ -260,7 +303,11 @@ async function adoptDbTokensIfFresher(
 	if (dbTokenValid && (dbAccount.expires_at ?? 0) > (account.expires_at ?? 0)) {
 		account.access_token = dbAccount.access_token;
 		account.expires_at = dbAccount.expires_at;
-		if (dbAccount.refresh_token) {
+		// (round-3 item 3) A newer access token does not imply a newer
+		// refresh token: never regress account.refresh_token to an older one
+		// merely because the DB row happens to carry some (possibly stale)
+		// value alongside the fresher access token.
+		if (dbAccount.refresh_token && dbRefreshTokenNotOlder) {
 			account.refresh_token = dbAccount.refresh_token;
 			account.refresh_token_issued_at = dbAccount.refresh_token_issued_at;
 		}
@@ -273,16 +320,11 @@ async function adoptDbTokensIfFresher(
 	}
 
 	// (finding 6) Sync a rotated refresh token only when the DB's is not
-	// provably older than the in-memory snapshot's. A DB row that predates
-	// issued-at tracking (dbIssuedAt === null) is never trusted over a
-	// snapshot that DOES have an issued-at, since we cannot tell whether the
-	// untracked DB write happened before or after it.
-	const dbIssuedAt = dbAccount.refresh_token_issued_at ?? null;
-	const memIssuedAt = account.refresh_token_issued_at ?? null;
+	// provably older than the in-memory snapshot's.
 	if (
 		dbAccount.refresh_token &&
 		dbAccount.refresh_token !== account.refresh_token &&
-		(memIssuedAt === null || (dbIssuedAt !== null && dbIssuedAt >= memIssuedAt))
+		dbRefreshTokenNotOlder
 	) {
 		account.refresh_token = dbAccount.refresh_token;
 		account.refresh_token_issued_at = dbAccount.refresh_token_issued_at;
@@ -444,22 +486,40 @@ export async function refreshAccessTokenSafe(
 								result.refreshToken,
 							);
 					} else {
-						await ctx.dbOps.updateAccountTokens(
+						// (round-3 item 4) Null-safe CAS: an account that refreshed
+						// without a refresh token must not blind-overwrite
+						// credentials a concurrent manual re-auth may have just
+						// written.
+						persisted = await ctx.dbOps.updateAccountTokensIfRefreshTokenAbsent(
 							account.id,
 							result.accessToken,
 							result.expiresAt,
 							result.refreshToken,
 						);
-						persisted = true;
 					}
-					if (!persisted) {
+					if (persisted) {
+						clearPendingRotation(account.id);
+					} else {
 						log.warn(
 							`Skipped persisting refreshed tokens for ${account.name}: refresh token changed underneath (superseded by a newer rotation or manual re-auth)`,
 						);
 					}
 				} catch (persistError) {
+					// (round-3 item 1) A rotation the provider has already
+					// committed must never be silently dropped: the DB still
+					// holds the consumed token, and a later stale consumer would
+					// replay it, get invalid_grant, and CAS-flag a healthy
+					// account. Record it so every subsequent touchpoint retries
+					// the persist, serves the rotated credentials, and
+					// suppresses flagging meanwhile.
+					recordPendingRotation(account.id, {
+						accessToken: result.accessToken,
+						expiresAt: result.expiresAt,
+						refreshToken: result.refreshToken,
+						attemptedRefreshToken: attemptedRefreshToken ?? "",
+					});
 					log.error(
-						`Failed to persist refreshed tokens for ${account.name} — continuing with in-memory tokens`,
+						`Failed to persist refreshed tokens for ${account.name} — rotation queued for re-persist`,
 						persistError,
 					);
 				}
@@ -507,6 +567,15 @@ export async function refreshAccessTokenSafe(
 					account.name,
 				);
 				if (authFailureReason) {
+					// (round-3 item 1) A pending unpersisted rotation means WE
+					// rotated successfully moments ago — this failure is a
+					// replay of the consumed token, not a dead account.
+					if (getPendingRotation(account.id)) {
+						log.warn(
+							`Skipping requires_reauth for ${account.name}: a successful rotation is awaiting persist (replayed a consumed token)`,
+						);
+						throw new TokenRefreshError(account.id, new Error(enhancedMessage));
+					}
 					// Rotation-race guard: a definitive rejection of a refresh token
 					// that is no longer the account's current one means another
 					// consumer rotated successfully after our snapshot was taken.

--- a/packages/proxy/src/handlers/token-manager.ts
+++ b/packages/proxy/src/handlers/token-manager.ts
@@ -220,6 +220,68 @@ export function extractAuthFailureReason(
 }
 
 /**
+ * Re-reads the account row from the database and adopts fresher credentials
+ * than the caller's in-memory snapshot. The auto-refresh scheduler (and any
+ * long-lived caller) hands us an account object built from a loop-start
+ * SELECT; if another consumer rotated the tokens since, refreshing with the
+ * snapshot's consumed refresh token yields a definitive-looking invalid_grant
+ * that would falsely flag a healthy account for re-auth.
+ *
+ * Returns the adopted access token when the DB row holds one valid beyond
+ * TOKEN_SAFETY_WINDOW_MS (caller must skip the refresh), otherwise null —
+ * after syncing a rotated refresh_token/refresh_token_issued_at into the
+ * snapshot so any refresh that still happens uses the live token.
+ */
+async function adoptDbTokensIfFresher(
+	account: Account,
+	ctx: ProxyContext,
+): Promise<string | null> {
+	let dbAccount: Account | null = null;
+	try {
+		dbAccount = await ctx.dbOps.getAccount(account.id);
+	} catch (error) {
+		log.warn(
+			`Failed to re-read account ${account.name} before refresh — proceeding with in-memory snapshot`,
+			error,
+		);
+		return null;
+	}
+	if (!dbAccount) return null;
+
+	const dbTokenValid =
+		typeof dbAccount.access_token === "string" &&
+		typeof dbAccount.expires_at === "number" &&
+		dbAccount.expires_at - Date.now() > TOKEN_SAFETY_WINDOW_MS;
+
+	if (dbTokenValid && dbAccount.access_token !== account.access_token) {
+		account.access_token = dbAccount.access_token;
+		account.expires_at = dbAccount.expires_at;
+		if (dbAccount.refresh_token) {
+			account.refresh_token = dbAccount.refresh_token;
+		}
+		account.refresh_token_issued_at = dbAccount.refresh_token_issued_at;
+		refreshFailures.delete(account.id);
+		backoffCounters.delete(account.id);
+		log.info(
+			`Adopted fresher tokens from DB for account ${account.name} — skipping refresh`,
+		);
+		return dbAccount.access_token;
+	}
+
+	if (
+		dbAccount.refresh_token &&
+		dbAccount.refresh_token !== account.refresh_token
+	) {
+		account.refresh_token = dbAccount.refresh_token;
+		account.refresh_token_issued_at = dbAccount.refresh_token_issued_at;
+		log.info(
+			`Adopted rotated refresh token from DB for account ${account.name} before refreshing`,
+		);
+	}
+	return null;
+}
+
+/**
  * Safely refreshes an access token with deduplication
  * @param account - The account to refresh token for
  * @param ctx - The proxy context
@@ -317,7 +379,18 @@ export async function refreshAccessTokenSafe(
 		backoffCounters.delete(account.id);
 	}
 
-	// Check if a refresh is already in progress for this account
+	// The caller's account object may be a stale snapshot (the auto-refresh
+	// scheduler builds one from a loop-start SELECT). Re-read the row and adopt
+	// fresher credentials before initiating a refresh — refreshing with an
+	// already-rotated refresh token produces a false-definitive invalid_grant.
+	if (!ctx.refreshInFlight.has(account.id)) {
+		const adopted = await adoptDbTokensIfFresher(account, ctx);
+		if (adopted) return adopted;
+	}
+
+	// Check if a refresh is already in progress for this account.
+	// NOTE: no await may sit between this check and refreshInFlight.set() —
+	// microtask atomicity is what deduplicates concurrent callers.
 	if (!ctx.refreshInFlight.has(account.id)) {
 		// Get the provider for this account
 		const provider = getProvider(account.provider) || ctx.provider;

--- a/packages/proxy/src/handlers/token-manager.ts
+++ b/packages/proxy/src/handlers/token-manager.ts
@@ -500,8 +500,8 @@ export async function refreshAccessTokenSafe(
 				// requires_reauth so the account is pulled from routing until a manual
 				// re-auth clears it. Detection runs on the RAW provider message (which
 				// preserves the machine error code) here, BEFORE it is wrapped into
-				// TokenRefreshError (whose .message is a fixed string). Mirrors the
-				// success-path enqueue idiom. Transient failures never match.
+				// TokenRefreshError (whose .message is a fixed string). Transient failures
+				// never match.
 				const authFailureReason = extractAuthFailureReason(
 					originalError,
 					account.name,

--- a/packages/proxy/src/handlers/token-manager.ts
+++ b/packages/proxy/src/handlers/token-manager.ts
@@ -485,6 +485,12 @@ export async function refreshAccessTokenSafe(
 				// the general in-memory update further down so the live
 				// `account` object never installs the losing credentials.
 				let adoptAuthoritative = false;
+				// Token this call resolves with — defaults to the just-minted
+				// (possibly losing) refresh result; overwritten below if the
+				// adopted DB row's access token is itself servable, since the
+				// losing token's session family may have been revoked by the
+				// winning manual re-auth.
+				let resolveWithToken = result.accessToken;
 				try {
 					let persisted: boolean;
 					if (attemptedRefreshToken) {
@@ -525,6 +531,22 @@ export async function refreshAccessTokenSafe(
 										dbAccount.refresh_token_issued_at;
 								}
 								adoptAuthoritative = true;
+								// The winning writer (manual re-auth or a newer rotation)
+								// may have revoked the losing token's session family —
+								// serve the adopted access token instead when it is
+								// itself servable, so the caller isn't handed a token
+								// that fails auth despite valid credentials sitting in
+								// memory.
+								const adoptedTokenIsServable =
+									typeof dbAccount.access_token === "string" &&
+									typeof dbAccount.expires_at === "number" &&
+									dbAccount.expires_at - Date.now() > TOKEN_SAFETY_WINDOW_MS;
+								if (adoptedTokenIsServable && dbAccount.access_token) {
+									resolveWithToken = dbAccount.access_token;
+								}
+								log.warn(
+									`Persist CAS lost for ${account.name} — serving the ${adoptedTokenIsServable ? "adopted authoritative" : "just-minted (losing)"} access token`,
+								);
 							}
 						} catch (readError) {
 							log.warn(
@@ -577,7 +599,7 @@ export async function refreshAccessTokenSafe(
 					newRefreshToken: result.refreshToken !== account.refresh_token,
 					provider: account.provider,
 				});
-				return result.accessToken;
+				return resolveWithToken;
 			})
 			.catch(async (error) => {
 				// Record the failure timestamp for backoff


### PR DESCRIPTION
## Problem

When two consumers refresh the same OAuth account within seconds (UsageFetcher polling + AutoRefreshScheduler probing), the second attempt can replay an already-consumed (rotated) refresh token from a stale loop-start snapshot. The provider answers `invalid_grant`, which the definitive-auth-failure detector treats as a dead account: `requires_reauth = 1`, pulling the account from routing AND from auto-refresh — permanently, with no self-heal, despite the account holding freshly rotated valid tokens.

This is not theoretical: on 2026-08-11 a production instance had 7 of its 8 OAuth accounts flagged this way; 4 of them held valid tokens at that very moment. Log signature: `⚠️ Refresh token has unknown creation date` immediately followed by `invalid_grant: Refresh token not found or invalid`. A second variant (lost async DB write of a successful rotation, e.g. process killed before the write queue drained — `AsyncDbWriter.enqueue` also drops jobs at queue capacity) leaves a genuinely consumed refresh token in the DB, producing endless `invalid_grant: Refresh token expired` retries every ~30 minutes.

## Fix (three layers, defense in depth)

**Token-manager funnel** (`packages/proxy/src/handlers/token-manager.ts`):
- An in-flight refresh is joined **before** the backoff check, so concurrent callers share the outcome instead of failing on a backoff seeded by an unrelated earlier failure.
- Before initiating a refresh, the account row is re-read and fresher credentials are adopted (monotonic ordering by `expires_at` / `refresh_token_issued_at`, not string inequality) — a consumed refresh token is never replayed from a stale snapshot.
- Rotated-token persistence happens **inside the shared refresh promise** via a compare-and-set write (`UPDATE ... WHERE id = ? AND refresh_token = <attempted>`), never via the lossy async metadata queue; `refreshInFlight` is held until the write settles, and cleanup is identity-safe (a re-auth installing a new entry can't be clobbered by a stale `finally`).
- On a definitive auth failure, `requires_reauth = 1` is an atomic CAS conditioned on the exact token the provider rejected; the auth-failure alert fires only when the flag actually landed. A DB error during verification leaves the flag unset ("unable to verify" is not evidence of a dead token — the next cycle retries); a rejection of a superseded token is recovered from the DB instead of condemning the account.

**Proactive scheduler paths** (`packages/proxy/src/auto-refresh-scheduler.ts`, qwen/xai/codex refreshes that bypass the funnel): same CAS flagging and CAS token writes, routed through the retry-wrapped dbOps layer (the raw adapter's PG path has no transient-error retry).

**Pending-rotation registry** (`packages/proxy/src/handlers/pending-rotation-registry.ts`, new): when a provider-side rotation succeeds but the DB persist fails even after retries, the rotation is recorded (anchor = the token the DB still holds) and re-persisted at every subsequent touchpoint; meanwhile the rotated credentials are served from memory and `requires_reauth` flagging is suppressed for that account. Chained rotations during a long DB outage compress onto the original anchor, and a concurrent flush landing mid-rotation rebases the surviving entry's anchor — so the CAS always targets what the DB provably holds.

## Tests

30+ new tests across:
- `packages/proxy/src/handlers/__tests__/token-manager-rotation-race.test.ts` (adoption/monotonicity, benign-race recovery, CAS flag gating, persist-failure queueing, anchor chains, in-flight-join-before-backoff),
- `packages/proxy/src/handlers/__tests__/pending-rotation-registry.test.ts` (flush outcome semantics, anchor compression, identity-guarded deletes under concurrent re-record),
- `packages/proxy/src/__tests__/auto-refresh-rotation-race-guard.test.ts` (scheduler CAS four-outcome semantics, pending-skip),
- `packages/database/src/repositories/__tests__/account-cas-writes.test.ts` (CAS + null-safe CAS writes against a real SQLite adapter).

No schema changes (plain conditional UPDATEs — nothing to port to migrations-pg). Existing suites stay green (`bun test packages/proxy packages/database`: 1241+ pass; the only failures are pre-existing on main — test-isolation issues unrelated to this change).

## Production validation

Running in production since 2026-08-11 (local build on top of current main incl. #406). The post-restart thundering herd — the exact trigger of the original incident — completed with zero false flags. The changes also passed three independent review rounds, including an external adversarial review that signed off on the final state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
