### PR TITLE
fix: scope anomaly alert cooldown by account:model instead of requestId

### DIFF
--- a/packages/http-api/src/services/__tests__/alerts.test.ts
+++ b/packages/http-api/src/services/__tests__/alerts.test.ts
@@ -510,6 +510,91 @@ describe("anomaly alert cooldown scope (issue #411 regression)", () => {
 		}
 	});
 
+	test("a request with no model does not share a cooldown bucket with a request whose model is a NUL character (greptile review follow-up)", async () => {
+		// `model` is attacker-controlled — taken verbatim from the inbound
+		// request's JSON `model` field with no charset restriction, unlike
+		// account names. A fixed sentinel string for "no model" (e.g. a NUL
+		// character) would alias a request with no model at all with a
+		// request whose model happens to equal that exact sentinel. This
+		// test proves encodeScopePart's length-prefix encoding keeps the two
+		// cases in independent cooldown buckets regardless of what
+		// characters a real model value contains.
+		const sqlite = new Database(":memory:");
+		ensureSchema(sqlite);
+		const adapter = new BunSqlAdapter(sqlite);
+		const config = Object.assign(new EventEmitter(), {
+			getAlertDailySpendUsd: () => 0,
+			getAlertTokensPerHour: () => 0,
+			getAlertRequestTokens: () => 0,
+			getAlertAnomalyEnabled: () => true,
+			getAlertAnomalyIntervalMinutes: () => 5,
+			getAlertAnomalyBaselineWindowMinutes: () => 60,
+			getAlertAnomalyLoopMinRequests: () => 10_000,
+			getAlertCooldownMinutes: () => 60,
+			getAlertWebhookUrl: () => "",
+		}) as unknown as Config;
+		const service = new AlertService(adapter, config);
+
+		async function seedGroup(
+			model: string | null,
+			idPrefix: string,
+		): Promise<void> {
+			const now = Date.now();
+			const scoringSince = now - 5 * 60 * 1000;
+			const spreadValues = [80, 100, 130];
+			for (let i = 0; i < 21; i++) {
+				await adapter.run(
+					`INSERT INTO requests
+						(id, timestamp, method, path, account_used, status_code, success,
+						 response_time_ms, failover_attempts, model, total_tokens, cost_usd,
+						 input_tokens, output_tokens, cache_read_input_tokens,
+						 cache_creation_input_tokens)
+					 VALUES (?, ?, 'POST', '/v1/messages', 'acct', 200, 1, 100, 0, ?, ?, 0, ?, 0, 0, 0)`,
+					[
+						`${idPrefix}-baseline-${i}`,
+						scoringSince - (10 + i) * 60 * 1000,
+						model,
+						spreadValues[i % spreadValues.length],
+						spreadValues[i % spreadValues.length],
+					],
+				);
+			}
+			await adapter.run(
+				`INSERT INTO requests
+					(id, timestamp, method, path, account_used, status_code, success,
+					 response_time_ms, failover_attempts, model, total_tokens, cost_usd,
+					 input_tokens, output_tokens, cache_read_input_tokens,
+					 cache_creation_input_tokens)
+				 VALUES (?, ?, 'POST', '/v1/messages', 'acct', 200, 1, 100, 0, ?, ?, 0, ?, 0, 0, 0)`,
+				[`${idPrefix}-spike`, now - 1000, model, 100_000, 100_000],
+			);
+		}
+
+		try {
+			await adapter.run(
+				`INSERT INTO accounts (id, name, created_at) VALUES (?, ?, ?)`,
+				["acct", "acct", Date.now()],
+			);
+			// Group 1: no model attribution at all (model IS NULL).
+			await seedGroup(null, "nomodel");
+			// Group 2: a request whose model is literally a NUL character —
+			// the exact value the old fixed-sentinel encoding aliased with null.
+			await seedGroup("\x00", "nulmodel");
+
+			await service.evaluateAnomalies();
+
+			const alerts = await service.listAlerts();
+			const outlierAlerts = alerts.filter(
+				(a) => a.type === "anomaly_token_outlier",
+			);
+			const flaggedIds = outlierAlerts.map((a) => a.requestId).sort();
+			expect(flaggedIds).toEqual(["nomodel-spike", "nulmodel-spike"]);
+		} finally {
+			service.stop();
+			sqlite.close();
+		}
+	});
+
 	test("two distinct outlier requests on the same account/model within one cooldown bucket only persist one alert", async () => {
 		const sqlite = new Database(":memory:");
 		ensureSchema(sqlite);

--- a/packages/http-api/src/services/__tests__/alerts.test.ts
+++ b/packages/http-api/src/services/__tests__/alerts.test.ts
@@ -369,3 +369,115 @@ describe("evaluateAnomalies leave-one-out contract (issue #410 regression)", () 
 		}
 	});
 });
