### PR TITLE
refactor: consolidate stream-drain helpers into shared drainReaderWithDeadline

### DIFF
--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -33,6 +33,8 @@ export {
 export * from "./types";
 // Export usage fetcher
 export * from "./usage-fetcher";
+// Export shared stream-drain helpers
+export * from "./utils/stream-drain";
 // Export xAI usage fetcher
 export * from "./xai-usage-fetcher";
 // Export Zai usage fetcher

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -14,6 +14,7 @@ import type { Account } from "@better-ccflare/types";
 import { BaseProvider } from "../../base";
 import { resolveProviderModelDefault } from "../../provider-model-defaults";
 import type { RateLimitInfo, TokenRefreshResult } from "../../types";
+import { drainReaderWithDeadline } from "../../utils/stream-drain";
 import {
 	CodexStreamLiveness,
 	type CodexStreamLivenessOptions,
@@ -1698,47 +1699,23 @@ export class CodexProvider extends BaseProvider {
 			// every call site — streamLiveness never issues another read, so once
 			// reconciled this helper owns the reader for the rest of its life.
 			//
-			// Bounded by CODEX_STREAM_DRAIN_DEADLINE_MS: a stuck-but-open upstream
-			// (exactly the scenario raw_silence_timeout's 8-minute ceiling exists
-			// for) would otherwise hang this drain forever, reintroducing the hang
-			// the ceiling was meant to prevent. On deadline, `drainAbort` (when
-			// supplied) is aborted so the fetch's underlying connection is
-			// actually torn down — releaseLock() alone only frees the reader
-			// object, it does not touch the connection.
+			// Bounded by CODEX_STREAM_DRAIN_DEADLINE_MS, shared with Anthropic's
+			// equivalent drain in `anthropic-terminal-recovery.ts` via
+			// `drainReaderWithDeadline()` in
+			// `packages/providers/src/utils/stream-drain.ts` — see that helper
+			// for the deadline-race-then-drain-loop implementation, including
+			// the `beforeDrain` reconciliation step used below. Errors are
+			// swallowed (`swallowErrors: true`) since this drain is purely
+			// best-effort cleanup running detached from `cancelUpstreamOnce`'s
+			// fire-and-forget caller.
 			const drainUpstream = async (): Promise<void> => {
 				if (!reader) return;
-				let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
-				const deadline = new Promise<"deadline">((resolve) => {
-					deadlineTimer = setTimeout(
-						() => resolve("deadline"),
-						this.streamDrainDeadlineMs,
-					);
+				await drainReaderWithDeadline(reader, {
+					deadlineMs: this.streamDrainDeadlineMs,
+					drainAbort,
+					beforeDrain: () => streamLiveness.settlePendingReadForCleanup(),
+					swallowErrors: true,
 				});
-				try {
-					const reconciled = await Promise.race([
-						streamLiveness
-							.settlePendingReadForCleanup()
-							.then(() => "settled" as const),
-						deadline,
-					]);
-					if (reconciled === "deadline") {
-						drainAbort?.abort(new Error("Codex drain deadline exceeded"));
-						return;
-					}
-					while (true) {
-						const outcome = await Promise.race([reader.read(), deadline]);
-						if (outcome === "deadline") {
-							drainAbort?.abort(new Error("Codex drain deadline exceeded"));
-							return;
-						}
-						if (outcome.done) return;
-					}
-				} catch {
-					// Swallow — draining is best-effort cleanup.
-				} finally {
-					if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
-					reader.releaseLock();
-				}
 			};
 			const cancelUpstreamOnce = (_reason: unknown): void => {
 				if (upstreamCancelStarted || !reader) return;

--- a/packages/providers/src/utils/stream-drain.test.ts
+++ b/packages/providers/src/utils/stream-drain.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "bun:test";
+import { drainReaderWithDeadline } from "./stream-drain";
+
+function makeReader(chunks: (Uint8Array | Error)[]): {
+	reader: ReadableStreamDefaultReader<Uint8Array>;
+	releasedAt: () => number | null;
+} {
+	const stream = new ReadableStream<Uint8Array>({
+		start(controller) {
+			for (const chunk of chunks) {
+				if (chunk instanceof Error) {
+					controller.error(chunk);
+					return;
+				}
+				controller.enqueue(chunk);
+			}
+			controller.close();
+		},
+	});
+	const reader = stream.getReader();
+	let releasedAt: number | null = null;
+	const originalReleaseLock = reader.releaseLock.bind(reader);
+	reader.releaseLock = () => {
+		releasedAt = performance.now();
+		originalReleaseLock();
+	};
+	return { reader, releasedAt: () => releasedAt };
+}
+
+function makeHangingReader(): {
+	reader: ReadableStreamDefaultReader<Uint8Array>;
+	releasedAt: () => number | null;
+} {
+	const stream = new ReadableStream<Uint8Array>({
+		start() {
+			// Never enqueue or close — reads on this reader hang forever.
+		},
+	});
+	const reader = stream.getReader();
+	let releasedAt: number | null = null;
+	const originalReleaseLock = reader.releaseLock.bind(reader);
+	reader.releaseLock = () => {
+		releasedAt = performance.now();
+		originalReleaseLock();
+	};
+	return { reader, releasedAt: () => releasedAt };
+}
+
+describe("drainReaderWithDeadline", () => {
+	it("drains all chunks to done and releases the lock", async () => {
+		const { reader, releasedAt } = makeReader([
+			Uint8Array.from([1, 2, 3]),
+			Uint8Array.from([4, 5]),
+		]);
+
+		await drainReaderWithDeadline(reader, { deadlineMs: 1000 });
+
+		expect(releasedAt()).not.toBeNull();
+	});
+
+	it("aborts drainAbort and releases the lock when the deadline expires mid-read", async () => {
+		const { reader, releasedAt } = makeHangingReader();
+		const drainAbort = new AbortController();
+
+		await drainReaderWithDeadline(reader, {
+			deadlineMs: 20,
+			drainAbort,
+		});
+
+		expect(drainAbort.signal.aborted).toBe(true);
+		expect(releasedAt()).not.toBeNull();
+	});
+
+	it("does not throw on deadline expiry when drainAbort is omitted", async () => {
+		const { reader, releasedAt } = makeHangingReader();
+
+		await drainReaderWithDeadline(reader, { deadlineMs: 20 });
+
+		expect(releasedAt()).not.toBeNull();
+	});
+
+	it("races beforeDrain against the deadline and proceeds to the read loop once it settles", async () => {
+		const { reader, releasedAt } = makeReader([Uint8Array.from([9])]);
+		let beforeDrainRan = false;
+
+		await drainReaderWithDeadline(reader, {
+			deadlineMs: 1000,
+			beforeDrain: async () => {
+				beforeDrainRan = true;
+				await Bun.sleep(5);
+			},
+		});
+
+		expect(beforeDrainRan).toBe(true);
+		expect(releasedAt()).not.toBeNull();
+	});
+
+	it("aborts and returns without touching the reader when beforeDrain outlasts the deadline", async () => {
+		const { reader, releasedAt } = makeHangingReader();
+		const drainAbort = new AbortController();
+		let beforeDrainStarted = false;
+
+		await drainReaderWithDeadline(reader, {
+			deadlineMs: 15,
+			drainAbort,
+			beforeDrain: async () => {
+				beforeDrainStarted = true;
+				await new Promise(() => {
+					// Never resolves — deadline must win the race.
+				});
+			},
+		});
+
+		expect(beforeDrainStarted).toBe(true);
+		expect(drainAbort.signal.aborted).toBe(true);
+		expect(releasedAt()).not.toBeNull();
+	});
+
+	it("propagates a read error when swallowErrors is false (default)", async () => {
+		const { reader } = makeReader([new Error("boom")]);
+
+		await expect(
+			drainReaderWithDeadline(reader, { deadlineMs: 1000 }),
+		).rejects.toThrow("boom");
+	});
+
+	it("swallows a read error when swallowErrors is true", async () => {
+		const { reader, releasedAt } = makeReader([new Error("boom")]);
+
+		await expect(
+			drainReaderWithDeadline(reader, {
+				deadlineMs: 1000,
+				swallowErrors: true,
+			}),
+		).resolves.toBeUndefined();
+		expect(releasedAt()).not.toBeNull();
+	});
+
+	it("releases the lock even when swallowErrors is false and the error propagates", async () => {
+		const { reader, releasedAt } = makeReader([new Error("boom")]);
+
+		await expect(
+			drainReaderWithDeadline(reader, { deadlineMs: 1000 }),
+		).rejects.toThrow();
+		expect(releasedAt()).not.toBeNull();
+	});
+});

--- a/packages/providers/src/utils/stream-drain.ts
+++ b/packages/providers/src/utils/stream-drain.ts
@@ -18,3 +18,87 @@ export async function drainReader(
 		reader.releaseLock();
 	}
 }
+
+export interface DrainReaderWithDeadlineOptions {
+	/**
+	 * Upper bound on how long the drain will wait for `beforeDrain` (if
+	 * supplied) and then for `reader.read()` to settle — one deadline shared
+	 * across both phases, not a fresh one per phase. On expiry, `drainAbort`
+	 * (when supplied) is aborted so the underlying fetch's connection is
+	 * actually torn down — `reader.releaseLock()` alone only frees the reader
+	 * object, it does not touch the connection.
+	 */
+	deadlineMs: number;
+	drainAbort?: AbortController;
+	/**
+	 * Optional pre-step raced against the same deadline before the reader is
+	 * touched (e.g. Codex reconciling an in-flight read owned by a liveness
+	 * tracker, which allows at most one outstanding `reader.read()` at a
+	 * time). Must resolve to let the drain proceed to the read loop; if the
+	 * deadline wins the race instead, `drainAbort` is aborted and the
+	 * function returns without touching the reader.
+	 */
+	beforeDrain?: () => Promise<void>;
+	/**
+	 * When true, errors from `beforeDrain`/`reader.read()` are swallowed
+	 * (matches Codex's `drainUpstream`, which wraps the whole operation in
+	 * try/catch since it's purely best-effort cleanup running detached from
+	 * any caller that awaits it). When false (default), errors propagate to
+	 * the caller (matches Anthropic's `drainUpstreamReader`, whose only
+	 * caller either `.catch()`s the returned promise itself or returns it
+	 * unchanged from the stream's native `cancel()` handler — the caller
+	 * owns error handling, not the drain helper).
+	 */
+	swallowErrors?: boolean;
+}
+
+/**
+ * Deadline-bounded, abort-capable variant of `drainReader`, shared by
+ * `anthropic-terminal-recovery.ts` and Codex's `provider.ts`. See
+ * `drainReader` above for why draining (not `reader.cancel()`) is needed;
+ * this variant additionally bounds the wait so a stuck-but-open upstream
+ * can't hold the connection open forever, and optionally reconciles a
+ * pre-step (Codex's liveness handoff) before taking ownership of the reader.
+ */
+export async function drainReaderWithDeadline(
+	reader: ReadableStreamDefaultReader<Uint8Array>,
+	options: DrainReaderWithDeadlineOptions,
+): Promise<void> {
+	const { deadlineMs, drainAbort, beforeDrain, swallowErrors } = options;
+	let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+	const runDrain = async (): Promise<void> => {
+		const deadline = new Promise<"deadline">((resolve) => {
+			deadlineTimer = setTimeout(() => resolve("deadline"), deadlineMs);
+		});
+
+		if (beforeDrain) {
+			const reconciled = await Promise.race([
+				beforeDrain().then(() => "settled" as const),
+				deadline,
+			]);
+			if (reconciled === "deadline") {
+				drainAbort?.abort(new Error("Drain deadline exceeded"));
+				return;
+			}
+		}
+
+		while (true) {
+			const outcome = await Promise.race([reader.read(), deadline]);
+			if (outcome === "deadline") {
+				drainAbort?.abort(new Error("Drain deadline exceeded"));
+				return;
+			}
+			if (outcome.done) return;
+		}
+	};
+
+	try {
+		await runDrain();
+	} catch (error) {
+		if (!swallowErrors) throw error;
+		// Swallow — draining is best-effort cleanup (Codex's prior behavior).
+	} finally {
+		if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
+		reader.releaseLock();
+	}
+}

--- a/packages/proxy/src/anthropic-terminal-recovery.ts
+++ b/packages/proxy/src/anthropic-terminal-recovery.ts
@@ -1,3 +1,5 @@
+import { drainReaderWithDeadline } from "@better-ccflare/providers";
+
 export const ANTHROPIC_MESSAGE_STOP_FRAME =
 	'event: message_stop\ndata: {"type":"message_stop"}\n\n';
 
@@ -171,32 +173,20 @@ export function createAnthropicTerminalRecoveryStream(
 	// `ReadableStreamDefaultReader` (the stream is locked to it), not a raw
 	// stream `drainBody` could call `.getReader()` on again.
 	//
-	// Bounded by `drainDeadlineMs`: a stuck-but-open upstream (the case
-	// `recover()`'s timeout path exists for) would otherwise leave this loop
-	// pending forever, holding the socket open where the no-op `cancel()` it
-	// replaced would have resolved instantly. On deadline, `drainAbort` (when
-	// supplied) is aborted so the fetch's underlying connection is actually
-	// torn down — `reader.releaseLock()` alone only frees the reader object,
-	// it does not touch the connection, so without an abort signal the socket
-	// would be left to whatever timeout Bun applies on its own.
-	const drainUpstreamReader = async (): Promise<void> => {
-		let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
-		try {
-			const deadline = new Promise<{ done: true }>((resolve) => {
-				deadlineTimer = setTimeout(() => {
-					drainAbort?.abort(new Error("Drain deadline exceeded"));
-					resolve({ done: true });
-				}, drainDeadlineMs);
-			});
-			while (true) {
-				const { done } = await Promise.race([reader.read(), deadline]);
-				if (done) return;
-			}
-		} finally {
-			if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
-			reader.releaseLock();
-		}
-	};
+	// Bounded by `drainDeadlineMs`, shared with Codex's equivalent drain in
+	// `codex/provider.ts` via `drainReaderWithDeadline()` in
+	// `packages/providers/src/utils/stream-drain.ts` — see that helper for
+	// the deadline-race-then-drain-loop implementation. Errors are not
+	// swallowed here (`swallowErrors` omitted): the caller (`cancelUpstream`)
+	// either `.catch()`s this promise itself (`cancelAfterForcedClose`) or
+	// returns it unchanged from the stream's native `cancel()` handler, so
+	// error handling stays the caller's responsibility, matching prior
+	// behavior.
+	const drainUpstreamReader = (): Promise<void> =>
+		drainReaderWithDeadline(reader, {
+			deadlineMs: drainDeadlineMs,
+			drainAbort,
+		});
 
 	const cancelUpstream = (_reason: unknown): Promise<void> => {
 		if (upstreamCancelPromise) return upstreamCancelPromise;


### PR DESCRIPTION
## Summary
- PR #418 (issue #382) fixed Bun's `reader.cancel()` no-op leak in two places independently, plus a third pre-existing narrower helper — leaving three near-duplicate deadline-bounded drain implementations that could drift apart.
- Extracts the shared deadline-race-then-drain-loop logic into `drainReaderWithDeadline()` in `packages/providers/src/utils/stream-drain.ts`, with an optional `beforeDrain` step for Codex's stream-liveness reconciliation and a `swallowErrors` flag so each caller's original error-handling behavior is preserved exactly.
- `anthropic-terminal-recovery.ts` and `codex/provider.ts` now both delegate to the shared helper instead of maintaining their own copies. `drainReader` (the unbounded, no-deadline variant used by openai/anthropic/base-anthropic-compatible providers) is untouched — out of scope per the plan.
- Refactor-only, no intended behavior change: deadline constants (`ANTHROPIC_DRAIN_DEADLINE_MS`, `CODEX_STREAM_DRAIN_DEADLINE_MS`), `drainAbort` wiring, and fire-and-forget semantics (including the non-awaited `upstreamDrainPromise` in Codex's `finally`, per the regression fixed in `5485e997`) are all preserved unchanged.

## Test plan
- [x] `bun run lint && bun run typecheck && bun run format` — clean
- [x] `anthropic-terminal-recovery.test.ts`, `bun-leak-273-safety.test.ts`, `bun-leak-273-regression.test.ts`, `codex/provider.test.ts`, `codex/stream-liveness.test.ts` — 162/162 pass
- [x] Full `packages/providers` + `packages/proxy` suites — pass (pre-existing unrelated flakiness in `request-handler-client-abort.test.ts` verified present on `main` too, not introduced by this change)
- [x] GitNexus `detect_changes` — LOW risk, only the two expected call sites affected, no unexpected execution flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)