### PR TITLE
fix(cli): keep account mode help in sync

### DIFF
--- a/apps/cli/__tests__/cli.test.ts
+++ b/apps/cli/__tests__/cli.test.ts
@@ -167,13 +167,17 @@ describe("CLI Integration Tests", () => {
 			expect(result.stdout).toContain("--compact");
 		});
 
-		it("should show account mode options", async () => {
+		it("should show every accepted account mode", async () => {
 			const result = await runCLI(["--help"]);
 
 			expect(result.stdout).toContain("claude-oauth");
 			expect(result.stdout).toContain("console");
 			expect(result.stdout).toContain("zai");
 			expect(result.stdout).toContain("openai-compatible");
+			// ollama is accepted by --mode validation and must be discoverable here.
+			// Keeping this assertion next to the validation test prevents the help
+			// surface from drifting silently when a provider mode is added.
+			expect(result.stdout).toContain("ollama");
 		});
 
 		it("should exit quickly for help command", async () => {
@@ -245,6 +249,7 @@ describe("CLI Integration Tests", () => {
 			expect(output).toContain("Please provide --mode to specify account type");
 			expect(output).toContain("--mode");
 			expect(output).toContain("--priority");
+			expect(output).toContain("ollama");
 		});
 
 		it("should show example usage for add account", async () => {

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -856,7 +856,7 @@ Options:
   --ssl-cert <path>    Path to SSL certificate file (enables HTTPS)
   --stats              Show statistics (JSON output)
   --add-account <name> Add a new account
-    --mode <claude-oauth|console|zai|minimax|nanogpt|anthropic-compatible|openai-compatible|bedrock|kilo|alibaba-coding-plan|codex|xai>  Account mode (default: claude-oauth)
+    --mode <claude-oauth|console|zai|minimax|nanogpt|anthropic-compatible|openai-compatible|bedrock|kilo|alibaba-coding-plan|codex|xai|ollama>  Account mode (default: claude-oauth)
       claude-oauth: Claude CLI account (OAuth)
       console: Claude API account (OAuth)
       zai: z.ai account (API key)
@@ -871,6 +871,7 @@ Options:
       alibaba-coding-plan: Alibaba Coding Plan International provider (API key)
       codex: Codex (OpenAI OAuth) provider
       xai: xAI/Grok provider (imports local Grok CLI OAuth credentials)
+      ollama: Ollama local provider (no API key required)
     --priority <number>   Account priority (default: 0)
   --list               List all accounts
   --remove <name>      Remove an account
@@ -1038,6 +1039,9 @@ Examples:
 			);
 			console.error(
 				"  --mode xai                 xAI/Grok (Grok CLI OAuth) provider",
+			);
+			console.error(
+				"  --mode ollama              Ollama local provider (no API key required)",
 			);
 			console.error("\nExample:");
 			console.error(


### PR DESCRIPTION
## Description
The CLI already accepts `ollama` as an account mode, but users could not discover it from `--help` or the missing-mode error. This patch keeps both user-facing mode lists aligned with validation and adds regression assertions for both surfaces.

## Type of Change
- [x] Bug fix (non-breaking change which fixes existing behavior)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Changes Made
- Add `ollama` to the `--help` mode synopsis and description list.
- Add `ollama` to the `--add-account` missing-mode error output.
- Assert that both surfaces advertise every mode covered by this regression.

## Testing
- [x] `bun test apps/cli/__tests__/cli.test.ts` — 28 passed, 0 failed (67 assertions).
- [x] `bun run typecheck` — passed.
- [x] `bunx biome check apps/cli/src/main.ts apps/cli/__tests__/cli.test.ts` — passed.
- [x] `bun run format` — passed; unrelated formatter-only changes were excluded from this PR.
- [x] `git diff --check` — passed.
- [x] The change generates no new warnings in the modified files.

## Screenshots (if applicable)
Not applicable for this CLI output change.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly where the regression contract is not obvious
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Related Issues
None.