+
+describe("anomaly alert cooldown scope (issue #411 regression)", () => {
+	test("anomaly_token_outlier and anomaly_output_blowup are scoped by account:model, not requestId", () => {
+		// Before the fix, buildThresholdAlertId was called with event.requestId
+		// as the scope — unique per request — so the cooldown time-bucket could
+		// never dedupe two distinct outlier requests, no matter how close in
+		// time. Scoping by account:model (matching the anomaly_runaway_loop and
+		// anomaly_model_misrouting pattern) lets same-bucket requests collide.
+		const first = buildThresholdAlertId(
+			"anomaly_token_outlier",
+			"acct:model-a",
+			123_456,
+			60,
+		);
+		const second = buildThresholdAlertId(
+			"anomaly_token_outlier",
+			"acct:model-a",
+			200_000,
+			60,
+		);
+		expect(first).toBe(second);
+
+		const blowupFirst = buildThresholdAlertId(
+			"anomaly_output_blowup",
+			"acct:model-a",
+			123_456,
+			60,
+		);
+		const blowupSecond = buildThresholdAlertId(
+			"anomaly_output_blowup",
+			"acct:model-a",
+			200_000,
+			60,
+		);
+		expect(blowupFirst).toBe(blowupSecond);
+
+		// A different model must still get its own bucket.
+		const differentModel = buildThresholdAlertId(
+			"anomaly_token_outlier",
+			"acct:model-b",
+			123_456,
+			60,
+		);
+		expect(differentModel).not.toBe(first);
+	});
+
+	test("two distinct outlier requests on the same account/model within one cooldown bucket only persist one alert", async () => {
+		const sqlite = new Database(":memory:");
+		ensureSchema(sqlite);
+		const adapter = new BunSqlAdapter(sqlite);
+		const config = Object.assign(new EventEmitter(), {
+			getAlertDailySpendUsd: () => 0,
+			getAlertTokensPerHour: () => 0,
+			getAlertRequestTokens: () => 0,
+			getAlertAnomalyEnabled: () => true,
+			getAlertAnomalyIntervalMinutes: () => 5,
+			getAlertAnomalyBaselineWindowMinutes: () => 60,
+			getAlertAnomalyLoopMinRequests: () => 10_000,
+			getAlertCooldownMinutes: () => 60,
+			getAlertWebhookUrl: () => "",
+		}) as unknown as Config;
+		const service = new AlertService(adapter, config);
+
+		try {
+			const now = Date.now();
+			const scoringSince = now - 5 * 60 * 1000;
+			const spreadValues = [80, 100, 130];
+			for (let i = 0; i < 21; i++) {
+				await adapter.run(
+					`INSERT INTO requests
+						(id, timestamp, method, path, account_used, status_code, success,
+						 response_time_ms, failover_attempts, model, total_tokens, cost_usd,
+						 input_tokens, output_tokens, cache_read_input_tokens,
+						 cache_creation_input_tokens)
+					 VALUES (?, ?, 'POST', '/v1/messages', 'acct', 200, 1, 100, 0, 'model-a', ?, 0, ?, 0, 0, 0)`,
+					[
+						`baseline-${i}`,
+						scoringSince - (10 + i) * 60 * 1000,
+						spreadValues[i % spreadValues.length],
+						spreadValues[i % spreadValues.length],
+					],
+				);
+			}
+			// Two distinct spike requests, same account+model, both inside the
+			// same 60-minute cooldown bucket. Pre-fix, both would have fired
+			// (scope = requestId, unique per row); post-fix, only the first
+			// should persist and the second must be swallowed by the cooldown.
+			for (const id of ["spike-1", "spike-2"]) {
+				await adapter.run(
+					`INSERT INTO requests
+						(id, timestamp, method, path, account_used, status_code, success,
+						 response_time_ms, failover_attempts, model, total_tokens, cost_usd,
+						 input_tokens, output_tokens, cache_read_input_tokens,
+						 cache_creation_input_tokens)
+					 VALUES (?, ?, 'POST', '/v1/messages', 'acct', 200, 1, 100, 0, 'model-a', ?, 0, ?, 0, 0, 0)`,
+					[id, now - 1000, 100_000, 100_000],
+				);
+			}
+
+			await service.evaluateAnomalies();
+
+			const alerts = await service.listAlerts();
+			const outlierAlerts = alerts.filter(
+				(a) => a.type === "anomaly_token_outlier",
+			);
+			expect(outlierAlerts).toHaveLength(1);
+		} finally {
+			service.stop();
+			sqlite.close();
+		}
+	});
+});

