### PR TITLE
fix: make PG retention cleanup timeout and batch size configurable (#412)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -222,7 +222,9 @@ The schema and any missing columns are created automatically on startup. No manu
 |----------|---------|-------------|
 | `BETTER_CCFLARE_DB_POOL_MAX` | `10` | Maximum pooled connections |
 | `BETTER_CCFLARE_DB_IDLE_TIMEOUT` | `0` (disabled) | Seconds before an idle pooled connection is closed |
-| `BETTER_CCFLARE_DB_STATEMENT_TIMEOUT` | `7000` | Server-side statement timeout in milliseconds (clamped below the 8000ms client-side timeout) |
+| `BETTER_CCFLARE_DB_STATEMENT_TIMEOUT` | `7000` | Server-side statement timeout in milliseconds (clamped below the client-side timeout — see `BETTER_CCFLARE_DB_CLIENT_TIMEOUT`) |
+| `BETTER_CCFLARE_DB_CLIENT_TIMEOUT` | `8000` | Client-side query timeout in milliseconds for PostgreSQL — the `statement_timeout` ceiling is derived from this value minus 1000ms |
+| `BETTER_CCFLARE_DB_CLEANUP_BATCH_SIZE` | `200` | Row batch size per DELETE statement during retention cleanup — lower this if rows are large (e.g. big JSON payloads) and cleanup batches are timing out |
 | `BETTER_CCFLARE_DB_PG_PREPARE` | `false` | Set to `true` to re-enable named prepared statement caching |
 
 ```yaml

--- a/docs/database.md
+++ b/docs/database.md
@@ -369,13 +369,17 @@ These environment variables only apply when `DATABASE_URL` points to PostgreSQL:
 |----------|---------|--------------|
 | `BETTER_CCFLARE_DB_POOL_MAX` | `10` | Maximum number of pooled connections |
 | `BETTER_CCFLARE_DB_IDLE_TIMEOUT` | `0` (disabled) | Seconds before an idle pooled connection is closed |
-| `BETTER_CCFLARE_DB_STATEMENT_TIMEOUT` | `7000` | Server-side `statement_timeout` in milliseconds. Clamped to stay below the client-side query timeout (8000ms) so PostgreSQL cancels and frees the connection before the client gives up; invalid or out-of-range values fall back to the default |
+| `BETTER_CCFLARE_DB_STATEMENT_TIMEOUT` | `7000` | Server-side `statement_timeout` in milliseconds. Clamped to stay below the client-side query timeout (see `BETTER_CCFLARE_DB_CLIENT_TIMEOUT`, default 8000ms) so PostgreSQL cancels and frees the connection before the client gives up; invalid or out-of-range values fall back to the default |
+| `BETTER_CCFLARE_DB_CLIENT_TIMEOUT` | `8000` | Client-side query timeout in milliseconds for PostgreSQL — the `statement_timeout` ceiling above is derived from this value minus 1000ms. Raising this also raises that ceiling (#412) |
+| `BETTER_CCFLARE_DB_CLEANUP_BATCH_SIZE` | `200` | Row batch size per DELETE statement during retention cleanup — lower this if rows are large (e.g. big JSON payloads) and cleanup batches are timing out (#412) |
 | `BETTER_CCFLARE_DB_PG_PREPARE` | `false` | Set to `true` to enable named prepared statement caching. Left disabled by default to avoid a known class of bugs in Bun's native PostgreSQL driver ([oven-sh/bun#16774](https://github.com/oven-sh/bun/issues/16774)) where concurrent queries sharing a pooled connection can corrupt binary integer decoding under load |
 
 ```bash
 export BETTER_CCFLARE_DB_POOL_MAX=20
 export BETTER_CCFLARE_DB_IDLE_TIMEOUT=30
 export BETTER_CCFLARE_DB_STATEMENT_TIMEOUT=5000
+export BETTER_CCFLARE_DB_CLIENT_TIMEOUT=8000
+export BETTER_CCFLARE_DB_CLEANUP_BATCH_SIZE=200
 ```
 
 ### Runtime Configuration
@@ -515,26 +519,26 @@ The server performs automatic cleanup once at startup, then hourly for the lifet
 
 You can change retention windows via environment variables, the config file, or the dashboard (Overview → Data Retention). A manual "Clean up now" action is also available for use between the hourly ticks.
 
-Deletes are batched (2000 rows per statement, looped until exhausted) rather than issued as one unbounded `DELETE`, so cleanup keeps working on tables large enough to exceed PostgreSQL's `statement_timeout` (see `BETTER_CCFLARE_DB_STATEMENT_TIMEOUT` above) instead of failing permanently. Batches on `usage_snapshots` — which has no unique surrogate key — bound each statement by physical row identity (SQLite `rowid` / PostgreSQL `ctid`) rather than by its natural key, so a batch of duplicate-keyed rows can't expand into an unbounded delete.
+Deletes are batched (200 rows per statement by default, looped until exhausted) rather than issued as one unbounded `DELETE`, so cleanup keeps working on tables large enough to exceed PostgreSQL's `statement_timeout` (see `BETTER_CCFLARE_DB_STATEMENT_TIMEOUT` above) instead of failing permanently. The batch size is configurable via `BETTER_CCFLARE_DB_CLEANUP_BATCH_SIZE` — lower it further if rows are large (e.g. TOASTed JSON payloads) and batches are still timing out (#412). Batches on `usage_snapshots` — which has no unique surrogate key — bound each statement by physical row identity (SQLite `rowid` / PostgreSQL `ctid`) rather than by its natural key, so a batch of duplicate-keyed rows can't expand into an unbounded delete.
 
 1. **Payload Storage**: Batched cleanup of old payloads, plus orphaned payloads left behind by deleted requests:
 ```sql
 DELETE FROM request_payloads WHERE id IN (
-  SELECT id FROM request_payloads WHERE timestamp IS NOT NULL AND timestamp < ? LIMIT 2000
+  SELECT id FROM request_payloads WHERE timestamp IS NOT NULL AND timestamp < ? LIMIT 200
 );
--- looped until a batch returns fewer than 2000 rows, then:
+-- looped until a batch returns fewer rows than the configured batch size, then:
 DELETE FROM request_payloads WHERE id IN (
   SELECT rp.id FROM request_payloads rp
   LEFT JOIN requests r ON r.id = rp.id
   WHERE r.id IS NULL
-  LIMIT 2000
+  LIMIT 200
 );
 ```
 
 2. **Request Metadata**: Batched cleanup of old request records:
 ```sql
 DELETE FROM requests WHERE id IN (
-  SELECT id FROM requests WHERE timestamp < ? LIMIT 2000
+  SELECT id FROM requests WHERE timestamp < ? LIMIT 200
 );
 ```
 
@@ -542,11 +546,11 @@ DELETE FROM requests WHERE id IN (
 ```sql
 -- SQLite
 DELETE FROM usage_snapshots WHERE rowid IN (
-  SELECT rowid FROM usage_snapshots WHERE timestamp < ? LIMIT 2000
+  SELECT rowid FROM usage_snapshots WHERE timestamp < ? LIMIT 200
 );
 -- PostgreSQL
 DELETE FROM usage_snapshots WHERE ctid IN (
-  SELECT ctid FROM usage_snapshots WHERE timestamp < ? LIMIT 2000
+  SELECT ctid FROM usage_snapshots WHERE timestamp < ? LIMIT 200
 );
 ```
 

--- a/packages/database/src/__tests__/cleanup-config.test.ts
+++ b/packages/database/src/__tests__/cleanup-config.test.ts
@@ -49,6 +49,14 @@ describe("getCleanupBatchSize", () => {
 		process.env[ENV_KEY] = "-100";
 		expect(getCleanupBatchSize()).toBe(200);
 	});
+
+	it("falls back to 200 for a fractional value", () => {
+		// A non-integer would be bound directly into a SQL LIMIT and compared
+		// against an integer deleted-row count to detect the last batch —
+		// both would break silently on a fraction like 200.5.
+		process.env[ENV_KEY] = "200.5";
+		expect(getCleanupBatchSize()).toBe(200);
+	});
 });
 
 describe("PG_CLIENT_QUERY_TIMEOUT_MS", () => {

--- a/packages/database/src/__tests__/cleanup-config.test.ts
+++ b/packages/database/src/__tests__/cleanup-config.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for the retention-cleanup config helpers added for #412
+ * (PG deadlock on large/TOASTed request_payloads rows).
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+	getCleanupBatchSize,
+	PG_CLIENT_QUERY_TIMEOUT_MS,
+} from "../adapters/bun-sql-adapter";
+
+const ENV_KEY = "BETTER_CCFLARE_DB_CLEANUP_BATCH_SIZE";
+
+describe("getCleanupBatchSize", () => {
+	let prev: string | undefined;
+
+	beforeEach(() => {
+		prev = process.env[ENV_KEY];
+	});
+
+	afterEach(() => {
+		if (prev === undefined) {
+			delete process.env[ENV_KEY];
+		} else {
+			process.env[ENV_KEY] = prev;
+		}
+	});
+
+	it("falls back to 200 when unset", () => {
+		delete process.env[ENV_KEY];
+		expect(getCleanupBatchSize()).toBe(200);
+	});
+
+	it("respects a valid positive override", () => {
+		process.env[ENV_KEY] = "500";
+		expect(getCleanupBatchSize()).toBe(500);
+	});
+
+	it("falls back to 200 for a non-numeric value", () => {
+		process.env[ENV_KEY] = "not-a-number";
+		expect(getCleanupBatchSize()).toBe(200);
+	});
+
+	it("falls back to 200 for zero", () => {
+		process.env[ENV_KEY] = "0";
+		expect(getCleanupBatchSize()).toBe(200);
+	});
+
+	it("falls back to 200 for a negative value", () => {
+		process.env[ENV_KEY] = "-100";
+		expect(getCleanupBatchSize()).toBe(200);
+	});
+});
+
+describe("PG_CLIENT_QUERY_TIMEOUT_MS", () => {
+	// Computed once at module load from BETTER_CCFLARE_DB_CLIENT_TIMEOUT, so a
+	// live re-init test would require re-importing the module under a fresh
+	// registry with the env var pre-set. No existing test in this directory
+	// does that for module-load-time config, so we keep this as a smoke test
+	// of the documented default (no override present in this test run).
+	it("defaults to 8000 when no override is set at module load", () => {
+		expect(PG_CLIENT_QUERY_TIMEOUT_MS).toBe(8000);
+	});
+});

--- a/packages/database/src/__tests__/cleanup-old-requests.test.ts
+++ b/packages/database/src/__tests__/cleanup-old-requests.test.ts
@@ -6,7 +6,10 @@
  */
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { BunSqlAdapter } from "../adapters/bun-sql-adapter";
+import {
+	BunSqlAdapter,
+	getCleanupBatchSize,
+} from "../adapters/bun-sql-adapter";
 import { ensureSchema, runMigrations } from "../migrations";
 
 // ---------------------------------------------------------------------------
@@ -154,7 +157,7 @@ describe("cleanupOldRequests", () => {
 
 		it("removes ALL orphaned payloads even when there are more than one batch's worth (regression for #384)", async () => {
 			const old = Date.now() - 95 * 24 * 60 * 60 * 1000; // 95 days ago
-			const orphanCount = 2500; // exceeds the 2000-row batch size
+			const orphanCount = getCleanupBatchSize() + 500; // exceeds one batch
 
 			for (let i = 0; i < orphanCount; i++) {
 				insertRequest(db, `orphan-${i}`, old, true);

--- a/packages/database/src/__tests__/usage-history-cleanup.test.ts
+++ b/packages/database/src/__tests__/usage-history-cleanup.test.ts
@@ -9,7 +9,10 @@
  */
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { BunSqlAdapter } from "../adapters/bun-sql-adapter";
+import {
+	BunSqlAdapter,
+	getCleanupBatchSize,
+} from "../adapters/bun-sql-adapter";
 import { ensureSchema, runMigrations } from "../migrations";
 import { UsageHistoryRepository } from "../repositories/usage-history.repository";
 
@@ -92,7 +95,7 @@ describe("UsageHistoryRepository.deleteOlderThan", () => {
 
 	it("removes ALL old snapshots even when there are more than one batch's worth (regression for #384)", async () => {
 		const old = Date.now() - 95 * 24 * 60 * 60 * 1000; // 95 days ago
-		const oldCount = 2500; // exceeds the 2000-row batch size
+		const oldCount = getCleanupBatchSize() + 500; // exceeds one batch
 
 		// Vary account_id/window_key per row so the composite key
 		// (account_id, timestamp, window_key) stays unique even when several
@@ -114,7 +117,7 @@ describe("UsageHistoryRepository.deleteOlderThan", () => {
 	it("deletes only old rows and preserves recent rows when both coexist across multiple batches", async () => {
 		const old = Date.now() - 95 * 24 * 60 * 60 * 1000;
 		const recent = Date.now() - 1 * 24 * 60 * 60 * 1000;
-		const oldCount = 2200; // exceeds the 2000-row batch size
+		const oldCount = getCleanupBatchSize() + 200; // exceeds one batch
 		const recentCount = 10;
 
 		for (let i = 0; i < oldCount; i++) {

--- a/packages/database/src/adapters/bun-sql-adapter.ts
+++ b/packages/database/src/adapters/bun-sql-adapter.ts
@@ -58,8 +58,29 @@ function convertPlaceholders(sql: string): string {
  * cancels the query and frees the connection before the client gives up —
  * otherwise the client unblocks while the query (and its pool connection)
  * is still running on the server.
+ *
+ * Configurable via BETTER_CCFLARE_DB_CLIENT_TIMEOUT (default 8000ms) — the
+ * server-side statement_timeout clamp in DatabaseOperations derives its
+ * ceiling from this value. See issue #412.
  */
-export const PG_CLIENT_QUERY_TIMEOUT_MS = 8000;
+const requestedClientTimeout = Number(
+	process.env.BETTER_CCFLARE_DB_CLIENT_TIMEOUT,
+);
+export const PG_CLIENT_QUERY_TIMEOUT_MS =
+	Number.isFinite(requestedClientTimeout) && requestedClientTimeout > 0
+		? requestedClientTimeout
+		: 8000;
+
+/**
+ * Row batch size (per DELETE statement) used by retention cleanup loops.
+ * Configurable via BETTER_CCFLARE_DB_CLEANUP_BATCH_SIZE — lower this if rows
+ * are large (e.g. TOASTed payload JSON) and batches are hitting the
+ * statement_timeout before completing. See issue #412.
+ */
+export function getCleanupBatchSize(): number {
+	const requested = Number(process.env.BETTER_CCFLARE_DB_CLEANUP_BATCH_SIZE);
+	return Number.isFinite(requested) && requested > 0 ? requested : 200;
+}
 
 /**
  * Unified SQL adapter that abstracts over bun:sqlite (sync) and Bun.SQL/PostgreSQL (async).

--- a/packages/database/src/adapters/bun-sql-adapter.ts
+++ b/packages/database/src/adapters/bun-sql-adapter.ts
@@ -67,7 +67,7 @@ const requestedClientTimeout = Number(
 	process.env.BETTER_CCFLARE_DB_CLIENT_TIMEOUT,
 );
 export const PG_CLIENT_QUERY_TIMEOUT_MS =
-	Number.isFinite(requestedClientTimeout) && requestedClientTimeout > 0
+	Number.isInteger(requestedClientTimeout) && requestedClientTimeout > 0
 		? requestedClientTimeout
 		: 8000;
 
@@ -76,10 +76,14 @@ export const PG_CLIENT_QUERY_TIMEOUT_MS =
  * Configurable via BETTER_CCFLARE_DB_CLEANUP_BATCH_SIZE — lower this if rows
  * are large (e.g. TOASTed payload JSON) and batches are hitting the
  * statement_timeout before completing. See issue #412.
+ *
+ * Requires an integer: the value is bound directly into a SQL LIMIT and
+ * compared against an integer deleted-row count to detect the last batch, so
+ * a fractional value (e.g. 200.5) would break both.
  */
 export function getCleanupBatchSize(): number {
 	const requested = Number(process.env.BETTER_CCFLARE_DB_CLEANUP_BATCH_SIZE);
-	return Number.isFinite(requested) && requested > 0 ? requested : 200;
+	return Number.isInteger(requested) && requested > 0 ? requested : 200;
 }
 
 /**

--- a/packages/database/src/database-operations.ts
+++ b/packages/database/src/database-operations.ts
@@ -307,6 +307,9 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 			// zero/negative (PG treats 0 as "disabled"), or too-large override is
 			// silently clamped rather than trusted, since an unbounded value here
 			// reopens the exact connection-leak bug this timeout exists to close.
+			// PG_CLIENT_QUERY_TIMEOUT_MS itself is configurable via
+			// BETTER_CCFLARE_DB_CLIENT_TIMEOUT (default 8000ms), so raising that
+			// env var also raises this clamp's ceiling (#412).
 			const requestedPgStatementTimeout = Number(
 				process.env.BETTER_CCFLARE_DB_STATEMENT_TIMEOUT,
 			);

--- a/packages/database/src/repositories/request.repository.ts
+++ b/packages/database/src/repositories/request.repository.ts
@@ -3,6 +3,7 @@ import type {
 	AgentAttributionSource,
 	ProjectAttributionSource,
 } from "@better-ccflare/types";
+import { getCleanupBatchSize } from "../adapters/bun-sql-adapter";
 import { decryptPayload, encryptPayload } from "../payload-encryption";
 import { BaseRepository } from "./base.repository";
 
@@ -618,9 +619,11 @@ export class RequestRepository extends BaseRepository<RequestData> {
 	}
 
 	async deleteOlderThan(cutoffTs: number): Promise<number> {
-		// Increased from 500 to 2000 for more aggressive cleanup of large databases.
 		// The covering index idx_requests_cleanup makes each batch faster.
-		const BATCH_SIZE = 2000;
+		// Batch size is configurable via BETTER_CCFLARE_DB_CLEANUP_BATCH_SIZE
+		// (default 200) — lower it if rows are large and batches are timing
+		// out against statement_timeout (#412).
+		const BATCH_SIZE = getCleanupBatchSize();
 		let total = 0;
 		let deleted: number;
 		do {
@@ -640,7 +643,9 @@ export class RequestRepository extends BaseRepository<RequestData> {
 		// DELETE here can exceed the PG statement_timeout once the table is large.
 		// LEFT JOIN instead of NOT IN (SELECT ...) avoids the slow anti-join plan
 		// NOT IN produces against a large subquery on both SQLite and PostgreSQL.
-		const BATCH_SIZE = 2000;
+		// Batch size is configurable via BETTER_CCFLARE_DB_CLEANUP_BATCH_SIZE
+		// (default 200) — lower it if rows are large (#412).
+		const BATCH_SIZE = getCleanupBatchSize();
 		let total = 0;
 		let deleted: number;
 		do {
@@ -659,9 +664,11 @@ export class RequestRepository extends BaseRepository<RequestData> {
 	}
 
 	async deletePayloadsOlderThan(cutoffTs: number): Promise<number> {
-		// Increased from 500 to 2000 for more aggressive cleanup of large databases.
 		// The covering index idx_request_payloads_cleanup makes each batch faster.
-		const BATCH_SIZE = 2000;
+		// Batch size is configurable via BETTER_CCFLARE_DB_CLEANUP_BATCH_SIZE
+		// (default 200) — lower it if rows are large (e.g. TOASTed payload JSON)
+		// and batches are timing out against statement_timeout (#412).
+		const BATCH_SIZE = getCleanupBatchSize();
 		let total = 0;
 		let deleted: number;
 		do {

--- a/packages/database/src/repositories/usage-history.repository.ts
+++ b/packages/database/src/repositories/usage-history.repository.ts
@@ -1,5 +1,6 @@
 import { weeklyScopedWindowKey } from "@better-ccflare/core";
 import type { PredictionPoint, UsageSnapshotRow } from "@better-ccflare/types";
+import { getCleanupBatchSize } from "../adapters/bun-sql-adapter";
 import { BaseRepository } from "./base.repository";
 
 /** Duck-typed usage window: an object with a numeric `utilization` and a `resets_at` key. */
@@ -175,7 +176,10 @@ export class UsageHistoryRepository extends BaseRepository<UsageSnapshotRow> {
 		// physical rows deleted per statement, independent of key duplicates.
 		// idx_usage_snapshots_ts (on timestamp alone) makes the inner SELECT
 		// efficient on both dialects.
-		const BATCH_SIZE = 2000;
+		// Batch size is configurable via BETTER_CCFLARE_DB_CLEANUP_BATCH_SIZE
+		// (default 200) — lower it if rows are large and batches are timing
+		// out against statement_timeout (#412).
+		const BATCH_SIZE = getCleanupBatchSize();
 		const physicalIdSql = this.adapter.isSQLite
 			? `DELETE FROM usage_snapshots WHERE rowid IN (
 					SELECT rowid FROM usage_snapshots WHERE timestamp < ? LIMIT ?


### PR DESCRIPTION
## Summary
- Fixes #412 — retention cleanup on PostgreSQL could deadlock permanently when `request_payloads` rows are large (TOASTed): the hardcoded 8s client-side query timeout left only 7s of server-side `statement_timeout` headroom, and the hardcoded 2000-row batch size was far too large to finish detoasting within that window, so every cleanup batch timed out, rolled back, and made zero progress forever.
- `PG_CLIENT_QUERY_TIMEOUT_MS` is now configurable via `BETTER_CCFLARE_DB_CLIENT_TIMEOUT` (default unchanged: `8000`ms). The existing `statement_timeout` clamp in `DatabaseOperations` already derives its ceiling from this constant, so raising the client timeout now also raises that ceiling — no separate change needed there beyond a clarifying comment.
- Retention cleanup batch size (`request.repository.ts` × 3 methods, `usage-history.repository.ts` × 1 method) is now configurable via `BETTER_CCFLARE_DB_CLEANUP_BATCH_SIZE`, with the default **lowered from 2000 to 200** rows — the value the issue reporter confirmed was comfortable in their environment.
- Updated `docs/configuration.md` and `docs/database.md` with the two new env vars and corrected batch-size references.

## Test plan
- [x] `bun run lint && bun run typecheck && bun run format` — pass, no new warnings in touched files
- [x] `cd packages/database && bun test` — 288 pass, 4 skip (pre-existing), 0 fail
- [x] Added `packages/database/src/__tests__/cleanup-config.test.ts` covering `getCleanupBatchSize()` env-var parsing/fallback behavior
- [x] Updated two existing regression tests (`cleanup-old-requests.test.ts`, `usage-history-cleanup.test.ts`) that previously hardcoded row counts against the old 2000-row batch boundary to instead derive from `getCleanupBatchSize()`
- [x] Ran `detect_changes()` (GitNexus) — confirmed diff only touches expected symbols/processes, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)