### PR TITLE
fix: drain discarded response bodies instead of no-op cancel (#382)

### DIFF
--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -63,9 +63,16 @@ describe("CodexProvider stream liveness", () => {
 		const provider = new CodexProvider({
 			streamHeartbeatIntervalMs: 20,
 			streamRawSilenceTimeoutMs: 200,
+			streamDrainDeadlineMs: 300,
 		});
 		let upstreamController: ReadableStreamDefaultController<Uint8Array>;
-		let upstreamCancelReason: unknown;
+		// After response.completed, cancelUpstreamOnce no longer calls
+		// reader.cancel() — it drains the reader via reader.read() instead
+		// (issue #382: Bun's reader.cancel() is a documented RSS-leaking
+		// no-op). A read() that never resolves is the equivalent
+		// never-blocks-finalization hazard under the new drain design: prove
+		// it is bounded by streamDrainDeadlineMs and the stream still
+		// finalizes.
 		const upstream = new ReadableStream<Uint8Array>({
 			start(controller) {
 				upstreamController = controller;
@@ -80,16 +87,16 @@ describe("CodexProvider stream liveness", () => {
 					),
 				);
 			},
-			cancel(reason) {
-				upstreamCancelReason = reason;
-			},
 		});
+		const drainAbort = new AbortController();
 		const transformed = await provider.processResponse(
 			new Response(upstream, {
 				status: 200,
 				headers: { "content-type": "text/event-stream" },
 			}),
 			null,
+			undefined,
+			drainAbort,
 		);
 		const reader = transformed.body?.getReader();
 		if (!reader) throw new Error("transformed response has no body");
@@ -123,6 +130,8 @@ describe("CodexProvider stream liveness", () => {
 				),
 			),
 		);
+		// Never resolve the upstream stream after this point: the drain loop's
+		// reader.read() calls will hang until streamDrainDeadlineMs fires.
 
 		let terminalBody = "";
 		while (true) {
@@ -132,49 +141,55 @@ describe("CodexProvider stream liveness", () => {
 		}
 		expect(terminalBody).toContain("event: message_stop");
 		expect(terminalBody).not.toContain("event: ping");
-		expect(upstreamCancelReason).toBeDefined();
+		expect(drainAbort.signal.aborted).toBeTrue();
 	});
 
 	it("terminates raw upstream silence after synthetic heartbeats", async () => {
 		const provider = new CodexProvider({
 			streamHeartbeatIntervalMs: 15,
 			streamRawSilenceTimeoutMs: 70,
+			streamDrainDeadlineMs: 150,
 		});
-		let upstreamCancelReason: unknown;
+		// No data is ever enqueued, and read() never resolves — the drain loop
+		// started by the raw_silence_timeout's cancelUpstreamOnce() call must
+		// still be bounded by streamDrainDeadlineMs rather than hanging forever.
 		const upstream = new ReadableStream<Uint8Array>({
-			cancel(reason) {
-				upstreamCancelReason = reason;
+			pull() {
 				return new Promise<void>(() => {});
 			},
 		});
+		const drainAbort = new AbortController();
 		const transformed = await provider.processResponse(
 			new Response(upstream, {
 				status: 200,
 				headers: { "content-type": "text/event-stream" },
 			}),
 			null,
+			undefined,
+			drainAbort,
 		);
 
 		const body = await Promise.race([
 			transformed.text(),
-			Bun.sleep(300).then(() => {
+			Bun.sleep(500).then(() => {
 				throw new Error("timed-out Codex stream did not terminate");
 			}),
 		]);
-		expect(upstreamCancelReason).toBeInstanceOf(Error);
 		expect(body).toContain("event: error");
 		expect(body).toContain(
 			"Codex upstream timed out while waiting for response data.",
 		);
 		expect(body).not.toContain("rawSilenceTimeoutMs");
+		expect(drainAbort.signal.aborted).toBeTrue();
 	});
 
-	it("does not await a hanging upstream cancellation after a terminal event", async () => {
+	it("does not await a hanging upstream drain after a terminal event", async () => {
 		const provider = new CodexProvider({
 			streamHeartbeatIntervalMs: 100,
 			streamRawSilenceTimeoutMs: 500,
+			streamDrainDeadlineMs: 150,
 		});
-		let cancelCalls = 0;
+		let readCalls = 0;
 		const upstream = new ReadableStream<Uint8Array>({
 			start(controller) {
 				controller.enqueue(
@@ -192,26 +207,35 @@ describe("CodexProvider stream liveness", () => {
 					),
 				);
 			},
-			cancel() {
-				cancelCalls++;
+			// Once the terminal event is processed, cancelUpstreamOnce's
+			// drainUpstream() takes over the reader and calls read() in a loop
+			// looking for `done`. Simulate a stuck-but-open upstream: the first
+			// read() (which delivers the terminal SSE bytes) resolves normally,
+			// but any subsequent read() the drain loop issues never resolves.
+			pull(_controller) {
+				readCalls++;
+				if (readCalls === 1) return;
 				return new Promise<void>(() => {});
 			},
 		});
+		const drainAbort = new AbortController();
 		const transformed = await provider.processResponse(
 			new Response(upstream, {
 				status: 200,
 				headers: { "content-type": "text/event-stream" },
 			}),
 			null,
+			undefined,
+			drainAbort,
 		);
 		const body = await Promise.race([
 			transformed.text(),
-			Bun.sleep(300).then(() => {
+			Bun.sleep(500).then(() => {
 				throw new Error("terminal Codex stream did not reach EOF");
 			}),
 		]);
 		expect(body).toContain("event: message_stop");
-		expect(cancelCalls).toBe(1);
+		expect(drainAbort.signal.aborted).toBeTrue();
 	});
 });
 

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -58,6 +58,24 @@ const eventLine = (name: string, data: unknown) => [
 	"",
 ];
 
+// The upstream drain (cancelUpstreamOnce -> drainUpstream) now runs detached
+// from writer.close() (fire-and-forget, matching the Anthropic
+// terminal-recovery pattern): the client-visible stream can reach EOF before
+// the background drain has hit its deadline and aborted drainAbort. Poll
+// instead of asserting immediately after stream completion.
+async function waitForAbort(
+	signal: AbortSignal,
+	timeoutMs: number,
+): Promise<void> {
+	const start = Date.now();
+	while (!signal.aborted) {
+		if (Date.now() - start > timeoutMs) {
+			throw new Error("drainAbort did not abort within expected time");
+		}
+		await Bun.sleep(5);
+	}
+}
+
 describe("CodexProvider stream liveness", () => {
 	it("keeps a silent SSE stream alive until response.completed arrives", async () => {
 		const provider = new CodexProvider({
@@ -141,7 +159,9 @@ describe("CodexProvider stream liveness", () => {
 		}
 		expect(terminalBody).toContain("event: message_stop");
 		expect(terminalBody).not.toContain("event: ping");
-		expect(drainAbort.signal.aborted).toBeTrue();
+		// The drain runs detached from writer.close() now, so it may not have
+		// hit its deadline yet at stream EOF; wait for it to abort.
+		await waitForAbort(drainAbort.signal, 1000);
 	});
 
 	it("terminates raw upstream silence after synthetic heartbeats", async () => {
@@ -180,7 +200,9 @@ describe("CodexProvider stream liveness", () => {
 			"Codex upstream timed out while waiting for response data.",
 		);
 		expect(body).not.toContain("rawSilenceTimeoutMs");
-		expect(drainAbort.signal.aborted).toBeTrue();
+		// The drain runs detached from writer.close() now, so it may not have
+		// hit its deadline yet at stream EOF; wait for it to abort.
+		await waitForAbort(drainAbort.signal, 1000);
 	});
 
 	it("does not await a hanging upstream drain after a terminal event", async () => {
@@ -235,7 +257,9 @@ describe("CodexProvider stream liveness", () => {
 			}),
 		]);
 		expect(body).toContain("event: message_stop");
-		expect(drainAbort.signal.aborted).toBeTrue();
+		// The drain runs detached from writer.close() now, so it may not have
+		// hit its deadline yet at stream EOF; wait for it to abort.
+		await waitForAbort(drainAbort.signal, 1000);
 	});
 });
 

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -1873,9 +1873,15 @@ export class CodexProvider extends BaseProvider {
 				streamLiveness.stop();
 				if (!upstreamCancelStarted) {
 					await streamLiveness.settlePendingReadForCleanup();
-				} else if (upstreamDrainPromise) {
-					await upstreamDrainPromise;
 				}
+				// Do NOT await upstreamDrainPromise here: draining exists to free the
+				// native off-heap buffer behind the upstream response (issue #382),
+				// not to gate client-visible stream completion. cancelUpstreamOnce
+				// already attaches a .catch(() => undefined) at assignment, so the
+				// drain runs detached in the background — bounded by
+				// streamDrainDeadlineMs / drainAbort — while writer.close() proceeds
+				// immediately, matching the fire-and-forget pattern used by
+				// cancelAfterForcedClose in anthropic-terminal-recovery.ts.
 				await writer.close();
 			}
 		};

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -393,11 +393,28 @@ function isCodexSubscriptionEndpoint(account?: Account): boolean {
 export interface CodexProviderOptionsForTests {
 	streamHeartbeatIntervalMs?: number;
 	streamRawSilenceTimeoutMs?: number;
+	streamDrainDeadlineMs?: number;
 }
+
+/**
+ * Upper bound on how long processEvents' post-cancel upstream drain will
+ * wait for reader.read() to settle before giving up. `reader.cancel()` is a
+ * documented no-op on every released Bun version (oven-sh/bun#35093): it
+ * never releases the native off-heap buffer backing the upstream fetch
+ * Response body, leaking RSS while JS heap stays flat (issue #382). Draining
+ * the reader to `done` instead actually releases the buffer.
+ *
+ * A dedicated constant (not a shared import from packages/proxy's
+ * ANTHROPIC_DRAIN_DEADLINE_MS) because packages/providers cannot depend on
+ * packages/proxy — proxy's package.json depends on
+ * @better-ccflare/providers, so the reverse import would be circular.
+ */
+export const CODEX_STREAM_DRAIN_DEADLINE_MS = 30_000;
 
 export class CodexProvider extends BaseProvider {
 	name = "codex";
 	private readonly streamLivenessOptions: CodexStreamLivenessOptions;
+	private readonly streamDrainDeadlineMs: number;
 
 	constructor(options: CodexProviderOptionsForTests = {}) {
 		super();
@@ -405,6 +422,8 @@ export class CodexProvider extends BaseProvider {
 			heartbeatIntervalMs: options.streamHeartbeatIntervalMs,
 			rawSilenceTimeoutMs: options.streamRawSilenceTimeoutMs,
 		};
+		this.streamDrainDeadlineMs =
+			options.streamDrainDeadlineMs ?? CODEX_STREAM_DRAIN_DEADLINE_MS;
 	}
 	// Fallback map: proxy-operations.ts injects x-better-ccflare-request-id and
 	// x-better-ccflare-request-stream into the upstream response before calling
@@ -629,6 +648,8 @@ export class CodexProvider extends BaseProvider {
 	async processResponse(
 		response: Response,
 		_account: Account | null,
+		_requestHeaders?: Headers,
+		drainAbort?: AbortController,
 	): Promise<Response> {
 		const contentType = response.headers.get("content-type");
 		const requestId = response.headers.get("x-better-ccflare-request-id");
@@ -649,7 +670,7 @@ export class CodexProvider extends BaseProvider {
 		const isEventStream = contentType?.includes("text/event-stream") ?? false;
 		if (isEventStream) {
 			if (requestedStream) {
-				return this.transformStreamingResponse(response);
+				return this.transformStreamingResponse(response, drainAbort);
 			}
 			return this.transformSseResponseToJson(response);
 		}
@@ -671,7 +692,7 @@ export class CodexProvider extends BaseProvider {
 					headers,
 				});
 				if (requestedStream) {
-					return this.transformStreamingResponse(sseResponse);
+					return this.transformStreamingResponse(sseResponse, drainAbort);
 				}
 				return this.transformSseResponseToJson(sseResponse);
 			}
@@ -1543,7 +1564,10 @@ export class CodexProvider extends BaseProvider {
 		});
 	}
 
-	private transformStreamingResponse(response: Response): Response {
+	private transformStreamingResponse(
+		response: Response,
+		drainAbort?: AbortController,
+	): Response {
 		const requestId =
 			response.headers.get("x-better-ccflare-request-id") ?? "unknown";
 		if (process.env.DEBUG?.includes("model") || process.env.DEBUG === "true") {
@@ -1656,14 +1680,71 @@ export class CodexProvider extends BaseProvider {
 		const processEvents = async () => {
 			const reader = response.body?.getReader();
 			let upstreamCancelStarted = false;
-			const cancelUpstreamOnce = (reason: unknown): void => {
+			let upstreamDrainPromise: Promise<void> | null = null;
+
+			// `reader.cancel()` is a documented no-op on every released Bun
+			// version (oven-sh/bun#35093): it never releases the native off-heap
+			// buffer backing the upstream fetch Response body, leaking RSS while
+			// JS heap stays flat (issue #382). Draining the reader to `done`
+			// instead actually releases the buffer.
+			//
+			// CodexStreamLiveness never issues concurrent reads (ensurePendingRead
+			// allows at most one outstanding reader.read() at a time), so before
+			// this helper can take exclusive ownership of the reader it must first
+			// reconcile with any read `streamLiveness` still has outstanding —
+			// racing settlePendingReadForCleanup() itself (rather than peeking at
+			// the private pendingRead) against the same deadline. Once `stop()`
+			// has been called — guaranteed by the time cancelUpstreamOnce fires on
+			// every call site — streamLiveness never issues another read, so once
+			// reconciled this helper owns the reader for the rest of its life.
+			//
+			// Bounded by CODEX_STREAM_DRAIN_DEADLINE_MS: a stuck-but-open upstream
+			// (exactly the scenario raw_silence_timeout's 8-minute ceiling exists
+			// for) would otherwise hang this drain forever, reintroducing the hang
+			// the ceiling was meant to prevent. On deadline, `drainAbort` (when
+			// supplied) is aborted so the fetch's underlying connection is
+			// actually torn down — releaseLock() alone only frees the reader
+			// object, it does not touch the connection.
+			const drainUpstream = async (): Promise<void> => {
+				if (!reader) return;
+				let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+				const deadline = new Promise<"deadline">((resolve) => {
+					deadlineTimer = setTimeout(
+						() => resolve("deadline"),
+						this.streamDrainDeadlineMs,
+					);
+				});
+				try {
+					const reconciled = await Promise.race([
+						streamLiveness
+							.settlePendingReadForCleanup()
+							.then(() => "settled" as const),
+						deadline,
+					]);
+					if (reconciled === "deadline") {
+						drainAbort?.abort(new Error("Codex drain deadline exceeded"));
+						return;
+					}
+					while (true) {
+						const outcome = await Promise.race([reader.read(), deadline]);
+						if (outcome === "deadline") {
+							drainAbort?.abort(new Error("Codex drain deadline exceeded"));
+							return;
+						}
+						if (outcome.done) return;
+					}
+				} catch {
+					// Swallow — draining is best-effort cleanup.
+				} finally {
+					if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
+					reader.releaseLock();
+				}
+			};
+			const cancelUpstreamOnce = (_reason: unknown): void => {
 				if (upstreamCancelStarted || !reader) return;
 				upstreamCancelStarted = true;
-				try {
-					void reader.cancel(reason).catch(() => undefined);
-				} catch {
-					// Cancellation is best effort; downstream termination must still finish.
-				}
+				upstreamDrainPromise = drainUpstream();
+				upstreamDrainPromise.catch(() => undefined);
 			};
 			try {
 				if (!reader) throw new Error("Response body is not readable");
@@ -1790,7 +1871,11 @@ export class CodexProvider extends BaseProvider {
 				cancelUpstreamOnce(error);
 			} finally {
 				streamLiveness.stop();
-				await streamLiveness.settlePendingReadForCleanup();
+				if (!upstreamCancelStarted) {
+					await streamLiveness.settlePendingReadForCleanup();
+				} else if (upstreamDrainPromise) {
+					await upstreamDrainPromise;
+				}
 				await writer.close();
 			}
 		};

--- a/packages/providers/src/providers/openai/provider.ts
+++ b/packages/providers/src/providers/openai/provider.ts
@@ -15,6 +15,7 @@ import {
 import type { Account } from "@better-ccflare/types";
 import { BaseProvider } from "../../base";
 import type { RateLimitInfo, TokenRefreshResult } from "../../types";
+import { drainReader } from "../../utils/stream-drain";
 
 const log = new Logger("OpenAICompatibleProvider");
 
@@ -143,11 +144,16 @@ export class OpenAICompatibleProvider extends BaseProvider {
 				// original is discarded here. `clone()` teed the body — leaving
 				// the original branch unread keeps the tee buffering for a body
 				// nobody will ever consume, on every JSON response this provider
-				// converts. Cancelling disturbs it immediately; the promise is
-				// not awaited because nothing downstream depends on it. Only the
-				// success path may do this: the catch below falls through and
-				// returns the original, which must stay intact. See issue #356.
-				response.body?.cancel().catch(() => {});
+				// converts. `reader.cancel()` is a no-op on every released Bun
+				// (oven-sh/bun#35093) and does not release the native buffer;
+				// drain to `done` instead — see drainReader() (#382). The promise
+				// is not awaited because nothing downstream depends on it. Only
+				// the success path may do this: the catch below falls through
+				// and returns the original, which must stay intact. See #356.
+				const discardedBody = response.body;
+				if (discardedBody && !discardedBody.locked) {
+					void drainReader(discardedBody.getReader());
+				}
 
 				return new Response(JSON.stringify(anthropicData), {
 					status: response.status,

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -66,6 +66,7 @@ export interface Provider {
 		response: Response,
 		account: Account | null,
 		requestHeaders?: Headers,
+		drainAbort?: AbortController,
 	): Promise<Response>;
 
 	/**

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -1359,6 +1359,7 @@ export async function proxyWithAccount(
 			taggedRawResponse,
 			account,
 			req.headers,
+			drainAbortController,
 		);
 
 		// Failover to next account on upstream 401 — credentials are invalid/expired
@@ -1417,6 +1418,7 @@ export async function proxyWithAccount(
 							retryTaggedRaw,
 							account,
 							req.headers,
+							drainAbortController,
 						);
 
 						cancelDiscardedResponseBody(response);


### PR DESCRIPTION
## Summary
- Bun's `ReadableStream.cancel()`/`reader.cancel()` is a documented no-op on every released version (oven-sh/bun#35093) — it never frees the native buffer backing a fetch `Response` body, causing off-heap RSS growth under sustained proxy traffic.
- Replaces `.cancel()` with draining the stream to `done` at both flagged leak sites:
  - OpenAI provider (`packages/providers/src/providers/openai/provider.ts`) — already committed as `2344d63d`.
  - Codex provider (`packages/providers/src/providers/codex/provider.ts`) — new in this PR. `cancelUpstreamOnce` now runs a bounded `drainUpstream()` that first reconciles with `CodexStreamLiveness`'s single-outstanding-read invariant (avoids throwing on a concurrent read, avoids reintroducing the `raw_silence_timeout` hang) before draining the reader to `done`, with a 30s deadline (`CODEX_STREAM_DRAIN_DEADLINE_MS`, overridable via `streamDrainDeadlineMs` for tests) that aborts a passed-in `AbortController` on timeout.
- Threads an optional `drainAbort?: AbortController` 4th param through `Provider.processResponse` (additive, backward-compatible) and wires the proxy's existing `drainAbortController` into both `processResponse` call sites in `proxy-operations.ts`.
- A third flagged site (`codex/on-demand-fetch.ts:127`) was investigated and found not to be a real leak — `controller.abort()` already runs immediately before that `.cancel()` call, tearing down the connection — left untouched.

## Test plan
- [x] `bun run lint && bun run typecheck && bun run format` — clean
- [x] `bun test packages/providers` — 636/636 pass
- [x] `bun test packages/proxy` — 974/981 pass (7 failures reproduce identically on baseline `main`, confirmed pre-existing/unrelated flakiness via `git stash` comparison)
- [x] Codex stream-liveness tests redesigned around the new drain mechanism (hanging `read()` + `drainAbort.signal.aborted` assertions, short `streamDrainDeadlineMs`) — all pass
- [x] GitNexus `detect_changes` — MEDIUM risk (expected for an interface signature change), all 16 changed symbols matched the plan, no unexpected ripple

Fixes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)