### PR TITLE
fix(provider): keep Codex streams alive during silent reasoning

### DIFF
--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -58,6 +58,163 @@ const eventLine = (name: string, data: unknown) => [
 	"",
 ];
 
+describe("CodexProvider stream liveness", () => {
+	it("keeps a silent SSE stream alive until response.completed arrives", async () => {
+		const provider = new CodexProvider({
+			streamHeartbeatIntervalMs: 20,
+			streamRawSilenceTimeoutMs: 200,
+		});
+		let upstreamController: ReadableStreamDefaultController<Uint8Array>;
+		let upstreamCancelReason: unknown;
+		const upstream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				upstreamController = controller;
+				controller.enqueue(
+					new TextEncoder().encode(
+						sseBody(
+							eventLine("response.in_progress", {
+								type: "response.in_progress",
+								response: { id: "resp_silent", model: "gpt-5.6-sol" },
+							}),
+						),
+					),
+				);
+			},
+			cancel(reason) {
+				upstreamCancelReason = reason;
+			},
+		});
+		const transformed = await provider.processResponse(
+			new Response(upstream, {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			}),
+			null,
+		);
+		const reader = transformed.body?.getReader();
+		if (!reader) throw new Error("transformed response has no body");
+		const decoder = new TextDecoder();
+
+		const first = await reader.read();
+		expect(decoder.decode(first.value)).toBe(
+			'event: ping\ndata: {"type":"ping"}\n\n',
+		);
+		const second = await Promise.race([
+			reader.read(),
+			Bun.sleep(100).then(() => {
+				throw new Error("Codex heartbeat did not arrive");
+			}),
+		]);
+		expect(decoder.decode(second.value)).toBe(
+			'event: ping\ndata: {"type":"ping"}\n\n',
+		);
+
+		upstreamController.enqueue(
+			new TextEncoder().encode(
+				sseBody(
+					eventLine("response.completed", {
+						type: "response.completed",
+						response: {
+							id: "resp_silent",
+							model: "gpt-5.6-sol",
+							usage: { input_tokens: 1, output_tokens: 0 },
+						},
+					}),
+				),
+			),
+		);
+
+		let terminalBody = "";
+		while (true) {
+			const { value, done } = await reader.read();
+			if (done) break;
+			terminalBody += decoder.decode(value, { stream: true });
+		}
+		expect(terminalBody).toContain("event: message_stop");
+		expect(terminalBody).not.toContain("event: ping");
+		expect(upstreamCancelReason).toBeDefined();
+	});
+
+	it("terminates raw upstream silence after synthetic heartbeats", async () => {
+		const provider = new CodexProvider({
+			streamHeartbeatIntervalMs: 15,
+			streamRawSilenceTimeoutMs: 70,
+		});
+		let upstreamCancelReason: unknown;
+		const upstream = new ReadableStream<Uint8Array>({
+			cancel(reason) {
+				upstreamCancelReason = reason;
+				return new Promise<void>(() => {});
+			},
+		});
+		const transformed = await provider.processResponse(
+			new Response(upstream, {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			}),
+			null,
+		);
+
+		const body = await Promise.race([
+			transformed.text(),
+			Bun.sleep(300).then(() => {
+				throw new Error("timed-out Codex stream did not terminate");
+			}),
+		]);
+		expect(upstreamCancelReason).toBeInstanceOf(Error);
+		expect(body).toContain("event: error");
+		expect(body).toContain(
+			"Codex upstream timed out while waiting for response data.",
+		);
+		expect(body).not.toContain("rawSilenceTimeoutMs");
+	});
+
+	it("does not await a hanging upstream cancellation after a terminal event", async () => {
+		const provider = new CodexProvider({
+			streamHeartbeatIntervalMs: 100,
+			streamRawSilenceTimeoutMs: 500,
+		});
+		let cancelCalls = 0;
+		const upstream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(
+					new TextEncoder().encode(
+						sseBody(
+							eventLine("response.completed", {
+								type: "response.completed",
+								response: {
+									id: "resp_terminal_cancel",
+									model: "gpt-5.6-sol",
+									usage: { input_tokens: 1, output_tokens: 0 },
+								},
+							}),
+						),
+					),
+				);
+			},
+			cancel() {
+				cancelCalls++;
+				return new Promise<void>(() => {});
+			},
+		});
+		const transformed = await provider.processResponse(
+			new Response(upstream, {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			}),
+			null,
+		);
+		const body = await Promise.race([
+			transformed.text(),
+			Bun.sleep(300).then(() => {
+				throw new Error("terminal Codex stream did not reach EOF");
+			}),
+		]);
+		expect(body).toContain("event: message_stop");
+		expect(cancelCalls).toBe(1);
+	});
+});
+
 describe("CodexProvider request conversion", () => {
 	it("handles messages and synthetic count_tokens paths", () => {
 		const provider = new CodexProvider();

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -14,6 +14,10 @@ import type { Account } from "@better-ccflare/types";
 import { BaseProvider } from "../../base";
 import { resolveProviderModelDefault } from "../../provider-model-defaults";
 import type { RateLimitInfo, TokenRefreshResult } from "../../types";
+import {
+	CodexStreamLiveness,
+	type CodexStreamLivenessOptions,
+} from "./stream-liveness";
 import { normalizeCodexInputUsage } from "./usage";
 
 const log = new Logger("CodexProvider");
@@ -386,8 +390,22 @@ function isCodexSubscriptionEndpoint(account?: Account): boolean {
 	}
 }
 
+export interface CodexProviderOptionsForTests {
+	streamHeartbeatIntervalMs?: number;
+	streamRawSilenceTimeoutMs?: number;
+}
+
 export class CodexProvider extends BaseProvider {
 	name = "codex";
+	private readonly streamLivenessOptions: CodexStreamLivenessOptions;
+
+	constructor(options: CodexProviderOptionsForTests = {}) {
+		super();
+		this.streamLivenessOptions = {
+			heartbeatIntervalMs: options.streamHeartbeatIntervalMs,
+			rawSilenceTimeoutMs: options.streamRawSilenceTimeoutMs,
+		};
+	}
 	// Fallback map: proxy-operations.ts injects x-better-ccflare-request-id and
 	// x-better-ccflare-request-stream into the upstream response before calling
 	// processResponse, so headerRequestedStream is normally set. This map covers
@@ -1560,6 +1578,7 @@ export class CodexProvider extends BaseProvider {
 		const writer = writable.getWriter();
 		const encoder = new TextEncoder();
 		const decoder = new TextDecoder();
+		const streamLiveness = new CodexStreamLiveness(this.streamLivenessOptions);
 
 		const writeSSE = async (event: string, data: unknown) => {
 			const payload =
@@ -1603,6 +1622,7 @@ export class CodexProvider extends BaseProvider {
 			}
 			const line = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
 			await writer.write(encoder.encode(line));
+			streamLiveness.recordDownstreamWrite();
 		};
 		const ensureMessageStart = async () => {
 			if (state.hasSentMessageStart) return;
@@ -1634,12 +1654,62 @@ export class CodexProvider extends BaseProvider {
 		};
 
 		const processEvents = async () => {
+			const reader = response.body?.getReader();
+			let upstreamCancelStarted = false;
+			const cancelUpstreamOnce = (reason: unknown): void => {
+				if (upstreamCancelStarted || !reader) return;
+				upstreamCancelStarted = true;
+				try {
+					void reader.cancel(reason).catch(() => undefined);
+				} catch {
+					// Cancellation is best effort; downstream termination must still finish.
+				}
+			};
 			try {
-				const reader = response.body?.getReader();
 				if (!reader) throw new Error("Response body is not readable");
 
 				while (true) {
-					const { value, done } = await reader.read();
+					const outcome = await streamLiveness.next(reader);
+					if (outcome.type === "stopped") break;
+					if (outcome.type === "heartbeat_due") {
+						// A silent Codex stream (long reasoning turns) must still look
+						// alive to the Anthropic client and to any intermediary idle
+						// timeout. A ping carries no content and cannot disturb the
+						// message/content-block sequence.
+						if (state.hasSentTerminalEvents) break;
+						if (streamLiveness.canEmitHeartbeat()) {
+							await writeSSE("ping", { type: "ping" });
+							streamLiveness.recordDownstreamWrite();
+						}
+						continue;
+					}
+					if (outcome.type === "raw_silence_timeout") {
+						// Synthetic pings must never keep a byte-silent upstream alive
+						// forever: surface a terminal error instead of hanging.
+						const timeoutMessage =
+							"Codex upstream timed out while waiting for response data.";
+						cancelUpstreamOnce(new Error(timeoutMessage));
+						if (!state.hasSentTerminalEvents) {
+							await ensureMessageStart();
+							if (state.hasSentContentBlockStart) {
+								await writeSSE("content_block_stop", {
+									type: "content_block_stop",
+									index: state.contentBlockIndex,
+								});
+								state.contentBlockIndex++;
+								state.hasSentContentBlockStart = false;
+							}
+							await writeSSE("error", {
+								type: "error",
+								error: { type: "api_error", message: timeoutMessage },
+							});
+							state.hasSentTerminalEvents = true;
+						}
+						return;
+					}
+					if (outcome.type === "upstream_error") throw outcome.error;
+
+					const { value, done } = outcome.result;
 					if (done) break;
 
 					state.buffer += decoder.decode(value, { stream: true });
@@ -1680,6 +1750,11 @@ export class CodexProvider extends BaseProvider {
 							writeSSE,
 							ensureMessageStart,
 						);
+						if (state.hasSentTerminalEvents) {
+							streamLiveness.stop();
+							cancelUpstreamOnce("Codex terminal response received");
+							break;
+						}
 					}
 				}
 
@@ -1712,7 +1787,10 @@ export class CodexProvider extends BaseProvider {
 				}
 			} catch (error) {
 				log.error("Error processing Codex SSE stream:", error);
+				cancelUpstreamOnce(error);
 			} finally {
+				streamLiveness.stop();
+				await streamLiveness.settlePendingReadForCleanup();
 				await writer.close();
 			}
 		};

--- a/packages/providers/src/providers/codex/stream-liveness.test.ts
+++ b/packages/providers/src/providers/codex/stream-liveness.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "bun:test";
+import {
+	CODEX_STREAM_HEARTBEAT_INTERVAL_MS,
+	CODEX_STREAM_RAW_SILENCE_TIMEOUT_MS,
+	CodexStreamLiveness,
+} from "./stream-liveness";
+
+function makeSilentReader() {
+	let controller: ReadableStreamDefaultController<Uint8Array>;
+	let cancelReason: unknown;
+	const stream = new ReadableStream<Uint8Array>({
+		start(value) {
+			controller = value;
+		},
+		cancel(reason) {
+			cancelReason = reason;
+		},
+	});
+	return {
+		reader: stream.getReader(),
+		push(bytes: number[] = [1]) {
+			controller.enqueue(Uint8Array.from(bytes));
+		},
+		getCancelReason: () => cancelReason,
+	};
+}
+
+describe("CodexStreamLiveness", () => {
+	it("keeps production deadlines inside the proxy liveness contract", () => {
+		expect(CODEX_STREAM_HEARTBEAT_INTERVAL_MS).toBe(25_000);
+		expect(CODEX_STREAM_RAW_SILENCE_TIMEOUT_MS).toBe(8 * 60_000);
+		expect(CODEX_STREAM_HEARTBEAT_INTERVAL_MS).toBeLessThan(120_000);
+	});
+
+	it("emits periodic heartbeat deadlines until canonical output resets the clock", async () => {
+		const upstream = makeSilentReader();
+		const liveness = new CodexStreamLiveness({
+			heartbeatIntervalMs: 20,
+			rawSilenceTimeoutMs: 250,
+		});
+
+		const first = await liveness.next(upstream.reader);
+		expect(first.type).toBe("heartbeat_due");
+		liveness.recordDownstreamWrite();
+
+		await Bun.sleep(12);
+		liveness.recordDownstreamWrite();
+		const resetAt = performance.now();
+		const second = await liveness.next(upstream.reader);
+
+		expect(second.type).toBe("heartbeat_due");
+		expect(performance.now() - resetAt).toBeGreaterThanOrEqual(15);
+
+		liveness.stop();
+		await upstream.reader.cancel("test complete");
+	});
+
+	it("resets the hard raw-silence deadline only when actual upstream bytes arrive", async () => {
+		const upstream = makeSilentReader();
+		const liveness = new CodexStreamLiveness({
+			heartbeatIntervalMs: 15,
+			rawSilenceTimeoutMs: 75,
+		});
+
+		const first = await liveness.next(upstream.reader);
+		expect(first.type).toBe("heartbeat_due");
+		liveness.recordDownstreamWrite();
+
+		await Bun.sleep(25);
+		upstream.push([1, 2, 3]);
+		const bytes = await liveness.next(upstream.reader);
+		expect(bytes).toMatchObject({ type: "upstream" });
+		if (bytes.type === "upstream") {
+			expect(bytes.result.value?.byteLength).toBe(3);
+		}
+
+		const resetAt = performance.now();
+		let outcome = await liveness.next(upstream.reader);
+		while (outcome.type === "heartbeat_due") {
+			liveness.recordDownstreamWrite();
+			outcome = await liveness.next(upstream.reader);
+		}
+
+		expect(outcome.type).toBe("raw_silence_timeout");
+		expect(performance.now() - resetAt).toBeGreaterThanOrEqual(65);
+		expect((await liveness.next(upstream.reader)).type).toBe("stopped");
+		await upstream.reader.cancel("test complete");
+	});
+
+	it("stops a pending deadline without leaving a heartbeat timer active", async () => {
+		const upstream = makeSilentReader();
+		const liveness = new CodexStreamLiveness({
+			heartbeatIntervalMs: 20,
+			rawSilenceTimeoutMs: 100,
+		});
+		const pending = liveness.next(upstream.reader);
+
+		liveness.stop();
+
+		expect((await pending).type).toBe("stopped");
+		await upstream.reader.cancel("downstream cancelled");
+		expect(upstream.getCancelReason()).toBe("downstream cancelled");
+		await Bun.sleep(30);
+		expect((await liveness.next(upstream.reader)).type).toBe("stopped");
+	});
+
+	it("keeps losing stop and capacity subscriptions bounded", async () => {
+		const upstream = makeSilentReader();
+		const liveness = new CodexStreamLiveness({
+			heartbeatIntervalMs: 1,
+			rawSilenceTimeoutMs: 1_000,
+		});
+		let activeCapacityWaiters = 0;
+		let maxActiveCapacityWaiters = 0;
+		let abortedCapacityWaiters = 0;
+		const gate = {
+			isReady: () => false,
+			waitUntilReady(signal?: AbortSignal) {
+				activeCapacityWaiters++;
+				maxActiveCapacityWaiters = Math.max(
+					maxActiveCapacityWaiters,
+					activeCapacityWaiters,
+				);
+				return new Promise<void>((resolve) => {
+					if (!signal) return;
+					const onAbort = () => {
+						signal.removeEventListener("abort", onAbort);
+						activeCapacityWaiters--;
+						abortedCapacityWaiters++;
+						resolve();
+					};
+					signal.addEventListener("abort", onAbort, { once: true });
+					if (signal.aborted) onAbort();
+				});
+			},
+		};
+
+		await Bun.sleep(2);
+		for (let index = 0; index < 50; index++) {
+			upstream.push([index]);
+			expect((await liveness.next(upstream.reader, gate)).type).toBe(
+				"upstream",
+			);
+		}
+
+		const pending = liveness.next(upstream.reader, gate);
+		await Bun.sleep(1);
+		liveness.stop();
+
+		expect((await pending).type).toBe("stopped");
+		await upstream.reader.cancel("test complete");
+		expect(activeCapacityWaiters).toBe(0);
+		expect(maxActiveCapacityWaiters).toBe(1);
+		expect(abortedCapacityWaiters).toBe(51);
+	});
+
+	it("waits for the retained read to settle before teardown can release its lock", async () => {
+		type ReaderResult = Awaited<
+			ReturnType<ReadableStreamDefaultReader<Uint8Array>["read"]>
+		>;
+		let settleRead: ((result: ReaderResult) => void) | null = null;
+		const reader = {
+			read: () =>
+				new Promise<ReaderResult>((resolve) => {
+					settleRead = resolve;
+				}),
+		};
+		const liveness = new CodexStreamLiveness({
+			heartbeatIntervalMs: 100,
+			rawSilenceTimeoutMs: 200,
+		});
+		const pending = liveness.next(reader);
+		await Bun.sleep(1);
+		liveness.stop();
+		expect((await pending).type).toBe("stopped");
+
+		let cleanupFinished = false;
+		const cleanup = liveness.settlePendingReadForCleanup().then(() => {
+			cleanupFinished = true;
+		});
+		await Bun.sleep(5);
+		expect(cleanupFinished).toBeFalse();
+
+		settleRead?.({ done: true, value: undefined });
+		await cleanup;
+		expect(cleanupFinished).toBeTrue();
+	});
+});

--- a/packages/providers/src/providers/codex/stream-liveness.ts
+++ b/packages/providers/src/providers/codex/stream-liveness.ts
@@ -1,0 +1,255 @@
+// Match the proxy's Anthropic precommit rescue cadence, comfortably inside
+// the independent protocol-idle and socket ceilings.
+export const CODEX_STREAM_HEARTBEAT_INTERVAL_MS = 25_000;
+// Synthetic downstream traffic must never keep a byte-silent upstream alive
+// indefinitely.
+export const CODEX_STREAM_RAW_SILENCE_TIMEOUT_MS = 8 * 60_000;
+
+export interface CodexStreamLivenessOptions {
+	heartbeatIntervalMs?: number;
+	rawSilenceTimeoutMs?: number;
+}
+
+export interface CodexStreamHeartbeatGate {
+	isReady(): boolean;
+	waitUntilReady(signal: AbortSignal): Promise<void>;
+}
+
+type CodexStreamReader = Pick<ReadableStreamDefaultReader<Uint8Array>, "read">;
+
+type CodexUpstreamReadResult = Awaited<
+	ReturnType<ReadableStreamDefaultReader<Uint8Array>["read"]>
+>;
+
+export type CodexStreamLivenessOutcome =
+	| {
+			type: "upstream";
+			result: CodexUpstreamReadResult;
+	  }
+	| {
+			type: "upstream_error";
+			error: unknown;
+	  }
+	| {
+			type: "heartbeat_due";
+	  }
+	| {
+			type: "raw_silence_timeout";
+	  }
+	| {
+			type: "stopped";
+	  };
+
+type PendingReadOutcome =
+	| Extract<CodexStreamLivenessOutcome, { type: "upstream" }>
+	| Extract<CodexStreamLivenessOutcome, { type: "upstream_error" }>;
+
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+function requireTimerDelay(value: number, name: string): number {
+	if (
+		!Number.isSafeInteger(value) ||
+		value <= 0 ||
+		value > MAX_TIMER_DELAY_MS
+	) {
+		throw new RangeError(
+			`${name} must be a positive safe integer no greater than ${MAX_TIMER_DELAY_MS}`,
+		);
+	}
+	return value;
+}
+
+/**
+ * Serializes upstream reads with downstream heartbeat and raw-silence
+ * deadlines. A pending reader.read() is retained when a heartbeat wins the
+ * race, so the provider never issues concurrent reads or bypasses its normal
+ * downstream backpressure path.
+ */
+export class CodexStreamLiveness {
+	private readonly heartbeatIntervalMs: number;
+	private readonly rawSilenceTimeoutMs: number;
+	private nextHeartbeatAt: number;
+	private rawSilenceDeadlineAt: number;
+	private pendingRead: Promise<void> | null = null;
+	private settledRead: PendingReadOutcome | null = null;
+	private activeTimer: ReturnType<typeof setTimeout> | null = null;
+	private stopped = false;
+	private activeStopResolver: (() => void) | null = null;
+
+	constructor(options: CodexStreamLivenessOptions = {}) {
+		this.heartbeatIntervalMs = requireTimerDelay(
+			options.heartbeatIntervalMs ?? CODEX_STREAM_HEARTBEAT_INTERVAL_MS,
+			"heartbeatIntervalMs",
+		);
+		this.rawSilenceTimeoutMs = requireTimerDelay(
+			options.rawSilenceTimeoutMs ?? CODEX_STREAM_RAW_SILENCE_TIMEOUT_MS,
+			"rawSilenceTimeoutMs",
+		);
+		const now = performance.now();
+		this.nextHeartbeatAt = now + this.heartbeatIntervalMs;
+		this.rawSilenceDeadlineAt = now + this.rawSilenceTimeoutMs;
+	}
+
+	/**
+	 * Record a canonical downstream frame after it has actually been enqueued.
+	 * Synthetic pings move only the heartbeat cadence; they never touch the
+	 * independent raw-upstream-silence deadline.
+	 */
+	recordDownstreamWrite(): void {
+		if (this.stopped) return;
+		this.nextHeartbeatAt = performance.now() + this.heartbeatIntervalMs;
+	}
+
+	/**
+	 * Re-check immediately before a scheduled heartbeat enqueue. An upstream
+	 * read that settled while downstream capacity was unavailable always wins.
+	 */
+	canEmitHeartbeat(): boolean {
+		const now = performance.now();
+		return (
+			!this.stopped &&
+			this.settledRead === null &&
+			now < this.rawSilenceDeadlineAt &&
+			now >= this.nextHeartbeatAt
+		);
+	}
+
+	stop(): void {
+		if (this.stopped) return;
+		this.stopped = true;
+		if (this.activeTimer !== null) {
+			clearTimeout(this.activeTimer);
+			this.activeTimer = null;
+		}
+		const resolveActiveWait = this.activeStopResolver;
+		this.activeStopResolver = null;
+		resolveActiveWait?.();
+	}
+
+	async settlePendingReadForCleanup(): Promise<void> {
+		await this.pendingRead;
+		this.pendingRead = null;
+		this.settledRead = null;
+	}
+
+	private ensurePendingRead(reader: CodexStreamReader): void {
+		if (this.pendingRead !== null) return;
+		this.pendingRead = reader.read().then(
+			(result) => {
+				this.settledRead = { type: "upstream", result };
+			},
+			(error) => {
+				this.settledRead = { type: "upstream_error", error };
+			},
+		);
+	}
+
+	async next(
+		reader: CodexStreamReader,
+		heartbeatGate?: CodexStreamHeartbeatGate,
+	): Promise<CodexStreamLivenessOutcome> {
+		while (!this.stopped) {
+			this.ensurePendingRead(reader);
+			if (this.settledRead !== null) {
+				const outcome = this.settledRead;
+				this.settledRead = null;
+				this.pendingRead = null;
+				if (
+					outcome.type === "upstream" &&
+					!outcome.result.done &&
+					outcome.result.value.byteLength > 0
+				) {
+					this.rawSilenceDeadlineAt =
+						performance.now() + this.rawSilenceTimeoutMs;
+				}
+				return outcome;
+			}
+
+			let now = performance.now();
+			if (now >= this.rawSilenceDeadlineAt) {
+				// A stream enqueue immediately before this call resolves read() in
+				// a queued microtask. Give that already-produced data one turn to
+				// settle before declaring a deadline winner.
+				await Promise.resolve();
+				if (this.settledRead !== null) continue;
+				this.stop();
+				return { type: "raw_silence_timeout" };
+			}
+			let heartbeatDue = now >= this.nextHeartbeatAt;
+			if (
+				heartbeatDue &&
+				(heartbeatGate === undefined || heartbeatGate.isReady())
+			) {
+				await Promise.resolve();
+				if (this.settledRead !== null) continue;
+				now = performance.now();
+				if (now >= this.rawSilenceDeadlineAt) continue;
+				heartbeatDue = now >= this.nextHeartbeatAt;
+				if (
+					heartbeatDue &&
+					(heartbeatGate === undefined || heartbeatGate.isReady())
+				) {
+					return { type: "heartbeat_due" };
+				}
+			}
+
+			const pendingRead = this.pendingRead;
+			if (pendingRead === null) {
+				throw new Error("Codex stream liveness lost its pending upstream read");
+			}
+			const delay = Math.max(
+				0,
+				(heartbeatDue
+					? this.rawSilenceDeadlineAt
+					: Math.min(this.nextHeartbeatAt, this.rawSilenceDeadlineAt)) - now,
+			);
+			const timerSignal = new Promise<"timer">((resolve) => {
+				this.activeTimer = setTimeout(() => resolve("timer"), delay);
+				(
+					this.activeTimer as ReturnType<typeof setTimeout> & {
+						unref?: () => void;
+					}
+				).unref?.();
+			});
+			let resolveStopped!: () => void;
+			const stoppedSignal = new Promise<"stopped">((resolve) => {
+				resolveStopped = () => resolve("stopped");
+			});
+			this.activeStopResolver = resolveStopped;
+			const capacityAbortController =
+				heartbeatDue && heartbeatGate !== undefined
+					? new AbortController()
+					: null;
+			const waiters: Array<Promise<"read" | "timer" | "capacity" | "stopped">> =
+				[pendingRead.then(() => "read" as const), timerSignal, stoppedSignal];
+			if (capacityAbortController !== null && heartbeatGate !== undefined) {
+				waiters.push(
+					Promise.resolve()
+						.then(() =>
+							heartbeatGate.waitUntilReady(capacityAbortController.signal),
+						)
+						.then(() => "capacity" as const),
+				);
+			}
+			let outcome: "read" | "timer" | "capacity" | "stopped";
+			try {
+				outcome = await Promise.race(waiters);
+			} finally {
+				if (this.activeStopResolver === resolveStopped) {
+					this.activeStopResolver = null;
+				}
+				capacityAbortController?.abort();
+				if (this.activeTimer !== null) {
+					clearTimeout(this.activeTimer);
+					this.activeTimer = null;
+				}
+			}
+
+			if (outcome === "stopped") return { type: "stopped" };
+			// Re-enter at the top so a settled upstream read is consumed before
+			// a simultaneously available heartbeat/capacity signal.
+		}
+
+		return { type: "stopped" };
+	}
+}


### PR DESCRIPTION
## Description
The CLI already accepts `ollama` as an account mode, but users could not discover it from `--help` or the missing-mode error. This patch keeps both user-facing mode lists aligned with validation and adds regression assertions for both surfaces.

## Type of Change
- [x] Bug fix (non-breaking change which fixes existing behavior)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Changes Made
- Add `ollama` to the `--help` mode synopsis and description list.
- Add `ollama` to the `--add-account` missing-mode error output.
- Assert that both surfaces advertise every mode covered by this regression.

## Testing
- [x] `bun test apps/cli/__tests__/cli.test.ts` — 28 passed, 0 failed (67 assertions).
- [x] `bun run typecheck` — passed.
- [x] `bunx biome check apps/cli/src/main.ts apps/cli/__tests__/cli.test.ts` — passed.
- [x] `bun run format` — passed; unrelated formatter-only changes were excluded from this PR.
- [x] `git diff --check` — passed.
- [x] The change generates no new warnings in the modified files.

## Screenshots (if applicable)
Not applicable for this CLI output change.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly where the regression contract is not obvious
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Related Issues
None.