--- a/packages/http-api/src/services/__tests__/alerts.test.ts
+++ b/packages/http-api/src/services/__tests__/alerts.test.ts
@@ -15,7 +15,6 @@ import {
 	buildThresholdAlertId,
 	shouldFireAlert,
 } from "../alerts";
-import { GROUP_KEY_SEPARATOR } from "../anomaly-insights";
 
 const CONFIG: AlertsConfigPayload = {
 	dailySpendUsd: 10,
@@ -416,37 +415,99 @@ describe("anomaly alert cooldown scope (issue #411 regression)", () => {
 		expect(differentModel).not.toBe(first);
 	});
 
-	test("scope join uses GROUP_KEY_SEPARATOR so an account literally named 'Unknown' cannot collide with a missing account (review follow-up)", () => {
-		// The normalizeKey fallback for a missing account is the literal
-		// string "Unknown" (anomaly-insights.ts). A plain `:` join would let
-		// an account genuinely named "Unknown" produce the exact same scope
-		// string as a request with no account at all for the same model —
-		// over-suppressing alerts for the real "Unknown" account. Joining
-		// with the reserved GROUP_KEY_SEPARATOR (used elsewhere in
-		// anomaly-insights.ts for the identical reason) keeps them distinct
-		// as long as the separator itself never appears in account/model
-		// values, which holds here.
-		const missingAccount = buildThresholdAlertId(
-			"anomaly_token_outlier",
-			`Unknown${GROUP_KEY_SEPARATOR}model-a`,
-			123_456,
-			60,
-		);
-		const literalUnknownAccount = buildThresholdAlertId(
-			"anomaly_token_outlier",
-			`Unknown${GROUP_KEY_SEPARATOR}model-a`,
-			123_456,
-			60,
-		);
-		// Same inputs still collide (that's the whole point of the cooldown).
-		expect(missingAccount).toBe(literalUnknownAccount);
+	test("an account literally named 'Unknown' does not share a cooldown bucket with a request that has no account at all (greptile review follow-up)", async () => {
+		// TokenOutlierEvent.account/.model are already normalized for display
+		// (null -> the literal string "Unknown") before alerts.ts ever sees
+		// them, so a scope built from those display fields alone — even with
+		// a safe separator — cannot tell a real account named "Unknown" apart
+		// from a request with no account. This test proves the actual fix:
+		// the cooldown scope is built from event.accountRaw/.modelRaw (the
+		// pre-normalization fields), so the two cases get independent
+		// buckets and neither spike alert is swallowed by the other's
+		// cooldown.
+		const sqlite = new Database(":memory:");
+		ensureSchema(sqlite);
+		const adapter = new BunSqlAdapter(sqlite);
+		const config = Object.assign(new EventEmitter(), {
+			getAlertDailySpendUsd: () => 0,
+			getAlertTokensPerHour: () => 0,
+			getAlertRequestTokens: () => 0,
+			getAlertAnomalyEnabled: () => true,
+			getAlertAnomalyIntervalMinutes: () => 5,
+			getAlertAnomalyBaselineWindowMinutes: () => 60,
+			getAlertAnomalyLoopMinRequests: () => 10_000,
+			getAlertCooldownMinutes: () => 60,
+			getAlertWebhookUrl: () => "",
+		}) as unknown as Config;
+		const service = new AlertService(adapter, config);
 
-		// But a plain `:` join WOULD have collapsed these two distinct pairs
-		// ("Unknown"+"model-a" vs "Unknown:model"+"a") into the same string;
-		// the separator keeps them apart.
-		const pairOne = `Unknown${GROUP_KEY_SEPARATOR}model-a`;
-		const pairTwo = `Unknown${GROUP_KEY_SEPARATOR}model${GROUP_KEY_SEPARATOR}a`;
-		expect(pairOne).not.toBe(pairTwo);
+		async function seedGroup(
+			accountName: string | null,
+			idPrefix: string,
+		): Promise<void> {
+			// requests.account_used is a foreign key into accounts.id, and the
+			// anomaly query joins to accounts.name for display — so a request
+			// attributed to a real account must have a matching accounts row,
+			// or the join always yields NULL regardless of account_used.
+			const accountUsed = accountName === null ? null : `${idPrefix}-account`;
+			if (accountName !== null) {
+				await adapter.run(
+					`INSERT INTO accounts (id, name, created_at) VALUES (?, ?, ?)`,
+					[accountUsed, accountName, Date.now()],
+				);
+			}
+			const now = Date.now();
+			const scoringSince = now - 5 * 60 * 1000;
+			const spreadValues = [80, 100, 130];
+			for (let i = 0; i < 21; i++) {
+				await adapter.run(
+					`INSERT INTO requests
+						(id, timestamp, method, path, account_used, status_code, success,
+						 response_time_ms, failover_attempts, model, total_tokens, cost_usd,
+						 input_tokens, output_tokens, cache_read_input_tokens,
+						 cache_creation_input_tokens)
+					 VALUES (?, ?, 'POST', '/v1/messages', ?, 200, 1, 100, 0, 'model-a', ?, 0, ?, 0, 0, 0)`,
+					[
+						`${idPrefix}-baseline-${i}`,
+						scoringSince - (10 + i) * 60 * 1000,
+						accountUsed,
+						spreadValues[i % spreadValues.length],
+						spreadValues[i % spreadValues.length],
+					],
+				);
+			}
+			await adapter.run(
+				`INSERT INTO requests
+					(id, timestamp, method, path, account_used, status_code, success,
+					 response_time_ms, failover_attempts, model, total_tokens, cost_usd,
+					 input_tokens, output_tokens, cache_read_input_tokens,
+					 cache_creation_input_tokens)
+				 VALUES (?, ?, 'POST', '/v1/messages', ?, 200, 1, 100, 0, 'model-a', ?, 0, ?, 0, 0, 0)`,
+				[`${idPrefix}-spike`, now - 1000, accountUsed, 100_000, 100_000],
+			);
+		}
+
+		try {
+			// Group 1: no account attribution at all (account_used IS NULL).
+			await seedGroup(null, "noacct");
+			// Group 2: a real account whose name is literally "Unknown".
+			await seedGroup("Unknown", "literal");
+
+			await service.evaluateAnomalies();
+
+			const alerts = await service.listAlerts();
+			const outlierAlerts = alerts.filter(
+				(a) => a.type === "anomaly_token_outlier",
+			);
+			// Both spikes must be flagged independently — if the cooldown scope
+			// collapsed null and the literal "Unknown" into one bucket, only
+			// one of these two would have persisted.
+			const flaggedIds = outlierAlerts.map((a) => a.requestId).sort();
+			expect(flaggedIds).toEqual(["literal-spike", "noacct-spike"]);
+		} finally {
+			service.stop();
+			sqlite.close();
+		}
 	});
 
 	test("two distinct outlier requests on the same account/model within one cooldown bucket only persist one alert", async () => {

--- a/packages/http-api/src/services/__tests__/alerts.test.ts
+++ b/packages/http-api/src/services/__tests__/alerts.test.ts
@@ -15,6 +15,7 @@ import {
 	buildThresholdAlertId,
 	shouldFireAlert,
 } from "../alerts";
+import { GROUP_KEY_SEPARATOR } from "../anomaly-insights";
 
 const CONFIG: AlertsConfigPayload = {
 	dailySpendUsd: 10,
@@ -413,6 +414,39 @@ describe("anomaly alert cooldown scope (issue #411 regression)", () => {
 			60,
 		);
 		expect(differentModel).not.toBe(first);
+	});
+
+	test("scope join uses GROUP_KEY_SEPARATOR so an account literally named 'Unknown' cannot collide with a missing account (review follow-up)", () => {
+		// The normalizeKey fallback for a missing account is the literal
+		// string "Unknown" (anomaly-insights.ts). A plain `:` join would let
+		// an account genuinely named "Unknown" produce the exact same scope
+		// string as a request with no account at all for the same model —
+		// over-suppressing alerts for the real "Unknown" account. Joining
+		// with the reserved GROUP_KEY_SEPARATOR (used elsewhere in
+		// anomaly-insights.ts for the identical reason) keeps them distinct
+		// as long as the separator itself never appears in account/model
+		// values, which holds here.
+		const missingAccount = buildThresholdAlertId(
+			"anomaly_token_outlier",
+			`Unknown${GROUP_KEY_SEPARATOR}model-a`,
+			123_456,
+			60,
+		);
+		const literalUnknownAccount = buildThresholdAlertId(
+			"anomaly_token_outlier",
+			`Unknown${GROUP_KEY_SEPARATOR}model-a`,
+			123_456,
+			60,
+		);
+		// Same inputs still collide (that's the whole point of the cooldown).
+		expect(missingAccount).toBe(literalUnknownAccount);
+
+		// But a plain `:` join WOULD have collapsed these two distinct pairs
+		// ("Unknown"+"model-a" vs "Unknown:model"+"a") into the same string;
+		// the separator keeps them apart.
+		const pairOne = `Unknown${GROUP_KEY_SEPARATOR}model-a`;
+		const pairTwo = `Unknown${GROUP_KEY_SEPARATOR}model${GROUP_KEY_SEPARATOR}a`;
+		expect(pairOne).not.toBe(pairTwo);
 	});
 
 	test("two distinct outlier requests on the same account/model within one cooldown bucket only persist one alert", async () => {

--- a/packages/http-api/src/services/alerts.ts
+++ b/packages/http-api/src/services/alerts.ts
@@ -114,6 +114,27 @@ export function buildThresholdAlertId(
 	return `${type}:${scope}:${Math.floor(timestamp / bucketMs)}`;
 }
 
+/**
+ * Sentinel for "no value" in a cooldown scope key: a NUL control character,
+ * which account/model names can never contain (account names are
+ * restricted to letters, numbers, spaces, hyphens, underscores, and dots —
+ * see patterns.accountName), so it can never collide with a real value.
+ */
+const SCOPE_NULL_SENTINEL = "\x00";
+
+/**
+ * Encodes a possibly-null raw value for use inside a cooldown scope key,
+ * distinguishing "no value" from a real value that happens to equal the
+ * display fallback ("Unknown"). `event.account`/`event.model` on anomaly
+ * events are already normalized (null -> "Unknown") for display purposes,
+ * so a scope built directly from those two fields cannot tell an account
+ * literally named "Unknown" apart from a request with no account at all —
+ * this must be built from the raw (pre-normalization) field instead.
+ */
+function encodeScopePart(raw: string | null): string {
+	return raw === null ? SCOPE_NULL_SENTINEL : raw;
+}
+
 export function buildRunawayLoopAlertId(
 	loop: RunawayLoopGroup,
 	cooldownMinutes: number,
@@ -513,7 +534,7 @@ export class AlertService {
 			alerts.push({
 				id: buildThresholdAlertId(
 					"anomaly_token_outlier",
-					`${event.account}${GROUP_KEY_SEPARATOR}${event.model}`,
+					`${encodeScopePart(event.accountRaw)}${GROUP_KEY_SEPARATOR}${encodeScopePart(event.modelRaw)}`,
 					event.timestamp,
 					config.cooldownMinutes,
 				),
@@ -538,7 +559,7 @@ export class AlertService {
 			alerts.push({
 				id: buildThresholdAlertId(
 					"anomaly_output_blowup",
-					`${event.account}${GROUP_KEY_SEPARATOR}${event.model}`,
+					`${encodeScopePart(event.accountRaw)}${GROUP_KEY_SEPARATOR}${encodeScopePart(event.modelRaw)}`,
 					event.timestamp,
 					config.cooldownMinutes,
 				),

--- a/packages/http-api/src/services/alerts.ts
+++ b/packages/http-api/src/services/alerts.ts
@@ -115,14 +115,6 @@ export function buildThresholdAlertId(
 }
 
 /**
- * Sentinel for "no value" in a cooldown scope key: a NUL control character,
- * which account/model names can never contain (account names are
- * restricted to letters, numbers, spaces, hyphens, underscores, and dots —
- * see patterns.accountName), so it can never collide with a real value.
- */
-const SCOPE_NULL_SENTINEL = "\x00";
-
-/**
  * Encodes a possibly-null raw value for use inside a cooldown scope key,
  * distinguishing "no value" from a real value that happens to equal the
  * display fallback ("Unknown"). `event.account`/`event.model` on anomaly
@@ -130,9 +122,19 @@ const SCOPE_NULL_SENTINEL = "\x00";
  * so a scope built directly from those two fields cannot tell an account
  * literally named "Unknown" apart from a request with no account at all —
  * this must be built from the raw (pre-normalization) field instead.
+ *
+ * `model` is attacker-controlled (taken verbatim from the inbound request's
+ * JSON `model` field, with no charset restriction — unlike account names,
+ * which are validated against patterns.accountName), so no fixed sentinel
+ * string is safe: a client could always send a model value equal to
+ * whatever sentinel was chosen. Instead, length-prefix the value
+ * (`${length}:${value}`) and use a length of 0 for null. Two distinct
+ * inputs can never produce the same encoding this way, regardless of what
+ * characters either one contains — the length prefix is unambiguous.
  */
 function encodeScopePart(raw: string | null): string {
-	return raw === null ? SCOPE_NULL_SENTINEL : raw;
+	if (raw === null) return "0:";
+	return `${raw.length}:${raw}`;
 }
 
 export function buildRunawayLoopAlertId(

--- a/packages/http-api/src/services/alerts.ts
+++ b/packages/http-api/src/services/alerts.ts
@@ -512,7 +512,7 @@ export class AlertService {
 			alerts.push({
 				id: buildThresholdAlertId(
 					"anomaly_token_outlier",
-					event.requestId,
+					`${event.account}:${event.model}`,
 					event.timestamp,
 					config.cooldownMinutes,
 				),
@@ -537,7 +537,7 @@ export class AlertService {
 			alerts.push({
 				id: buildThresholdAlertId(
 					"anomaly_output_blowup",
-					event.requestId,
+					`${event.account}:${event.model}`,
 					event.timestamp,
 					config.cooldownMinutes,
 				),

--- a/packages/http-api/src/services/alerts.ts
+++ b/packages/http-api/src/services/alerts.ts
@@ -20,6 +20,7 @@ import type {
 import {
 	type AnomalyRequestRow,
 	buildAnomalyInsightsResponse,
+	GROUP_KEY_SEPARATOR,
 	sanitizeProjectForDisplay,
 } from "./anomaly-insights";
 
@@ -512,7 +513,7 @@ export class AlertService {
 			alerts.push({
 				id: buildThresholdAlertId(
 					"anomaly_token_outlier",
-					`${event.account}:${event.model}`,
+					`${event.account}${GROUP_KEY_SEPARATOR}${event.model}`,
 					event.timestamp,
 					config.cooldownMinutes,
 				),
@@ -537,7 +538,7 @@ export class AlertService {
 			alerts.push({
 				id: buildThresholdAlertId(
 					"anomaly_output_blowup",
-					`${event.account}:${event.model}`,
+					`${event.account}${GROUP_KEY_SEPARATOR}${event.model}`,
 					event.timestamp,
 					config.cooldownMinutes,
 				),

--- a/packages/http-api/src/services/anomaly-insights.ts
+++ b/packages/http-api/src/services/anomaly-insights.ts
@@ -414,6 +414,8 @@ export function detectTokenOutliers(
 			timestamp: row.timestamp,
 			account: normalizeKey(row.account),
 			model: normalizeKey(row.model),
+			accountRaw: row.account,
+			modelRaw: row.model,
 			project: row.project,
 			metric,
 			value,

--- a/packages/http-api/src/services/anomaly-insights.ts
+++ b/packages/http-api/src/services/anomaly-insights.ts
@@ -180,7 +180,7 @@ export function sanitizeProjectForDisplay(
 }
 
 const UNKNOWN_KEY = "Unknown";
-const GROUP_KEY_SEPARATOR = "\u001f"; // unit separator: never appears in names, keys cannot collide
+export const GROUP_KEY_SEPARATOR = "\u001f"; // unit separator: never appears in names, keys cannot collide
 const MAX_EXAMPLE_REQUEST_IDS = 5;
 
 function normalizeKey(key: string | null | undefined): string {

--- a/packages/types/src/insights.ts
+++ b/packages/types/src/insights.ts
@@ -148,6 +148,17 @@ export interface TokenOutlierEvent {
 	timestamp: number;
 	account: string;
 	model: string;
+	/**
+	 * Pre-normalization account, as stored on the request row: `null` when
+	 * the request has no account attribution. Unlike `account` (which
+	 * collapses a missing account to the literal display string
+	 * "Unknown"), this preserves the null/non-null distinction so a
+	 * consumer building a dedup or grouping key can tell "no account" apart
+	 * from a real account that happens to be named "Unknown".
+	 */
+	accountRaw: string | null;
+	/** Pre-normalization model — see `accountRaw`. */
+	modelRaw: string | null;
 	project: string | null;
 	metric: TokenOutlierMetric;
 	value: number;


### PR DESCRIPTION
## Summary
- `anomaly_token_outlier` and `anomaly_output_blowup` built their cooldown dedup key from `event.requestId`, which is unique per request — so `ALERT_COOLDOWN_MINUTES` could never suppress a duplicate alert for these two types (1,840 alerts fired through a nominal 60-minute cooldown per the issue report).
- Scope the cooldown key by `account:model` instead, matching the pattern already used by `anomaly_runaway_loop` and `anomaly_model_misrouting` in the same file.
- `requestId` remains in the alert payload for traceability, per the issue's suggested direction.

Fixes #411

## Test plan
- [x] Added a unit test proving `buildThresholdAlertId` now produces identical IDs for two distinct timestamps in the same cooldown bucket when scoped by `account:model`, and a distinct ID for a different model.
- [x] Added an integration test seeding two distinct outlier requests on the same account/model within one cooldown bucket, asserting only one `anomaly_token_outlier` alert persists (pre-fix this would have been two).
- [x] `bun test packages/http-api/src/services/__tests__/alerts.test.ts` — 11 pass, 0 fail.
- [x] `bun run lint && bun run typecheck && bun run format` — clean (pre-existing unrelated warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)