### PR TITLE
feat(load-balancer): add strict ranking mode to session-drain-soonest

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -101,6 +101,8 @@ function buildStrategy(
 			return new SessionAffinityStrategy(sessionDurationMs);
 		case StrategyName.SessionDrainSoonest:
 			return new SessionDrainSoonestStrategy(sessionDurationMs);
+		case StrategyName.SessionDrainSoonestStrict:
+			return new SessionDrainSoonestStrategy(sessionDurationMs, "strict");
 		default:
 			return new SessionStrategy(sessionDurationMs);
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,7 +69,7 @@ The configuration file is stored at:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `lb_strategy` | string | `"session"` | Load balancing strategy. Use session-class strategies only: `"session"` (default) or `"session-drain-soonest"` (same session semantics, prefers the soonest-resetting weekly window). Per-request spreading strategies risk account bans — see warning below |
+| `lb_strategy` | string | `"session"` | Load balancing strategy. Use session-class strategies only: `"session"` (default), `"session-drain-soonest"` (same session semantics, prefers the soonest-resetting weekly window), or `"session-drain-soonest-strict"` (drain ranking applies to every selection; an active 5h session only breaks ties). Per-request spreading strategies risk account bans — see warning below |
 | `client_id` | string | `"9d1c250a-e61b-44d9-88ed-5944d1962f5e"` | OAuth client ID for authentication |
 | `retry_attempts` | number | `3` | Maximum number of retry attempts for failed requests |
 | `retry_delay_ms` | number | `1000` | Initial delay in milliseconds between retry attempts |
@@ -79,12 +79,13 @@ The configuration file is stored at:
 
 ### Load Balancing Strategy
 
-⚠️ **WARNING**: Only use session-class strategies — `session` (default) or `session-drain-soonest`, which shares the same 5-hour session affinity semantics. Strategies that spread individual requests across accounts can trigger Claude's anti-abuse systems and result in account bans.
+⚠️ **WARNING**: Only use session-class strategies — `session` (default), `session-drain-soonest`, or `session-drain-soonest-strict`, which share the same 5-hour session semantics. Strategies that spread individual requests across accounts can trigger Claude's anti-abuse systems and result in account bans.
 
 | Strategy | Description | Use Case |
 |----------|-------------|----------|
 | `session` | Maintains client-account affinity for session duration, with automatic alignment to Anthropic OAuth usage window resets | Default and recommended - mimics natural usage patterns and optimizes resource utilization |
-| `session-drain-soonest` | Same session semantics as `session` (5h windows, auto-fallback, session stickiness), but at every fresh selection (session start/expiry, account unavailable) it prefers the account whose weekly_all usage window resets soonest, so weekly capacity is drained before it expires ("use it or lose it"). Active sessions are never preempted by drain ranking mid-window; the one deliberate exception is auto-fallback reactivation (same as `session`): an eligible account whose usage window has reset takes over immediately. Accounts without weekly telemetry rank last; ties fall back to priority, then utilization | Multi-account pools with staggered weekly resets where unused weekly capacity should be consumed before it is lost |
+| `session-drain-soonest` | Same session semantics as `session` (5h windows, auto-fallback, session stickiness), but at every fresh selection (session start/expiry, account unavailable) it prefers the account whose weekly_all usage window resets soonest, so weekly capacity is drained before it expires ("use it or lose it"). Active sessions are never preempted by drain ranking mid-window; the one deliberate exception is auto-fallback reactivation (same as `session`): an eligible account whose usage window has reset takes over immediately. Accounts without weekly telemetry rank last; ties fall back to priority, then utilization. Note: with several concurrently active sessions (opened by served requests, keepalive probes, or the usage poller), the MOST RECENTLY started session holds all traffic — the drain ranking only orders the failover tail | Multi-account pools with staggered weekly resets where unused weekly capacity should be consumed before it is lost |
+| `session-drain-soonest-strict` | Same strategy class in strict mode: one canonical comparator ranks every available account at every selection — earliest future weekly_all reset first, then active-session status as the tie-break (an active 5h session no longer pins the account), then priority, utilization, and account id. The drain-earliest account keeps winning even after its own 5h window ages out; with all weekly resets unknown (cold usage cache right after a restart) the incumbent active account keeps the traffic. Auto-fallback reactivation still forces position 0 | Pools where traffic must actually follow the earliest-resetting account instead of the most recently started session |
 
 ### Logging Configuration (Environment Only)
 

--- a/docs/routing-architecture.md
+++ b/docs/routing-architecture.md
@@ -1,14 +1,15 @@
 # Account Routing Architecture
 
-This document explains how better-ccflare picks an account for each proxied request: the master pipeline, the four load-balancing strategies, usage-throttling, model-scoped capacity routing, and auto-fallback. It is a technical reference for understanding *why* a given request landed on a given account — for user-facing setup guides see [Load Balancing](./load-balancing.md), [Auto-Fallback Configuration](./auto-fallback.md), [Combos](./combos.md), and [Configuration](./configuration.md).
+This document explains how better-ccflare picks an account for each proxied request: the master pipeline, the load-balancing strategies, usage-throttling, model-scoped capacity routing, and auto-fallback. It is a technical reference for understanding *why* a given request landed on a given account — for user-facing setup guides see [Load Balancing](./load-balancing.md), [Auto-Fallback Configuration](./auto-fallback.md), [Combos](./combos.md), and [Configuration](./configuration.md).
 
 ## Table of Contents
 
 1. [Overview: Three Orthogonal Axes](#overview-three-orthogonal-axes)
 2. [Master Pipeline](#master-pipeline)
-3. [The Four Load-Balancing Strategies](#the-four-load-balancing-strategies)
+3. [The Load-Balancing Strategies](#the-load-balancing-strategies)
    - [session](#session-sessionstrategy)
    - [session-drain-soonest](#session-drain-soonest-sessiondrainsoonestrategy)
+   - [session-drain-soonest-strict](#session-drain-soonest-strict-sessiondrainsooneststrategy-in-strict-mode)
    - [session-affinity](#session-affinity-sessionaffinitystrategy)
    - [least-used](#least-used-leastusedstrategy)
 4. [Usage Throttling](#usage-throttling)
@@ -17,7 +18,7 @@ This document explains how better-ccflare picks an account for each proxied requ
 
 ## Overview: Three Orthogonal Axes
 
-Account routing is controlled by three independent settings that can each be changed at runtime without restarting the server: the **load-balancing strategy** (`lb_strategy` — which of the four strategies below picks the candidate order), **usage-throttling** (`usage_throttling_five_hour_enabled` / `usage_throttling_weekly_enabled` — an optional pacing gate applied after strategy selection), and **model-scoped capacity routing** (`model_scoped_capacity_routing` — `off` or `exhausted`, an optional per-model-family exclusion filter). Any runtime "combination" you observe (e.g. `least-used` with weekly throttling and capacity routing both on) is not a special combined mode — it is simply the master pipeline below with the configured strategy plugged into the `Strategy.select` step, and the two optional gates turned on or off. Understanding the pipeline once is enough to reason about every valid combination of the three settings.
+Account routing is controlled by three independent settings that can each be changed at runtime without restarting the server: the **load-balancing strategy** (`lb_strategy` — which of the strategies below picks the candidate order), **usage-throttling** (`usage_throttling_five_hour_enabled` / `usage_throttling_weekly_enabled` — an optional pacing gate applied after strategy selection), and **model-scoped capacity routing** (`model_scoped_capacity_routing` — `off` or `exhausted`, an optional per-model-family exclusion filter). Any runtime "combination" you observe (e.g. `least-used` with weekly throttling and capacity routing both on) is not a special combined mode — it is simply the master pipeline below with the configured strategy plugged into the `Strategy.select` step, and the two optional gates turned on or off. Understanding the pipeline once is enough to reason about every valid combination of the three settings.
 
 ## Master Pipeline
 
@@ -66,9 +67,9 @@ window.
 
 *Source: `packages/proxy/src/proxy.ts` (`handleProxy`, `applyUsageThrottling`), `packages/proxy/src/handlers/account-selector.ts` (`selectAccountsForRequest`), `packages/proxy/src/handlers/proxy-operations.ts` + `packages/proxy/src/handlers/retryable-429.ts` (the three no-bench 429 classes).*
 
-## The Four Load-Balancing Strategies
+## The Load-Balancing Strategies
 
-`lb_strategy` selects one of four implementations (`packages/load-balancer/src/strategies/`), all constructed in `apps/server/src/server.ts`. All four return an ordered list of candidate accounts; the first entry is tried first, the rest are failover order.
+`lb_strategy` selects one of the implementations in `packages/load-balancer/src/strategies/` (all constructed in `apps/server/src/server.ts`; the two drain-soonest entries share one class in different modes). All of them return an ordered list of candidate accounts; the first entry is tried first, the rest are failover order.
 
 ### session (SessionStrategy)
 
@@ -106,6 +107,26 @@ flowchart TD
 ```
 
 *Source: `packages/load-balancer/src/strategies/session-drain-soonest.ts`.*
+
+Caveat of the default ("sticky") mode: with several concurrently active
+sessions — the production-normal state, since served requests, keepalive
+probes, and the usage-poller rollover callback all open sessions — the
+"active session" check resolves to the account with the MOST RECENT
+`session_start`, and that account holds all traffic until another account
+receives a fresher write. The drain ranking then only orders the failover
+tail.
+
+### session-drain-soonest-strict (SessionDrainSoonestStrategy in strict mode)
+
+The same strategy class constructed in `"strict"` mode (`StrategyName.SessionDrainSoonestStrict`). Instead of the active-session pre-filter, one canonical comparator ranks every *available* account:
+
+1. earliest future `weekly_all` reset (unknown or past reset sorts last),
+2. active-session status — an active 5h session breaks reset ties but never pins an account,
+3. priority ASC,
+4. utilization ASC,
+5. account id (determinism anchor, so equal candidates never depend on input order).
+
+Consequences: the drain-earliest account keeps winning even after its own 5h window ages out (it gets a fresh session on selection — no lock-out), and in the cold-cache case (all weekly resets unknown, e.g. right after a restart) the incumbent active account keeps the traffic instead of utilization-ranked spraying. The auto-fallback exception and the bypass header behave identically in both modes; behind a forced fallback the tail follows the strict comparator, so the failover loop always walks one consistent order.
 
 ### session-affinity (SessionAffinityStrategy)
 

--- a/packages/config/src/strategy-source.test.ts
+++ b/packages/config/src/strategy-source.test.ts
@@ -81,6 +81,17 @@ describe("getStrategy / getStrategySource", () => {
 		}
 	});
 
+	it("accepts session-drain-soonest-strict as a valid env override", () => {
+		process.env.LB_STRATEGY = StrategyName.SessionDrainSoonestStrict;
+		const { config, cleanup } = makeConfig();
+		try {
+			expect(config.getStrategy()).toBe(StrategyName.SessionDrainSoonestStrict);
+			expect(config.getStrategySource()).toBe("env");
+		} finally {
+			cleanup();
+		}
+	});
+
 	it("falls back to the default for an invalid env value when the file predates lb_strategy", () => {
 		process.env.LB_STRATEGY = "not-a-real-strategy";
 		const { config, cleanup } = makeConfigFromRawFile({});

--- a/packages/dashboard-web/src/components/overview/RoutingCard.test.tsx
+++ b/packages/dashboard-web/src/components/overview/RoutingCard.test.tsx
@@ -136,11 +136,18 @@ describe("getStrategySelectItems", () => {
 	const listed: readonly StrategySelectItem[] = [
 		{ label: "Session", value: "session" },
 		{ label: "Session — drain soonest", value: "session-drain-soonest" },
+		{
+			label: "Session — drain soonest (strict)",
+			value: "session-drain-soonest-strict",
+		},
 	];
 
-	it("returns only the two listed options when the current strategy is one of them", () => {
+	it("returns only the three listed options when the current strategy is one of them", () => {
 		expect(getStrategySelectItems("session")).toEqual(listed);
 		expect(getStrategySelectItems("session-drain-soonest")).toEqual(listed);
+		expect(getStrategySelectItems("session-drain-soonest-strict")).toEqual(
+			listed,
+		);
 	});
 
 	it("appends the current strategy as a disabled item when it is not listed", () => {

--- a/packages/dashboard-web/src/components/overview/RoutingCard.test.tsx
+++ b/packages/dashboard-web/src/components/overview/RoutingCard.test.tsx
@@ -39,9 +39,13 @@ describe("RoutingCardView", () => {
 		expect(html).toContain("Model-scoped capacity routing");
 	});
 
-	it("explains the drain-soonest tiebreaker in the strategy description", () => {
+	it("describes both drain-soonest modes honestly in the strategy description", () => {
 		const html = render();
-		expect(html).toContain("priority becomes a tiebreaker");
+		// The sticky mode's actual behaviour (never preempted, ranking only
+		// orders re-selection/failover) — not the drain promise it used to make.
+		expect(html).toContain("never preempted");
+		// The strict mode's rule: an active session only breaks ties.
+		expect(html).toContain("only breaks ties");
 		// The safety note about not offering per-request spreading strategies.
 		expect(html).toContain("Only session-class strategies are shown");
 	});

--- a/packages/dashboard-web/src/components/overview/RoutingCard.tsx
+++ b/packages/dashboard-web/src/components/overview/RoutingCard.tsx
@@ -28,12 +28,16 @@ import { Switch } from "../ui/switch";
 // anti-abuse systems and get accounts banned, so they are deliberately not
 // listed here even though StrategyName defines them. Values come from the
 // shared StrategyName enum (not hardcoded strings) so this list can never
-// drift from the authoritative 4 values in @better-ccflare/core.
+// drift from the authoritative values in @better-ccflare/core.
 const STRATEGY_OPTIONS: ReadonlyArray<{ label: string; value: string }> = [
 	{ label: "Session", value: StrategyName.Session },
 	{
 		label: "Session — drain soonest",
 		value: StrategyName.SessionDrainSoonest,
+	},
+	{
+		label: "Session — drain soonest (strict)",
+		value: StrategyName.SessionDrainSoonestStrict,
 	},
 ];
 
@@ -44,16 +48,16 @@ export interface StrategySelectItem {
 }
 
 /**
- * Build the strategy Select's item list. The dashboard only offers the two
+ * Build the strategy Select's item list. The dashboard only offers the
  * session-class strategies above, but the server's effective strategy
- * (getStrategy()) can be any of the four StrategyName values — settable via
+ * (getStrategy()) can be any StrategyName value — settable via
  * LB_STRATEGY, an older config file, or a hand-edited one. An out-of-list
  * value used to leave the Select's trigger blank with no indication it was
- * active, and selecting either listed option would silently overwrite it
+ * active, and selecting a listed option would silently overwrite it
  * with no recovery path (routing-settings-ui-2026-07-20 review, rank 1).
- * When the current strategy isn't one of the two listed options, it is
+ * When the current strategy isn't one of the listed options, it is
  * appended as a disabled item labelled "<value> (current)" so its state is
- * visible without being re-selectable; the two deliberate options stay
+ * visible without being re-selectable; the deliberate options stay
  * selectable.
  */
 export function getStrategySelectItems(
@@ -128,7 +132,12 @@ export function RoutingCardView({
 							<span className="font-medium">Session — drain soonest</span>{" "}
 							shares the same session semantics but, at every fresh selection,
 							prefers the account whose weekly window resets soonest so capacity
-							is used before it expires; priority becomes a tiebreaker.
+							is used before it expires; priority becomes a tiebreaker. The{" "}
+							<span className="font-medium">strict</span> variant applies that
+							drain ranking to every selection — an active 5h session only
+							breaks ties instead of pinning the current account — so traffic
+							follows the earliest-resetting account instead of the most
+							recently started session.
 						</div>
 						<Select
 							disabled={strategyDisabled || strategyEnvLocked}

--- a/packages/dashboard-web/src/components/overview/RoutingCard.tsx
+++ b/packages/dashboard-web/src/components/overview/RoutingCard.tsx
@@ -129,15 +129,18 @@ export function RoutingCardView({
 						<div className="text-sm text-muted-foreground">
 							<span className="font-medium">Session</span> keeps each client on
 							one account for the session duration.{" "}
-							<span className="font-medium">Session — drain soonest</span>{" "}
-							shares the same session semantics but, at every fresh selection,
-							prefers the account whose weekly window resets soonest so capacity
-							is used before it expires; priority becomes a tiebreaker. The{" "}
-							<span className="font-medium">strict</span> variant applies that
-							drain ranking to every selection — an active 5h session only
-							breaks ties instead of pinning the current account — so traffic
-							follows the earliest-resetting account instead of the most
-							recently started session.
+							<span className="font-medium">Session — drain soonest</span> is
+							sticky: the most recently started 5h session holds all traffic and
+							is never preempted; the weekly-reset ranking only orders
+							re-selection and failover, so with several concurrently active
+							sessions traffic does not follow the earliest-resetting account.{" "}
+							<span className="font-medium">
+								Session — drain soonest (strict)
+							</span>{" "}
+							ranks every selection by earliest weekly reset (skipping accounts
+							whose capacity for the request&apos;s model family is exhausted);
+							an active 5h session only breaks ties, so capacity is drained
+							before it expires.
 						</div>
 						<Select
 							disabled={strategyDisabled || strategyEnvLocked}

--- a/packages/load-balancer/src/index.ts
+++ b/packages/load-balancer/src/index.ts
@@ -1,3 +1,4 @@
+export type { SessionDrainSoonestMode } from "./strategies";
 export {
 	LeastUsedStrategy,
 	SessionAffinityStrategy,

--- a/packages/load-balancer/src/strategies/__tests__/session-drain-soonest-active-selection.test.ts
+++ b/packages/load-balancer/src/strategies/__tests__/session-drain-soonest-active-selection.test.ts
@@ -1,4 +1,9 @@
-import { beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+	clearAllProbeBackoff,
+	PROBE_BACKOFF_PENALTY_THRESHOLD_MS,
+	setProbeBackoff,
+} from "@better-ccflare/core";
 import { SessionDrainSoonestStrategy } from "@better-ccflare/load-balancer";
 import type {
 	Account,
@@ -279,9 +284,62 @@ describe("SessionDrainSoonestStrategy — strict ranking mode (A11)", () => {
 	let store: MockStrategyStore;
 
 	beforeEach(() => {
+		clearAllProbeBackoff();
 		strategy = new SessionDrainSoonestStrategy(undefined, "strict");
 		store = new MockStrategyStore();
 		strategy.initialize(store);
+	});
+
+	afterEach(() => {
+		clearAllProbeBackoff();
+	});
+
+	it("a probe-backed-off account does not win strict-mode position 0 on priority alone", () => {
+		const now = Date.now();
+		// Equal weekly reset and equal activity (both inactive) puts this tie on
+		// priority — where a raw a.priority - b.priority comparison would let
+		// the backed-off account win purely because it configures a better
+		// (lower) priority number. compareAccountPreference must intervene
+		// first, exactly like the sibling sticky comparator already does.
+		const backedOff = makeAccount({
+			id: "sick",
+			name: "sick",
+			priority: 0, // better priority number — must NOT win while penalised
+			session_start: null,
+		});
+		const healthy = makeAccount({
+			id: "well",
+			name: "well",
+			priority: 5,
+			session_start: null,
+		});
+		store.setWeeklyReset("sick", now + 1 * DAY);
+		store.setWeeklyReset("well", now + 1 * DAY);
+		setProbeBackoff(backedOff.id, now + PROBE_BACKOFF_PENALTY_THRESHOLD_MS);
+
+		const result = strategy.select([backedOff, healthy], meta);
+		expect(result.map((a) => a.id)).toEqual(["well", "sick"]);
+		expect(strategy.peek([backedOff, healthy])).toBe("well");
+	});
+
+	it("leaves strict priority order alone when nobody is penalised", () => {
+		const now = Date.now();
+		const lowPrio = makeAccount({
+			id: "acc-a",
+			name: "acc-a",
+			priority: 5,
+			session_start: null,
+		});
+		const highPrio = makeAccount({
+			id: "acc-z",
+			name: "acc-z",
+			priority: 0,
+			session_start: null,
+		});
+		store.setWeeklyReset("acc-a", now + 1 * DAY);
+		store.setWeeklyReset("acc-z", now + 1 * DAY);
+
+		expect(strategy.select([lowPrio, highPrio], meta)[0].id).toBe("acc-z");
 	});
 
 	it("select() picks the drain-earliest account even when another account has the youngest active session", () => {

--- a/packages/load-balancer/src/strategies/__tests__/session-drain-soonest-active-selection.test.ts
+++ b/packages/load-balancer/src/strategies/__tests__/session-drain-soonest-active-selection.test.ts
@@ -1,0 +1,545 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { SessionDrainSoonestStrategy } from "@better-ccflare/load-balancer";
+import type {
+	Account,
+	RequestMeta,
+	StrategyStore,
+} from "@better-ccflare/types";
+
+// ---------------------------------------------------------------------------
+// Characterization tests for HOLDER SELECTION among MULTIPLE active sessions.
+//
+// The sibling suite (session-drain-soonest.test.ts) covers stickiness with a
+// single active session and drain ranking with none. This file pins the
+// behaviour in the production-normal case that suite never exercises: several
+// accounts hold an active 5h session AT THE SAME TIME, and the strategy must
+// pick ONE of them. Sessions are opened by a served request when none is
+// active (updateAccountUsage only writes session_start if it is NULL or older
+// than the session duration — account.repository.ts), and created/reset
+// independently by the usage-poller rollover callback and by
+// keepalive/auto-refresh probes.
+//
+// Current behaviour (pinned here, GREEN against main): the account with the
+// MOST RECENT session_start wins position 0 regardless of its weekly-reset
+// rank — the drain comparator only orders the tail. Observed in production
+// (2026-08-19/20 trace): 3 570/3 570 events tail-sorted correctly, 0 drain
+// decisions at position 0; the earliest-reset account received 12 % of
+// traffic while ranked #1 in 100 % of decisions.
+//
+// These tests document the status quo so a future "strict" ranking option can
+// change it deliberately (new tests) instead of silently.
+// ---------------------------------------------------------------------------
+
+// Shared Account factory — mirrors session-drain-soonest.test.ts's makeAccount
+// so tests focus on the fields that actually differ.
+function makeAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "test-account",
+		name: "test-account",
+		provider: "anthropic",
+		api_key: null,
+		refresh_token: "test",
+		access_token: "test",
+		expires_at: Date.now() + 3600_000,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: Date.now(),
+		rate_limited_until: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		custom_endpoint: null,
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		...overrides,
+	};
+}
+
+// Mock StrategyStore — same shape as the sibling suite's. Indexed by account
+// id only (provider is ignored), so every test uses unique ids and sets reset
+// and utilization explicitly where the scenario depends on them.
+class MockStrategyStore implements StrategyStore {
+	utilizationMap: Map<string, number | null> = new Map();
+	weeklyResetMap: Map<string, number | null> = new Map();
+
+	resetAccountSession(_accountId: string, _timestamp: number): void {}
+
+	resumeAccount(_accountId: string): void {}
+
+	getAccountUtilization(accountId: string, _provider: string): number | null {
+		if (!this.utilizationMap.has(accountId)) return null;
+		return this.utilizationMap.get(accountId) ?? null;
+	}
+
+	getAccountWeeklyReset(accountId: string, _provider: string): number | null {
+		if (!this.weeklyResetMap.has(accountId)) return null;
+		return this.weeklyResetMap.get(accountId) ?? null;
+	}
+
+	setUtilization(accountId: string, value: number | null): void {
+		this.utilizationMap.set(accountId, value);
+	}
+
+	setWeeklyReset(accountId: string, value: number | null): void {
+		this.weeklyResetMap.set(accountId, value);
+	}
+}
+
+const meta: RequestMeta = {
+	id: "test-request",
+	headers: new Headers(),
+	path: "/v1/messages",
+	method: "POST",
+	timestamp: Date.now(),
+};
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+describe("SessionDrainSoonestStrategy — holder selection among multiple active sessions (characterization)", () => {
+	let strategy: SessionDrainSoonestStrategy;
+	let store: MockStrategyStore;
+
+	beforeEach(() => {
+		strategy = new SessionDrainSoonestStrategy();
+		store = new MockStrategyStore();
+		strategy.initialize(store);
+	});
+
+	/**
+	 * Two available accounts, both with an active session. The YOUNGER
+	 * session wins position 0 even though the older-session account resets
+	 * a full five days earlier AND has lower utilization — the drain
+	 * comparator does not participate in the holder choice at all.
+	 *
+	 * Deliberately stacked against the winner: later reset, higher
+	 * utilization. Only session_start recency differs in its favour.
+	 */
+	it("select() picks the youngest active session even when an older active session has a strictly earlier weekly reset", () => {
+		const now = Date.now();
+		const drainEarly = makeAccount({
+			id: "drain-early",
+			name: "drain-early",
+			session_start: now - 2 * HOUR, // active, but older
+		});
+		const drainLate = makeAccount({
+			id: "drain-late",
+			name: "drain-late",
+			session_start: now - 30 * 60 * 1000, // active, youngest
+		});
+		store.setWeeklyReset("drain-early", now + 1 * DAY);
+		store.setWeeklyReset("drain-late", now + 6 * DAY);
+		store.setUtilization("drain-early", 10);
+		store.setUtilization("drain-late", 90);
+
+		// Both input orders, so a stable sort cannot fake the result.
+		const resultA = strategy.select([drainEarly, drainLate], meta);
+		expect(resultA[0].id).toBe("drain-late");
+
+		const resultB = strategy.select(
+			[
+				makeAccount({
+					id: "drain-late",
+					name: "drain-late",
+					session_start: now - 30 * 60 * 1000,
+				}),
+				makeAccount({
+					id: "drain-early",
+					name: "drain-early",
+					session_start: now - 2 * HOUR,
+				}),
+			],
+			meta,
+		);
+		expect(resultB[0].id).toBe("drain-late");
+	});
+
+	/**
+	 * The production "coronation" mechanism, shown as a TRANSITION: the
+	 * incumbent drain-rank-1 holder wins first; the moment another account
+	 * receives a fresh session_start (in production written by the
+	 * usage-poller rollover callback, by keepalive/auto-refresh probes, or
+	 * by a served request when no session was active — none of which carry
+	 * drain intent), that account takes position 0.
+	 */
+	it("a freshly opened session takes position 0 from a drain-earlier active holder", () => {
+		const now = Date.now();
+		const incumbent = makeAccount({
+			id: "incumbent",
+			name: "incumbent",
+			session_start: now - 3 * HOUR, // holding, drain rank 1
+		});
+		const middle = makeAccount({
+			id: "middle",
+			name: "middle",
+			session_start: now - 4 * HOUR,
+		});
+		const other = makeAccount({
+			id: "other",
+			name: "other",
+			session_start: null, // no session yet
+		});
+		store.setWeeklyReset("incumbent", now + 1 * DAY);
+		store.setWeeklyReset("middle", now + 2 * DAY);
+		store.setWeeklyReset("other", now + 6 * DAY);
+
+		// Phase 1: without the fresh write, the incumbent holds position 0.
+		const before = strategy.select([incumbent, middle, other], meta);
+		expect(before[0].id).toBe("incumbent");
+
+		// Phase 2: a probe/poller-equivalent write opens a session on the
+		// drain-LATEST account — it takes the crown immediately.
+		other.session_start = now - 60 * 1000;
+		const after = strategy.select([incumbent, middle, other], meta);
+		expect(after[0].id).toBe("other");
+		// The tail IS drain-sorted — the comparator works, it just never
+		// decides position 0 (matches the production trace: 3 570/3 570
+		// tails correct).
+		expect(after.map((a) => a.id)).toEqual(["other", "incumbent", "middle"]);
+	});
+
+	/**
+	 * Tie on session_start: the active-session scan uses a strict `>`, so
+	 * with IDENTICAL timestamps the FIRST account in input order wins —
+	 * the current holder choice is input-order-dependent in this edge.
+	 * (The strict mode replaces this with a deterministic account-id
+	 * anchor.)
+	 */
+	it("with identical session_start values, input order decides position 0", () => {
+		const now = Date.now();
+		const sharedStart = now - 1 * HOUR;
+		const mk = (id: string) =>
+			makeAccount({ id, name: id, session_start: sharedStart });
+		store.setWeeklyReset("acc-a", now + 2 * DAY);
+		store.setWeeklyReset("acc-z", now + 2 * DAY);
+
+		expect(strategy.select([mk("acc-z"), mk("acc-a")], meta)[0].id).toBe(
+			"acc-z",
+		);
+		expect(strategy.select([mk("acc-a"), mk("acc-z")], meta)[0].id).toBe(
+			"acc-a",
+		);
+	});
+
+	/**
+	 * peek() must agree with select() on the youngest-wins rule — the
+	 * dashboard's "Primary" badge is computed from peek().
+	 */
+	it("peek() agrees with select(): youngest active session wins over a drain-earlier active one", () => {
+		const now = Date.now();
+		const drainEarly = makeAccount({
+			id: "drain-early",
+			name: "drain-early",
+			session_start: now - 2 * HOUR,
+		});
+		const drainLate = makeAccount({
+			id: "drain-late",
+			name: "drain-late",
+			session_start: now - 30 * 60 * 1000,
+		});
+		store.setWeeklyReset("drain-early", now + 1 * DAY);
+		store.setWeeklyReset("drain-late", now + 6 * DAY);
+
+		// peek() first — select() may mutate account state via
+		// resetSessionIfExpired.
+		expect(strategy.peek([drainEarly, drainLate])).toBe("drain-late");
+		expect(strategy.select([drainEarly, drainLate], meta)[0].id).toBe(
+			"drain-late",
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// SOLL-Tests: the "strict" ranking mode (A11).
+//
+// One canonical comparator instead of the active-session pre-filter:
+//   weekly_all reset ASC (unknown/past last)
+//   → has active session (active before inactive)
+//   → priority ASC → utilization ASC → account id (determinism anchor).
+//
+// session_start gates nothing anymore at position 0 — the active-session
+// STATUS breaks weekly-reset ties; session-start recency is never compared.
+// Normal case: the drain-earliest available account wins, active or not (no
+// lock-out when a holder ages out of its 5h window). Tie case (cold cache
+// after restart: all resets null): an ACTIVE account beats an inactive one,
+// so the incumbent holder keeps the traffic instead of utilization-based
+// spraying that would flush every account's prompt cache.
+// ---------------------------------------------------------------------------
+
+describe("SessionDrainSoonestStrategy — strict ranking mode (A11)", () => {
+	let strategy: SessionDrainSoonestStrategy;
+	let store: MockStrategyStore;
+
+	beforeEach(() => {
+		strategy = new SessionDrainSoonestStrategy(undefined, "strict");
+		store = new MockStrategyStore();
+		strategy.initialize(store);
+	});
+
+	it("select() picks the drain-earliest account even when another account has the youngest active session", () => {
+		const now = Date.now();
+		const drainEarly = makeAccount({
+			id: "drain-early",
+			name: "drain-early",
+			session_start: now - 2 * HOUR,
+		});
+		const drainLate = makeAccount({
+			id: "drain-late",
+			name: "drain-late",
+			session_start: now - 30 * 60 * 1000, // youngest — must NOT win
+		});
+		store.setWeeklyReset("drain-early", now + 1 * DAY);
+		store.setWeeklyReset("drain-late", now + 6 * DAY);
+
+		const result = strategy.select([drainLate, drainEarly], meta);
+		expect(result.map((a) => a.id)).toEqual(["drain-early", "drain-late"]);
+	});
+
+	it("no lock-out: a drain-earliest holder that AGED OUT of its 5h window keeps winning and gets a fresh session", () => {
+		const now = Date.now();
+		// Held for >5h straight — under the sticky mode this account could
+		// never win again until a probe re-opened its window (the observed
+		// production lock-out).
+		const agedOut = makeAccount({
+			id: "aged-out",
+			name: "aged-out",
+			session_start: now - 6 * HOUR,
+			session_request_count: 941,
+		});
+		const activeLater = makeAccount({
+			id: "active-later",
+			name: "active-later",
+			session_start: now - 10 * 60 * 1000,
+		});
+		store.setWeeklyReset("aged-out", now + 1 * DAY);
+		store.setWeeklyReset("active-later", now + 6 * DAY);
+
+		const resetCalls: string[] = [];
+		store.resetAccountSession = (accountId: string) => {
+			resetCalls.push(accountId);
+		};
+
+		const result = strategy.select([activeLater, agedOut], meta);
+		expect(result[0].id).toBe("aged-out");
+		// Selecting it re-opens its window: exactly one store reset, and the
+		// in-memory account reflects the fresh session.
+		expect(resetCalls).toEqual(["aged-out"]);
+		expect(agedOut.session_start).toBeGreaterThanOrEqual(now);
+		expect(agedOut.session_request_count).toBe(0);
+	});
+
+	it("cold-cache tie: with all weekly resets unknown, an ACTIVE account beats an inactive one (no utilization spraying)", () => {
+		const now = Date.now();
+		const incumbent = makeAccount({
+			id: "incumbent",
+			name: "incumbent",
+			session_start: now - 1 * HOUR, // the current holder
+		});
+		const idle = makeAccount({
+			id: "idle",
+			name: "idle",
+			session_start: null,
+		});
+		// No weekly resets at all (usageCache cold after restart) — and the
+		// utilizations deliberately favour the idle account, which must NOT
+		// matter: activity outranks utilization in the tie chain.
+		store.setUtilization("incumbent", 90);
+		store.setUtilization("idle", 10);
+
+		expect(strategy.peek([incumbent, idle])).toBe("incumbent");
+		expect(strategy.select([incumbent, idle], meta)[0].id).toBe("incumbent");
+	});
+
+	it("full tie falls through priority → utilization → account id deterministically", () => {
+		const now = Date.now();
+		// The id-smaller account is deliberately the OLDER session: the
+		// sticky mode would pick acc-b (youngest), so this discriminates
+		// "account id decides" from "recency decides".
+		const a = makeAccount({
+			id: "acc-a",
+			name: "acc-a",
+			session_start: now - 2 * HOUR,
+		});
+		const b = makeAccount({
+			id: "acc-b",
+			name: "acc-b",
+			session_start: now - 1 * HOUR,
+		});
+		// Same (missing) reset, both active, same priority, same utilization
+		// → the account id decides, in both input orders.
+		expect(strategy.select([b, a], meta)[0].id).toBe("acc-a");
+		expect(
+			strategy.select(
+				[
+					makeAccount({
+						id: "acc-a",
+						name: "acc-a",
+						session_start: now - 2 * HOUR,
+					}),
+					makeAccount({
+						id: "acc-b",
+						name: "acc-b",
+						session_start: now - 1 * HOUR,
+					}),
+				],
+				meta,
+			)[0].id,
+		).toBe("acc-a");
+	});
+
+	it("peek() and select() agree in strict mode", () => {
+		const now = Date.now();
+		const drainEarly = makeAccount({
+			id: "drain-early",
+			name: "drain-early",
+			session_start: null,
+		});
+		const drainLate = makeAccount({
+			id: "drain-late",
+			name: "drain-late",
+			session_start: now - 5 * 60 * 1000,
+		});
+		store.setWeeklyReset("drain-early", now + 1 * DAY);
+		store.setWeeklyReset("drain-late", now + 6 * DAY);
+
+		expect(strategy.peek([drainLate, drainEarly])).toBe("drain-early");
+		expect(strategy.select([drainLate, drainEarly], meta)[0].id).toBe(
+			"drain-early",
+		);
+	});
+
+	it("selecting an account without an active session starts one (resetAccountSession is called)", () => {
+		const now = Date.now();
+		const agedOut = makeAccount({
+			id: "aged-out",
+			name: "aged-out",
+			session_start: null,
+		});
+		const activeLater = makeAccount({
+			id: "active-later",
+			name: "active-later",
+			session_start: now - 10 * 60 * 1000,
+		});
+		store.setWeeklyReset("aged-out", now + 1 * DAY);
+		store.setWeeklyReset("active-later", now + 6 * DAY);
+
+		const calls: string[] = [];
+		store.resetAccountSession = (accountId: string) => {
+			calls.push(accountId);
+		};
+
+		strategy.select([activeLater, agedOut], meta);
+		expect(calls).toContain("aged-out");
+	});
+
+	it("with equal reset and activity, priority beats better utilization and a smaller id", () => {
+		const now = Date.now();
+		const lowPrio = makeAccount({
+			id: "acc-a", // smaller id — must NOT win
+			name: "acc-a",
+			priority: 5,
+			session_start: now - 1 * HOUR,
+		});
+		const highPrio = makeAccount({
+			id: "acc-z",
+			name: "acc-z",
+			priority: 0,
+			session_start: now - 1 * HOUR,
+		});
+		store.setUtilization("acc-a", 10); // better utilization — must NOT win
+		store.setUtilization("acc-z", 90);
+
+		expect(strategy.select([lowPrio, highPrio], meta)[0].id).toBe("acc-z");
+	});
+
+	it("with equal reset, activity, and priority, lower utilization beats a smaller id", () => {
+		const now = Date.now();
+		const higherUtil = makeAccount({
+			id: "acc-a", // smaller id — must NOT win
+			name: "acc-a",
+			session_start: now - 1 * HOUR,
+		});
+		const lowerUtil = makeAccount({
+			id: "acc-z",
+			name: "acc-z",
+			session_start: now - 1 * HOUR,
+		});
+		store.setUtilization("acc-a", 90);
+		store.setUtilization("acc-z", 10);
+
+		expect(strategy.select([higherUtil, lowerUtil], meta)[0].id).toBe("acc-z");
+	});
+
+	it("the bypass header keeps strict ranking but suppresses the session mutation", () => {
+		const now = Date.now();
+		const agedOut = makeAccount({
+			id: "aged-out",
+			name: "aged-out",
+			session_start: now - 6 * HOUR,
+		});
+		const activeLater = makeAccount({
+			id: "active-later",
+			name: "active-later",
+			session_start: now - 10 * 60 * 1000,
+		});
+		store.setWeeklyReset("aged-out", now + 1 * DAY);
+		store.setWeeklyReset("active-later", now + 6 * DAY);
+
+		const resetCalls: string[] = [];
+		store.resetAccountSession = (accountId: string) => {
+			resetCalls.push(accountId);
+		};
+
+		const bypassMeta: RequestMeta = {
+			...meta,
+			headers: new Headers({ "x-better-ccflare-bypass-session": "true" }),
+		};
+		const result = strategy.select([activeLater, agedOut], bypassMeta);
+
+		expect(result[0].id).toBe("aged-out"); // ranking unchanged
+		expect(resetCalls).toEqual([]); // no session mutation
+		expect(agedOut.session_start).toBe(now - 6 * HOUR);
+	});
+
+	it("the documented auto-fallback exception still forces position 0; its tail is strict-sorted", () => {
+		const now = Date.now();
+		const fallback = makeAccount({
+			id: "fallback",
+			name: "fallback",
+			auto_fallback_enabled: true,
+			rate_limit_reset: now - 60_000, // window reset has passed
+			session_start: null,
+		});
+		// Tail discriminator: the drain-later account has the YOUNGER active
+		// session — the sticky comparator would not reorder these two by
+		// activity, but a recency-based tail would put drain-late first.
+		const drainEarly = makeAccount({
+			id: "drain-early",
+			name: "drain-early",
+			session_start: now - 2 * HOUR,
+		});
+		const drainLate = makeAccount({
+			id: "drain-late",
+			name: "drain-late",
+			session_start: now - 10 * 60 * 1000,
+		});
+		store.setWeeklyReset("fallback", now + 6 * DAY);
+		store.setWeeklyReset("drain-early", now + 1 * DAY);
+		store.setWeeklyReset("drain-late", now + 3 * DAY);
+
+		const result = strategy.select([drainLate, drainEarly, fallback], meta);
+		expect(result.map((a) => a.id)).toEqual([
+			"fallback",
+			"drain-early",
+			"drain-late",
+		]);
+	});
+});

--- a/packages/load-balancer/src/strategies/index.ts
+++ b/packages/load-balancer/src/strategies/index.ts
@@ -20,6 +20,7 @@ import { codexWindowHasReset } from "./session-window-reset";
 
 export { LeastUsedStrategy } from "./least-used";
 export { SessionAffinityStrategy } from "./session-affinity";
+export type { SessionDrainSoonestMode } from "./session-drain-soonest";
 export { SessionDrainSoonestStrategy } from "./session-drain-soonest";
 
 export class SessionStrategy implements LoadBalancingStrategy {

--- a/packages/load-balancer/src/strategies/session-drain-soonest.ts
+++ b/packages/load-balancer/src/strategies/session-drain-soonest.ts
@@ -129,9 +129,12 @@ export class SessionDrainSoonestStrategy implements LoadBalancingStrategy {
 	 * The single canonical comparator of "strict" mode: earliest future
 	 * weekly reset first (unknown/past last), then ACTIVE sessions before
 	 * inactive ones (this tie-break — not a pre-filter — is what prevents
-	 * both the sticky lock-in and cold-cache spraying), then priority ASC,
-	 * utilization ASC, and the account id as a total-order determinism
-	 * anchor so equal candidates never depend on input order.
+	 * both the sticky lock-in and cold-cache spraying), then priority
+	 * preference (compareAccountPreference — a sustained probe-backoff
+	 * penalty outranks a configured priority number, same as the sibling
+	 * sticky comparator above), utilization ASC, and the account id as a
+	 * total-order determinism anchor so equal candidates never depend on
+	 * input order.
 	 */
 	private compareAccountsStrict(a: Account, b: Account, now: number): number {
 		const resetA = this.getWeeklyReset(a, now);
@@ -144,7 +147,8 @@ export class SessionDrainSoonestStrategy implements LoadBalancingStrategy {
 		const activeA = this.hasActiveSession(a, now) ? 1 : 0;
 		const activeB = this.hasActiveSession(b, now) ? 1 : 0;
 		if (activeA !== activeB) return activeB - activeA;
-		if (a.priority !== b.priority) return a.priority - b.priority;
+		const preference = compareAccountPreference(a, b, now);
+		if (preference !== 0) return preference;
 		const utilA = this.store?.getAccountUtilization?.(a.id, a.provider) ?? 0;
 		const utilB = this.store?.getAccountUtilization?.(b.id, b.provider) ?? 0;
 		if (utilA !== utilB) return utilA - utilB;

--- a/packages/load-balancer/src/strategies/session-drain-soonest.ts
+++ b/packages/load-balancer/src/strategies/session-drain-soonest.ts
@@ -50,16 +50,42 @@ import { codexWindowHasReset } from "./session-window-reset";
  *
  * peek() mirrors select()'s decision exactly (same requirement as every
  * other strategy here) since the dashboard's "Primary" badge is driven by it.
+ *
+ * ── "strict" mode ────────────────────────────────────────────────────────
+ *
+ * The default ("sticky") holder choice above means the drain comparator only
+ * ever orders the tail: with several concurrently active sessions — the
+ * production-normal state, since served requests, keepalive probes, and the
+ * usage-poller rollover callback all open sessions — whichever account most
+ * recently received a session_start write holds ALL traffic, regardless of
+ * its weekly-reset rank.
+ *
+ * In "strict" mode one canonical comparator ranks every available account:
+ * earliest future weekly reset first, then active-session accounts before
+ * inactive ones, then priority, utilization, and finally the account id as a
+ * determinism anchor. session_start no longer gates position 0 — the
+ * active-session STATUS breaks weekly-reset ties, while session-start
+ * recency is never compared. Consequences: the drain-earliest account keeps winning even
+ * after its own 5h window ages out (no lock-out), and in the cold-cache case
+ * (all weekly resets unknown, e.g. right after a restart) the incumbent
+ * active account keeps the traffic instead of utilization-ranked spraying.
+ * The auto-fallback exception and the bypass header behave identically in
+ * both modes.
  */
+export type SessionDrainSoonestMode = "sticky" | "strict";
+
 export class SessionDrainSoonestStrategy implements LoadBalancingStrategy {
 	private sessionDurationMs: number;
+	private mode: SessionDrainSoonestMode;
 	private store: StrategyStore | null = null;
 	private log = new Logger("SessionDrainSoonestStrategy");
 
 	constructor(
 		sessionDurationMs: number = TIME_CONSTANTS.ANTHROPIC_SESSION_DURATION_DEFAULT,
+		mode: SessionDrainSoonestMode = "sticky",
 	) {
 		this.sessionDurationMs = sessionDurationMs;
+		this.mode = mode;
 	}
 
 	initialize(store: StrategyStore): void {
@@ -97,6 +123,34 @@ export class SessionDrainSoonestStrategy implements LoadBalancingStrategy {
 		const utilA = this.store?.getAccountUtilization?.(a.id, a.provider) ?? 0;
 		const utilB = this.store?.getAccountUtilization?.(b.id, b.provider) ?? 0;
 		return utilA - utilB;
+	}
+
+	/**
+	 * The single canonical comparator of "strict" mode: earliest future
+	 * weekly reset first (unknown/past last), then ACTIVE sessions before
+	 * inactive ones (this tie-break — not a pre-filter — is what prevents
+	 * both the sticky lock-in and cold-cache spraying), then priority ASC,
+	 * utilization ASC, and the account id as a total-order determinism
+	 * anchor so equal candidates never depend on input order.
+	 */
+	private compareAccountsStrict(a: Account, b: Account, now: number): number {
+		const resetA = this.getWeeklyReset(a, now);
+		const resetB = this.getWeeklyReset(b, now);
+		if (resetA !== resetB) {
+			if (resetA === null) return 1;
+			if (resetB === null) return -1;
+			return resetA - resetB;
+		}
+		const activeA = this.hasActiveSession(a, now) ? 1 : 0;
+		const activeB = this.hasActiveSession(b, now) ? 1 : 0;
+		if (activeA !== activeB) return activeB - activeA;
+		if (a.priority !== b.priority) return a.priority - b.priority;
+		const utilA = this.store?.getAccountUtilization?.(a.id, a.provider) ?? 0;
+		const utilB = this.store?.getAccountUtilization?.(b.id, b.provider) ?? 0;
+		if (utilA !== utilB) return utilA - utilB;
+		if (a.id < b.id) return -1;
+		if (a.id > b.id) return 1;
+		return 0;
 	}
 
 	private resetSessionIfExpired(account: Account): void {
@@ -178,6 +232,13 @@ export class SessionDrainSoonestStrategy implements LoadBalancingStrategy {
 		const chosenFallback = fallbackCandidates.find((c) => isAvailable(c));
 		if (chosenFallback) {
 			return chosenFallback.id;
+		}
+
+		if (this.mode === "strict") {
+			const availableStrict = accounts
+				.filter((a) => isAvailable(a))
+				.sort((a, b) => this.compareAccountsStrict(a, b, now));
+			return availableStrict[0]?.id ?? null;
 		}
 
 		let activeAccount: Account | null = null;
@@ -276,12 +337,37 @@ export class SessionDrainSoonestStrategy implements LoadBalancingStrategy {
 				`Auto-fallback triggered to account ${chosenFallback.name} (priority: ${chosenFallback.priority}, auto-fallback enabled)`,
 			);
 			// chosenFallback is forced to position 0 — auto-fallback is a
-			// priority rule that overrides drain-soonest ranking. The rest of
-			// the available pool is drain-sorted behind it.
+			// priority rule that overrides the ranking in BOTH modes. The
+			// rest of the available pool follows the mode's comparator, so
+			// the failover loop always walks one consistent order.
 			const others = accounts
 				.filter((a) => a.id !== chosenFallback.id && getCachedAvailability(a))
-				.sort((a, b) => this.compareAccounts(a, b, now));
+				.sort((a, b) =>
+					this.mode === "strict"
+						? this.compareAccountsStrict(a, b, now)
+						: this.compareAccounts(a, b, now),
+				);
 			return [chosenFallback, ...others];
+		}
+
+		if (this.mode === "strict") {
+			// One canonical comparator over every AVAILABLE account — active
+			// sessions do not gate position 0, they only break reset ties.
+			// The returned list is fully strict-sorted, so the failover loop
+			// walks exactly the drain order.
+			const availableStrict = accounts
+				.filter((a) => getCachedAvailability(a))
+				.sort((a, b) => this.compareAccountsStrict(a, b, now));
+			if (availableStrict.length === 0) return [];
+
+			const chosenAccount = availableStrict[0];
+			if (!bypassSession) {
+				this.resetSessionIfExpired(chosenAccount);
+			}
+			this.log.debug(
+				`Strict drain selection: ${chosenAccount.name} (${availableStrict.length} available)`,
+			);
+			return availableStrict;
 		}
 
 		let activeAccount: Account | null = null;

--- a/packages/types/src/strategy.ts
+++ b/packages/types/src/strategy.ts
@@ -5,6 +5,10 @@ export enum StrategyName {
 	LeastUsed = "least-used",
 	SessionAffinity = "session-affinity",
 	SessionDrainSoonest = "session-drain-soonest",
+	// Same strategy class in "strict" mode: one canonical comparator ranks
+	// every available account (earliest weekly reset first; an active 5h
+	// session only breaks ties instead of gating position 0).
+	SessionDrainSoonestStrict = "session-drain-soonest-strict",
 }
 
 /**


### PR DESCRIPTION
**Why:** Under `session-drain-soonest`, position 0 goes to whichever account most recently received a `session_start` write — and those writes come from paths that carry no drain intent (any served request opening a session, the usage-poller rollover callback, keepalive/auto-refresh probes). In a 5.5h production trace (3,570 selections, 6 holder transitions — each matching a `session_start` write to the second), the drain comparator sorted every failover tail correctly but decided position 0 exactly **zero** times: the account ranked #1 (earliest weekly reset) in 100% of decisions received 12% of traffic, while the latest-reset account received 35%. Expiring weekly quota goes unused — the opposite of what the strategy name promises.

**What changes (semantically):**

```mermaid
flowchart LR
    subgraph sticky ["session-drain-soonest — unchanged default"]
        A1{"any account with an<br/>active 5h session?"} -->|yes| A2["most RECENT session_start<br/>holds ALL traffic<br/>(never preempted)"]
        A1 -->|no| A3["earliest weekly reset wins"]
        A2 -.-> A4["drain order only<br/>sorts the failover tail"]
    end
    subgraph strict ["session-drain-soonest-strict — new, opt-in"]
        B1["rank ALL available accounts:<br/>earliest weekly reset first"] --> B2{"reset tie?<br/>(e.g. cold usage cache)"}
        B2 -->|no| B3["drain-earliest account gets<br/>the traffic — active or not<br/>(fresh session opened on selection)"]
        B2 -->|yes| B4["ACTIVE session wins the tie —<br/>incumbent keeps traffic,<br/>no utilization spraying"]
    end
    sticky ~~~ strict
```

**Changes:**
- Additive instead of behavioural: the never-preempted sticky rule is documented intent (code comment + pinned tests), so the default stays byte-identical. `session-drain-soonest-strict` constructs the same class with a mode flag.
- One canonical comparator in strict mode (weekly_all reset → active-session status as tie-break → priority → utilization → account id as determinism anchor) rather than an active-session pre-filter — this avoids a lock-out once the holder ages out of its own 5h window, and keeps the incumbent during the cold-cache window right after a restart.
- The auto-fallback exception still forces position 0 in both modes; behind it the tail follows the mode's comparator, so the failover loop always walks one consistent order.
- Characterization tests pin the current sticky behaviour first (the multi-active-session case the existing suite never exercises), then the strict tests pin the new mode.

**Accepted risk:** strict mode reads the weekly reset from the in-memory usage cache; for a short window after a restart (~1 min measured) all resets are unknown and ranking falls through the tie-break chain. The active-session tie-break keeps the incumbent during that window; persisting the last known weekly reset in the DB would remove the window entirely and is left as a follow-up.

**BC note:** purely additive — one new `StrategyName` value, accepted by config/env/API validation automatically and offered in the dashboard; the default and the existing `session-drain-soonest` behaviour are unchanged.

**Verification:** 14 new tests (4 characterization + 10 strict) in `session-drain-soonest-active-selection.test.ts`; 128 tests green across load-balancer, config and dashboard-web; the pre-existing drain-soonest suite passes unchanged; lint/typecheck/format clean. The production trace and DB forensics behind the Why are available on request. A production canary run of the strict mode on our own installation is in progress.
