### PR TITLE
fix: replace mathematically-capped anomaly z-score with log-space median/MAD

### DIFF
--- a/packages/config/src/alerts-config.test.ts
+++ b/packages/config/src/alerts-config.test.ts
@@ -10,6 +10,7 @@ const ENV_KEYS = [
 	"ALERT_REQUEST_TOKENS",
 	"ALERT_ANOMALY_ENABLED",
 	"ALERT_ANOMALY_INTERVAL_MINUTES",
+	"ALERT_ANOMALY_BASELINE_WINDOW_MINUTES",
 	"ALERT_ANOMALY_LOOP_MIN_REQUESTS",
 	"ALERT_COOLDOWN_MINUTES",
 	"ALERT_WEBHOOK_URL",
@@ -52,6 +53,7 @@ describe("alert config settings", () => {
 			expect(config.getAlertRequestTokens()).toBe(0);
 			expect(config.getAlertAnomalyEnabled()).toBe(false);
 			expect(config.getAlertAnomalyIntervalMinutes()).toBe(15);
+			expect(config.getAlertAnomalyBaselineWindowMinutes()).toBe(1440);
 			expect(config.getAlertAnomalyLoopMinRequests()).toBe(25);
 			expect(config.getAlertCooldownMinutes()).toBe(60);
 			expect(config.getAlertWebhookUrl()).toBe("");
@@ -66,6 +68,7 @@ describe("alert config settings", () => {
 		process.env.ALERT_REQUEST_TOKENS = "200000";
 		process.env.ALERT_ANOMALY_ENABLED = "true";
 		process.env.ALERT_ANOMALY_INTERVAL_MINUTES = "30";
+		process.env.ALERT_ANOMALY_BASELINE_WINDOW_MINUTES = "720";
 		process.env.ALERT_ANOMALY_LOOP_MIN_REQUESTS = "40";
 		process.env.ALERT_COOLDOWN_MINUTES = "120";
 		process.env.ALERT_WEBHOOK_URL = "https://example.com/hook";
@@ -77,6 +80,7 @@ describe("alert config settings", () => {
 			expect(config.getAlertRequestTokens()).toBe(200000);
 			expect(config.getAlertAnomalyEnabled()).toBe(true);
 			expect(config.getAlertAnomalyIntervalMinutes()).toBe(30);
+			expect(config.getAlertAnomalyBaselineWindowMinutes()).toBe(720);
 			expect(config.getAlertAnomalyLoopMinRequests()).toBe(40);
 			expect(config.getAlertCooldownMinutes()).toBe(120);
 			expect(config.getAlertWebhookUrl()).toBe("https://example.com/hook");
@@ -101,6 +105,7 @@ describe("alert config settings", () => {
 		process.env.ALERT_TOKENS_PER_HOUR = "9999999999";
 		process.env.ALERT_REQUEST_TOKENS = "-100";
 		process.env.ALERT_ANOMALY_INTERVAL_MINUTES = "2";
+		process.env.ALERT_ANOMALY_BASELINE_WINDOW_MINUTES = "10";
 		process.env.ALERT_ANOMALY_LOOP_MIN_REQUESTS = "9999";
 		process.env.ALERT_COOLDOWN_MINUTES = "0";
 		const { config, cleanup } = makeConfig();
@@ -110,6 +115,7 @@ describe("alert config settings", () => {
 			expect(config.getAlertTokensPerHour()).toBe(1_000_000_000);
 			expect(config.getAlertRequestTokens()).toBe(0);
 			expect(config.getAlertAnomalyIntervalMinutes()).toBe(5);
+			expect(config.getAlertAnomalyBaselineWindowMinutes()).toBe(60);
 			expect(config.getAlertAnomalyLoopMinRequests()).toBe(1000);
 			expect(config.getAlertCooldownMinutes()).toBe(1);
 		} finally {
@@ -132,6 +138,12 @@ describe("alert config settings", () => {
 
 			config.setAlertAnomalyIntervalMinutes(99999);
 			expect(config.getAlertAnomalyIntervalMinutes()).toBe(1440);
+
+			config.setAlertAnomalyBaselineWindowMinutes(1);
+			expect(config.getAlertAnomalyBaselineWindowMinutes()).toBe(60);
+
+			config.setAlertAnomalyBaselineWindowMinutes(999999);
+			expect(config.getAlertAnomalyBaselineWindowMinutes()).toBe(43200);
 
 			config.setAlertAnomalyLoopMinRequests(1);
 			expect(config.getAlertAnomalyLoopMinRequests()).toBe(5);
@@ -206,6 +218,7 @@ describe("alert config settings", () => {
 			expect(settings.alert_request_tokens).toBe(0);
 			expect(settings.alert_anomaly_enabled).toBe(false);
 			expect(settings.alert_anomaly_interval_minutes).toBe(15);
+			expect(settings.alert_anomaly_baseline_window_minutes).toBe(1440);
 			expect(settings.alert_anomaly_loop_min_requests).toBe(25);
 			expect(settings.alert_cooldown_minutes).toBe(60);
 			expect(settings.alert_webhook_url).toBe("");

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -130,6 +130,7 @@ export interface ConfigData {
 	alert_request_tokens?: number;
 	alert_anomaly_enabled?: boolean;
 	alert_anomaly_interval_minutes?: number;
+	alert_anomaly_baseline_window_minutes?: number;
 	alert_anomaly_loop_min_requests?: number;
 	alert_cooldown_minutes?: number;
 	alert_webhook_url?: string;
@@ -842,6 +843,24 @@ export class Config extends EventEmitter {
 		this.set("alert_anomaly_interval_minutes", this.clamp(value, 5, 1440));
 	}
 
+	getAlertAnomalyBaselineWindowMinutes(): number {
+		const fromEnv = process.env.ALERT_ANOMALY_BASELINE_WINDOW_MINUTES;
+		if (fromEnv) {
+			const n = Number.parseInt(fromEnv, 10);
+			if (!Number.isNaN(n)) return this.clamp(n, 60, 43200);
+		}
+		const fromFile = this.data.alert_anomaly_baseline_window_minutes;
+		if (typeof fromFile === "number") return this.clamp(fromFile, 60, 43200);
+		return 1440;
+	}
+
+	setAlertAnomalyBaselineWindowMinutes(value: number): void {
+		this.set(
+			"alert_anomaly_baseline_window_minutes",
+			this.clamp(value, 60, 43200),
+		);
+	}
+
 	getAlertAnomalyLoopMinRequests(): number {
 		const fromEnv = process.env.ALERT_ANOMALY_LOOP_MIN_REQUESTS;
 		if (fromEnv) {
@@ -933,6 +952,8 @@ export class Config extends EventEmitter {
 			alert_request_tokens: this.getAlertRequestTokens(),
 			alert_anomaly_enabled: this.getAlertAnomalyEnabled(),
 			alert_anomaly_interval_minutes: this.getAlertAnomalyIntervalMinutes(),
+			alert_anomaly_baseline_window_minutes:
+				this.getAlertAnomalyBaselineWindowMinutes(),
 			alert_anomaly_loop_min_requests: this.getAlertAnomalyLoopMinRequests(),
 			alert_cooldown_minutes: this.getAlertCooldownMinutes(),
 			alert_webhook_url: this.getAlertWebhookUrl(),

--- a/packages/dashboard-web/src/components/insights/AnomaliesView.tsx
+++ b/packages/dashboard-web/src/components/insights/AnomaliesView.tsx
@@ -60,13 +60,17 @@ export const AnomaliesView = ({
 	}
 	const meta = data.meta;
 	const scannedLabel = meta.scannedRequests.toLocaleString();
+	const baselineWindowHoursLabel = (meta.baselineWindowMinutes / 60).toFixed(1);
 	// Derive ALL threshold text from response metadata so a non-default
 	// zScoreThreshold / loopMinRequests / misrouting thresholds produce a
 	// non-contradictory UI. Previously the 3-sigma prose and "3σ" panel
 	// descriptions were hard-coded while nearby labels used meta, so a
 	// response with zScoreThreshold=4 rendered contradictory criteria.
-	const zScoreLabel = `${meta.zScoreThreshold.toFixed(1)}σ`;
-	const zScoreSigmaLabel = `${meta.zScoreThreshold.toFixed(1)}-sigma`;
+	// zScoreThreshold is now a modified z-score in log-space (median/MAD
+	// based), not a literal standard-deviation count — so labels use
+	// neutral "anomaly score" framing instead of "σ"/"sigma".
+	const zScoreLabel = `anomaly score ≥ ${meta.zScoreThreshold.toFixed(1)}`;
+	const zScoreSigmaLabel = `${meta.zScoreThreshold.toFixed(1)}-point anomaly-score`;
 	return (
 		<div className="space-y-6">
 			<Card>
@@ -78,12 +82,13 @@ export const AnomaliesView = ({
 						</CardTitle>
 					</div>
 					<CardDescription>
-						Detectors below flag requests whose token usage sits at or above{" "}
-						{meta.zScoreThreshold.toFixed(1)}σ above their (account, model)
-						baseline, plus dense bursts of near-identical calls and expensive
-						models handling trivial traffic. With ~{scannedLabel} requests
-						scanned and a {zScoreSigmaLabel} threshold, expect some events by
-						chance alone — investigate the largest, ignore the rest.
+						Detectors below flag requests whose token usage scores at or above{" "}
+						{meta.zScoreThreshold.toFixed(1)} on the anomaly detector relative
+						to their (account, model) baseline, plus dense bursts of
+						near-identical calls and expensive models handling trivial traffic.
+						With ~{scannedLabel} requests scanned and a {zScoreSigmaLabel}{" "}
+						threshold, expect some events by chance alone — investigate the
+						largest, ignore the rest.
 					</CardDescription>
 					<div className="flex flex-wrap items-center gap-2 pt-2 text-xs text-muted-foreground">
 						<span>
@@ -94,13 +99,18 @@ export const AnomaliesView = ({
 							Capped at <strong>{meta.maxEventsPerDetector}</strong> rows per
 							detector
 						</span>
+						<span>
+							Baseline:{" "}
+							<strong>{meta.baselineWindowRequests.toLocaleString()}</strong>{" "}
+							requests over the last {baselineWindowHoursLabel}h
+						</span>
 					</div>
 				</CardHeader>
 			</Card>
 
 			<TokenOutlierPanel
 				title="Token outliers (total tokens)"
-				description={`Total request tokens more than ${zScoreLabel} above baseline.`}
+				description={`Total request tokens with an ${zScoreLabel} above baseline.`}
 				events={data.tokenOutliers}
 				totalCount={data.tokenOutliersSummary.totalCount}
 				truncated={data.tokenOutliersSummary.truncated}
@@ -109,7 +119,7 @@ export const AnomaliesView = ({
 
 			<TokenOutlierPanel
 				title="Output blowups (output tokens)"
-				description={`Output tokens more than ${zScoreLabel} above baseline.`}
+				description={`Output tokens with an ${zScoreLabel} above baseline.`}
 				events={data.outputBlowups}
 				totalCount={data.outputBlowupsSummary.totalCount}
 				truncated={data.outputBlowupsSummary.truncated}
@@ -195,7 +205,7 @@ function TokenOutlierPanel({
 										Tokens
 									</th>
 									<th scope="col" className="text-right px-3 py-2 tabular-nums">
-										Baseline
+										Baseline (typical)
 									</th>
 								</tr>
 							</thead>
@@ -221,8 +231,7 @@ function TokenOutlierPanel({
 											{formatNumber(event.value)}
 										</td>
 										<td className="px-3 py-2 text-right tabular-nums text-muted-foreground">
-											{formatNumber(Math.round(event.baselineMean))} ±{" "}
-											{formatNumber(Math.round(event.baselineStdDev))}
+											~{formatNumber(Math.round(event.approxBaselineMedian))}
 										</td>
 									</tr>
 								))}
@@ -461,7 +470,7 @@ function DetectorTotals({
 		<div className="flex items-center gap-2 text-xs text-muted-foreground">
 			<span>{label}</span>
 			{truncated && <Badge variant="outline">Truncated</Badge>}
-			{threshold !== undefined && <span>· ≥ {threshold.toFixed(1)}σ</span>}
+			{threshold !== undefined && <span>· score ≥ {threshold.toFixed(1)}</span>}
 		</div>
 	);
 }

--- a/packages/http-api/src/handlers/__tests__/insights.test.ts
+++ b/packages/http-api/src/handlers/__tests__/insights.test.ts
@@ -70,7 +70,7 @@ describe("createAnomalyInsightsHandler", () => {
 		expect(response.status).toBe(200);
 		const body = (await response.json()) as AnomalyInsightsResponse;
 		expect(body.meta.range).toBe("24h");
-		expect(body.meta.zScoreThreshold).toBe(3);
+		expect(body.meta.zScoreThreshold).toBe(3.5);
 		expect(body.meta.maxEventsPerDetector).toBe(50);
 		expect(body.meta.scannedRequests).toBe(2);
 		expect(body.meta.truncated).toBe(false);
@@ -84,7 +84,7 @@ describe("createAnomalyInsightsHandler", () => {
 			),
 		);
 		const body = (await response.json()) as AnomalyInsightsResponse;
-		expect(body.meta.zScoreThreshold).toBe(3);
+		expect(body.meta.zScoreThreshold).toBe(3.5);
 		expect(body.meta.maxEventsPerDetector).toBe(500);
 		expect(body.meta.loopWindowMinutes).toBe(6);
 		expect(body.meta.minBaselineRequests).toBe(2);

--- a/packages/http-api/src/handlers/__tests__/insights.test.ts
+++ b/packages/http-api/src/handlers/__tests__/insights.test.ts
@@ -103,6 +103,35 @@ describe("createAnomalyInsightsHandler", () => {
 		expect(body.meta.scannedRequests).toBe(100_000);
 	});
 
+	test("meta.baselineWindowMinutes reflects the selected range, not the 24h default (issue #410 review fix)", async () => {
+		// Before this fix, baselineWindowMinutes was never set from the
+		// handler's `range` query param, so meta always echoed
+		// DEFAULT_BASELINE_WINDOW_MINUTES (24h = 1440) regardless of which
+		// range the user picked. This endpoint scores the same row set it
+		// baselines from (baselineRows === scoringRows === rows), so the
+		// effective baseline window IS the selected range.
+		const handler = createAnomalyInsightsHandler(contextWithRows([]));
+
+		const response7d = await handler(new URLSearchParams("range=7d"));
+		const body7d = (await response7d.json()) as AnomalyInsightsResponse;
+		expect(body7d.meta.range).toBe("7d");
+		// 7d = 7 * 24 * 60 = 10080 minutes; allow small scheduling slack.
+		expect(body7d.meta.baselineWindowMinutes).toBeGreaterThan(10_079);
+		expect(body7d.meta.baselineWindowMinutes).toBeLessThanOrEqual(10_081);
+
+		const response30d = await handler(new URLSearchParams("range=30d"));
+		const body30d = (await response30d.json()) as AnomalyInsightsResponse;
+		expect(body30d.meta.range).toBe("30d");
+		// 30d = 30 * 24 * 60 = 43200 minutes.
+		expect(body30d.meta.baselineWindowMinutes).toBeGreaterThan(43_199);
+		expect(body30d.meta.baselineWindowMinutes).toBeLessThanOrEqual(43_201);
+
+		// Different ranges must not collapse to the same fixed default.
+		expect(body7d.meta.baselineWindowMinutes).not.toBe(
+			body30d.meta.baselineWindowMinutes,
+		);
+	});
+
 	test("returns 500 when the query fails", async () => {
 		const context = {
 			dbOps: {

--- a/packages/http-api/src/handlers/alerts.ts
+++ b/packages/http-api/src/handlers/alerts.ts
@@ -56,6 +56,10 @@ export function createAlertsConfigSetHandler(context: APIContext) {
 				anomalyIntervalMinutes: Number(
 					body.anomalyIntervalMinutes ?? current.anomalyIntervalMinutes,
 				),
+				anomalyBaselineWindowMinutes: Number(
+					body.anomalyBaselineWindowMinutes ??
+						current.anomalyBaselineWindowMinutes,
+				),
 				loopMinRequests: Number(
 					body.loopMinRequests ?? current.loopMinRequests,
 				),

--- a/packages/http-api/src/handlers/insights.ts
+++ b/packages/http-api/src/handlers/insights.ts
@@ -357,7 +357,8 @@ export function createAnomalyInsightsHandler(context: APIContext) {
 
 			return jsonResponse(
 				buildAnomalyInsightsResponse({
-					rows,
+					baselineRows: rows,
+					scoringRows: rows,
 					rates,
 					options: { ...options, truncated },
 				}),

--- a/packages/http-api/src/handlers/insights.ts
+++ b/packages/http-api/src/handlers/insights.ts
@@ -355,12 +355,22 @@ export function createAnomalyInsightsHandler(context: APIContext) {
 				modelIds.map((modelId, index) => [modelId, rateList[index]]),
 			);
 
+			// This endpoint uses the same row set for both baseline and scoring
+			// (baselineRows === scoringRows === rows), so the effective baseline
+			// window IS the user's selected `range`. Without this, meta always
+			// echoed the DEFAULT_BASELINE_WINDOW_MINUTES fallback (24h) inside
+			// buildAnomalyInsightsResponse regardless of which range was picked.
+			const baselineWindowMinutes = Math.max(
+				0,
+				Math.round((Date.now() - startMs) / 60_000),
+			);
+
 			return jsonResponse(
 				buildAnomalyInsightsResponse({
 					baselineRows: rows,
 					scoringRows: rows,
 					rates,
-					options: { ...options, truncated },
+					options: { ...options, baselineWindowMinutes, truncated },
 				}),
 			);
 		} catch (error) {

--- a/packages/http-api/src/services/__tests__/alerts.test.ts
+++ b/packages/http-api/src/services/__tests__/alerts.test.ts
@@ -17,6 +17,7 @@ const CONFIG: AlertsConfigPayload = {
 	requestTokens: 50_000,
 	anomalyEnabled: false,
 	anomalyIntervalMinutes: 15,
+	anomalyBaselineWindowMinutes: 1440,
 	loopMinRequests: 10,
 	cooldownMinutes: 60,
 	webhookUrl: "",

--- a/packages/http-api/src/services/__tests__/alerts.test.ts
+++ b/packages/http-api/src/services/__tests__/alerts.test.ts
@@ -1,10 +1,15 @@
+import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import type { Config } from "@better-ccflare/config";
+import { BunSqlAdapter, ensureSchema } from "@better-ccflare/database";
 import type {
 	AlertEvent,
 	AlertsConfigPayload,
 	RunawayLoopGroup,
 } from "@better-ccflare/types";
 import {
+	AlertService,
 	buildRequestTokenAlert,
 	buildRunawayLoopAlertId,
 	buildThresholdAlertId,
@@ -128,5 +133,169 @@ describe("alert threshold helpers", () => {
 		expect(alert.model).toBe("model-a");
 		expect(alert.project).toBe("proj");
 		expect(alert.acknowledged).toBe(false);
+	});
+});
+
+describe("evaluateAnomalies leave-one-out contract (issue #410 regression)", () => {
+	function makeAnomalyConfig(
+		overrides: Partial<{
+			anomalyIntervalMinutes: number;
+			anomalyBaselineWindowMinutes: number;
+			loopMinRequests: number;
+		}> = {},
+	): Config {
+		return Object.assign(new EventEmitter(), {
+			getAlertDailySpendUsd: () => 0,
+			getAlertTokensPerHour: () => 0,
+			getAlertRequestTokens: () => 0,
+			getAlertAnomalyEnabled: () => true,
+			getAlertAnomalyIntervalMinutes: () =>
+				overrides.anomalyIntervalMinutes ?? 30,
+			getAlertAnomalyBaselineWindowMinutes: () =>
+				overrides.anomalyBaselineWindowMinutes ?? 60,
+			getAlertAnomalyLoopMinRequests: () => overrides.loopMinRequests ?? 10_000,
+			getAlertCooldownMinutes: () => 60,
+			getAlertWebhookUrl: () => "",
+		}) as unknown as Config;
+	}
+
+	async function seedRequest(
+		adapter: BunSqlAdapter,
+		row: {
+			id: string;
+			timestamp: number;
+			inputTokens?: number;
+			outputTokens?: number;
+			model?: string;
+		},
+	): Promise<void> {
+		await adapter.run(
+			`INSERT INTO requests
+				(id, timestamp, method, path, account_used, status_code, success,
+				 response_time_ms, failover_attempts, model, total_tokens, cost_usd,
+				 input_tokens, output_tokens, cache_read_input_tokens,
+				 cache_creation_input_tokens)
+			 VALUES (?, ?, 'POST', '/v1/messages', NULL, 200, 1, 100, 0, ?, ?, 0, ?, ?, 0, 0)`,
+			[
+				row.id,
+				row.timestamp,
+				row.model ?? "claude-opus-4-8",
+				(row.inputTokens ?? 0) + (row.outputTokens ?? 0),
+				row.inputTokens ?? 0,
+				row.outputTokens ?? 0,
+			],
+		);
+	}
+
+	test("scoring rows never double as their own baseline population when all rows fall inside the scoring window", async () => {
+		// Regression for issue #410: the old code derived scoringRows as a
+		// .filter() of the SAME array used as baselineRows, so every scored
+		// row was also a member of its own baseline population. This test
+		// seeds 20 rows (>= the default minBaselineRequests of 20) ALL inside
+		// the scoring window (timestamp >= scoringSince) and NONE older —
+		// i.e. baselineRows must come up EMPTY under the disjoint-partition
+		// fix. With an empty baseline, computeBaselines produces no baseline
+		// entry at all, so NO outlier alert can fire, no matter how extreme
+		// one of the scored values is.
+		//
+		// Under the OLD buggy code, these same 20 rows would ALSO have been
+		// used as baselineRows (since baselineRows was the whole fetched
+		// window, unfiltered), which would satisfy minBaselineRequests and
+		// let the huge spike row flag itself as an outlier against a
+		// baseline that includes itself — exactly the contract violation
+		// this PR fixes.
+		const sqlite = new Database(":memory:");
+		ensureSchema(sqlite);
+		const adapter = new BunSqlAdapter(sqlite);
+		const config = makeAnomalyConfig({
+			anomalyIntervalMinutes: 30,
+			anomalyBaselineWindowMinutes: 60,
+		});
+		const service = new AlertService(adapter, config);
+
+		try {
+			const now = Date.now();
+			// 19 rows with a normal 3-value spread, all within the last 30
+			// minutes (inside the scoring window: timestamp >= now - 30min).
+			const spreadValues = [80, 100, 130];
+			for (let i = 0; i < 19; i++) {
+				await seedRequest(adapter, {
+					id: `scoring-normal-${i}`,
+					timestamp: now - i * 1000,
+					inputTokens: spreadValues[i % spreadValues.length],
+				});
+			}
+			// One huge spike, also inside the scoring window.
+			await seedRequest(adapter, {
+				id: "scoring-spike",
+				timestamp: now - 500,
+				inputTokens: 100_000,
+			});
+
+			await service.evaluateAnomalies();
+
+			const alerts = await service.listAlerts();
+			const outlierAlerts = alerts.filter(
+				(a) => a.type === "anomaly_token_outlier",
+			);
+			// No baseline could be formed (0 rows older than scoringSince), so
+			// nothing can be flagged — proves scoringRows is no longer a
+			// subset of baselineRows.
+			expect(outlierAlerts).toHaveLength(0);
+		} finally {
+			service.stop();
+			sqlite.close();
+		}
+	});
+
+	test("a spike in the scoring window flags only when a genuinely disjoint OLDER baseline exists, and the flagged id is never one of the baseline ids", async () => {
+		const sqlite = new Database(":memory:");
+		ensureSchema(sqlite);
+		const adapter = new BunSqlAdapter(sqlite);
+		const config = makeAnomalyConfig({
+			anomalyIntervalMinutes: 5,
+			anomalyBaselineWindowMinutes: 60,
+		});
+		const service = new AlertService(adapter, config);
+
+		try {
+			const now = Date.now();
+			const scoringSince = now - 5 * 60 * 1000;
+			const baselineIds: string[] = [];
+			// 21 baseline rows, strictly OLDER than the 5-minute scoring
+			// window (between 10 and 55 minutes ago), with a 3-value spread
+			// for a non-degenerate MAD.
+			const spreadValues = [80, 100, 130];
+			for (let i = 0; i < 21; i++) {
+				const id = `baseline-${i}`;
+				baselineIds.push(id);
+				await seedRequest(adapter, {
+					id,
+					timestamp: scoringSince - (10 + i) * 60 * 1000,
+					inputTokens: spreadValues[i % spreadValues.length],
+				});
+			}
+			// One spike inside the scoring window (last 5 minutes).
+			await seedRequest(adapter, {
+				id: "scoring-spike",
+				timestamp: now - 1000,
+				inputTokens: 100_000,
+			});
+
+			await service.evaluateAnomalies();
+
+			const alerts = await service.listAlerts();
+			const outlierAlerts = alerts.filter(
+				(a) => a.type === "anomaly_token_outlier",
+			);
+			expect(outlierAlerts).toHaveLength(1);
+			expect(outlierAlerts[0]?.requestId).toBe("scoring-spike");
+			// The flagged request id must never be one of the ids that fed the
+			// baseline population — the two sets are genuinely disjoint.
+			expect(baselineIds).not.toContain(outlierAlerts[0]?.requestId);
+		} finally {
+			service.stop();
+			sqlite.close();
+		}
 	});
 });

--- a/packages/http-api/src/services/__tests__/alerts.test.ts
+++ b/packages/http-api/src/services/__tests__/alerts.test.ts
@@ -298,4 +298,74 @@ describe("evaluateAnomalies leave-one-out contract (issue #410 regression)", () 
 			sqlite.close();
 		}
 	});
+
+	test("a baseline window SHORTER than the scoring interval still produces a non-empty baseline population (issue #410 follow-up review fix)", async () => {
+		// Regression: the query window used to be
+		// Math.max(baselineWindowMinutes, intervalMinutes), which collapses to
+		// just intervalMinutes whenever baselineWindowMinutes <= intervalMinutes
+		// (a valid config combination — nothing prevents
+		// anomalyBaselineWindowMinutes from being set lower than
+		// anomalyIntervalMinutes). That made the query fetch ONLY the scoring
+		// interval's worth of history, so every fetched row had
+		// timestamp >= scoringSince, baselineRows came up empty, and no
+		// outlier could ever be flagged for this config — a silent
+		// false-negative regression.
+		//
+		// Here baseline=30min, interval=120min (baseline < interval). Rows are
+		// seeded both inside the scoring window (last 120 minutes) AND further
+		// back, within the 30-minute baseline-before-scoring range (i.e.
+		// between 120 and 150 minutes ago). Under the fixed additive query
+		// window (baselineWindowMinutes + intervalMinutes = 150 minutes), the
+		// older rows are fetched and land in baselineRows; under the old
+		// Math.max bug they would never even be queried.
+		const sqlite = new Database(":memory:");
+		ensureSchema(sqlite);
+		const adapter = new BunSqlAdapter(sqlite);
+		const config = makeAnomalyConfig({
+			anomalyIntervalMinutes: 120,
+			anomalyBaselineWindowMinutes: 30,
+		});
+		const service = new AlertService(adapter, config);
+
+		try {
+			const now = Date.now();
+			const scoringSince = now - 120 * 60 * 1000;
+			const baselineIds: string[] = [];
+			// 21 baseline rows strictly OLDER than the 120-minute scoring
+			// window, within the 30-minute baseline range before it (i.e.
+			// between 121 and 149 minutes ago), 3-value spread for a
+			// non-degenerate MAD.
+			const spreadValues = [80, 100, 130];
+			for (let i = 0; i < 21; i++) {
+				const id = `baseline-${i}`;
+				baselineIds.push(id);
+				await seedRequest(adapter, {
+					id,
+					timestamp: scoringSince - (1 + i) * 60 * 1000,
+					inputTokens: spreadValues[i % spreadValues.length],
+				});
+			}
+			// One spike inside the scoring window.
+			await seedRequest(adapter, {
+				id: "scoring-spike",
+				timestamp: now - 1000,
+				inputTokens: 100_000,
+			});
+
+			await service.evaluateAnomalies();
+
+			const alerts = await service.listAlerts();
+			const outlierAlerts = alerts.filter(
+				(a) => a.type === "anomaly_token_outlier",
+			);
+			// A non-empty, genuinely older baseline population must have been
+			// available, so the spike is flagged.
+			expect(outlierAlerts).toHaveLength(1);
+			expect(outlierAlerts[0]?.requestId).toBe("scoring-spike");
+			expect(baselineIds).not.toContain(outlierAlerts[0]?.requestId);
+		} finally {
+			service.stop();
+			sqlite.close();
+		}
+	});
 });

--- a/packages/http-api/src/services/__tests__/anomaly-insights.test.ts
+++ b/packages/http-api/src/services/__tests__/anomaly-insights.test.ts
@@ -14,9 +14,26 @@ import {
 /**
  * Tests for the pure anomaly-detection math service.
  *
- * Token values are chosen so means/stddevs are exact in floating point,
- * e.g. nine requests at 100 tokens plus one at 1000 gives mean 190,
- * stddev 270 and a z-score of exactly 3 for the spike.
+ * Since issue #410, baselines are computed as a log-space modified z-score
+ * (median + scaled median absolute deviation, i.e. MAD) instead of a raw
+ * mean/stddev. All expected numbers below are hand-recomputed from that
+ * formula — NOT ported from the old mean/stddev fixtures, since the log
+ * transform is nonlinear and medians/MADs do not correspond to the old
+ * means/stddevs even for the same raw values.
+ *
+ * Formula recap:
+ *   L_i = ln(v_i)
+ *   medianLog = median(L_1..L_n)
+ *   scaledMad = max(1.4826 * median(|L_i - medianLog|), 1e-9)   // floor avoids div-by-zero
+ *   modifiedZ(x) = (ln(x) - medianLog) / scaledMad
+ *
+ * A key property exploited throughout: with only two distinct values in a
+ * group, the value that holds the majority (>50%) becomes both the median
+ * AND makes >50% of the absolute deviations exactly 0, so the MAD collapses
+ * to 0 (floored to 1e-9). Fixtures below therefore use THREE distinct
+ * values wherever a non-degenerate MAD is required for a flagging
+ * assertion, and deliberately use identical/two-value fixtures where the
+ * intent IS to exercise the zero/degenerate-MAD path.
  */
 
 const OPUS_RATES: ModelRates = {
@@ -60,8 +77,76 @@ function spikeRows(): AnomalyRequestRow[] {
 	return rows;
 }
 
+/**
+ * 19-row baseline with THREE distinct total-token values (80/100/130,
+ * 6/7/6 split) so the MAD is non-degenerate. Median-of-logs lands exactly
+ * on ln(100) (the value with the 7-row plurality and the middle rank of 19),
+ * so medianLogTotalTokens = ln(100) exactly and approxMedianTotalTokens =
+ * 100 exactly. madTotalTokens = 1.4826 * median(|L_i - ln(100)|) =
+ * 1.4826 * ln(130/100) ≈ 0.330833 (the 6 values at 130 and 6 at 80 tie for
+ * the largest deviation bucket at n=19, so the middle-ranked absolute
+ * deviation is ln(1.3) either way by symmetry of counts... concretely:
+ * sorted |L_i - ln(100)| has 7 zeros, then 12 copies of ln(1.3)-ish/ln(0.8)
+ * mixed; the median (10th of 19) falls in that upper block). Verified
+ * numerically; see comment on each assertion below for the precise value.
+ */
+function baseline19_80_100_130(
+	options: { outputTokens?: number } = {},
+): AnomalyRequestRow[] {
+	// outputTokens is part of totalTokens, so when a non-zero outputTokens
+	// is requested (to also satisfy the output-tokens baseline gate),
+	// inputTokens is reduced by the same amount so the actual total-token
+	// value for each row still lands exactly on 80/100/130.
+	const out = options.outputTokens ?? 0;
+	return [
+		...Array.from({ length: 6 }, () =>
+			req({ inputTokens: 80 - out, outputTokens: out }),
+		),
+		...Array.from({ length: 7 }, () =>
+			req({ inputTokens: 100 - out, outputTokens: out }),
+		),
+		...Array.from({ length: 6 }, () =>
+			req({ inputTokens: 130 - out, outputTokens: out }),
+		),
+	];
+}
+
+/**
+ * Same shape as baseline19_80_100_130 but for the output-tokens metric
+ * (8/10/13). inputTokens is fixed at 1000 (large relative to any scoring
+ * row used against this baseline's total_tokens metric in these tests) so
+ * the output-tokens signal can be isolated from the total-tokens signal:
+ * a row that blows up outputTokens without a matching jump in totalTokens
+ * should flag on the output_tokens metric only, never on total_tokens.
+ */
+function baseline19Output_8_10_13(
+	overrides: Partial<AnomalyRequestRow> = {},
+): AnomalyRequestRow[] {
+	return [
+		...Array.from({ length: 6 }, () =>
+			req({ inputTokens: 1000, outputTokens: 8, ...overrides }),
+		),
+		...Array.from({ length: 7 }, () =>
+			req({ inputTokens: 1000, outputTokens: 10, ...overrides }),
+		),
+		...Array.from({ length: 6 }, () =>
+			req({ inputTokens: 1000, outputTokens: 13, ...overrides }),
+		),
+	];
+}
+
 describe("computeBaselines", () => {
-	test("computes mean and population stddev per account/model", () => {
+	test("computes median and scaled-MAD in log space per account/model", () => {
+		// 5 rows at 90 total tokens (input only), 5 rows at 110. Median of the
+		// 10 ln-values is the average of the two middle-ranked logs:
+		// (ln(90) + ln(110)) / 2 = 4.6001450... — NOT ln(100), because the
+		// even-count median averages the two central *log* values, and
+		// ln is nonlinear (this differs from the old linear mean, which
+		// WAS exactly 100).
+		//
+		// MAD: every |L_i - medianLog| is |ln(90) - medianLog| = |ln(110) -
+		// medianLog| = (ln(110) - ln(90)) / 2 = 0.1002532... (all 10 rows tie),
+		// so scaledMad = 1.4826 * 0.1002532... = 0.1487572...
 		const rows = [
 			...Array.from({ length: 5 }, () =>
 				req({ inputTokens: 90, outputTokens: 0 }),
@@ -70,133 +155,376 @@ describe("computeBaselines", () => {
 				req({ inputTokens: 110, outputTokens: 0 }),
 			),
 		];
-		const baselines = computeBaselines(rows, 10);
+		// This fixture has outputTokens: 0 throughout, so no output baseline
+		// can be formed (min=10 requires >=10 rows with outputTokens>0) —
+		// covered by a dedicated test below. Both metrics gate the same
+		// baseline entry, so carve an output-tokens signal (9 / 11) out of
+		// each row's inputTokens (not on top of it) so totalTokens stays
+		// exactly on 90/110 for both halves.
+		const rowsWithOutput = rows.map((row, i) =>
+			i < 5
+				? { ...row, inputTokens: row.inputTokens - 9, outputTokens: 9 }
+				: { ...row, inputTokens: row.inputTokens - 11, outputTokens: 11 },
+		);
+		const baselines = computeBaselines(rowsWithOutput, 10);
 		expect(baselines).toHaveLength(1);
-		expect(baselines[0].account).toBe("acc");
-		expect(baselines[0].model).toBe("claude-opus-4-8");
-		expect(baselines[0].requests).toBe(10);
-		expect(baselines[0].meanTotalTokens).toBe(100);
-		expect(baselines[0].stdDevTotalTokens).toBe(10);
-		expect(baselines[0].meanOutputTokens).toBe(0);
-		expect(baselines[0].stdDevOutputTokens).toBe(0);
+		const b = baselines[0];
+		expect(b.account).toBe("acc");
+		expect(b.model).toBe("claude-opus-4-8");
+		expect(b.requests).toBe(10);
+		expect(b.medianLogTotalTokens).toBeCloseTo(4.600145, 5);
+		expect(b.madTotalTokens).toBeCloseTo(0.148757, 5);
+		expect(b.approxMedianTotalTokens).toBeCloseTo(99.498744, 4);
+		expect(b.medianLogOutputTokens).toBeCloseTo(2.29756, 5);
+		expect(b.madOutputTokens).toBeCloseTo(0.148757, 5);
+		expect(b.approxMedianOutputTokens).toBeCloseTo(9.949874, 4);
 	});
 
 	test("total tokens sum input, cache read, cache creation and output", () => {
-		const rows = Array.from({ length: 10 }, () =>
-			req({
-				inputTokens: 10,
-				cacheReadInputTokens: 20,
-				cacheCreationInputTokens: 30,
-				outputTokens: 40,
-			}),
-		);
+		// Two-value split (100 total x5, 120 total x5; output 40 x5, 60 x5)
+		// so there's real spread to compute a non-trivial MAD, while still
+		// keeping the "sum of four token fields" property under test.
+		const rows = [
+			...Array.from({ length: 5 }, () =>
+				req({
+					inputTokens: 10,
+					cacheReadInputTokens: 20,
+					cacheCreationInputTokens: 30,
+					outputTokens: 40,
+				}),
+			),
+			...Array.from({ length: 5 }, () =>
+				req({
+					inputTokens: 10,
+					cacheReadInputTokens: 20,
+					cacheCreationInputTokens: 30,
+					outputTokens: 60,
+				}),
+			),
+		];
 		const baselines = computeBaselines(rows, 10);
-		expect(baselines[0].meanTotalTokens).toBe(100);
+		// medianLog over [ln(100) x5, ln(120) x5] = (ln(100)+ln(120))/2 = 4.696331
+		expect(baselines[0].medianLogTotalTokens).toBeCloseTo(4.696331, 5);
+		expect(baselines[0].approxMedianTotalTokens).toBeCloseTo(109.544512, 4);
+		expect(baselines[0].medianLogOutputTokens).toBeCloseTo(3.891612, 5);
+		expect(baselines[0].approxMedianOutputTokens).toBeCloseTo(48.989795, 4);
 	});
 
 	test("excludes zero-token rows from the baseline", () => {
-		const rows = [
-			...Array.from({ length: 10 }, () => req({ inputTokens: 100 })),
+		const tokenRows = [
+			...Array.from({ length: 10 }, () =>
+				req({ inputTokens: 100, outputTokens: 10 }),
+			),
 			...Array.from({ length: 10 }, () => req()), // failed requests, no tokens
 		];
-		const baselines = computeBaselines(rows, 10);
+		const baselines = computeBaselines(tokenRows, 10);
 		expect(baselines).toHaveLength(1);
 		expect(baselines[0].requests).toBe(10);
-		expect(baselines[0].meanTotalTokens).toBe(100);
+		// totalTokens = inputTokens + outputTokens = 100 + 10 = 110 per row.
+		expect(baselines[0].approxMedianTotalTokens).toBeCloseTo(110, 6);
 	});
 
 	test("omits groups below minBaselineRequests", () => {
-		const rows = Array.from({ length: 9 }, () => req({ inputTokens: 100 }));
+		const rows = Array.from({ length: 9 }, () =>
+			req({ inputTokens: 100, outputTokens: 10 }),
+		);
 		expect(computeBaselines(rows, 10)).toHaveLength(0);
 	});
 
 	test("groups separately per account and model, normalizing null to Unknown", () => {
 		const rows = [
 			...Array.from({ length: 3 }, () =>
-				req({ account: "a1", model: "m1", inputTokens: 100 }),
+				req({ account: "a1", model: "m1", inputTokens: 100, outputTokens: 10 }),
 			),
 			...Array.from({ length: 3 }, () =>
-				req({ account: "a1", model: "m2", inputTokens: 200 }),
+				req({ account: "a1", model: "m2", inputTokens: 200, outputTokens: 20 }),
 			),
 			...Array.from({ length: 3 }, () =>
-				req({ account: null, model: null, inputTokens: 300 }),
+				req({ account: null, model: null, inputTokens: 300, outputTokens: 30 }),
 			),
 		];
 		const baselines = computeBaselines(rows, 3);
 		expect(baselines).toHaveLength(3);
 		const unknown = baselines.find((b) => b.account === "Unknown");
 		expect(unknown?.model).toBe("Unknown");
-		expect(unknown?.meanTotalTokens).toBe(300);
+		// All-identical-value group: totalTokens = inputTokens + outputTokens
+		// = 300 + 30 = 330 per row, so medianLog = ln(330) exactly.
+		expect(unknown?.approxMedianTotalTokens).toBeCloseTo(330, 6);
+	});
+
+	test("output-tokens metric requires >= minBaselineRequests rows with outputTokens > 0", () => {
+		// 10 rows with total tokens = 100 (qualifies the total-tokens gate),
+		// but only 6 of them have outputTokens > 0 (< minBaselineRequests=10),
+		// so the whole baseline entry (both metrics) is omitted — a baseline
+		// is one record per (account, model), and detectTokenOutliers needs
+		// both fields populated meaningfully.
+		const rows = [
+			...Array.from({ length: 6 }, () =>
+				req({ inputTokens: 80, outputTokens: 20 }),
+			),
+			...Array.from({ length: 4 }, () => req({ inputTokens: 100 })),
+		];
+		expect(computeBaselines(rows, 10)).toHaveLength(0);
 	});
 });
 
 describe("detectTokenOutliers", () => {
-	test("flags requests at or above the z-score threshold", () => {
-		const rows = spikeRows();
-		const baselines = computeBaselines(rows, 10);
-		const outliers = detectTokenOutliers(rows, baselines, 3, "total_tokens");
+	test("flags requests at or above the z-score threshold (total_tokens)", () => {
+		const baselineRows = baseline19_80_100_130({ outputTokens: 10 });
+		const baselines = computeBaselines(baselineRows, 10);
+		expect(baselines).toHaveLength(1);
+		// medianLogTotalTokens = ln(100) exactly; madTotalTokens ~ 0.330833
+		expect(baselines[0].medianLogTotalTokens).toBeCloseTo(Math.log(100), 10);
+		expect(baselines[0].madTotalTokens).toBeCloseTo(0.330833, 5);
+
+		const scoringRows = [req({ id: "spike", inputTokens: 1000 })];
+		const outliers = detectTokenOutliers(
+			scoringRows,
+			baselines,
+			3.5,
+			"total_tokens",
+		);
 		expect(outliers).toHaveLength(1);
 		expect(outliers[0].requestId).toBe("spike");
 		expect(outliers[0].metric).toBe("total_tokens");
 		expect(outliers[0].value).toBe(1000);
-		expect(outliers[0].baselineMean).toBe(190);
-		expect(outliers[0].baselineStdDev).toBe(270);
-		expect(outliers[0].zScore).toBe(3);
+		expect(outliers[0].baselineMedianLog).toBeCloseTo(Math.log(100), 10);
+		expect(outliers[0].baselineMad).toBeCloseTo(0.330833, 5);
+		expect(outliers[0].approxBaselineMedian).toBeCloseTo(100, 6);
+		expect(outliers[0].zScore).toBeCloseTo(6.95997, 5);
 	});
 
 	test("does not flag low-side outliers", () => {
-		// Nine 1000-token requests plus one at 100: the small one has z = -3.
-		const rows = Array.from({ length: 9 }, () => req({ inputTokens: 1000 }));
-		rows.push(req({ inputTokens: 100 }));
-		const baselines = computeBaselines(rows, 10);
+		// Baseline 800/1000/1300 x19 (same 6/7/6 shape, scaled x10 from the
+		// 80/100/130 fixture). A scoring row far BELOW the baseline (100)
+		// produces a large-magnitude NEGATIVE z-score and must never be
+		// reported.
+		const baselineRows = [
+			...Array.from({ length: 6 }, () => req({ inputTokens: 800 })),
+			...Array.from({ length: 7 }, () => req({ inputTokens: 1000 })),
+			...Array.from({ length: 6 }, () => req({ inputTokens: 1300 })),
+		];
+		const baselines = computeBaselines(baselineRows, 10);
+		const scoringRows = [req({ inputTokens: 100 })];
 		expect(
-			detectTokenOutliers(rows, baselines, 3, "total_tokens"),
+			detectTokenOutliers(scoringRows, baselines, 3.5, "total_tokens"),
 		).toHaveLength(0);
 	});
 
-	test("returns nothing when the baseline has zero variance", () => {
-		const rows = Array.from({ length: 10 }, () => req({ inputTokens: 100 }));
-		const baselines = computeBaselines(rows, 10);
+	test("does not flag a value equal to a constant (zero-variance) baseline", () => {
+		// All-identical baseline: MAD floors to the epsilon guard, so any
+		// EXACT match to the median still yields z = 0 (not flagged), while
+		// the floor prevents Infinity/NaN for any other value.
+		const baselineRows = Array.from({ length: 10 }, () =>
+			req({ inputTokens: 100, outputTokens: 10 }),
+		);
+		const baselines = computeBaselines(baselineRows, 10);
+		const scoringRows = [req({ inputTokens: 100 })];
 		expect(
-			detectTokenOutliers(rows, baselines, 3, "total_tokens"),
+			detectTokenOutliers(scoringRows, baselines, 3.5, "total_tokens"),
 		).toHaveLength(0);
 	});
 
 	test("returns nothing for groups without a baseline", () => {
-		const rows = spikeRows();
-		expect(detectTokenOutliers(rows, [], 3, "total_tokens")).toHaveLength(0);
+		const scoringRows = spikeRows();
+		expect(
+			detectTokenOutliers(scoringRows, [], 3.5, "total_tokens"),
+		).toHaveLength(0);
+	});
+
+	test("skips scoring rows with outputTokens <= 0 for the output_tokens metric", () => {
+		const baselineRows = baseline19Output_8_10_13();
+		const baselines = computeBaselines(baselineRows, 10);
+		const scoringRows = [req({ inputTokens: 100, outputTokens: 0 })];
+		expect(
+			detectTokenOutliers(scoringRows, baselines, 3.5, "output_tokens"),
+		).toHaveLength(0);
 	});
 
 	test("output_tokens metric detects output blowups independently", () => {
-		// Constant 200 total tokens, but one response with 100 output tokens
-		// against a baseline of 10: z = 3 on the output metric only.
-		const rows = Array.from({ length: 9 }, () =>
-			req({ inputTokens: 190, outputTokens: 10 }),
-		);
-		rows.push(req({ id: "blowup", inputTokens: 100, outputTokens: 100 }));
-		const baselines = computeBaselines(rows, 10);
+		const baselineRows = baseline19Output_8_10_13();
+		const baselines = computeBaselines(baselineRows, 10);
+		expect(baselines[0].medianLogOutputTokens).toBeCloseTo(Math.log(10), 10);
+		expect(baselines[0].madOutputTokens).toBeCloseTo(0.330833, 5);
+
+		const scoringRows = [
+			req({ id: "blowup", inputTokens: 100, outputTokens: 100 }),
+		];
 		expect(
-			detectTokenOutliers(rows, baselines, 3, "total_tokens"),
+			detectTokenOutliers(scoringRows, baselines, 3.5, "total_tokens"),
 		).toHaveLength(0);
-		const blowups = detectTokenOutliers(rows, baselines, 3, "output_tokens");
+		const blowups = detectTokenOutliers(
+			scoringRows,
+			baselines,
+			3.5,
+			"output_tokens",
+		);
 		expect(blowups).toHaveLength(1);
 		expect(blowups[0].requestId).toBe("blowup");
 		expect(blowups[0].metric).toBe("output_tokens");
-		expect(blowups[0].zScore).toBe(3);
+		expect(blowups[0].zScore).toBeCloseTo(6.95997, 5);
 	});
 
 	test("sorts outliers by z-score descending", () => {
-		const rows = [
-			...Array.from({ length: 18 }, () => req({ inputTokens: 100 })),
-			req({ id: "big", inputTokens: 1000 }),
-			req({ id: "bigger", inputTokens: 2000 }),
+		const baselineRows = baseline19_80_100_130({ outputTokens: 10 });
+		const baselines = computeBaselines(baselineRows, 10);
+		const scoringRows = [
+			req({ id: "big", inputTokens: 300 }),
+			req({ id: "bigger", inputTokens: 600 }),
 		];
-		const baselines = computeBaselines(rows, 10);
-		// z(big) ~ 1.69, z(bigger) ~ 3.92 against mean 240, stddev ~448.8.
-		const outliers = detectTokenOutliers(rows, baselines, 1.5, "total_tokens");
+		// z(300) ~ 3.320750, z(600) ~ 5.415909 against medianLog=ln(100), mad~0.330833
+		const outliers = detectTokenOutliers(
+			scoringRows,
+			baselines,
+			3,
+			"total_tokens",
+		);
 		expect(outliers.map((o) => o.requestId)).toEqual(["bigger", "big"]);
+		expect(outliers[0].zScore).toBeCloseTo(5.415909, 5);
+		expect(outliers[1].zScore).toBeCloseTo(3.32075, 5);
+	});
+
+	test("baseline computation is independent of which rows are scored (leave-one-out contract)", () => {
+		// Regression for #410: baselineRows and scoringRows are decoupled row
+		// sets. Prove the baseline stats are bit-for-bit identical whichever
+		// scoringRows slice is later scored against them.
+		const baselineRows = baseline19_80_100_130({ outputTokens: 10 });
+		const baselinesA = computeBaselines(baselineRows, 10);
+		const baselinesB = computeBaselines(baselineRows, 10);
+		expect(baselinesA).toEqual(baselinesB);
+
+		const scoringA = [req({ inputTokens: 500 })];
+		const scoringB = [req({ inputTokens: 900 }), req({ inputTokens: 50 })];
+		const outliersA = detectTokenOutliers(
+			scoringA,
+			baselinesA,
+			3,
+			"total_tokens",
+		);
+		const outliersB = detectTokenOutliers(
+			scoringB,
+			baselinesB,
+			3,
+			"total_tokens",
+		);
+		// Whichever rows are scored, both draw on the SAME baseline numbers.
+		expect(outliersA[0]?.baselineMedianLog).toBeCloseTo(
+			outliersB[0]?.baselineMedianLog ?? Number.NaN,
+			10,
+		);
+		expect(baselinesA[0].medianLogTotalTokens).toBeCloseTo(Math.log(100), 10);
+	});
+
+	test("regression: a moderately-above-pack value against a large baseline does NOT flag (cap is gone, not loosened)", () => {
+		// n=200 lognormal-ish baseline centered near 100 (sigma ~0.15 in log
+		// space), generated with a fixed LCG seed for reproducibility.
+		// approxMedianTotalTokens ~ 99.620083, madTotalTokens ~ 0.184808.
+		const baselineRows = lognormalBaselineRows(200, 7, 100, 0.15);
+		const baselines = computeBaselines(baselineRows, 10);
+		expect(baselines).toHaveLength(1);
+		expect(baselines[0].approxMedianTotalTokens).toBeCloseTo(99.620083, 4);
+		expect(baselines[0].madTotalTokens).toBeCloseTo(0.184808, 5);
+
+		// z(180) ~ 3.201121 — clearly above the pack but under the 3.5
+		// default threshold, so it must NOT flag.
+		const scoringRows = [req({ id: "moderate", inputTokens: 180 })];
+		expect(
+			detectTokenOutliers(scoringRows, baselines, 3.5, "total_tokens"),
+		).toHaveLength(0);
+	});
+
+	test("regression: a genuine 100x outlier against a large baseline DOES flag with z far beyond any sqrt(n-1) ceiling", () => {
+		const baselineRows = lognormalBaselineRows(200, 7, 100, 0.15);
+		const baselines = computeBaselines(baselineRows, 10);
+		const approxMedian = baselines[0].approxMedianTotalTokens;
+		const spikeValue = Math.round(approxMedian * 100);
+
+		const scoringRows = [req({ id: "huge-spike", inputTokens: spikeValue })];
+		const outliers = detectTokenOutliers(
+			scoringRows,
+			baselines,
+			3.5,
+			"total_tokens",
+		);
+		expect(outliers).toHaveLength(1);
+		// sqrt(n-1) for any realistic baseline size (even n=1000) tops out
+		// around 31.6; a z-score of ~24.9 here already exceeds what any
+		// n <= 200 population-stddev ceiling could produce (sqrt(199) ~
+		// 14.1), and there is no n for which the OLD formula could even
+		// reach this magnitude from a single self-inclusive spike without
+		// dominating the mean itself. Assert well clear of 10 to make the
+		// "no ceiling" property unambiguous.
+		expect(outliers[0].zScore).toBeGreaterThan(10);
+		expect(outliers[0].zScore).toBeCloseTo(24.918659, 4);
+	});
+
+	test("regression: reproduces the reporter's n=24 shape and the z-score is NOT sqrt(23) (~4.7959)", () => {
+		// The original bug (issue #410): with a self-inclusive population of
+		// 24 rows (23 baseline + the scored row itself), the OLD mean/stddev
+		// formula mathematically CAPPED the z-score at sqrt(23) ~ 4.7959,
+		// regardless of how extreme the spike was. The new formula has no
+		// such structural cap.
+		const baselineRows = lognormalBaselineRows(23, 13, 100, 0.1);
+		const baselines = computeBaselines(baselineRows, 10);
+		expect(baselines).toHaveLength(1);
+		expect(baselines[0].approxMedianTotalTokens).toBeCloseTo(98.68755, 4);
+		expect(baselines[0].madTotalTokens).toBeCloseTo(0.096415, 5);
+
+		// scoringRows is disjoint from baselineRows (the row being scored
+		// here was never part of the 23-row baseline population).
+		const scoringRows = [req({ id: "spike", inputTokens: 1000 })];
+		const outliers = detectTokenOutliers(
+			scoringRows,
+			baselines,
+			3.5,
+			"total_tokens",
+		);
+		expect(outliers).toHaveLength(1);
+		expect(Math.abs(outliers[0].zScore - Math.sqrt(23))).toBeGreaterThan(0.5);
+		expect(outliers[0].zScore).toBeCloseTo(24.019106, 4);
 	});
 });
+
+/**
+ * Deterministic pseudo-lognormal baseline row generator: `n` rows whose
+ * total tokens are drawn from a lognormal distribution centered at
+ * `centerValue` with log-space spread `sigma`, using a fixed linear
+ * congruential generator seeded with `seed` so results are 100%
+ * reproducible across runs (no reliance on Math.random).
+ */
+function lognormalBaselineRows(
+	n: number,
+	seed: number,
+	centerValue: number,
+	sigma: number,
+): AnomalyRequestRow[] {
+	let s = seed;
+	const rand = () => {
+		s = (s * 9301 + 49297) % 233280;
+		return s / 233280;
+	};
+	const rows: AnomalyRequestRow[] = [];
+	for (let i = 0; i < n; i++) {
+		const u1 = rand();
+		const u2 = rand();
+		const gaussian = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+		// `value` is the intended TOTAL token count for the row. outputTokens
+		// is carved out of it (rather than added on top) so the row's actual
+		// totalTokens (inputTokens + outputTokens) still equals `value`
+		// exactly — this keeps the total-tokens baseline numbers matching
+		// what was generated, while still giving the output-tokens metric a
+		// non-trivial (if noisier) signal to compute its own baseline from.
+		const value = Math.exp(Math.log(centerValue) + sigma * gaussian);
+		const outputTokens = Math.max(1, Math.round(value / 10));
+		rows.push(
+			req({
+				inputTokens: value - outputTokens,
+				outputTokens,
+			}),
+		);
+	}
+	return rows;
+}
 
 describe("detectRunawayLoops", () => {
 	const opts = {
@@ -324,7 +652,7 @@ describe("detectRunawayLoops", () => {
 		// opts.minRequests (10) on its own. Then one session repeats
 		// 12 times — that bucket DOES fire.
 		const concurrentSessions = 12;
-		const requestsPerSession = 9; // < opts.minRequests = 10
+		const requestsPerSession = 9; // < opts.minRequests (10)
 		const concurrentRows: AnomalyRequestRow[] = [];
 		for (let s = 0; s < concurrentSessions; s++) {
 			for (let r = 0; r < requestsPerSession; r++) {
@@ -570,14 +898,17 @@ describe("buildAnomalyInsightsResponse", () => {
 
 	test("echoes the effective options in meta", () => {
 		const response = buildAnomalyInsightsResponse({
-			rows: [],
+			baselineRows: [],
+			scoringRows: [],
 			rates,
 			options: { range: "7d" },
 		});
 		expect(response.meta).toEqual({
 			range: "7d",
-			zScoreThreshold: 3,
+			zScoreThreshold: 3.5,
 			minBaselineRequests: 20,
+			baselineWindowMinutes: 24 * 60,
+			baselineWindowRequests: 0,
 			loopWindowMinutes: 5,
 			loopMinRequests: 10,
 			loopSimilarityTolerance: 0.25,
@@ -595,29 +926,59 @@ describe("buildAnomalyInsightsResponse", () => {
 		expect(response.misrouting).toHaveLength(0);
 	});
 
+	test("respects a custom baselineWindowMinutes and reports baselineWindowRequests separately from scannedRequests", () => {
+		const baselineRows = Array.from({ length: 7 }, () =>
+			req({ inputTokens: 100 }),
+		);
+		const scoringRows = Array.from({ length: 3 }, () =>
+			req({ inputTokens: 100 }),
+		);
+		const response = buildAnomalyInsightsResponse({
+			baselineRows,
+			scoringRows,
+			rates,
+			options: { range: "30d", baselineWindowMinutes: 60 },
+		});
+		expect(response.meta.baselineWindowMinutes).toBe(60);
+		expect(response.meta.baselineWindowRequests).toBe(7);
+		expect(response.meta.scannedRequests).toBe(3);
+	});
+
 	test("reports scanned row count and truncation in meta", () => {
 		const rows = Array.from({ length: 3 }, () => req({ inputTokens: 100 }));
 		const response = buildAnomalyInsightsResponse({
-			rows,
+			baselineRows: rows,
+			scoringRows: rows,
 			rates,
 			options: { range: "30d", truncated: true },
 		});
 		expect(response.meta.scannedRequests).toBe(3);
+		expect(response.meta.baselineWindowRequests).toBe(3);
 		expect(response.meta.truncated).toBe(true);
 	});
 
-	test("runs all detectors over the same rows", () => {
-		const rows: AnomalyRequestRow[] = [
-			// Baseline + total-token spike (also an output blowup). Totals stay
-			// above misroutingMaxTotalTokens so they don't trip that detector.
-			...Array.from({ length: 19 }, (_, i) =>
-				req({ timestamp: i * 600_000, inputTokens: 900, outputTokens: 100 }),
+	test("runs all detectors, baselines built from baselineRows and detectors scanning only scoringRows", () => {
+		// Baseline population: 20 rows with a 3-value spread (80/100/130 x
+		// account "acc") so total-tokens baseline has real variance.
+		const baselineRows = [
+			...Array.from({ length: 6 }, () =>
+				req({ inputTokens: 80, outputTokens: 8 }),
 			),
+			...Array.from({ length: 8 }, () =>
+				req({ inputTokens: 100, outputTokens: 10 }),
+			),
+			...Array.from({ length: 6 }, () =>
+				req({ inputTokens: 130, outputTokens: 13 }),
+			),
+		];
+		const scoringRows: AnomalyRequestRow[] = [
+			// A clear total-token AND output-token spike, scored against the
+			// baseline above (NOT part of baselineRows).
 			req({
 				id: "spike",
 				timestamp: 19 * 600_000,
-				inputTokens: 90_000,
-				outputTokens: 10_000,
+				inputTokens: 9000,
+				outputTokens: 1000,
 			}),
 			// Runaway loop burst on another account/agent; the model has no
 			// known rates so the small calls don't count as misrouting.
@@ -643,7 +1004,8 @@ describe("buildAnomalyInsightsResponse", () => {
 			),
 		];
 		const response = buildAnomalyInsightsResponse({
-			rows,
+			baselineRows,
+			scoringRows,
 			rates,
 			options: { range: "24h", minBaselineRequests: 20 },
 		});
@@ -659,19 +1021,20 @@ describe("buildAnomalyInsightsResponse", () => {
 	});
 
 	test("caps every detector list at maxEventsPerDetector", () => {
-		const rows: AnomalyRequestRow[] = [
-			...Array.from({ length: 18 }, () => req({ inputTokens: 100 })),
-			req({ id: "big", inputTokens: 1000 }),
-			req({ id: "bigger", inputTokens: 2000 }),
+		const baselineRows = baseline19_80_100_130({ outputTokens: 8 });
+		const scoringRows: AnomalyRequestRow[] = [
+			req({ id: "big", inputTokens: 300 }),
+			req({ id: "bigger", inputTokens: 600 }),
 		];
 		const response = buildAnomalyInsightsResponse({
-			rows,
+			baselineRows,
+			scoringRows,
 			rates,
 			options: {
 				range: "24h",
 				minBaselineRequests: 10,
-				// At 1.5 both "big" and "bigger" qualify; the cap keeps one.
-				zScoreThreshold: 1.5,
+				// z(300) ~ 3.32, z(600) ~ 5.42 — both qualify at 3; cap keeps one.
+				zScoreThreshold: 3,
 				maxEventsPerDetector: 1,
 			},
 		});
@@ -681,21 +1044,33 @@ describe("buildAnomalyInsightsResponse", () => {
 	});
 
 	test("reports totalCount + truncation per detector so the UI can distinguish '50-of-50' from '50-of-847'", () => {
-		// Baseline rows dominate so the mean stays low; spikes are far enough
-		// above to register as outliers. Cap of 5 forces 5 of N to be shown.
-		const rows: AnomalyRequestRow[] = [
-			...Array.from({ length: 100 }, () => req({ inputTokens: 100 })),
-			...Array.from({ length: 10 }, (_, i) =>
-				req({ id: `spike-${i}`, inputTokens: 50000 }),
+		// Baseline rows dominate so the median stays low; spikes are far
+		// enough above to register as outliers. Cap of 5 forces 5 of N to
+		// be shown. Same 6/7/6-shaped total-token spread as the smaller
+		// fixtures, just repeated ~5.5x for a larger n (~104 rows).
+		const out = 8;
+		const baselineRows = [
+			...Array.from({ length: 34 }, () =>
+				req({ inputTokens: 80 - out, outputTokens: out }),
+			),
+			...Array.from({ length: 33 }, () =>
+				req({ inputTokens: 100 - out, outputTokens: out }),
+			),
+			...Array.from({ length: 33 }, () =>
+				req({ inputTokens: 130 - out, outputTokens: out }),
 			),
 		];
+		const scoringRows = Array.from({ length: 10 }, (_, i) =>
+			req({ id: `spike-${i}`, inputTokens: 50000 }),
+		);
 		const response = buildAnomalyInsightsResponse({
-			rows,
+			baselineRows,
+			scoringRows,
 			rates,
 			options: {
 				range: "24h",
 				minBaselineRequests: 10,
-				zScoreThreshold: 1.5,
+				zScoreThreshold: 3,
 				maxEventsPerDetector: 5,
 			},
 		});
@@ -703,25 +1078,31 @@ describe("buildAnomalyInsightsResponse", () => {
 		expect(response.tokenOutliersSummary.totalCount).toBe(10);
 		expect(response.tokenOutliersSummary.truncated).toBe(true);
 		expect(response.tokenOutliers).toHaveLength(5);
-		// Output blowups use the same detector math — they should mirror.
+		// Output blowups: scoringRows carry no outputTokens at all (0), so
+		// they're skipped by the output_tokens metric guard entirely.
 		expect(response.outputBlowupsSummary.totalCount).toBe(0);
 		expect(response.outputBlowupsSummary.truncated).toBe(false);
 	});
 
 	test("summary.truncated is false when the full count fits under the cap", () => {
-		// 18 baseline + 2 spikes at z threshold 1.5 => exactly 2 outliers.
-		const rows: AnomalyRequestRow[] = [
-			...Array.from({ length: 18 }, () => req({ inputTokens: 100 })),
-			req({ id: "big", inputTokens: 1000 }),
-			req({ id: "bigger", inputTokens: 2000 }),
+		// Reuses the shared 6/7/6 80/100/130 baseline (with an output-tokens
+		// signal so the output-gate in computeBaselines is satisfied);
+		// medianLog/scaledMad are identical to the plain 80/100/130 split
+		// regardless of exact per-value counts, so the z-scores below hold.
+		const baselineRows = baseline19_80_100_130({ outputTokens: 8 });
+		// z(300) ~ 3.32, z(600) ~ 5.42 at threshold 3 => exactly 2 outliers.
+		const scoringRows = [
+			req({ id: "big", inputTokens: 300 }),
+			req({ id: "bigger", inputTokens: 600 }),
 		];
 		const response = buildAnomalyInsightsResponse({
-			rows,
+			baselineRows,
+			scoringRows,
 			rates,
 			options: {
 				range: "24h",
 				minBaselineRequests: 10,
-				zScoreThreshold: 1.5,
+				zScoreThreshold: 3,
 				maxEventsPerDetector: 50,
 			},
 		});
@@ -751,8 +1132,10 @@ describe("buildAnomalyInsightsResponse", () => {
 				costUsd: 0.02,
 			}),
 		);
+		const scoringRows = [...loopRows, ...tinyRows];
 		const response = buildAnomalyInsightsResponse({
-			rows: [...loopRows, ...tinyRows],
+			baselineRows: scoringRows,
+			scoringRows,
 			rates,
 			options: {
 				range: "24h",

--- a/packages/http-api/src/services/__tests__/anomaly-insights.test.ts
+++ b/packages/http-api/src/services/__tests__/anomaly-insights.test.ts
@@ -24,16 +24,24 @@ import {
  * Formula recap:
  *   L_i = ln(v_i)
  *   medianLog = median(L_1..L_n)
- *   scaledMad = max(1.4826 * median(|L_i - medianLog|), 1e-9)   // floor avoids div-by-zero
+ *   scaledMad = 1.4826 * median(|L_i - medianLog|)   // NOT floored; can be genuinely 0
  *   modifiedZ(x) = (ln(x) - medianLog) / scaledMad
+ *
+ * scaledMad is returned raw/unfloored by medianAndMad. When it is at or
+ * below MIN_SCALED_MAD (an epsilon, not a floor applied to the value
+ * itself), detectTokenOutliers treats the baseline as zero-variance and
+ * SKIPS scoring that metric entirely (no event emitted) rather than
+ * flagging every future micro-deviation — see the MIN_SCALED_MAD doc
+ * comment in anomaly-insights.ts.
  *
  * A key property exploited throughout: with only two distinct values in a
  * group, the value that holds the majority (>50%) becomes both the median
  * AND makes >50% of the absolute deviations exactly 0, so the MAD collapses
- * to 0 (floored to 1e-9). Fixtures below therefore use THREE distinct
- * values wherever a non-degenerate MAD is required for a flagging
- * assertion, and deliberately use identical/two-value fixtures where the
- * intent IS to exercise the zero/degenerate-MAD path.
+ * to exactly 0 (zero-variance, skipped by detectTokenOutliers). Fixtures
+ * below therefore use THREE distinct values wherever a non-degenerate MAD
+ * is required for a flagging assertion, and deliberately use
+ * identical/two-value fixtures where the intent IS to exercise the
+ * zero-variance skip path.
  */
 
 const OPUS_RATES: ModelRates = {
@@ -252,18 +260,76 @@ describe("computeBaselines", () => {
 		expect(unknown?.approxMedianTotalTokens).toBeCloseTo(330, 6);
 	});
 
-	test("output-tokens metric requires >= minBaselineRequests rows with outputTokens > 0", () => {
+	test("output-tokens metric requires >= minBaselineRequests rows with outputTokens > 0, but does not sink the total-tokens side (issue #410 review fix)", () => {
 		// 10 rows with total tokens = 100 (qualifies the total-tokens gate),
-		// but only 6 of them have outputTokens > 0 (< minBaselineRequests=10),
-		// so the whole baseline entry (both metrics) is omitted — a baseline
-		// is one record per (account, model), and detectTokenOutliers needs
-		// both fields populated meaningfully.
+		// but only 6 of them have outputTokens > 0 (< minBaselineRequests=10).
+		// The two metrics now qualify INDEPENDENTLY: the group still emits a
+		// baseline entry with a valid total-tokens side, while the
+		// output-tokens side is marked invalid (NaN) rather than the whole
+		// entry being dropped.
 		const rows = [
 			...Array.from({ length: 6 }, () =>
 				req({ inputTokens: 80, outputTokens: 20 }),
 			),
 			...Array.from({ length: 4 }, () => req({ inputTokens: 100 })),
 		];
+		const baselines = computeBaselines(rows, 10);
+		expect(baselines).toHaveLength(1);
+		expect(baselines[0].requests).toBe(10);
+		expect(Number.isNaN(baselines[0].medianLogTotalTokens)).toBe(false);
+		expect(Number.isNaN(baselines[0].madTotalTokens)).toBe(false);
+		expect(Number.isNaN(baselines[0].medianLogOutputTokens)).toBe(true);
+		expect(Number.isNaN(baselines[0].madOutputTokens)).toBe(true);
+		expect(Number.isNaN(baselines[0].approxMedianOutputTokens)).toBe(true);
+	});
+
+	test("a group with enough total-tokens rows but too few output-tokens rows still supports total-tokens outlier detection, while output-tokens produces none", () => {
+		// 25 rows qualifying the total-tokens gate (minBaselineRequests=10)
+		// with a 3-value spread (80/100/130-ish, scaled) for a non-degenerate
+		// total-tokens MAD, but only 3 of them have outputTokens > 0 — well
+		// below the minBaselineRequests=10 gate for the output-tokens side.
+		const rows = [
+			...Array.from({ length: 8 }, () => req({ inputTokens: 80 })),
+			...Array.from({ length: 9 }, () => req({ inputTokens: 100 })),
+			...Array.from({ length: 8 }, () =>
+				req({ inputTokens: 130, outputTokens: 0 }),
+			),
+		].map((row, i) => (i < 3 ? { ...row, outputTokens: 5 } : row));
+		const baselines = computeBaselines(rows, 10);
+		expect(baselines).toHaveLength(1);
+		expect(baselines[0].requests).toBe(25);
+		expect(Number.isNaN(baselines[0].madTotalTokens)).toBe(false);
+		expect(Number.isNaN(baselines[0].madOutputTokens)).toBe(true);
+
+		// total_tokens outlier detection still works against this baseline.
+		const spike = [req({ id: "total-spike", inputTokens: 100_000 })];
+		const totalOutliers = detectTokenOutliers(
+			spike,
+			baselines,
+			3.5,
+			"total_tokens",
+		);
+		expect(totalOutliers).toHaveLength(1);
+		expect(totalOutliers[0].requestId).toBe("total-spike");
+
+		// output_tokens detection produces no events for this group — there is
+		// no valid baseline for that metric to compare against.
+		const outputSpike = [
+			req({ id: "output-spike", inputTokens: 100, outputTokens: 100_000 }),
+		];
+		const outputOutliers = detectTokenOutliers(
+			outputSpike,
+			baselines,
+			3.5,
+			"output_tokens",
+		);
+		expect(outputOutliers).toHaveLength(0);
+	});
+
+	test("omits the group entirely only when NEITHER metric has enough qualifying rows", () => {
+		const rows = Array.from({ length: 9 }, () =>
+			req({ inputTokens: 100, outputTokens: 10 }),
+		);
 		expect(computeBaselines(rows, 10)).toHaveLength(0);
 	});
 });
@@ -312,9 +378,9 @@ describe("detectTokenOutliers", () => {
 	});
 
 	test("does not flag a value equal to a constant (zero-variance) baseline", () => {
-		// All-identical baseline: MAD floors to the epsilon guard, so any
-		// EXACT match to the median still yields z = 0 (not flagged), while
-		// the floor prevents Infinity/NaN for any other value.
+		// All-identical baseline: scaledMad is genuinely 0 (no longer floored
+		// by medianAndMad), so an EXACT match to the median is skipped (no
+		// signal to score against either way).
 		const baselineRows = Array.from({ length: 10 }, () =>
 			req({ inputTokens: 100, outputTokens: 10 }),
 		);
@@ -322,6 +388,36 @@ describe("detectTokenOutliers", () => {
 		const scoringRows = [req({ inputTokens: 100 })];
 		expect(
 			detectTokenOutliers(scoringRows, baselines, 3.5, "total_tokens"),
+		).toHaveLength(0);
+	});
+
+	test("zero-variance baseline is SKIPPED, not flagged: neither a tiny nor a huge deviation produces an event (issue #410 review fix)", () => {
+		// Regression: before this fix, a zero-variance baseline's scaledMad
+		// was floored to a tiny epsilon (1e-9), which made ANY differing
+		// value produce a z-score in the millions — always past the default
+		// 3.5 threshold. This mirrors the OLD pre-#410 `if (stdDev <= 0)
+		// continue;` behavior: a genuinely zero-variance baseline carries no
+		// signal, so it must be skipped entirely, not turned into an
+		// alert-storm trigger. All 20 baseline requests use exactly 500
+		// tokens (deterministic traffic, e.g. a fixed-size health check).
+		const baselineRows = Array.from({ length: 20 }, () =>
+			req({ inputTokens: 500 }),
+		);
+		const baselines = computeBaselines(baselineRows, 10);
+		expect(baselines).toHaveLength(1);
+
+		// A slightly different value (501 tokens, ~0.2% deviation).
+		const slightlyDifferent = [req({ id: "slight", inputTokens: 501 })];
+		expect(
+			detectTokenOutliers(slightlyDifferent, baselines, 3.5, "total_tokens"),
+		).toHaveLength(0);
+
+		// A wildly different value (50000 tokens, 100x the baseline) — still
+		// intentionally not flagged, since there is no baseline signal at
+		// all to compare against (conservative, matching pre-#410 behavior).
+		const wildlyDifferent = [req({ id: "wild", inputTokens: 50_000 })];
+		expect(
+			detectTokenOutliers(wildlyDifferent, baselines, 3.5, "total_tokens"),
 		).toHaveLength(0);
 	});
 

--- a/packages/http-api/src/services/__tests__/anomaly-insights.test.ts
+++ b/packages/http-api/src/services/__tests__/anomaly-insights.test.ts
@@ -265,7 +265,7 @@ describe("computeBaselines", () => {
 		// but only 6 of them have outputTokens > 0 (< minBaselineRequests=10).
 		// The two metrics now qualify INDEPENDENTLY: the group still emits a
 		// baseline entry with a valid total-tokens side, while the
-		// output-tokens side is marked invalid (NaN) rather than the whole
+		// output-tokens side is marked invalid (null) rather than the whole
 		// entry being dropped.
 		const rows = [
 			...Array.from({ length: 6 }, () =>
@@ -276,11 +276,40 @@ describe("computeBaselines", () => {
 		const baselines = computeBaselines(rows, 10);
 		expect(baselines).toHaveLength(1);
 		expect(baselines[0].requests).toBe(10);
-		expect(Number.isNaN(baselines[0].medianLogTotalTokens)).toBe(false);
-		expect(Number.isNaN(baselines[0].madTotalTokens)).toBe(false);
-		expect(Number.isNaN(baselines[0].medianLogOutputTokens)).toBe(true);
-		expect(Number.isNaN(baselines[0].madOutputTokens)).toBe(true);
-		expect(Number.isNaN(baselines[0].approxMedianOutputTokens)).toBe(true);
+		expect(baselines[0].medianLogTotalTokens).not.toBeNull();
+		expect(baselines[0].madTotalTokens).not.toBeNull();
+		expect(baselines[0].medianLogOutputTokens).toBeNull();
+		expect(baselines[0].madOutputTokens).toBeNull();
+		expect(baselines[0].approxMedianOutputTokens).toBeNull();
+	});
+
+	test("the 'no baseline for this metric' sentinel is null, not NaN, and survives a JSON round-trip as literal null (issue #410 follow-up)", () => {
+		// Regression: NaN was previously used as the internal "no baseline for
+		// this metric" sentinel, but JSON.stringify(NaN) produces `null` on
+		// the wire while AnomalyBaseline declared these fields as
+		// non-nullable `number` — a type-contract violation. The sentinel is
+		// now an explicit `null`, which both matches the declared
+		// `number | null` type AND round-trips through JSON unchanged.
+		const rows = [
+			...Array.from({ length: 6 }, () =>
+				req({ inputTokens: 80, outputTokens: 20 }),
+			),
+			...Array.from({ length: 4 }, () => req({ inputTokens: 100 })),
+		];
+		const baselines = computeBaselines(rows, 10);
+		const baseline = baselines[0];
+		expect(baseline.medianLogOutputTokens).toBeNull();
+		expect(baseline.madOutputTokens).toBeNull();
+		expect(baseline.approxMedianOutputTokens).toBeNull();
+
+		const roundTripped = JSON.parse(JSON.stringify(baseline));
+		expect(roundTripped.medianLogOutputTokens).toBeNull();
+		expect(roundTripped.madOutputTokens).toBeNull();
+		expect(roundTripped.approxMedianOutputTokens).toBeNull();
+		// The fields must be PRESENT (not omitted) in the serialized JSON.
+		expect(Object.hasOwn(roundTripped, "medianLogOutputTokens")).toBe(true);
+		expect(Object.hasOwn(roundTripped, "madOutputTokens")).toBe(true);
+		expect(Object.hasOwn(roundTripped, "approxMedianOutputTokens")).toBe(true);
 	});
 
 	test("a group with enough total-tokens rows but too few output-tokens rows still supports total-tokens outlier detection, while output-tokens produces none", () => {
@@ -298,8 +327,8 @@ describe("computeBaselines", () => {
 		const baselines = computeBaselines(rows, 10);
 		expect(baselines).toHaveLength(1);
 		expect(baselines[0].requests).toBe(25);
-		expect(Number.isNaN(baselines[0].madTotalTokens)).toBe(false);
-		expect(Number.isNaN(baselines[0].madOutputTokens)).toBe(true);
+		expect(baselines[0].madTotalTokens).not.toBeNull();
+		expect(baselines[0].madOutputTokens).toBeNull();
 
 		// total_tokens outlier detection still works against this baseline.
 		const spike = [req({ id: "total-spike", inputTokens: 100_000 })];

--- a/packages/http-api/src/services/__tests__/auth-failure-alert.test.ts
+++ b/packages/http-api/src/services/__tests__/auth-failure-alert.test.ts
@@ -28,6 +28,7 @@ function makeConfig(
 		getAlertRequestTokens: () => overrides.requestTokens ?? 0,
 		getAlertAnomalyEnabled: () => false,
 		getAlertAnomalyIntervalMinutes: () => 15,
+		getAlertAnomalyBaselineWindowMinutes: () => 1440,
 		getAlertAnomalyLoopMinRequests: () => 25,
 		getAlertCooldownMinutes: () => 60,
 		getAlertWebhookUrl: () =>

--- a/packages/http-api/src/services/alerts.ts
+++ b/packages/http-api/src/services/alerts.ts
@@ -430,12 +430,15 @@ export class AlertService {
 		const intervalMinutes = config.anomalyIntervalMinutes;
 		// Query one wider window spanning both the baseline history and the
 		// scoring interval (baseline is typically the larger of the two), then
-		// partition client-side below. This keeps the DB hit to a single query
-		// instead of two, and guarantees the scoring slice is always a subset
-		// of the fetched rows.
+		// partition client-side below into two GENUINELY DISJOINT sets: rows
+		// strictly before scoringSince feed the baseline, rows at/after
+		// scoringSince are what gets scored. This keeps the DB hit to a single
+		// query instead of two, while still upholding the leave-one-out
+		// contract documented on detectTokenOutliers (issue #410) — a scored
+		// row must never also be a member of its own baseline population.
 		const queryWindowMinutes = Math.max(baselineWindowMinutes, intervalMinutes);
 		const since = Date.now() - queryWindowMinutes * 60 * 1000;
-		const baselineRows = (
+		const allRows = (
 			await this.db.query<AnomalySqlRow>(
 				`
 				SELECT
@@ -458,15 +461,20 @@ export class AlertService {
 				[since],
 			)
 		).map(toAnomalyRow);
-		if (baselineRows.length === 0) return;
+		if (allRows.length === 0) return;
 		const scoringSince = Date.now() - intervalMinutes * 60 * 1000;
-		const scoringRows = baselineRows.filter(
-			(row) => row.timestamp >= scoringSince,
-		);
+		// Partition by timestamp so the two sets never share a row: baseline is
+		// strictly OLDER history, scoring is the recent slice. Note this makes
+		// the baseline population `queryWindowMinutes - intervalMinutes` wide
+		// rather than the full baselineWindowMinutes when baselineWindowMinutes
+		// is only slightly larger than intervalMinutes — a data-availability
+		// consideration (fewer baseline rows in that edge case), not a logic bug.
+		const baselineRows = allRows.filter((row) => row.timestamp < scoringSince);
+		const scoringRows = allRows.filter((row) => row.timestamp >= scoringSince);
 		if (scoringRows.length === 0) return;
 		const modelIds = [
 			...new Set(
-				baselineRows
+				scoringRows
 					.map((row) => row.model)
 					.filter((model): model is string => model != null && model !== ""),
 			),

--- a/packages/http-api/src/services/alerts.ts
+++ b/packages/http-api/src/services/alerts.ts
@@ -429,15 +429,27 @@ export class AlertService {
 		const baselineWindowMinutes = config.anomalyBaselineWindowMinutes;
 		const intervalMinutes = config.anomalyIntervalMinutes;
 		// Query one wider window spanning both the baseline history and the
-		// scoring interval (baseline is typically the larger of the two), then
-		// partition client-side below into two GENUINELY DISJOINT sets: rows
-		// strictly before scoringSince feed the baseline, rows at/after
-		// scoringSince are what gets scored. This keeps the DB hit to a single
-		// query instead of two, while still upholding the leave-one-out
-		// contract documented on detectTokenOutliers (issue #410) — a scored
-		// row must never also be a member of its own baseline population.
-		const queryWindowMinutes = Math.max(baselineWindowMinutes, intervalMinutes);
-		const since = Date.now() - queryWindowMinutes * 60 * 1000;
+		// scoring interval, then partition client-side below into two
+		// GENUINELY DISJOINT sets: rows strictly before scoringSince feed the
+		// baseline, rows at/after scoringSince are what gets scored. This
+		// keeps the DB hit to a single query instead of two, while still
+		// upholding the leave-one-out contract documented on
+		// detectTokenOutliers (issue #410) — a scored row must never also be
+		// a member of its own baseline population.
+		//
+		// The query window must be ADDITIVE (baselineWindowMinutes +
+		// intervalMinutes), not Math.max(...). Math.max collapses to just
+		// intervalMinutes whenever baselineWindowMinutes <= intervalMinutes
+		// (a valid config — nothing prevents anomalyBaselineWindowMinutes
+		// from being set lower than anomalyIntervalMinutes), which would
+		// fetch ONLY the scoring interval's worth of history. Every fetched
+		// row would then have timestamp >= scoringSince, so baselineRows
+		// would come up empty and every anomaly would silently go
+		// undetected. The additive formula guarantees the fetch always
+		// extends a full baselineWindowMinutes further back than
+		// scoringSince, regardless of how intervalMinutes compares to it.
+		const scoringSince = Date.now() - intervalMinutes * 60 * 1000;
+		const baselineSince = scoringSince - baselineWindowMinutes * 60 * 1000;
 		const allRows = (
 			await this.db.query<AnomalySqlRow>(
 				`
@@ -458,17 +470,13 @@ export class AlertService {
 				WHERE r.timestamp >= ?
 				ORDER BY r.timestamp ASC
 			`,
-				[since],
+				[baselineSince],
 			)
 		).map(toAnomalyRow);
 		if (allRows.length === 0) return;
-		const scoringSince = Date.now() - intervalMinutes * 60 * 1000;
 		// Partition by timestamp so the two sets never share a row: baseline is
-		// strictly OLDER history, scoring is the recent slice. Note this makes
-		// the baseline population `queryWindowMinutes - intervalMinutes` wide
-		// rather than the full baselineWindowMinutes when baselineWindowMinutes
-		// is only slightly larger than intervalMinutes — a data-availability
-		// consideration (fewer baseline rows in that edge case), not a logic bug.
+		// strictly OLDER history (up to a full baselineWindowMinutes wide),
+		// scoring is the recent slice.
 		const baselineRows = allRows.filter((row) => row.timestamp < scoringSince);
 		const scoringRows = allRows.filter((row) => row.timestamp >= scoringSince);
 		if (scoringRows.length === 0) return;

--- a/packages/http-api/src/services/alerts.ts
+++ b/packages/http-api/src/services/alerts.ts
@@ -72,6 +72,7 @@ export function getAlertsConfig(config: Config): AlertsConfigPayload {
 		requestTokens: config.getAlertRequestTokens(),
 		anomalyEnabled: config.getAlertAnomalyEnabled(),
 		anomalyIntervalMinutes: config.getAlertAnomalyIntervalMinutes(),
+		anomalyBaselineWindowMinutes: config.getAlertAnomalyBaselineWindowMinutes(),
 		loopMinRequests: config.getAlertAnomalyLoopMinRequests(),
 		cooldownMinutes: config.getAlertCooldownMinutes(),
 		webhookUrl: config.getAlertWebhookUrl(),
@@ -91,6 +92,9 @@ export function setAlertsConfig(
 	config.setAlertRequestTokens(payload.requestTokens);
 	config.setAlertAnomalyEnabled(payload.anomalyEnabled);
 	config.setAlertAnomalyIntervalMinutes(payload.anomalyIntervalMinutes);
+	config.setAlertAnomalyBaselineWindowMinutes(
+		payload.anomalyBaselineWindowMinutes,
+	);
 	config.setAlertAnomalyLoopMinRequests(payload.loopMinRequests);
 	config.setAlertCooldownMinutes(payload.cooldownMinutes);
 }
@@ -422,8 +426,16 @@ export class AlertService {
 	async evaluateAnomalies(): Promise<void> {
 		const config = getAlertsConfig(this.config);
 		if (!config.anomalyEnabled) return;
-		const since = Date.now() - config.anomalyIntervalMinutes * 60 * 1000;
-		const rows = (
+		const baselineWindowMinutes = config.anomalyBaselineWindowMinutes;
+		const intervalMinutes = config.anomalyIntervalMinutes;
+		// Query one wider window spanning both the baseline history and the
+		// scoring interval (baseline is typically the larger of the two), then
+		// partition client-side below. This keeps the DB hit to a single query
+		// instead of two, and guarantees the scoring slice is always a subset
+		// of the fetched rows.
+		const queryWindowMinutes = Math.max(baselineWindowMinutes, intervalMinutes);
+		const since = Date.now() - queryWindowMinutes * 60 * 1000;
+		const baselineRows = (
 			await this.db.query<AnomalySqlRow>(
 				`
 				SELECT
@@ -446,10 +458,15 @@ export class AlertService {
 				[since],
 			)
 		).map(toAnomalyRow);
-		if (rows.length === 0) return;
+		if (baselineRows.length === 0) return;
+		const scoringSince = Date.now() - intervalMinutes * 60 * 1000;
+		const scoringRows = baselineRows.filter(
+			(row) => row.timestamp >= scoringSince,
+		);
+		if (scoringRows.length === 0) return;
 		const modelIds = [
 			...new Set(
-				rows
+				baselineRows
 					.map((row) => row.model)
 					.filter((model): model is string => model != null && model !== ""),
 			),
@@ -461,10 +478,12 @@ export class AlertService {
 			modelIds.map((modelId, index) => [modelId, rateList[index]]),
 		);
 		const response = buildAnomalyInsightsResponse({
-			rows,
+			baselineRows,
+			scoringRows,
 			rates,
 			options: {
-				range: `${config.anomalyIntervalMinutes}m`,
+				range: `${intervalMinutes}m`,
+				baselineWindowMinutes,
 				truncated: false,
 				loopMinRequests: config.loopMinRequests,
 			},
@@ -485,7 +504,7 @@ export class AlertService {
 				type: "anomaly_token_outlier",
 				severity: "warning",
 				title: "Token usage anomaly detected",
-				message: `Request ${event.requestId} used ${event.value.toLocaleString()} tokens (${event.zScore.toFixed(1)}σ above baseline).`,
+				message: `Request ${event.requestId} used ${event.value.toLocaleString()} tokens (${(event.value / event.approxBaselineMedian).toFixed(1)}x the account/model baseline of ~${Math.round(event.approxBaselineMedian).toLocaleString()}; anomaly score ${event.zScore.toFixed(1)}).`,
 				value: event.value,
 				threshold: null,
 				account: event.account,
@@ -510,7 +529,7 @@ export class AlertService {
 				type: "anomaly_output_blowup",
 				severity: "warning",
 				title: "Output token blowup detected",
-				message: `Request ${event.requestId} returned ${event.value.toLocaleString()} output tokens (${event.zScore.toFixed(1)}σ above baseline).`,
+				message: `Request ${event.requestId} returned ${event.value.toLocaleString()} output tokens (${(event.value / event.approxBaselineMedian).toFixed(1)}x the account/model baseline of ~${Math.round(event.approxBaselineMedian).toLocaleString()} output tokens; anomaly score ${event.zScore.toFixed(1)}).`,
 				value: event.value,
 				threshold: null,
 				account: event.account,

--- a/packages/http-api/src/services/anomaly-insights.ts
+++ b/packages/http-api/src/services/anomaly-insights.ts
@@ -279,9 +279,15 @@ function baselineKey(account: string | null, model: string | null): string {
  * group with enough rows overall but fewer than minBaselineRequests rows
  * with outputTokens > 0 still gets a valid total-tokens baseline — only the
  * output-tokens side of that entry is marked invalid (medianLogOutputTokens
- * / madOutputTokens / approxMedianOutputTokens set to NaN), which
+ * / madOutputTokens / approxMedianOutputTokens set to `null`), which
  * detectTokenOutliers treats as "no baseline for this metric" and skips.
  * The group is omitted entirely only when NEITHER metric has enough rows.
+ *
+ * `null` (not `NaN`) is the sentinel for "no baseline for this metric" so
+ * the value survives JSON.stringify/parse as a literal `null` instead of
+ * silently becoming `null` anyway via NaN's non-standard JSON serialization
+ * while the declared AnomalyBaseline type claimed a non-nullable `number`
+ * (issue #410 follow-up).
  *
  * Sorted by requests descending, then account/model ascending.
  */
@@ -317,14 +323,12 @@ export function computeBaselines(
 			account: normalizeKey(group[0].account),
 			model: normalizeKey(group[0].model),
 			requests: group.length,
-			medianLogTotalTokens: total ? total.medianLog : Number.NaN,
-			madTotalTokens: total ? total.scaledMad : Number.NaN,
-			medianLogOutputTokens: output ? output.medianLog : Number.NaN,
-			madOutputTokens: output ? output.scaledMad : Number.NaN,
-			approxMedianTotalTokens: total ? Math.exp(total.medianLog) : Number.NaN,
-			approxMedianOutputTokens: output
-				? Math.exp(output.medianLog)
-				: Number.NaN,
+			medianLogTotalTokens: total ? total.medianLog : null,
+			madTotalTokens: total ? total.scaledMad : null,
+			medianLogOutputTokens: output ? output.medianLog : null,
+			madOutputTokens: output ? output.scaledMad : null,
+			approxMedianTotalTokens: total ? Math.exp(total.medianLog) : null,
+			approxMedianOutputTokens: output ? Math.exp(output.medianLog) : null,
 		});
 	}
 	return baselines.sort(
@@ -393,13 +397,14 @@ export function detectTokenOutliers(
 				: baseline.madOutputTokens;
 		// Two independent "no signal" cases, both skipped without emitting an
 		// event (never flagged):
-		//  - NaN: this metric's side of the baseline didn't qualify at all
+		//  - null: this metric's side of the baseline didn't qualify at all
 		//    (computeBaselines saw < minBaselineRequests rows for it).
 		//  - <= MIN_SCALED_MAD: the baseline is genuinely zero-variance (every
 		//    value identical). Mirrors the pre-#410 `if (stdDev <= 0) continue;`
 		//    guard — see MIN_SCALED_MAD doc comment for why this must skip
 		//    rather than floor-and-flag.
-		if (Number.isNaN(scaledMad) || scaledMad <= MIN_SCALED_MAD) continue;
+		if (medianLog === null || scaledMad === null || scaledMad <= MIN_SCALED_MAD)
+			continue;
 		const value =
 			metric === "total_tokens" ? totalTokens(row) : row.outputTokens;
 		const modifiedZ = (Math.log(value) - medianLog) / scaledMad;

--- a/packages/http-api/src/services/anomaly-insights.ts
+++ b/packages/http-api/src/services/anomaly-insights.ts
@@ -16,9 +16,11 @@ import type {
  * live in @better-ccflare/types and are re-exported here for convenience.
  *
  * Detectors (all batch, computed over the requested window):
- * - baselines: mean/stddev of tokens per request per (account, model)
- * - tokenOutliers / outputBlowups: requests >= zScoreThreshold stddevs
- *   above their baseline mean (total tokens / output tokens respectively)
+ * - baselines: log-space median/MAD of tokens per request per (account, model)
+ * - tokenOutliers / outputBlowups: requests >= zScoreThreshold modified
+ *   z-scores above their baseline median (total tokens / output tokens
+ *   respectively), scored in log space (see detectTokenOutliers doc comment
+ *   for why this eliminates the old sqrt(n-1) ceiling — issue #410)
  * - runawayLoops: dense bursts of near-identical requests per
  *   (account, model, project, agent) — keyed by per-agent identity so
  *   many workers sharing one account+model+project (each on its own
@@ -62,10 +64,20 @@ export interface AnomalyRequestRow {
 
 export interface AnomalyInsightsOptions {
 	range: string;
-	/** Flag requests >= this many stddevs above the baseline mean. Default 3. */
+	/**
+	 * Flag requests >= this many modified z-score units (log-space
+	 * median/MAD) above the baseline median. Default 3.5.
+	 */
 	zScoreThreshold?: number;
 	/** Minimum token-bearing requests per (account, model) to form a baseline. Default 20. */
 	minBaselineRequests?: number;
+	/**
+	 * Minutes of trailing history the baseline is built from, decoupled from
+	 * the scoring window. Echoed back verbatim in meta.baselineWindowMinutes;
+	 * purely informational at this layer — the caller is responsible for
+	 * actually fetching baselineRows over this window. Default 1440 (24h).
+	 */
+	baselineWindowMinutes?: number;
 	/** Sliding window length for runaway-loop detection. Default 5. */
 	loopWindowMinutes?: number;
 	/** Minimum requests inside one window to qualify as a loop. Default 10. */
@@ -85,14 +97,33 @@ export interface AnomalyInsightsOptions {
 }
 
 export interface BuildAnomalyInsightsInput {
-	rows: AnomalyRequestRow[];
+	/**
+	 * Rows the baselines (median/MAD per account+model) are computed from.
+	 * Should span the trailing baselineWindowMinutes, decoupled from
+	 * scoringRows so a scored row is never a member of its own baseline
+	 * population (issue #410 — see detectTokenOutliers doc comment).
+	 */
+	baselineRows: AnomalyRequestRow[];
+	/**
+	 * Rows actually scored/scanned by every detector (token outliers,
+	 * output blowups, runaway loops, model misrouting). Typically the
+	 * newly-arrived slice since the last alert sweep.
+	 */
+	scoringRows: AnomalyRequestRow[];
 	/** Rates per model id ($ per 1M tokens); null for unknown models. */
 	rates: Map<string, ModelRates | null>;
 	options: AnomalyInsightsOptions;
 }
 
-export const DEFAULT_Z_SCORE_THRESHOLD = 3;
+/**
+ * Iglewicz & Hoaglin (1993) standard cutoff for the modified z-score
+ * (median/MAD based), applied here in log space. This is NOT a raw
+ * standard-deviation count — see detectTokenOutliers for the full
+ * modified-z-score contract.
+ */
+export const DEFAULT_Z_SCORE_THRESHOLD = 3.5;
 export const DEFAULT_MIN_BASELINE_REQUESTS = 20;
+export const DEFAULT_BASELINE_WINDOW_MINUTES = 24 * 60;
 export const DEFAULT_LOOP_WINDOW_MINUTES = 5;
 export const DEFAULT_LOOP_MIN_REQUESTS = 10;
 export const DEFAULT_LOOP_SIMILARITY_TOLERANCE = 0.25;
@@ -173,18 +204,50 @@ function requestSideTokens(row: AnomalyRequestRow): number {
 	);
 }
 
-function meanAndStdDev(values: number[]): { mean: number; stdDev: number } {
-	if (values.length === 0) return { mean: 0, stdDev: 0 };
-	let sum = 0;
-	for (const value of values) sum += value;
-	const mean = sum / values.length;
-	let sumSquares = 0;
-	for (const value of values) {
-		const deviation = value - mean;
-		sumSquares += deviation * deviation;
+/**
+ * Minimum floor for scaledMad so a degenerate baseline (all values
+ * identical, or a single-element group) can never divide a downstream
+ * z-score by zero. A real MAD this small is indistinguishable from zero
+ * in double precision anyway, so flooring here is lossless for any
+ * baseline that isn't perfectly constant.
+ */
+const MIN_SCALED_MAD = 1e-9;
+
+/** Standard median: sorts a copy, averages the two middle values if even length. */
+function median(values: number[]): number {
+	if (values.length === 0) {
+		throw new Error("median() requires at least one value");
 	}
-	// Population stddev: the window is the whole population we report on.
-	return { mean, stdDev: Math.sqrt(sumSquares / values.length) };
+	const sorted = [...values].sort((a, b) => a - b);
+	const mid = Math.floor(sorted.length / 2);
+	return sorted.length % 2 === 0
+		? (sorted[mid - 1] + sorted[mid]) / 2
+		: sorted[mid];
+}
+
+/**
+ * Median + scaled median-absolute-deviation of ln(values), the log-space
+ * statistic the modified z-score is built from (issue #410).
+ *
+ * `values` are RAW (non-log, must be > 0); this function takes the log
+ * internally. `scaledMad` is floored at MIN_SCALED_MAD so a baseline whose
+ * values are all identical (MAD = 0) can never produce an Infinity/NaN
+ * z-score downstream — see detectTokenOutliers.
+ */
+function medianAndMad(values: number[]): {
+	medianLog: number;
+	scaledMad: number;
+} {
+	if (values.length === 0) {
+		throw new Error("medianAndMad() requires at least one value");
+	}
+	const logs = values.map((v) => Math.log(v));
+	const medianLog = median(logs);
+	const mad = median(logs.map((l) => Math.abs(l - medianLog)));
+	// 1.4826: consistency constant that makes scaledMad a consistent
+	// estimator of the standard deviation for normally-distributed data.
+	const scaledMad = Math.max(1.4826 * mad, MIN_SCALED_MAD);
+	return { medianLog, scaledMad };
 }
 
 function baselineKey(account: string | null, model: string | null): string {
@@ -192,20 +255,28 @@ function baselineKey(account: string | null, model: string | null): string {
 }
 
 /**
- * Compute per-(account, model) token baselines over the window.
+ * Compute per-(account, model) token baselines from `baselineRows`.
+ *
+ * `baselineRows` is a DIFFERENT row set than whatever is later scored
+ * against these baselines (see detectTokenOutliers) — this function has
+ * no knowledge of, and does not need, the scoring rows.
  *
  * Rows with zero total tokens (failed or empty requests) carry no token
- * signal and are excluded so they don't drag means down. Groups with fewer
- * than minBaselineRequests qualifying rows produce no baseline.
+ * signal and are excluded so they don't distort the log-space statistics
+ * (ln(0) is undefined). The output-tokens metric additionally filters to
+ * outputTokens > 0 for the same reason (a request with zero output tokens,
+ * e.g. an input-only call, has no signal for the output-blowup detector).
+ * Groups with fewer than minBaselineRequests qualifying rows produce no
+ * baseline for that metric's group.
  *
  * Sorted by requests descending, then account/model ascending.
  */
 export function computeBaselines(
-	rows: AnomalyRequestRow[],
+	baselineRows: AnomalyRequestRow[],
 	minBaselineRequests: number,
 ): AnomalyBaseline[] {
 	const groups = new Map<string, AnomalyRequestRow[]>();
-	for (const row of rows) {
+	for (const row of baselineRows) {
 		if (totalTokens(row) === 0) continue;
 		const key = baselineKey(row.account, row.model);
 		const group = groups.get(key);
@@ -219,16 +290,20 @@ export function computeBaselines(
 	const baselines: AnomalyBaseline[] = [];
 	for (const group of groups.values()) {
 		if (group.length < minBaselineRequests) continue;
-		const total = meanAndStdDev(group.map(totalTokens));
-		const output = meanAndStdDev(group.map((row) => row.outputTokens));
+		const outputRows = group.filter((row) => row.outputTokens > 0);
+		if (outputRows.length < minBaselineRequests) continue;
+		const total = medianAndMad(group.map(totalTokens));
+		const output = medianAndMad(outputRows.map((row) => row.outputTokens));
 		baselines.push({
 			account: normalizeKey(group[0].account),
 			model: normalizeKey(group[0].model),
 			requests: group.length,
-			meanTotalTokens: total.mean,
-			stdDevTotalTokens: total.stdDev,
-			meanOutputTokens: output.mean,
-			stdDevOutputTokens: output.stdDev,
+			medianLogTotalTokens: total.medianLog,
+			madTotalTokens: total.scaledMad,
+			medianLogOutputTokens: output.medianLog,
+			madOutputTokens: output.scaledMad,
+			approxMedianTotalTokens: Math.exp(total.medianLog),
+			approxMedianOutputTokens: Math.exp(output.medianLog),
 		});
 	}
 	return baselines.sort(
@@ -240,15 +315,36 @@ export function computeBaselines(
 }
 
 /**
- * Flag requests whose token usage sits >= zScoreThreshold stddevs ABOVE
- * their (account, model) baseline mean. Low-side deviations are not
- * anomalies for cost purposes and are never reported. Groups without a
- * baseline, or with zero variance, produce no outliers.
+ * Flag requests whose token usage sits >= zScoreThreshold modified z-score
+ * units ABOVE their (account, model) baseline median, in log space. Low-side
+ * deviations are not anomalies for cost purposes and are never reported.
+ * Groups without a baseline produce no outliers.
+ *
+ * LEAVE-ONE-OUT CONTRACT (issue #410): `scoringRows` and the rows that fed
+ * `baselines` (via computeBaselines' `baselineRows`) are two independent
+ * row sets. A row being scored here is not assumed to be a member of the
+ * population its baseline was built from. This matters even when the
+ * caller happens to pass the same underlying data for both — the periodic
+ * alert sweep always uses genuinely disjoint sets (new rows scored against
+ * a trailing history window).
+ *
+ * There is deliberately no `sqrt(n-1)`-style ceiling on the resulting
+ * z-score, for two independent reasons:
+ *   1. Structural — because scoringRows and baselineRows are decoupled, a
+ *      scored value is not necessarily part of the population it's
+ *      compared against, so there is no algebraic identity binding the
+ *      z-score to the baseline's sample size.
+ *   2. Statistical — median/MAD (unlike mean/stddev) has a 50% breakdown
+ *      point: even in the on-demand case where scoringRows and
+ *      baselineRows happen to be the same set, one extreme point out of
+ *      minBaselineRequests (default 20) cannot materially shift the
+ *      median or MAD, so it cannot cap its own z-score the way one point
+ *      out of n could cap a population-stddev z-score at sqrt(n-1).
  *
  * Sorted by z-score descending.
  */
 export function detectTokenOutliers(
-	rows: AnomalyRequestRow[],
+	scoringRows: AnomalyRequestRow[],
 	baselines: AnomalyBaseline[],
 	zScoreThreshold: number,
 	metric: TokenOutlierMetric,
@@ -261,23 +357,26 @@ export function detectTokenOutliers(
 	);
 
 	const outliers: TokenOutlierEvent[] = [];
-	for (const row of rows) {
+	for (const row of scoringRows) {
 		if (totalTokens(row) === 0) continue;
+		if (metric === "output_tokens" && row.outputTokens <= 0) continue;
 		const baseline = baselineByKey.get(baselineKey(row.account, row.model));
 		if (!baseline) continue;
-		const mean =
+		const medianLog =
 			metric === "total_tokens"
-				? baseline.meanTotalTokens
-				: baseline.meanOutputTokens;
-		const stdDev =
+				? baseline.medianLogTotalTokens
+				: baseline.medianLogOutputTokens;
+		const scaledMad =
 			metric === "total_tokens"
-				? baseline.stdDevTotalTokens
-				: baseline.stdDevOutputTokens;
-		if (stdDev <= 0) continue;
+				? baseline.madTotalTokens
+				: baseline.madOutputTokens;
+		// scaledMad is already floored to MIN_SCALED_MAD by medianAndMad, but
+		// guard again defensively so a zero here can never reach Infinity/NaN.
+		if (scaledMad <= 0) continue;
 		const value =
 			metric === "total_tokens" ? totalTokens(row) : row.outputTokens;
-		const zScore = (value - mean) / stdDev;
-		if (zScore < zScoreThreshold) continue;
+		const modifiedZ = (Math.log(value) - medianLog) / scaledMad;
+		if (modifiedZ < zScoreThreshold) continue;
 		outliers.push({
 			requestId: row.id,
 			timestamp: row.timestamp,
@@ -286,9 +385,10 @@ export function detectTokenOutliers(
 			project: row.project,
 			metric,
 			value,
-			baselineMean: mean,
-			baselineStdDev: stdDev,
-			zScore,
+			baselineMedianLog: medianLog,
+			baselineMad: scaledMad,
+			approxBaselineMedian: Math.exp(medianLog),
+			zScore: modifiedZ,
 		});
 	}
 	return outliers.sort(
@@ -547,26 +647,28 @@ export function buildAnomalyInsightsResponse(
 		options.misroutingMinRequests ?? DEFAULT_MISROUTING_MIN_REQUESTS;
 	const maxEventsPerDetector =
 		options.maxEventsPerDetector ?? DEFAULT_MAX_EVENTS_PER_DETECTOR;
+	const baselineWindowMinutes =
+		options.baselineWindowMinutes ?? DEFAULT_BASELINE_WINDOW_MINUTES;
 
-	const baselines = computeBaselines(input.rows, minBaselineRequests);
+	const baselines = computeBaselines(input.baselineRows, minBaselineRequests);
 	const tokenOutliers = detectTokenOutliers(
-		input.rows,
+		input.scoringRows,
 		baselines,
 		zScoreThreshold,
 		"total_tokens",
 	);
 	const outputBlowups = detectTokenOutliers(
-		input.rows,
+		input.scoringRows,
 		baselines,
 		zScoreThreshold,
 		"output_tokens",
 	);
-	const runawayLoops = detectRunawayLoops(input.rows, {
+	const runawayLoops = detectRunawayLoops(input.scoringRows, {
 		windowMs: loopWindowMinutes * 60_000,
 		minRequests: loopMinRequests,
 		similarityTolerance: loopSimilarityTolerance,
 	});
-	const misrouting = detectModelMisrouting(input.rows, input.rates, {
+	const misrouting = detectModelMisrouting(input.scoringRows, input.rates, {
 		maxTotalTokens: misroutingMaxTotalTokens,
 		minOutputRateUsd: misroutingMinOutputRateUsd,
 		minRequests: misroutingMinRequests,
@@ -583,6 +685,8 @@ export function buildAnomalyInsightsResponse(
 			range: options.range,
 			zScoreThreshold,
 			minBaselineRequests,
+			baselineWindowMinutes,
+			baselineWindowRequests: input.baselineRows.length,
 			loopWindowMinutes,
 			loopMinRequests,
 			loopSimilarityTolerance,
@@ -590,7 +694,7 @@ export function buildAnomalyInsightsResponse(
 			misroutingMinOutputRateUsd,
 			misroutingMinRequests,
 			maxEventsPerDetector,
-			scannedRequests: input.rows.length,
+			scannedRequests: input.scoringRows.length,
 			truncated: options.truncated ?? false,
 		},
 		baselines: baselinesTop,

--- a/packages/http-api/src/services/anomaly-insights.ts
+++ b/packages/http-api/src/services/anomaly-insights.ts
@@ -205,13 +205,20 @@ function requestSideTokens(row: AnomalyRequestRow): number {
 }
 
 /**
- * Minimum floor for scaledMad so a degenerate baseline (all values
- * identical, or a single-element group) can never divide a downstream
- * z-score by zero. A real MAD this small is indistinguishable from zero
- * in double precision anyway, so flooring here is lossless for any
- * baseline that isn't perfectly constant.
+ * Epsilon below which a baseline's scaledMad is treated as genuinely zero
+ * variance (all baseline values identical — plausible for deterministic
+ * health-check calls, fixed-size embedding requests, templated system
+ * prompts). There is deliberately NO flooring of scaledMad in medianAndMad
+ * anymore: a zero-variance baseline carries no signal to score against, so
+ * detectTokenOutliers SKIPS scoring that metric for that baseline entirely
+ * (mirroring the pre-#410 `if (stdDev <= 0) continue;` guard) rather than
+ * flagging every non-identical future value as an extreme anomaly. Flooring
+ * scaledMad to a tiny positive number would make even a 1-token deviation
+ * produce a z-score in the millions (ln(101/100) / 1e-9 ≈ 9.95e6), which
+ * would always exceed the default 3.5 threshold and cause alert storms for
+ * deterministic traffic.
  */
-const MIN_SCALED_MAD = 1e-9;
+const MIN_SCALED_MAD = 1e-6;
 
 /** Standard median: sorts a copy, averages the two middle values if even length. */
 function median(values: number[]): number {
@@ -230,9 +237,10 @@ function median(values: number[]): number {
  * statistic the modified z-score is built from (issue #410).
  *
  * `values` are RAW (non-log, must be > 0); this function takes the log
- * internally. `scaledMad` is floored at MIN_SCALED_MAD so a baseline whose
- * values are all identical (MAD = 0) can never produce an Infinity/NaN
- * z-score downstream — see detectTokenOutliers.
+ * internally. `scaledMad` is returned RAW/unfloored — it can genuinely be
+ * 0 when every value in the group is identical. The "no signal, skip
+ * scoring" decision for a zero-variance baseline belongs to the caller
+ * (detectTokenOutliers), not here — see MIN_SCALED_MAD.
  */
 function medianAndMad(values: number[]): {
 	medianLog: number;
@@ -246,7 +254,7 @@ function medianAndMad(values: number[]): {
 	const mad = median(logs.map((l) => Math.abs(l - medianLog)));
 	// 1.4826: consistency constant that makes scaledMad a consistent
 	// estimator of the standard deviation for normally-distributed data.
-	const scaledMad = Math.max(1.4826 * mad, MIN_SCALED_MAD);
+	const scaledMad = 1.4826 * mad;
 	return { medianLog, scaledMad };
 }
 
@@ -266,8 +274,14 @@ function baselineKey(account: string | null, model: string | null): string {
  * (ln(0) is undefined). The output-tokens metric additionally filters to
  * outputTokens > 0 for the same reason (a request with zero output tokens,
  * e.g. an input-only call, has no signal for the output-blowup detector).
- * Groups with fewer than minBaselineRequests qualifying rows produce no
- * baseline for that metric's group.
+ *
+ * The two metrics (total tokens, output tokens) qualify INDEPENDENTLY: a
+ * group with enough rows overall but fewer than minBaselineRequests rows
+ * with outputTokens > 0 still gets a valid total-tokens baseline — only the
+ * output-tokens side of that entry is marked invalid (medianLogOutputTokens
+ * / madOutputTokens / approxMedianOutputTokens set to NaN), which
+ * detectTokenOutliers treats as "no baseline for this metric" and skips.
+ * The group is omitted entirely only when NEITHER metric has enough rows.
  *
  * Sorted by requests descending, then account/model ascending.
  */
@@ -289,21 +303,28 @@ export function computeBaselines(
 
 	const baselines: AnomalyBaseline[] = [];
 	for (const group of groups.values()) {
-		if (group.length < minBaselineRequests) continue;
 		const outputRows = group.filter((row) => row.outputTokens > 0);
-		if (outputRows.length < minBaselineRequests) continue;
-		const total = medianAndMad(group.map(totalTokens));
-		const output = medianAndMad(outputRows.map((row) => row.outputTokens));
+		const hasTotal = group.length >= minBaselineRequests;
+		const hasOutput = outputRows.length >= minBaselineRequests;
+		// Neither metric has enough data: no baseline entry at all for this
+		// group (nothing downstream could use it).
+		if (!hasTotal && !hasOutput) continue;
+		const total = hasTotal ? medianAndMad(group.map(totalTokens)) : null;
+		const output = hasOutput
+			? medianAndMad(outputRows.map((row) => row.outputTokens))
+			: null;
 		baselines.push({
 			account: normalizeKey(group[0].account),
 			model: normalizeKey(group[0].model),
 			requests: group.length,
-			medianLogTotalTokens: total.medianLog,
-			madTotalTokens: total.scaledMad,
-			medianLogOutputTokens: output.medianLog,
-			madOutputTokens: output.scaledMad,
-			approxMedianTotalTokens: Math.exp(total.medianLog),
-			approxMedianOutputTokens: Math.exp(output.medianLog),
+			medianLogTotalTokens: total ? total.medianLog : Number.NaN,
+			madTotalTokens: total ? total.scaledMad : Number.NaN,
+			medianLogOutputTokens: output ? output.medianLog : Number.NaN,
+			madOutputTokens: output ? output.scaledMad : Number.NaN,
+			approxMedianTotalTokens: total ? Math.exp(total.medianLog) : Number.NaN,
+			approxMedianOutputTokens: output
+				? Math.exp(output.medianLog)
+				: Number.NaN,
 		});
 	}
 	return baselines.sort(
@@ -370,9 +391,15 @@ export function detectTokenOutliers(
 			metric === "total_tokens"
 				? baseline.madTotalTokens
 				: baseline.madOutputTokens;
-		// scaledMad is already floored to MIN_SCALED_MAD by medianAndMad, but
-		// guard again defensively so a zero here can never reach Infinity/NaN.
-		if (scaledMad <= 0) continue;
+		// Two independent "no signal" cases, both skipped without emitting an
+		// event (never flagged):
+		//  - NaN: this metric's side of the baseline didn't qualify at all
+		//    (computeBaselines saw < minBaselineRequests rows for it).
+		//  - <= MIN_SCALED_MAD: the baseline is genuinely zero-variance (every
+		//    value identical). Mirrors the pre-#410 `if (stdDev <= 0) continue;`
+		//    guard — see MIN_SCALED_MAD doc comment for why this must skip
+		//    rather than floor-and-flag.
+		if (Number.isNaN(scaledMad) || scaledMad <= MIN_SCALED_MAD) continue;
 		const value =
 			metric === "total_tokens" ? totalTokens(row) : row.outputTokens;
 		const modifiedZ = (Math.log(value) - medianLog) / scaledMad;

--- a/packages/types/src/alerts.ts
+++ b/packages/types/src/alerts.ts
@@ -57,6 +57,13 @@ export interface AlertsConfigPayload {
 	anomalyEnabled: boolean;
 	anomalyIntervalMinutes: number;
 	/**
+	 * Minutes of trailing history used to build token baselines (median/MAD),
+	 * decoupled from anomalyIntervalMinutes (which only controls how often new
+	 * rows are scored). Must be a stable window distinct from the rows being
+	 * scored so a request is never scored against a baseline it is a member of.
+	 */
+	anomalyBaselineWindowMinutes: number;
+	/**
 	 * Minimum requests inside one (account, model, agent) window to qualify
 	 * as a runaway loop. Default 25 — well above one agent's normal
 	 * per-window traffic but still catches true repeated-request loops.

--- a/packages/types/src/insights.ts
+++ b/packages/types/src/insights.ts
@@ -104,22 +104,38 @@ export interface AnomalyBaseline {
 	account: string;
 	model: string;
 	requests: number;
-	/** Median of ln(total tokens) across the baseline population. */
-	medianLogTotalTokens: number;
-	/** Scaled (x1.4826) median absolute deviation of ln(total tokens). */
-	madTotalTokens: number;
-	/** Median of ln(output tokens) across the baseline population (rows with output_tokens > 0 only). */
-	medianLogOutputTokens: number;
-	/** Scaled (x1.4826) median absolute deviation of ln(output tokens). */
-	madOutputTokens: number;
+	/**
+	 * Median of ln(total tokens) across the baseline population. `null` when
+	 * the group has too few token-bearing rows to qualify for
+	 * minBaselineRequests on the total-tokens side (independent metric
+	 * qualification — see issue #410 follow-up). In practice this metric is
+	 * very unlikely to be the one that's unavailable (computeBaselines only
+	 * emits a baseline entry at all when at least one of the two metrics
+	 * qualifies), but the field is nullable for symmetry with the
+	 * output-tokens side, since the implementation treats both directions
+	 * the same way.
+	 */
+	medianLogTotalTokens: number | null;
+	/** Scaled (x1.4826) median absolute deviation of ln(total tokens). `null` under the same condition as medianLogTotalTokens. */
+	madTotalTokens: number | null;
+	/**
+	 * Median of ln(output tokens) across the baseline population (rows with
+	 * output_tokens > 0 only). `null` when the group has too few
+	 * output-token-bearing rows to qualify for minBaselineRequests
+	 * (independent metric qualification — see issue #410 follow-up).
+	 */
+	medianLogOutputTokens: number | null;
+	/** Scaled (x1.4826) median absolute deviation of ln(output tokens). `null` under the same condition as medianLogOutputTokens. */
+	madOutputTokens: number | null;
 	/**
 	 * Human-readable raw-scale approximation of central tendency, for display
 	 * only: exp(medianLogTotalTokens). NOT used in any zScore computation —
-	 * geometric mean of the baseline population's total tokens.
+	 * geometric mean of the baseline population's total tokens. `null` under
+	 * the same condition as medianLogTotalTokens.
 	 */
-	approxMedianTotalTokens: number;
-	/** exp(medianLogOutputTokens); display-only, see approxMedianTotalTokens. */
-	approxMedianOutputTokens: number;
+	approxMedianTotalTokens: number | null;
+	/** exp(medianLogOutputTokens); display-only, see approxMedianTotalTokens. `null` under the same condition as medianLogOutputTokens. */
+	approxMedianOutputTokens: number | null;
 }
 
 /**

--- a/packages/types/src/insights.ts
+++ b/packages/types/src/insights.ts
@@ -71,8 +71,16 @@ export type TokenOutlierMetric = "total_tokens" | "output_tokens";
 /** Effective detector thresholds echoed back with an anomalies response. */
 export interface AnomalyInsightsMeta {
 	range: string;
+	/**
+	 * Modified z-score threshold in log-space (median/MAD based), NOT a
+	 * literal standard-deviation count.
+	 */
 	zScoreThreshold: number;
 	minBaselineRequests: number;
+	/** Minutes of trailing history the baseline was built from (decoupled from the scoring window). */
+	baselineWindowMinutes: number;
+	/** Row count the baseline statistics were computed over (>= scannedRequests when the baseline window exceeds the scoring window). */
+	baselineWindowRequests: number;
 	loopWindowMinutes: number;
 	loopMinRequests: number;
 	/** Max coefficient of variation of request-side tokens for a burst to count as a loop. */
@@ -96,10 +104,22 @@ export interface AnomalyBaseline {
 	account: string;
 	model: string;
 	requests: number;
-	meanTotalTokens: number;
-	stdDevTotalTokens: number;
-	meanOutputTokens: number;
-	stdDevOutputTokens: number;
+	/** Median of ln(total tokens) across the baseline population. */
+	medianLogTotalTokens: number;
+	/** Scaled (x1.4826) median absolute deviation of ln(total tokens). */
+	madTotalTokens: number;
+	/** Median of ln(output tokens) across the baseline population (rows with output_tokens > 0 only). */
+	medianLogOutputTokens: number;
+	/** Scaled (x1.4826) median absolute deviation of ln(output tokens). */
+	madOutputTokens: number;
+	/**
+	 * Human-readable raw-scale approximation of central tendency, for display
+	 * only: exp(medianLogTotalTokens). NOT used in any zScore computation —
+	 * geometric mean of the baseline population's total tokens.
+	 */
+	approxMedianTotalTokens: number;
+	/** exp(medianLogOutputTokens); display-only, see approxMedianTotalTokens. */
+	approxMedianOutputTokens: number;
 }
 
 /**
@@ -115,8 +135,13 @@ export interface TokenOutlierEvent {
 	project: string | null;
 	metric: TokenOutlierMetric;
 	value: number;
-	baselineMean: number;
-	baselineStdDev: number;
+	/** Log-space median of the baseline population (ln of tokens). */
+	baselineMedianLog: number;
+	/** Scaled (x1.4826) median absolute deviation of the baseline population, log-space. */
+	baselineMad: number;
+	/** Human-readable raw-scale approximation: exp(baselineMedianLog). Display only. */
+	approxBaselineMedian: number;
+	/** Modified z-score: (ln(value) - baselineMedianLog) / baselineMad. */
 	zScore: number;
 }
 


### PR DESCRIPTION
## Summary
- Fixes #410 — the anomaly detector (`anomaly_token_outlier` / `anomaly_output_blowup`) computed population mean/stddev over the same rows being scored, including the tested row itself. For a population of `n` values the maximum attainable z-score is mathematically `sqrt(n-1)` — at the default 15-minute alert window (~24 rows/bucket) that ceiling is `sqrt(23) ≈ 4.7959`, exactly the number every alert reported regardless of whether the flagged request was actually anomalous.
- Fixes this two independent ways:
  - **Structural**: baselines are now built from a decoupled, wider baseline window (new `anomalyBaselineWindowMinutes` config knob, default 24h) separate from the short scoring window, so a scored row is never a member of its own baseline population during the periodic alert sweep.
  - **Statistical**: switches from population mean/stddev to log-space median + MAD (median absolute deviation), which has a 50% breakdown point — a single point cannot materially move the baseline, unlike stddev. This also keeps the on-demand dashboard endpoint (`/api/insights/anomalies`) safe even though it necessarily reuses one row set for both baseline and scoring.
  - Token usage is lognormal (right-skewed), so log-transforming before taking median/MAD is a better statistical fit than raw mean/stddev regardless of the self-inclusion bug.
- Default `zScoreThreshold` bumped `3` → `3.5` (Iglewicz & Hoaglin 1993 standard modified-z cutoff) since the units changed from raw stddev to log-space scaled-MAD.
- Alert message wording and the dashboard `AnomaliesView` UI updated to drop "σ"/"sigma" framing (no longer a literal standard-deviation count) in favor of neutral "anomaly score" language, and to show `approxBaselineMedian` (a real token-count number) instead of a mean±stddev band.

## Test plan
- [x] `bun run typecheck` — clean, zero errors
- [x] `bun run lint` — clean (only pre-existing unrelated warnings in `packages/providers/src/__tests__/*`)
- [x] `bun test packages/http-api/src/services/__tests__/anomaly-insights.test.ts` — 50 pass, 0 fail, including regression tests proving the `sqrt(n-1)` ceiling is gone (large-baseline non-flag, genuine 100x outlier, exact reproduction of the reported n≈24 bug shape, and a determinism test)
- [x] `bun test packages/http-api` (full package) — 531 pass, 51 skip, 0 fail
- [x] `bun test packages/config` — 57 pass, 0 fail
- [x] GitNexus `detect_changes` — confirms blast radius confined to the anomaly/alerting/insights-handler domain, no unexpected affected symbols