### PR TITLE
feat(routing): add force_account_model - serve the model asked for, or none

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -16,6 +16,7 @@ import {
 	NETWORK,
 	registerCleanup,
 	registerDisposable,
+	setForceAccountModel,
 	setPricingLogger,
 	shutdown,
 	TIME_CONSTANTS,
@@ -780,6 +781,10 @@ export default async function startServer(options?: {
 			config.getProviderModelDefaultOverrides(),
 		),
 	);
+	// The code that renames models lives in core and providers, neither of
+	// which may depend on config; mirror the setting there before anything can
+	// route. The config POST handler mirrors it again after a write.
+	setForceAccountModel(config.getForceAccountModel());
 	installOutboundProxy(() => config.getOutboundProxy());
 	const outboundProxyUrl = config.getOutboundProxy();
 	if (outboundProxyUrl) {

--- a/packages/config/src/force-account-model.test.ts
+++ b/packages/config/src/force-account-model.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Config } from "./index";
+
+function makeConfig(): { config: Config; cleanup: () => void } {
+	const dir = mkdtempSync(join(tmpdir(), "better-ccflare-config-"));
+	return {
+		config: new Config(join(dir, "config.json")),
+		cleanup: () => rmSync(dir, { recursive: true, force: true }),
+	};
+}
+
+describe("getForceAccountModel / setForceAccountModel", () => {
+	const originalEnv = process.env.CCFLARE_FORCE_ACCOUNT_MODEL;
+
+	beforeEach(() => {
+		delete process.env.CCFLARE_FORCE_ACCOUNT_MODEL;
+	});
+
+	afterEach(() => {
+		if (originalEnv === undefined) {
+			delete process.env.CCFLARE_FORCE_ACCOUNT_MODEL;
+		} else {
+			process.env.CCFLARE_FORCE_ACCOUNT_MODEL = originalEnv;
+		}
+	});
+
+	it("is off by default: it changes what a Claude family name means, so it must be chosen", () => {
+		const { config, cleanup } = makeConfig();
+		try {
+			expect(config.getForceAccountModel()).toBe(false);
+			expect(config.getForceAccountModelSource()).toBe("default");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("ignores the environment entirely: this switch belongs to the dashboard", () => {
+		// Shipped without an environment variable on purpose. One that could
+		// override would force the UI to draw a control that accepts a click and
+		// does nothing — see ConfigFlagDialog.
+		process.env.CCFLARE_FORCE_ACCOUNT_MODEL = "true";
+		const { config, cleanup } = makeConfig();
+		try {
+			expect(config.getForceAccountModel()).toBe(false);
+			expect(config.getForceAccountModelSource()).toBe("default");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("honors a config-file value when no env var is set", () => {
+		const { config, cleanup } = makeConfig();
+		try {
+			config.setForceAccountModel(true);
+			expect(config.getForceAccountModel()).toBe(true);
+			expect(config.getForceAccountModelSource()).toBe("file");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("surfaces the effective value in getAllSettings", () => {
+		const { config, cleanup } = makeConfig();
+		try {
+			config.setForceAccountModel(true);
+			expect(config.getAllSettings().force_account_model).toBe(true);
+		} finally {
+			cleanup();
+		}
+	});
+});

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -124,6 +124,7 @@ export interface ConfigData {
 	model_scoped_capacity_routing?: ModelScopedCapacityRoutingMode;
 	combos_enabled?: boolean;
 	combo_session_fallback?: boolean;
+	force_account_model?: boolean;
 	provider_model_default_overrides?: ProviderModelDefaultOverrides;
 	agent_frontmatter_model_fallback?: boolean;
 	model_catalog_oauth_refresh_enabled?: boolean;
@@ -863,6 +864,33 @@ export class Config extends EventEmitter {
 		this.set("combo_session_fallback", value);
 	}
 
+	/**
+	 * Whether the model a client asked for must be the model that is sent.
+	 *
+	 * On, nothing renames the request on its way out: combos are skipped, so no
+	 * slot model is applied, and every mapping — the account's own, the global
+	 * override and the provider's built-in default — is inert. Account
+	 * selection instead keeps only accounts that can serve the requested model,
+	 * and a request with no such account gets an error rather than a different
+	 * model.
+	 *
+	 * Off by default: this changes what a Claude family name means for anyone
+	 * who relies on mapping (asking for a Claude model no longer reaches an
+	 * OpenAI account), so it must be chosen deliberately.
+	 */
+	getForceAccountModel(): boolean {
+		return this.resolveFlag(this.data.force_account_model, false).value;
+	}
+
+	/** "file" once anyone has set it, "default" while nobody has. */
+	getForceAccountModelSource(): "file" | "default" {
+		return this.resolveFlag(this.data.force_account_model, false).source;
+	}
+
+	setForceAccountModel(value: boolean): void {
+		this.set("force_account_model", value);
+	}
+
 	getProviderModelDefaultOverrides(): ProviderModelDefaultOverrides {
 		const raw = this.data.provider_model_default_overrides;
 		if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
@@ -1101,6 +1129,7 @@ export class Config extends EventEmitter {
 			model_scoped_capacity_routing: this.getModelScopedCapacityRouting(),
 			combos_enabled: this.getCombosEnabled(),
 			combo_session_fallback: this.getComboSessionFallback(),
+			force_account_model: this.getForceAccountModel(),
 			agent_frontmatter_model_fallback: this.getAgentFrontmatterModelFallback(),
 			model_catalog_oauth_refresh_enabled:
 				this.getModelCatalogOAuthRefreshEnabled(),

--- a/packages/core/src/force-account-model.test.ts
+++ b/packages/core/src/force-account-model.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import type { Account } from "@better-ccflare/types";
+import {
+	isForceAccountModelEnabled,
+	setForceAccountModel,
+} from "./force-account-model";
+import { mapModelName, providerAcceptsClientModel } from "./model-mappings";
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "acc-1",
+		name: "codex-account",
+		provider: "codex",
+		api_key: null,
+		refresh_token: "rt",
+		access_token: "at",
+		expires_at: Date.now() + 3_600_000,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: Date.now(),
+		rate_limited_until: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		custom_endpoint: null,
+		model_mappings: JSON.stringify({ opus: "gpt-5.6-sol" }),
+		cross_region_mode: null,
+		model_fallbacks: null,
+		...overrides,
+	};
+}
+
+afterEach(() => {
+	setForceAccountModel(false);
+});
+
+describe("force account model", () => {
+	it("is off until something turns it on", () => {
+		expect(isForceAccountModelEnabled()).toBe(false);
+	});
+
+	it("keeps mapping models while off", () => {
+		expect(mapModelName("claude-opus-4-1", makeAccount())).toBe("gpt-5.6-sol");
+	});
+
+	it("stops every rename while on, including an explicit account mapping", () => {
+		setForceAccountModel(true);
+		// The account asked for this rewrite and it is still refused: with the
+		// setting on, selection has already guaranteed the account can serve the
+		// model as written, so renaming here could only undo that guarantee.
+		expect(mapModelName("claude-opus-4-1", makeAccount())).toBe(
+			"claude-opus-4-1",
+		);
+	});
+
+	it("leaves a model with no mapping alone either way", () => {
+		const account = makeAccount({ model_mappings: null });
+		expect(mapModelName("gpt-5.6-sol", account)).toBe("gpt-5.6-sol");
+		setForceAccountModel(true);
+		expect(mapModelName("gpt-5.6-sol", account)).toBe("gpt-5.6-sol");
+	});
+});
+
+describe("providerAcceptsClientModel", () => {
+	it("is true only for providers whose upstream speaks Claude model ids", () => {
+		expect(providerAcceptsClientModel("anthropic")).toBe(true);
+		expect(providerAcceptsClientModel("claude-console-api")).toBe(true);
+		expect(providerAcceptsClientModel("codex")).toBe(false);
+		expect(providerAcceptsClientModel("zai")).toBe(false);
+	});
+
+	it("treats a missing provider as anthropic, matching the rest of the codebase", () => {
+		expect(providerAcceptsClientModel(null)).toBe(true);
+		expect(providerAcceptsClientModel(undefined)).toBe(true);
+	});
+});

--- a/packages/core/src/force-account-model.test.ts
+++ b/packages/core/src/force-account-model.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, it } from "bun:test";
 import type { Account } from "@better-ccflare/types";
 import {
 	isForceAccountModelEnabled,
+	isForceAccountModelExempt,
+	runForceAccountModelExempt,
 	setForceAccountModel,
 } from "./force-account-model";
 import { mapModelName, providerAcceptsClientModel } from "./model-mappings";
@@ -80,5 +82,81 @@ describe("providerAcceptsClientModel", () => {
 	it("treats a missing provider as anthropic, matching the rest of the codebase", () => {
 		expect(providerAcceptsClientModel(null)).toBe(true);
 		expect(providerAcceptsClientModel(undefined)).toBe(true);
+	});
+});
+
+/**
+ * The exempt scope exists for better-ccflare's own probes. A probe names a
+ * compiled-in Claude model for whatever account it is aimed at, so mapping is
+ * what makes it land — suppressing mapping there breaks the probe instead of
+ * honouring a promise about client requests.
+ */
+describe("force account model — internal-probe exemption scope", () => {
+	it("reads as off inside the scope and on again outside it", () => {
+		setForceAccountModel(true);
+
+		expect(isForceAccountModelEnabled()).toBe(true);
+		runForceAccountModelExempt(() => {
+			expect(isForceAccountModelEnabled()).toBe(false);
+			expect(isForceAccountModelExempt()).toBe(true);
+		});
+		expect(isForceAccountModelEnabled()).toBe(true);
+		expect(isForceAccountModelExempt()).toBe(false);
+	});
+
+	it("lets mapping happen again inside the scope", () => {
+		setForceAccountModel(true);
+		const account = makeAccount();
+
+		expect(mapModelName("claude-opus-4-1", account)).toBe("claude-opus-4-1");
+		runForceAccountModelExempt(() => {
+			// This is the whole point: without it the probe's Claude id reaches a
+			// Codex account untranslated and comes back as a refresh failure.
+			expect(mapModelName("claude-opus-4-1", account)).toBe("gpt-5.6-sol");
+		});
+	});
+
+	it("survives awaits, so a mapping deep in the request still sees it", async () => {
+		setForceAccountModel(true);
+
+		await runForceAccountModelExempt(async () => {
+			await Promise.resolve();
+			await new Promise((resolve) => setTimeout(resolve, 1));
+			expect(isForceAccountModelEnabled()).toBe(false);
+			expect(mapModelName("claude-opus-4-1", makeAccount())).toBe(
+				"gpt-5.6-sol",
+			);
+		});
+
+		expect(isForceAccountModelEnabled()).toBe(true);
+	});
+
+	it("does not leak into a concurrent request that is not a probe", async () => {
+		setForceAccountModel(true);
+		const account = makeAccount();
+		const seen: string[] = [];
+
+		// Interleaved on purpose: a scope that leaked across async boundaries
+		// would let one probe disable the operator's setting for real traffic
+		// that happens to be in flight beside it.
+		const probe = runForceAccountModelExempt(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 2));
+			seen.push(`probe:${mapModelName("claude-opus-4-1", account)}`);
+		});
+		const client = (async () => {
+			await new Promise((resolve) => setTimeout(resolve, 1));
+			seen.push(`client:${mapModelName("claude-opus-4-1", account)}`);
+		})();
+
+		await Promise.all([probe, client]);
+
+		expect(seen.sort()).toEqual([
+			"client:claude-opus-4-1",
+			"probe:gpt-5.6-sol",
+		]);
+	});
+
+	it("is off by default, so nothing is exempt until a scope opens", () => {
+		expect(isForceAccountModelExempt()).toBe(false);
 	});
 });

--- a/packages/core/src/force-account-model.ts
+++ b/packages/core/src/force-account-model.ts
@@ -1,3 +1,5 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
 /**
  * Process-wide switch for "force account model": send the model the client
  * asked for, or serve nothing.
@@ -14,6 +16,30 @@
  */
 let forceAccountModel = false;
 
+/**
+ * Requests exempt from the switch for the whole of their async lifetime.
+ *
+ * The switch is a promise about *client* requests: serve the model the caller
+ * named, or serve nothing. better-ccflare's own probes are not callers. The
+ * auto-refresh and cache-keepalive schedulers send a compiled-in list of Claude
+ * model ids to whatever account they are probing, provider and all, because
+ * their job is to touch the endpoint and read what comes back — not to deliver
+ * anyone's choice of model. Mapping is what makes that work on a non-Claude
+ * account, so suppressing mapping for a probe does not honour the promise, it
+ * just breaks the probe: the untranslated id comes back as an upstream
+ * rejection, which counts as a refresh failure, and five of those pause a
+ * perfectly healthy account.
+ *
+ * This is a scope rather than a parameter because the flag it overrides is
+ * ambient by necessity. `mapModelName` is the funnel every provider maps
+ * through and it takes no request; threading a boolean to it would change six
+ * call sites, several of which have no headers in hand. The proxy opens the
+ * scope once, at the top of the request, for a probe whose secret it has
+ * already verified — and every guard that reads the flag then answers
+ * correctly, including ones added later.
+ */
+const exemptScope = new AsyncLocalStorage<true>();
+
 /** Mirror the config value here. Called at boot and after a successful write. */
 export function setForceAccountModel(value: boolean): void {
 	forceAccountModel = value;
@@ -27,5 +53,25 @@ export function setForceAccountModel(value: boolean): void {
  * on the operator's behalf while this is on.
  */
 export function isForceAccountModelEnabled(): boolean {
-	return forceAccountModel;
+	return forceAccountModel && exemptScope.getStore() !== true;
+}
+
+/**
+ * Run `fn` — and everything it awaits — with the switch treated as off.
+ *
+ * Reserved for internal probes whose secret has been verified. Never key this
+ * on a marker header alone: a client that copied one out of a log would be
+ * opting itself out of the operator's setting.
+ */
+export function runForceAccountModelExempt<T>(fn: () => T): T {
+	return exemptScope.run(true, fn);
+}
+
+/**
+ * Whether the current scope is exempt. Exposed for callers that need to report
+ * or test the state rather than act on it; the guards themselves should keep
+ * reading `isForceAccountModelEnabled`, which already accounts for it.
+ */
+export function isForceAccountModelExempt(): boolean {
+	return exemptScope.getStore() === true;
 }

--- a/packages/core/src/force-account-model.ts
+++ b/packages/core/src/force-account-model.ts
@@ -1,0 +1,31 @@
+/**
+ * Process-wide switch for "force account model": send the model the client
+ * asked for, or serve nothing.
+ *
+ * It lives here, as a plain in-memory flag, for the same reason the provider
+ * default map does (see providers/src/provider-model-defaults.ts): the code
+ * that rewrites a model name sits in core and providers, and neither may
+ * depend on @better-ccflare/config without inverting the dependency graph.
+ * The config remains the source of truth — apps/server pushes the value in at
+ * boot, and the config POST handler pushes it again after a write, so the
+ * switch takes effect without a restart.
+ *
+ * Off by default, which is the behaviour every existing install has today.
+ */
+let forceAccountModel = false;
+
+/** Mirror the config value here. Called at boot and after a successful write. */
+export function setForceAccountModel(value: boolean): void {
+	forceAccountModel = value;
+}
+
+/**
+ * Whether model rewriting is currently forbidden.
+ *
+ * Callers should treat a true here as "return the model untouched" — never as
+ * "pick a different model": the entire point is that no code chooses a model
+ * on the operator's behalf while this is on.
+ */
+export function isForceAccountModelEnabled(): boolean {
+	return forceAccountModel;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,7 @@ export type ModelMappingData = {
 export type ModelFallback = { [modelFamily: string]: string };
 export * from "./alert-events";
 export * from "./auth-failure-events";
+export * from "./force-account-model";
 export {
 	type IntervalConfig,
 	intervalManager,
@@ -55,6 +56,7 @@ export {
 	parseCustomEndpointData,
 	parseModelFallbacks,
 	parseModelMappings,
+	providerAcceptsClientModel,
 	validateAndSanitizeModelFallbacks,
 	validateAndSanitizeModelMappings,
 	weeklyScopedWindowKey,

--- a/packages/core/src/model-mappings.ts
+++ b/packages/core/src/model-mappings.ts
@@ -1,5 +1,6 @@
 import { Logger } from "@better-ccflare/logger";
 import type { Account } from "@better-ccflare/types";
+import { isForceAccountModelEnabled } from "./force-account-model";
 import { safeJsonParse, validateModelMappings } from "./validation";
 
 const log = new Logger("ModelMappings");
@@ -250,10 +251,36 @@ export function getModelList(
 }
 
 /**
+ * Providers whose upstream natively accepts Claude model ids.
+ *
+ * Two features need the same answer and must not drift: a combo slot may only
+ * be left empty (passthrough) for these providers, and "force account model"
+ * may only route a Claude model id to these. On any other provider the name
+ * would arrive at an upstream that does not know it.
+ */
+const PROVIDERS_ACCEPTING_CLIENT_MODEL = new Set([
+	"anthropic",
+	"claude-console-api",
+]);
+
+/** Whether this provider understands a Claude model id without translation. */
+export function providerAcceptsClientModel(
+	provider: string | null | undefined,
+): boolean {
+	return PROVIDERS_ACCEPTING_CLIENT_MODEL.has(provider ?? "anthropic");
+}
+
+/**
  * Map Anthropic model name to provider-specific model name (first in list).
  * Optimized for known model patterns with direct matching (O(1) vs O(n log n))
  */
 export function mapModelName(anthropicModel: string, account: Account): string {
+	// With "force account model" on, no mapping may rename the request: the
+	// operator asked for this model by name, and an account that cannot serve
+	// it was already excluded during selection. Guarding the single place every
+	// provider funnels through is what makes that promise hold for all of them.
+	if (isForceAccountModelEnabled()) return anthropicModel;
+
 	const list = getModelList(anthropicModel, account);
 	if (!list) return anthropicModel;
 

--- a/packages/dashboard-web/src/components/overview/AdvancedSettingsCard.tsx
+++ b/packages/dashboard-web/src/components/overview/AdvancedSettingsCard.tsx
@@ -61,6 +61,52 @@ const ADVANCED_SETTINGS_ITEMS: AdvancedSettingItem[] = [
 			</ConfigFlagDialog>
 		),
 	},
+	{
+		id: "force-account-model",
+		title: "Force Account Model",
+		description:
+			"Send the model that was asked for, or nothing — no combo, no mapping, no substitute.",
+		dialog: (
+			<ConfigFlagDialog
+				title="Force Account Model"
+				description="Whether the model a client asks for must be the model that is sent."
+				path="/api/config/force-account-model"
+				switchLabel="Only serve the requested model"
+			>
+				<p>
+					On, nothing renames a request on its way out. Account selection keeps
+					only accounts that can serve the model as written, and a request with
+					no such account gets a 503 (
+					<code>force_account_model_no_account</code>) instead of a different
+					model. Switching account to serve the same model is still fine.
+				</p>
+				<p className="font-medium text-foreground">
+					It turns off three things you may be relying on:
+				</p>
+				<ul className="ml-4 list-disc space-y-0.5">
+					<li>combos — no slot model is applied</li>
+					<li>
+						account model mappings, the global provider defaults, and the
+						built-in map
+					</li>
+					<li>
+						the meaning of a Claude family name: asking for a Claude model now
+						reaches only accounts that speak Claude ids, so name the model you
+						actually want (for example the provider's own model id) in your
+						client
+					</li>
+				</ul>
+				<p>
+					Accounts that have listed their own models are checked against that
+					list. For the rest — nothing is persisted, so listings start empty
+					after each restart — the account's provider decides, which is coarse:
+					with several non-Claude providers configured a request can still reach
+					the wrong one. That surfaces as an upstream error, never as a silent
+					substitution.
+				</p>
+			</ConfigFlagDialog>
+		),
+	},
 ];
 
 export function AdvancedSettingsCard() {

--- a/packages/dashboard-web/src/components/overview/AdvancedSettingsCard.tsx
+++ b/packages/dashboard-web/src/components/overview/AdvancedSettingsCard.tsx
@@ -81,10 +81,14 @@ const ADVANCED_SETTINGS_ITEMS: AdvancedSettingItem[] = [
 					model. Switching account to serve the same model is still fine.
 				</p>
 				<p className="font-medium text-foreground">
-					It turns off three things you may be relying on:
+					It turns off four things you may be relying on:
 				</p>
 				<ul className="ml-4 list-disc space-y-0.5">
 					<li>combos — no slot model is applied</li>
+					<li>
+						agent model preferences — an agent is still attributed, but its
+						preferred model is not applied
+					</li>
 					<li>
 						account model mappings, the global provider defaults, and the
 						built-in map

--- a/packages/http-api/src/handlers/combos.ts
+++ b/packages/http-api/src/handlers/combos.ts
@@ -1,3 +1,4 @@
+import { providerAcceptsClientModel } from "@better-ccflare/core";
 import type { DatabaseOperations } from "@better-ccflare/database";
 import { BadRequest, NotFound } from "@better-ccflare/errors";
 import type {
@@ -8,21 +9,20 @@ import type {
 import { errorResponse } from "../utils/http-error";
 
 /**
- * Providers whose upstream natively accepts Claude model ids. Only for these
- * does a slot without a model (passthrough) make sense: the model the client
- * asked for arrives intact and is understood on the other side.
+ * A slot without a model (passthrough) only makes sense on a provider whose
+ * upstream natively accepts Claude model ids: the model the client asked for
+ * arrives intact and is understood on the other side.
  *
  * On any other provider, passthrough would hand a Claude name to an upstream
  * that does not know it, and translation would fall to the embedded default
  * map — the path that produced `400 gpt-5.3-codex ... ChatGPT account`.
+ *
+ * The list moved to core so that "force account model", which needs the same
+ * answer when deciding whether an account can serve a Claude id untranslated,
+ * cannot drift from it.
  */
-const PROVIDERS_ACCEPTING_CLIENT_MODEL = new Set([
-	"anthropic",
-	"claude-console-api",
-]);
-
 function allowsClientModel(provider: string | null | undefined): boolean {
-	return PROVIDERS_ACCEPTING_CLIENT_MODEL.has(provider ?? "anthropic");
+	return providerAcceptsClientModel(provider);
 }
 
 /**

--- a/packages/http-api/src/handlers/config.ts
+++ b/packages/http-api/src/handlers/config.ts
@@ -9,6 +9,7 @@ import {
 	NETWORK,
 	STRATEGIES,
 	type StrategyName,
+	setForceAccountModel as setForceAccountModelFlag,
 	TIME_CONSTANTS,
 	validateNumber,
 	validateString,
@@ -437,6 +438,36 @@ export function createConfigHandlers(
 			return jsonResponse({
 				enabled: config.getComboSessionFallback(),
 				source: config.getComboSessionFallbackSource(),
+			});
+		},
+
+		getForceAccountModel: (): Response => {
+			return jsonResponse({
+				enabled: config.getForceAccountModel(),
+				source: config.getForceAccountModelSource(),
+			});
+		},
+
+		setForceAccountModel: async (req: Request): Promise<Response> => {
+			const body = await req.json();
+			if (typeof body.enabled !== "boolean") {
+				return errorResponse(
+					BadRequest(
+						"Invalid force account model payload: expected 'enabled' to be a boolean",
+					),
+				);
+			}
+			config.setForceAccountModel(body.enabled);
+			// Push the effective value into the core mirror the model-rewriting
+			// code reads (core and providers cannot depend on config), so the
+			// switch takes effect without a restart. The effective value, not the
+			// requested one: the mirror must never claim more than the config does.
+			setForceAccountModelFlag(config.getForceAccountModel());
+			return jsonResponse({
+				success: true,
+				enabled: body.enabled,
+				source: config.getForceAccountModelSource(),
+				effective: config.getForceAccountModel(),
 			});
 		},
 

--- a/packages/http-api/src/router.ts
+++ b/packages/http-api/src/router.ts
@@ -426,6 +426,12 @@ export class APIRouter {
 		this.handlers.set("POST:/api/config/combo-session-fallback", (req) =>
 			configHandlers.setComboSessionFallback(req),
 		);
+		this.handlers.set("GET:/api/config/force-account-model", () =>
+			configHandlers.getForceAccountModel(),
+		);
+		this.handlers.set("POST:/api/config/force-account-model", (req) =>
+			configHandlers.setForceAccountModel(req),
+		);
 		this.handlers.set("POST:/api/maintenance/cleanup", () => cleanupHandler());
 		this.handlers.set("GET:/api/system/info", () => systemInfoHandler());
 		this.handlers.set("GET:/api/version/check", () => versionCheckHandler());

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import {
+	isForceAccountModelEnabled,
 	mapModelName,
 	ValidationError,
 	validateEndpointUrl,
@@ -776,6 +777,12 @@ export class CodexProvider extends BaseProvider {
 	// ── Private helpers ──────────────────────────────────────────────────────
 
 	private mapModel(anthropicModel: string, account?: Account): string {
+		// "Force account model" forbids every substitution below, including the
+		// family defaults derived from the account's own listing: those answer
+		// "which model should a Claude family become here", a question nobody
+		// asked when the client named the model outright.
+		if (isForceAccountModelEnabled()) return anthropicModel;
+
 		if (account) {
 			const mapped = mapModelName(anthropicModel, account);
 			if (mapped !== anthropicModel) {

--- a/packages/providers/src/utils/model-mapping-force-account-model.test.ts
+++ b/packages/providers/src/utils/model-mapping-force-account-model.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { setForceAccountModel } from "@better-ccflare/core";
+import type { Account } from "@better-ccflare/types";
+import { getModelName } from "./model-mapping";
+
+// getModelName is a sibling of core's mapModelName, reached only by the
+// vertex-ai provider. It was the one mapping path left unguarded when "force
+// account model" landed, which would have made the setting's promise false for
+// exactly one provider — the kind of gap nobody notices until someone with a
+// Vertex account reports that their model still gets rewritten.
+
+function makeAccount(): Account {
+	return {
+		id: "acc-1",
+		name: "vertex-account",
+		provider: "vertex-ai",
+		api_key: null,
+		refresh_token: "rt",
+		access_token: "at",
+		expires_at: Date.now() + 3_600_000,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: Date.now(),
+		rate_limited_until: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		custom_endpoint: null,
+		model_mappings: JSON.stringify({ opus: "gemini-2.5-pro" }),
+		cross_region_mode: null,
+		model_fallbacks: null,
+	};
+}
+
+afterEach(() => {
+	setForceAccountModel(false);
+});
+
+describe("getModelName under force account model", () => {
+	it("maps as usual while the setting is off", () => {
+		expect(getModelName("claude-opus-4-1", makeAccount())).toBe(
+			"gemini-2.5-pro",
+		);
+	});
+
+	it("returns the model untouched while the setting is on", () => {
+		setForceAccountModel(true);
+		expect(getModelName("claude-opus-4-1", makeAccount())).toBe(
+			"claude-opus-4-1",
+		);
+	});
+
+	it("is unaffected for an account with no mappings either way", () => {
+		const account = { ...makeAccount(), model_mappings: null };
+		expect(getModelName("gemini-2.5-pro", account)).toBe("gemini-2.5-pro");
+		setForceAccountModel(true);
+		expect(getModelName("gemini-2.5-pro", account)).toBe("gemini-2.5-pro");
+	});
+});

--- a/packages/providers/src/utils/model-mapping.ts
+++ b/packages/providers/src/utils/model-mapping.ts
@@ -1,4 +1,8 @@
-import { getModelFamily, parseModelMappings } from "@better-ccflare/core";
+import {
+	getModelFamily,
+	isForceAccountModelEnabled,
+	parseModelMappings,
+} from "@better-ccflare/core";
 import { Logger } from "@better-ccflare/logger";
 import type { Account } from "@better-ccflare/types";
 
@@ -51,6 +55,12 @@ export function getModelName(
 	anthropicModel: string,
 	account: Account | undefined,
 ): string {
+	// Sibling of core's mapModelName, and it needs the same guard: with "force
+	// account model" on, no mapping may rename the request. Missing it here
+	// would leave exactly one provider (vertex-ai, the only caller) still
+	// rewriting models while the setting promises nothing does.
+	if (isForceAccountModelEnabled()) return anthropicModel;
+
 	if (!anthropicModel || !account?.model_mappings) {
 		return anthropicModel;
 	}

--- a/packages/proxy/src/__tests__/force-account-model-probe-exemption.test.ts
+++ b/packages/proxy/src/__tests__/force-account-model-probe-exemption.test.ts
@@ -1,0 +1,140 @@
+/**
+ * A verified internal probe runs the whole request with `force_account_model`
+ * treated as off.
+ *
+ * The setting suppresses every model rename, which is right for a client
+ * request and wrong for a probe. The auto-refresh and cache-keepalive
+ * schedulers send a compiled-in list of Claude ids — `HAIKU_4_5`, then
+ * `SONNET_4_5`, then `SONNET_4` — to whatever account they are aimed at,
+ * because the point is to touch the endpoint and read the answer, not to
+ * deliver anyone's choice of model. Mapping is what makes that land on a
+ * non-Claude account. Leaving the setting on for a probe therefore honours
+ * nothing: `claude-haiku-4-5` goes to Codex untranslated, comes back as a
+ * rejection that is neither 404 nor 529, counts as a refresh failure, and five
+ * of those pause a healthy account with `pause_reason = 'failure_threshold'`.
+ *
+ * The exemption is keyed on the process-local probe secret, so a client that
+ * copies the marker header out of a log gets nothing.
+ */
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+	isForceAccountModelEnabled,
+	setForceAccountModel,
+} from "@better-ccflare/core";
+import type { ProxyContext } from "../handlers";
+import { INTERNAL_PROBE_SECRET_HEADER } from "../handlers/proxy-types";
+import { handleProxy } from "../proxy";
+
+const SECRET = "probe-secret";
+
+/**
+ * `canHandle` is the first thing the request body of the handler calls, so what
+ * it observes is what every later layer — selection, provider transform,
+ * mapping — observes too.
+ */
+function makeContext(observed: boolean[]): ProxyContext {
+	return {
+		strategy: { select: () => [] } as never,
+		dbOps: {
+			getAllAccounts: mock(async () => []),
+			getActiveComboForFamily: mock(async () => null),
+		} as never,
+		runtime: { port: 8080, clientId: "test" } as never,
+		config: {
+			getUsageThrottlingFiveHourEnabled: () => false,
+			getUsageThrottlingWeeklyEnabled: () => false,
+			getSystemPromptCacheTtl1h: () => false,
+			getAgentFrontmatterModelFallback: () => false,
+			getForceAccountModel: () => true,
+		} as never,
+		provider: {
+			name: "codex",
+			canHandle: () => {
+				observed.push(isForceAccountModelEnabled());
+				return true;
+			},
+		} as never,
+		refreshInFlight: new Map(),
+		asyncWriter: { enqueue: mock(() => {}) } as never,
+		internalProbeSecret: SECRET,
+	};
+}
+
+function makeRequest(headers: Record<string, string>): Request {
+	return new Request("https://proxy.local/v1/messages", {
+		method: "POST",
+		headers: { "Content-Type": "application/json", ...headers },
+		body: JSON.stringify({
+			model: "claude-haiku-4-5",
+			max_tokens: 10,
+			messages: [{ role: "user", content: "probe" }],
+		}),
+	});
+}
+
+async function observeFlag(headers: Record<string, string>): Promise<boolean> {
+	const observed: boolean[] = [];
+	await handleProxy(
+		makeRequest(headers),
+		new URL("https://proxy.local/v1/messages"),
+		makeContext(observed),
+	);
+	expect(observed).toHaveLength(1);
+	return observed[0];
+}
+
+beforeEach(() => {
+	setForceAccountModel(true);
+});
+
+afterEach(() => {
+	setForceAccountModel(false);
+});
+
+describe("force_account_model — internal-probe exemption on the request path", () => {
+	it("treats the setting as off for a secret-verified auto-refresh probe", async () => {
+		expect(
+			await observeFlag({
+				"x-better-ccflare-auto-refresh": "true",
+				[INTERNAL_PROBE_SECRET_HEADER]: SECRET,
+			}),
+		).toBe(false);
+	});
+
+	it("does the same for the cache-keepalive probe", async () => {
+		expect(
+			await observeFlag({
+				"x-better-ccflare-keepalive": "true",
+				[INTERNAL_PROBE_SECRET_HEADER]: SECRET,
+			}),
+		).toBe(false);
+	});
+
+	it("keeps the setting on for a marker sent with the wrong secret", async () => {
+		expect(
+			await observeFlag({
+				"x-better-ccflare-auto-refresh": "true",
+				[INTERNAL_PROBE_SECRET_HEADER]: "not-the-secret",
+			}),
+		).toBe(true);
+	});
+
+	it("keeps the setting on for a marker sent with no secret at all", async () => {
+		expect(await observeFlag({ "x-better-ccflare-auto-refresh": "true" })).toBe(
+			true,
+		);
+	});
+
+	it("keeps the setting on for ordinary client traffic", async () => {
+		expect(await observeFlag({})).toBe(true);
+	});
+
+	it("restores the flag once the request is done", async () => {
+		await observeFlag({
+			"x-better-ccflare-auto-refresh": "true",
+			[INTERNAL_PROBE_SECRET_HEADER]: SECRET,
+		});
+
+		expect(isForceAccountModelEnabled()).toBe(true);
+	});
+});

--- a/packages/proxy/src/__tests__/force-account-model-refusal-order.test.ts
+++ b/packages/proxy/src/__tests__/force-account-model-refusal-order.test.ts
@@ -111,10 +111,10 @@ function makeContext(
 	};
 }
 
-function makeRequest(): Request {
+function makeRequest(headers: Record<string, string> = {}): Request {
 	return new Request("https://proxy.local/v1/messages", {
 		method: "POST",
-		headers: { "Content-Type": "application/json" },
+		headers: { "Content-Type": "application/json", ...headers },
 		body: JSON.stringify({
 			model: "claude-sonnet-4-5",
 			messages: [{ role: "user", content: "hello" }],
@@ -202,6 +202,41 @@ describe("force_account_model refusal — ordering against capacity answers", ()
 		// Naming the model is the whole point of answering here rather than
 		// letting the generic pool_exhausted 503 through.
 		expect(JSON.stringify(error)).toContain("claude-sonnet-4-5");
+	});
+
+	it("is not outranked by a retry time an incompatible forced account cannot honour", async () => {
+		// The forced-account header returns before every other filter, so
+		// without the compatibility check in that path this account reaches the
+		// throttling branch and the caller is told to come back in two hours —
+		// for a wait that can never help, because this account will never speak
+		// this model.
+		const account = makeAccount({
+			id: "codex-1",
+			name: "codex-account",
+			provider: "codex",
+		});
+		usageCache.set(account.id, throttledUsage() as never);
+		const ctx = makeContext([account], { throttlingEnabled: true });
+
+		const realDateNow = Date.now;
+		Date.now = () => FROZEN_NOW;
+		let response: Response;
+		try {
+			response = await handleProxy(
+				makeRequest({ "x-better-ccflare-account-id": "codex-1" }),
+				new URL("https://proxy.local/v1/messages"),
+				ctx,
+			);
+		} finally {
+			Date.now = realDateNow;
+		}
+
+		expect(response.status).toBe(503);
+		expect(response.headers.get("Retry-After")).toBeNull();
+
+		const body = (await response.json()) as Record<string, unknown>;
+		const error = body.error as Record<string, unknown>;
+		expect(error.code).toBe("force_account_model_no_account");
 	});
 
 	it("beats the generic pool_exhausted 503 when throttling is off", async () => {

--- a/packages/proxy/src/__tests__/force-account-model-refusal-order.test.ts
+++ b/packages/proxy/src/__tests__/force-account-model-refusal-order.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Where the `force_account_model` refusal sits among the other empty-pool
+ * answers.
+ *
+ * The refusal says "nothing can serve the model you asked for". That is a
+ * statement about capability, and it must not be made when the real reason the
+ * pool is empty is capacity: an account that speaks the requested model
+ * perfectly well but is out of quota for the next forty minutes is a temporary,
+ * actionable state, and the exhaustion/throttling answers carry the `resetAt`
+ * and `Retry-After` that say when to come back. Answering the refusal over them
+ * would replace a fact with a falsehood and drop the retry time on the floor.
+ *
+ * So the refusal answers last among the structured responses — and still ahead
+ * of the generic `pool_exhausted` 503, which is the case it genuinely improves
+ * on by naming the model that went unserved.
+ */
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	mock,
+	spyOn,
+} from "bun:test";
+import { usageCache } from "@better-ccflare/providers";
+import type { Account } from "@better-ccflare/types";
+import type { ProxyContext } from "../handlers";
+import { handleProxy } from "../proxy";
+import * as usageCollectorModule from "../usage-collector";
+
+function stubUsageCollector() {
+	return spyOn(usageCollectorModule, "getUsageCollector").mockReturnValue({
+		handleStart: mock(() => {}),
+		handleChunk: mock(() => {}),
+		handleEnd: mock(() => Promise.resolve()),
+	} as unknown as usageCollectorModule.UsageCollector);
+}
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		// "anthropic" on purpose: it speaks Claude model ids, so the force-mode
+		// compatibility filter keeps it. Whatever empties the pool below is
+		// therefore capacity, never capability.
+		id: "acc-1",
+		name: "anthropic-account",
+		provider: "anthropic",
+		api_key: null,
+		refresh_token: "refresh-token",
+		access_token: "access-token",
+		expires_at: null,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: Date.now(),
+		rate_limited_until: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		custom_endpoint: null,
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		billing_type: null,
+		pause_reason: null,
+		refresh_token_issued_at: null,
+		...overrides,
+	};
+}
+
+function makeContext(
+	accounts: Account[],
+	opts?: { throttlingEnabled?: boolean },
+): ProxyContext {
+	return {
+		strategy: {
+			select: (accs: Account[]) => {
+				const now = Date.now();
+				return accs.filter(
+					(acc) =>
+						!acc.paused &&
+						(!acc.rate_limited_until || acc.rate_limited_until <= now),
+				);
+			},
+		} as never,
+		dbOps: {
+			getAllAccounts: mock(async () => accounts),
+			getActiveComboForFamily: mock(async () => null),
+		} as never,
+		runtime: { port: 8080, clientId: "test" } as never,
+		config: {
+			getUsageThrottlingFiveHourEnabled: () => opts?.throttlingEnabled ?? false,
+			getUsageThrottlingWeeklyEnabled: () => opts?.throttlingEnabled ?? false,
+			getSystemPromptCacheTtl1h: () => false,
+			getAgentFrontmatterModelFallback: () => false,
+			getForceAccountModel: () => true,
+		} as never,
+		provider: {
+			name: "anthropic",
+			canHandle: () => true,
+		} as never,
+		refreshInFlight: new Map(),
+		asyncWriter: { enqueue: mock(() => {}) } as never,
+	};
+}
+
+function makeRequest(): Request {
+	return new Request("https://proxy.local/v1/messages", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			model: "claude-sonnet-4-5",
+			messages: [{ role: "user", content: "hello" }],
+			max_tokens: 16,
+		}),
+	});
+}
+
+/**
+ * A five-hour window well ahead of its pacing line, mirroring the shape
+ * `proxy-usage-throttling.test.ts` already pins.
+ */
+const FROZEN_NOW = Date.UTC(2026, 3, 28, 12, 0, 0);
+
+function throttledUsage() {
+	return {
+		five_hour: {
+			utilization: 80,
+			resets_at: new Date(FROZEN_NOW + 2 * 60 * 60 * 1000).toISOString(),
+		},
+		seven_day: { utilization: 10, resets_at: null },
+	};
+}
+
+let savedPassthrough: string | undefined;
+
+beforeEach(() => {
+	savedPassthrough = process.env.CCFLARE_PASSTHROUGH_ON_EMPTY_POOL;
+	delete process.env.CCFLARE_PASSTHROUGH_ON_EMPTY_POOL;
+	usageCache.clear();
+	stubUsageCollector();
+});
+
+afterEach(() => {
+	usageCache.clear();
+	if (savedPassthrough === undefined) {
+		delete process.env.CCFLARE_PASSTHROUGH_ON_EMPTY_POOL;
+	} else {
+		process.env.CCFLARE_PASSTHROUGH_ON_EMPTY_POOL = savedPassthrough;
+	}
+});
+
+describe("force_account_model refusal — ordering against capacity answers", () => {
+	it("yields to the usage-throttling answer, which carries the retry time", async () => {
+		const account = makeAccount();
+		usageCache.set(account.id, throttledUsage() as never);
+		const ctx = makeContext([account], { throttlingEnabled: true });
+
+		const realDateNow = Date.now;
+		Date.now = () => FROZEN_NOW;
+		let response: Response;
+		try {
+			response = await handleProxy(
+				makeRequest(),
+				new URL("https://proxy.local/v1/messages"),
+				ctx,
+			);
+		} finally {
+			Date.now = realDateNow;
+		}
+
+		// The account speaks this model; it is only out of pace right now. The
+		// throttling answer says when to come back — the refusal would not.
+		expect(response.status).toBe(529);
+		expect(response.headers.get("Retry-After")).not.toBeNull();
+
+		const body = (await response.json()) as Record<string, unknown>;
+		const error = body.error as Record<string, unknown>;
+		expect(error.code).not.toBe("force_account_model_no_account");
+	});
+
+	it("still answers when the pool is empty with no capacity explanation", async () => {
+		const ctx = makeContext([]);
+
+		const response = await handleProxy(
+			makeRequest(),
+			new URL("https://proxy.local/v1/messages"),
+			ctx,
+		);
+
+		expect(response.status).toBe(503);
+		const body = (await response.json()) as Record<string, unknown>;
+		const error = body.error as Record<string, unknown>;
+		expect(error.code).toBe("force_account_model_no_account");
+		// Naming the model is the whole point of answering here rather than
+		// letting the generic pool_exhausted 503 through.
+		expect(JSON.stringify(error)).toContain("claude-sonnet-4-5");
+	});
+
+	it("beats the generic pool_exhausted 503 when throttling is off", async () => {
+		const account = makeAccount({ paused: true });
+		const ctx = makeContext([account]);
+
+		const response = await handleProxy(
+			makeRequest(),
+			new URL("https://proxy.local/v1/messages"),
+			ctx,
+		);
+
+		const body = (await response.json()) as Record<string, unknown>;
+		const error = body.error as Record<string, unknown>;
+		expect(error.code).toBe("force_account_model_no_account");
+		expect(error.type).not.toBe("pool_exhausted");
+	});
+});

--- a/packages/proxy/src/__tests__/force-account-model-refusal-order.test.ts
+++ b/packages/proxy/src/__tests__/force-account-model-refusal-order.test.ts
@@ -239,6 +239,36 @@ describe("force_account_model refusal — ordering against capacity answers", ()
 		expect(error.code).toBe("force_account_model_no_account");
 	});
 
+	it("is not outranked by the cooldown sweep behind the pool_exhausted answer", async () => {
+		// `pool_exhausted` is built from a *raw* account sweep — it re-reads every
+		// account of the provider straight from the DB, with no compatibility
+		// filter, and always emits a `Retry-After`. So an account that can never
+		// serve this model, merely because it happens to be on cooldown, is
+		// enough to produce a concrete retry time. That answer must stay behind
+		// the refusal: the wait it advertises would expire and change nothing.
+		const account = makeAccount({
+			id: "codex-1",
+			name: "codex-account",
+			provider: "codex",
+			rate_limited_until: Date.now() + 30 * 60 * 1000,
+		});
+		const ctx = makeContext([account]);
+
+		const response = await handleProxy(
+			makeRequest(),
+			new URL("https://proxy.local/v1/messages"),
+			ctx,
+		);
+
+		expect(response.status).toBe(503);
+		expect(response.headers.get("Retry-After")).toBeNull();
+
+		const body = (await response.json()) as Record<string, unknown>;
+		const error = body.error as Record<string, unknown>;
+		expect(error.code).toBe("force_account_model_no_account");
+		expect(error.type).not.toBe("pool_exhausted");
+	});
+
 	it("beats the generic pool_exhausted 503 when throttling is off", async () => {
 		const account = makeAccount({ paused: true });
 		const ctx = makeContext([account]);

--- a/packages/proxy/src/codex-model-catalog.ts
+++ b/packages/proxy/src/codex-model-catalog.ts
@@ -79,6 +79,26 @@ const lastGood = new Map<string, CodexModelListing>();
  */
 let providerWide: CodexModelListing | null = null;
 
+/**
+ * What this account itself already told us it can serve, or null.
+ *
+ * Never fetches and never borrows another account's list: it answers "do we
+ * know, for this account, first-hand?" — which is the only form of knowledge
+ * strong enough to exclude an account from routing. Account selection runs per
+ * request, so a network call here is out of the question, and a borrowed list
+ * excluding an account would be a guess wearing a fact's clothes.
+ *
+ * Expect null often: nothing is persisted, so every restart starts blank, and
+ * accounts that answer 401 on the listing endpoint never populate it at all.
+ * Callers must have an answer for "we do not know" that is not "refuse".
+ */
+export function getKnownCodexModels(
+	accountId: string,
+): CodexModelListing | null {
+	const own = lastGood.get(accountId);
+	return own ? { ...own, source: "cached" } : null;
+}
+
 /** Test seam: both registries are process-wide and leak between cases. */
 export function clearCodexModelCacheForTests(): void {
 	lastGood.clear();

--- a/packages/proxy/src/handlers/__tests__/account-selector-force-model.test.ts
+++ b/packages/proxy/src/handlers/__tests__/account-selector-force-model.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, mock } from "bun:test";
+import type {
+	Account,
+	ComboWithSlots,
+	RequestMeta,
+} from "@better-ccflare/types";
+import { clearCodexModelCacheForTests } from "../../codex-model-catalog";
+import {
+	getComboSlotInfo,
+	selectAccountsForRequest,
+} from "../account-selector";
+import type { ProxyContext } from "../proxy-types";
+
+// "Force account model" is a promise about the model, not about the account:
+// the request may move between accounts freely, and may never be served by an
+// account that would send a different model.
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "acc-1",
+		name: "account",
+		provider: "anthropic",
+		api_key: null,
+		refresh_token: "rt",
+		access_token: "at",
+		expires_at: Date.now() + 3_600_000,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: Date.now(),
+		rate_limited_until: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		custom_endpoint: null,
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		...overrides,
+	};
+}
+
+function makeRequestMeta(): RequestMeta {
+	return {
+		id: "req-1",
+		method: "POST",
+		path: "/v1/messages",
+		timestamp: Date.now(),
+		headers: new Headers(),
+	};
+}
+
+function makeCtx(opts: {
+	accounts: Account[];
+	forceAccountModel: boolean;
+	combo?: ComboWithSlots | null;
+}) {
+	const getActiveComboForFamily = mock(async () => opts.combo ?? null);
+	const ctx = {
+		strategy: {
+			select: mock((_all: Account[], _meta: RequestMeta) => opts.accounts),
+		},
+		dbOps: {
+			getAllAccounts: mock(async () => opts.accounts),
+			getActiveComboForFamily,
+		},
+		refreshInFlight: new Map(),
+		asyncWriter: { enqueue: mock(() => {}) },
+		config: {
+			getForceAccountModel: () => opts.forceAccountModel,
+			getCombosEnabled: () => true,
+		},
+	} as unknown as ProxyContext;
+	return { ctx, getActiveComboForFamily };
+}
+
+const claudeAccount = makeAccount({ id: "claude-1", provider: "anthropic" });
+const codexAccount = makeAccount({ id: "codex-1", provider: "codex" });
+
+describe("selectAccountsForRequest — force account model", () => {
+	it("sends a provider model id only to accounts of that provider", async () => {
+		clearCodexModelCacheForTests();
+		const { ctx } = makeCtx({
+			accounts: [claudeAccount, codexAccount],
+			forceAccountModel: true,
+		});
+
+		const result = await selectAccountsForRequest(
+			makeRequestMeta(),
+			ctx,
+			"gpt-5.6-sol",
+		);
+
+		expect(result.map((a) => a.id)).toEqual(["codex-1"]);
+	});
+
+	it("sends a Claude model id only to accounts that speak Claude ids", async () => {
+		clearCodexModelCacheForTests();
+		const { ctx } = makeCtx({
+			accounts: [claudeAccount, codexAccount],
+			forceAccountModel: true,
+		});
+
+		const result = await selectAccountsForRequest(
+			makeRequestMeta(),
+			ctx,
+			"claude-opus-4-1",
+		);
+
+		expect(result.map((a) => a.id)).toEqual(["claude-1"]);
+	});
+
+	it("keeps every account that can serve the model, so failover still works", async () => {
+		clearCodexModelCacheForTests();
+		const second = makeAccount({ id: "codex-2", provider: "codex" });
+		const { ctx } = makeCtx({
+			accounts: [codexAccount, second],
+			forceAccountModel: true,
+		});
+
+		const result = await selectAccountsForRequest(
+			makeRequestMeta(),
+			ctx,
+			"gpt-5.6-sol",
+		);
+
+		// Moving between accounts is allowed — it is moving between models that
+		// this setting forbids.
+		expect(result.map((a) => a.id)).toEqual(["codex-1", "codex-2"]);
+	});
+
+	it("returns nothing rather than an account that would send another model", async () => {
+		clearCodexModelCacheForTests();
+		const { ctx } = makeCtx({
+			accounts: [claudeAccount],
+			forceAccountModel: true,
+		});
+
+		const result = await selectAccountsForRequest(
+			makeRequestMeta(),
+			ctx,
+			"gpt-5.6-sol",
+		);
+
+		expect(result).toEqual([]);
+	});
+
+	it("never routes through a combo, since a slot exists to change the model", async () => {
+		clearCodexModelCacheForTests();
+		const combo: ComboWithSlots = {
+			id: "combo-1",
+			name: "Opus Combo",
+			description: null,
+			enabled: true,
+			created_at: Date.now(),
+			updated_at: Date.now(),
+			slots: [
+				{
+					id: "slot-1",
+					combo_id: "combo-1",
+					account_id: "codex-1",
+					model: "gpt-5.6-sol",
+					priority: 0,
+					enabled: true,
+				},
+			],
+		};
+		const { ctx, getActiveComboForFamily } = makeCtx({
+			accounts: [claudeAccount, codexAccount],
+			forceAccountModel: true,
+			combo,
+		});
+		const meta = makeRequestMeta();
+
+		const result = await selectAccountsForRequest(meta, ctx, "claude-opus-4-1");
+
+		expect(getActiveComboForFamily).not.toHaveBeenCalled();
+		expect(getComboSlotInfo(meta)).toBeNull();
+		// The combo would have sent this to the codex account as gpt-5.6-sol.
+		expect(result.map((a) => a.id)).toEqual(["claude-1"]);
+	});
+
+	it("changes nothing while off", async () => {
+		clearCodexModelCacheForTests();
+		const { ctx } = makeCtx({
+			accounts: [claudeAccount, codexAccount],
+			forceAccountModel: false,
+		});
+
+		const result = await selectAccountsForRequest(
+			makeRequestMeta(),
+			ctx,
+			"gpt-5.6-sol",
+		);
+
+		expect(result.map((a) => a.id)).toEqual(["claude-1", "codex-1"]);
+	});
+});

--- a/packages/proxy/src/handlers/__tests__/account-selector-force-model.test.ts
+++ b/packages/proxy/src/handlers/__tests__/account-selector-force-model.test.ts
@@ -203,3 +203,72 @@ describe("selectAccountsForRequest — force account model", () => {
 		expect(result.map((a) => a.id)).toEqual(["claude-1", "codex-1"]);
 	});
 });
+
+/**
+ * `x-better-ccflare-account-id` names an account outright, and that path
+ * returns before every other filter. Under this setting it still has to answer
+ * the one question the setting is about, because the two ways of not answering
+ * it are both worse: falling through to normal selection would send the request
+ * to a *different* account than the header named, and letting it through would
+ * put an account that can never serve this model in front of the capacity
+ * branches, which would then advertise a retry time for a wait that can never
+ * help.
+ */
+describe("selectAccountsForRequest — force account model, forced-account header", () => {
+	function metaForcing(accountId: string): RequestMeta {
+		return {
+			...makeRequestMeta(),
+			headers: new Headers({ "x-better-ccflare-account-id": accountId }),
+		};
+	}
+
+	it("refuses when the named account cannot serve the model as written", async () => {
+		clearCodexModelCacheForTests();
+		const { ctx } = makeCtx({
+			accounts: [claudeAccount, codexAccount],
+			forceAccountModel: true,
+		});
+
+		const result = await selectAccountsForRequest(
+			metaForcing("codex-1"),
+			ctx,
+			"claude-opus-4-1",
+		);
+
+		// Empty, which proxy.ts answers as force_account_model_no_account —
+		// and specifically not [claude-1], which would be the account swap.
+		expect(result).toEqual([]);
+	});
+
+	it("still honours the header when the named account can serve the model", async () => {
+		clearCodexModelCacheForTests();
+		const { ctx } = makeCtx({
+			accounts: [claudeAccount, codexAccount],
+			forceAccountModel: true,
+		});
+
+		const result = await selectAccountsForRequest(
+			metaForcing("codex-1"),
+			ctx,
+			"gpt-5.6-sol",
+		);
+
+		expect(result.map((a) => a.id)).toEqual(["codex-1"]);
+	});
+
+	it("leaves the header alone while off", async () => {
+		clearCodexModelCacheForTests();
+		const { ctx } = makeCtx({
+			accounts: [claudeAccount, codexAccount],
+			forceAccountModel: false,
+		});
+
+		const result = await selectAccountsForRequest(
+			metaForcing("codex-1"),
+			ctx,
+			"claude-opus-4-1",
+		);
+
+		expect(result.map((a) => a.id)).toEqual(["codex-1"]);
+	});
+});

--- a/packages/proxy/src/handlers/__tests__/account-selector-force-model.test.ts
+++ b/packages/proxy/src/handlers/__tests__/account-selector-force-model.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock } from "bun:test";
+import { CLAUDE_MODEL_IDS } from "@better-ccflare/core";
 import type {
 	Account,
 	ComboWithSlots,
@@ -9,7 +10,10 @@ import {
 	getComboSlotInfo,
 	selectAccountsForRequest,
 } from "../account-selector";
-import type { ProxyContext } from "../proxy-types";
+import {
+	INTERNAL_PROBE_SECRET_HEADER,
+	type ProxyContext,
+} from "../proxy-types";
 
 // "Force account model" is a promise about the model, not about the account:
 // the request may move between accounts freely, and may never be served by an
@@ -61,6 +65,7 @@ function makeCtx(opts: {
 	accounts: Account[];
 	forceAccountModel: boolean;
 	combo?: ComboWithSlots | null;
+	internalProbeSecret?: string;
 }) {
 	const getActiveComboForFamily = mock(async () => opts.combo ?? null);
 	const ctx = {
@@ -77,6 +82,7 @@ function makeCtx(opts: {
 			getForceAccountModel: () => opts.forceAccountModel,
 			getCombosEnabled: () => true,
 		},
+		internalProbeSecret: opts.internalProbeSecret,
 	} as unknown as ProxyContext;
 	return { ctx, getActiveComboForFamily };
 }
@@ -270,5 +276,86 @@ describe("selectAccountsForRequest — force account model, forced-account heade
 		);
 
 		expect(result.map((a) => a.id)).toEqual(["codex-1"]);
+	});
+});
+
+/**
+ * The auto-refresh scheduler is not a client asking for a model. It sends a
+ * compiled-in list of Claude model ids to whatever account it is probing —
+ * including Codex accounts — because its job is to touch the endpoint and read
+ * what comes back, not to deliver a caller's choice. Judging it by model
+ * compatibility is therefore a category error, and an expensive one: a refused
+ * probe counts as a refresh failure, and enough of those pause a perfectly
+ * healthy account with pause_reason='failure_threshold'.
+ *
+ * The exemption is keyed on `isInternalProbe`, which checks the process-local
+ * probe secret. A client that copies the marker header out of a log gets
+ * nothing, so this is a carve-out for us rather than a hole in the rule.
+ */
+describe("selectAccountsForRequest — force account model, internal probes", () => {
+	const SECRET = "probe-secret";
+
+	function probeMeta(accountId: string, secret: string | null): RequestMeta {
+		const headers = new Headers({
+			"x-better-ccflare-account-id": accountId,
+			"x-better-ccflare-auto-refresh": "true",
+		});
+		if (secret !== null) {
+			headers.set(INTERNAL_PROBE_SECRET_HEADER, secret);
+		}
+		return { ...makeRequestMeta(), headers };
+	}
+
+	it("lets a secret-verified probe reach an account the model does not match", async () => {
+		clearCodexModelCacheForTests();
+		const { ctx } = makeCtx({
+			accounts: [claudeAccount, codexAccount],
+			forceAccountModel: true,
+			internalProbeSecret: SECRET,
+		});
+
+		const result = await selectAccountsForRequest(
+			probeMeta("codex-1", SECRET),
+			ctx,
+			CLAUDE_MODEL_IDS.HAIKU_4_5,
+		);
+
+		// The probe reaches the Codex account it was aimed at. Refusing here is
+		// what would pause it.
+		expect(result.map((a) => a.id)).toEqual(["codex-1"]);
+	});
+
+	it("refuses a forged marker that cannot produce the secret", async () => {
+		clearCodexModelCacheForTests();
+		const { ctx } = makeCtx({
+			accounts: [claudeAccount, codexAccount],
+			forceAccountModel: true,
+			internalProbeSecret: SECRET,
+		});
+
+		const result = await selectAccountsForRequest(
+			probeMeta("codex-1", "not-the-secret"),
+			ctx,
+			CLAUDE_MODEL_IDS.HAIKU_4_5,
+		);
+
+		expect(result).toEqual([]);
+	});
+
+	it("refuses a marker sent with no secret at all", async () => {
+		clearCodexModelCacheForTests();
+		const { ctx } = makeCtx({
+			accounts: [claudeAccount, codexAccount],
+			forceAccountModel: true,
+			internalProbeSecret: SECRET,
+		});
+
+		const result = await selectAccountsForRequest(
+			probeMeta("codex-1", null),
+			ctx,
+			CLAUDE_MODEL_IDS.HAIKU_4_5,
+		);
+
+		expect(result).toEqual([]);
 	});
 });

--- a/packages/proxy/src/handlers/__tests__/agent-interceptor.rewrite-guard.test.ts
+++ b/packages/proxy/src/handlers/__tests__/agent-interceptor.rewrite-guard.test.ts
@@ -271,4 +271,107 @@ describe("interceptAndModifyRequest - rewrite guard integration", () => {
 		expect(result.appliedModel).toBe("claude-opus-model");
 		expect(result.modifiedBody).not.toBe(buffer);
 	});
+
+	// `force_account_model` is a second, independent veto on the same rewrite.
+	// The catalog guard asks "can this target be served?"; this one asks "is
+	// renaming allowed at all?" — and when the operator has said no, an agent
+	// preference is just one more way of sending a model other than the one
+	// that was asked for, exactly like a combo slot.
+	test("force account model on => no rewrite, agentUsed still set (header path)", async () => {
+		await dbOps.setAgentPreference("force-header-agent", "claude-opus-model");
+		const buffer = toArrayBuffer(createMockRequestBody());
+		const result = await interceptAndModifyRequest(
+			buffer,
+			dbOps,
+			new Headers({ "x-anthropic-agent-id": "force-header-agent" }),
+			{
+				// A catalog that *would* allow the rewrite, so the only thing
+				// stopping it is the setting under test.
+				getModelCatalog: async () =>
+					liveCatalog(["claude-3-5-sonnet-20241022", "claude-opus-model"]),
+				forceAccountModel: true,
+			},
+		);
+		expect(result.agentUsed).toBe("force-header-agent");
+		expect(result.appliedModel).toBe("claude-3-5-sonnet-20241022");
+		expect(result.originalModel).toBe("claude-3-5-sonnet-20241022");
+		expect(result.modifiedBody).toBe(buffer);
+	});
+
+	test("same preference and catalog with the setting off => rewrite proceeds", async () => {
+		await dbOps.setAgentPreference("force-header-agent", "claude-opus-model");
+		const buffer = toArrayBuffer(createMockRequestBody());
+		const result = await interceptAndModifyRequest(
+			buffer,
+			dbOps,
+			new Headers({ "x-anthropic-agent-id": "force-header-agent" }),
+			{
+				getModelCatalog: async () =>
+					liveCatalog(["claude-3-5-sonnet-20241022", "claude-opus-model"]),
+				forceAccountModel: false,
+			},
+		);
+		expect(result.appliedModel).toBe("claude-opus-model");
+		expect(result.modifiedBody).not.toBe(buffer);
+	});
+
+	test("force account model on => no rewrite (system-prompt path)", async () => {
+		writeAgent(
+			"force-agent.md",
+			"name: Force Agent\ndescription: test agent\nmodel: inherit",
+			"You are the force agent, a singular and unmistakable helper voice.",
+		);
+		await agentRegistry.registerWorkspace(tmpDir);
+		const agents = await agentRegistry.getAgents();
+		const agent = agents.find((a) => a.id.endsWith(":force-agent"));
+		expect(agent).toBeDefined();
+
+		await dbOps.setAgentPreference(
+			agent?.id ?? "force-agent",
+			"claude-opus-model",
+		);
+
+		const buffer = toArrayBuffer(
+			createMockRequestBody({
+				system:
+					"You are the force agent, a singular and unmistakable helper voice.",
+			}),
+		);
+		const result = await interceptAndModifyRequest(buffer, dbOps, undefined, {
+			getModelCatalog: async () =>
+				liveCatalog(["claude-3-5-sonnet-20241022", "claude-opus-model"]),
+			forceAccountModel: true,
+		});
+		expect(result.agentUsed).toBe(agent?.id);
+		expect(result.appliedModel).toBe("claude-3-5-sonnet-20241022");
+		expect(result.modifiedBody).toBe(buffer);
+	});
+
+	test("force account model on => the frontmatter fallback is vetoed too", async () => {
+		writeAgent(
+			"force-frontmatter-agent.md",
+			"name: Force Frontmatter Agent\ndescription: test agent\nmodel: claude-opus-model",
+			"You are the frontmatter force agent, an unrepeated and separate persona.",
+		);
+		await agentRegistry.registerWorkspace(tmpDir);
+		const agents = await agentRegistry.getAgents();
+		const agent = agents.find((a) => a.id.endsWith(":force-frontmatter-agent"));
+		expect(agent).toBeDefined();
+
+		const buffer = toArrayBuffer(
+			createMockRequestBody({
+				system:
+					"You are the frontmatter force agent, an unrepeated and separate persona.",
+			}),
+		);
+		const result = await interceptAndModifyRequest(buffer, dbOps, undefined, {
+			getModelCatalog: async () =>
+				liveCatalog(["claude-3-5-sonnet-20241022", "claude-opus-model"]),
+			frontmatterModelFallback: true,
+			forceAccountModel: true,
+		});
+		expect(result.agentUsed).toBe(agent?.id);
+		expect(result.appliedModel).toBe("claude-3-5-sonnet-20241022");
+		expect(result.modifiedBody).toBe(buffer);
+	});
 });

--- a/packages/proxy/src/handlers/account-selector.ts
+++ b/packages/proxy/src/handlers/account-selector.ts
@@ -512,6 +512,36 @@ export async function selectAccountsForRequest(
 					(acc) => acc.id === forcedAccountId,
 				);
 				if (forcedAccount) {
+					// With "force account model" on, a header naming an account
+					// does not get to skip the one rule the setting exists for.
+					//
+					// Refusing here — an empty selection, which proxy.ts answers
+					// as force_account_model_no_account — is deliberately not the
+					// same as falling through to normal selection below: that
+					// would send the request to a *different* account than the
+					// header named, substituting the account to protect a rule
+					// about models. Nor is it left to the provider's 400: an
+					// unfiltered forced account also reaches the capacity
+					// branches, which would advertise a `Retry-After` for an
+					// account that can never serve this model no matter how long
+					// the caller waits.
+					//
+					// Internal auto-refresh probes are not exempted. They pick a
+					// model from the account's own listing, so the check passes
+					// for them anyway, and an exemption keyed on a header any
+					// client can set would be a hole in the rule rather than a
+					// carve-out for us.
+					if (
+						model &&
+						isForceAccountModelEnabled(ctx) &&
+						!accountServesModel(forcedAccount, model)
+					) {
+						log.warn(
+							`Force account model: forced account ${forcedAccount.name} cannot serve "${model}" as requested — refusing rather than substituting the account or the model`,
+						);
+						return [];
+					}
+
 					// The auto-refresh scheduler sends dummy messages with x-better-ccflare-bypass-session
 					// to intentionally refresh accounts that are paused due to auto_pause_on_overage,
 					// or to probe accounts that are rate-limited (to detect when the window has reset).

--- a/packages/proxy/src/handlers/account-selector.ts
+++ b/packages/proxy/src/handlers/account-selector.ts
@@ -26,7 +26,7 @@ import {
 	isAccountExhaustedForModel,
 	type ModelFamilyExhaustionInfo,
 } from "./model-capacity";
-import type { ProxyContext } from "./proxy-types";
+import { isInternalProbe, type ProxyContext } from "./proxy-types";
 
 const log = new Logger("AccountSelector");
 
@@ -526,14 +526,24 @@ export async function selectAccountsForRequest(
 					// account that can never serve this model no matter how long
 					// the caller waits.
 					//
-					// Internal auto-refresh probes are not exempted. They pick a
-					// model from the account's own listing, so the check passes
-					// for them anyway, and an exemption keyed on a header any
-					// client can set would be a hole in the rule rather than a
-					// carve-out for us.
+					// Internal probes ARE exempted, and have to be. The
+					// auto-refresh scheduler sends a compiled-in list of Claude
+					// model ids to whatever account it is probing, so a Codex
+					// account's own probe fails this check by construction —
+					// and a probe answered with a refusal counts as a refresh
+					// failure, which is how a perfectly healthy account would
+					// end up paused with pause_reason='failure_threshold'.
+					//
+					// The exemption is keyed on `isInternalProbe`, which
+					// verifies the internal probe secret, and not on the
+					// bypass-session header a client can set. The probe is also
+					// not a client asking for a model: it exists to touch the
+					// endpoint and observe what comes back, so judging it by
+					// what the caller "asked for" is a category error.
 					if (
 						model &&
 						isForceAccountModelEnabled(ctx) &&
+						!isInternalProbe(meta.headers, ctx) &&
 						!accountServesModel(forcedAccount, model)
 					) {
 						log.warn(

--- a/packages/proxy/src/handlers/account-selector.ts
+++ b/packages/proxy/src/handlers/account-selector.ts
@@ -3,6 +3,7 @@ import {
 	getModelFamily,
 	isAccountAvailable,
 	isUsageExhausted,
+	providerAcceptsClientModel,
 } from "@better-ccflare/core";
 import { Logger } from "@better-ccflare/logger";
 import {
@@ -17,6 +18,7 @@ import type {
 	ComboSlotInfo,
 	RequestMeta,
 } from "@better-ccflare/types";
+import { getKnownCodexModels } from "../codex-model-catalog";
 import {
 	type FamilyExhaustionOrigin,
 	getFamilyExhaustionOrigin,
@@ -271,6 +273,50 @@ function isCapacityRoutingEnabled(ctx: ProxyContext): boolean {
  */
 function areCombosEnabled(ctx: ProxyContext): boolean {
 	return ctx.config?.getCombosEnabled?.() ?? true;
+}
+
+/**
+ * Whether the model a client asked for must be the model that is sent.
+ * Defaults to off for a context without a config, like every other setting
+ * read here.
+ */
+export function isForceAccountModelEnabled(ctx: ProxyContext): boolean {
+	return ctx.config?.getForceAccountModel?.() ?? false;
+}
+
+/**
+ * Whether `account` can serve `model` exactly as the client wrote it.
+ *
+ * Two rules, in order:
+ *
+ * 1. First-hand knowledge. If the account itself has listed the models it
+ *    serves, that list is the answer — and a borrowed list from a sibling
+ *    account deliberately does not count, since excluding an account on
+ *    someone else's evidence is a guess wearing a fact's clothes.
+ * 2. Otherwise, the namespace. A Claude model id can only travel untranslated
+ *    to a provider that speaks Claude ids, and a non-Claude id only to one
+ *    that does not.
+ *
+ * Rule 2 carries the weight in practice: listings are per-process and start
+ * empty after every restart, and some accounts answer 401 on the listing
+ * endpoint while serving traffic perfectly. It is coarse — with several
+ * non-Claude providers configured, a request can still reach the wrong one —
+ * but the failure is then an explicit upstream error, never a silent
+ * substitution, which is the promise this setting actually makes.
+ */
+function accountServesModel(account: Account, model: string): boolean {
+	const known =
+		account.provider === "codex" ? getKnownCodexModels(account.id) : null;
+	if (known) {
+		return known.models.some((entry) => entry.id === model);
+	}
+	return (
+		providerAcceptsClientModel(account.provider) === isClaudeModelId(model)
+	);
+}
+
+function isClaudeModelId(model: string): boolean {
+	return getModelFamily(model) !== null;
 }
 
 /**
@@ -567,10 +613,17 @@ export async function selectAccountsForRequest(
 		return filtered;
 	};
 
-	// Try combo-aware routing if a model is provided (skipped entirely when
-	// skipCombo is set — see the `options` doc above, or when combos are
-	// switched off).
-	if (model && !options?.skipCombo && areCombosEnabled(ctx)) {
+	// Try combo-aware routing if a model is provided. Skipped entirely when
+	// skipCombo is set (see the `options` doc above), when combos are switched
+	// off, and when the model is forced: a combo slot exists to send a
+	// different model than the one asked for, which is the one thing that
+	// setting forbids.
+	if (
+		model &&
+		!options?.skipCombo &&
+		areCombosEnabled(ctx) &&
+		!isForceAccountModelEnabled(ctx)
+	) {
 		const family = getModelFamily(model);
 		if (family) {
 			const validFamilies: readonly string[] = [
@@ -699,7 +752,24 @@ export async function selectAccountsForRequest(
 
 	const { ordered: rawOrderedAccounts, all: allAccounts } =
 		await getOrderedAccounts(meta, ctx);
-	const orderedAccounts = applyExclusions(rawOrderedAccounts);
+	let orderedAccounts = applyExclusions(rawOrderedAccounts);
+
+	// "Force account model": keep only accounts that can serve the requested
+	// model as written. Nothing downstream will rename it, so an account that
+	// would need a translation is not a candidate — and if that empties the
+	// list, the request fails rather than being served a model nobody asked
+	// for. Switching accounts is still fine; switching models is not.
+	if (model && isForceAccountModelEnabled(ctx)) {
+		const before = orderedAccounts.length;
+		orderedAccounts = orderedAccounts.filter((account) =>
+			accountServesModel(account, model),
+		);
+		if (orderedAccounts.length !== before) {
+			log.info(
+				`Force account model: ${orderedAccounts.length}/${before} account(s) can serve "${model}" as requested`,
+			);
+		}
+	}
 
 	// Model-scoped capacity filter for the non-combo (or combo-inactive/
 	// combo-exhausted-fallthrough) path: drop accounts whose weekly per-model

--- a/packages/proxy/src/handlers/agent-interceptor.ts
+++ b/packages/proxy/src/handlers/agent-interceptor.ts
@@ -49,6 +49,10 @@ export function isRewriteTargetServable(
  *   to the real `getModelCatalog`), consulted before applying a preference
  *   rewrite via `isRewriteTargetServable`. Tests inject a stub to avoid the
  *   real disk-cache/network-backed implementation.
+ * @param options.forceAccountModel - When true, no preference rewrite is
+ *   applied: an agent preference is another way of sending a model other than
+ *   the one asked for, exactly like a combo slot, and this setting declines
+ *   all of them. Agent attribution is unaffected — only the rewrite is.
  * @returns Modified request body and agent detection information
  */
 export async function interceptAndModifyRequest(
@@ -58,9 +62,11 @@ export async function interceptAndModifyRequest(
 	options?: {
 		frontmatterModelFallback?: boolean;
 		getModelCatalog?: () => Promise<ModelCatalog>;
+		forceAccountModel?: boolean;
 	},
 ): Promise<AgentInterceptResult> {
 	const loadModelCatalog = options?.getModelCatalog ?? getModelCatalog;
+	const skipModelRewrite = options?.forceAccountModel === true;
 	const bodyContext =
 		requestBody instanceof RequestBodyContext
 			? requestBody
@@ -130,7 +136,12 @@ export async function interceptAndModifyRequest(
 			// an agent's frontmatter `model` is never consulted here, since a
 			// declared agent id has no associated frontmatter to fall back to.
 			const preference = await dbOps.getAgentPreference(explicitAgentId);
-			const preferredModel = preference?.model;
+			if (skipModelRewrite && preference?.model) {
+				log.info(
+					`Force account model is on — agent ${explicitAgentId}'s preference for ${preference.model} does not apply; passing through ${originalModel}`,
+				);
+			}
+			const preferredModel = skipModelRewrite ? undefined : preference?.model;
 			if (preferredModel && preferredModel !== originalModel) {
 				const catalog = await loadModelCatalog();
 				if (isRewriteTargetServable(catalog, preferredModel)) {
@@ -284,9 +295,15 @@ export async function interceptAndModifyRequest(
 		// broken subagent spawns against dead alias targets in the past. A null
 		// agent.model means "inherit" (no preference) either way.
 		const preference = await dbOps.getAgentPreference(detectedAgent.id);
-		const preferredModel =
+		const declaredPreference =
 			preference?.model ??
 			(options?.frontmatterModelFallback ? detectedAgent.model : null);
+		if (skipModelRewrite && declaredPreference) {
+			log.info(
+				`Force account model is on — agent ${detectedAgent.id}'s preference for ${declaredPreference} does not apply; passing through ${originalModel}`,
+			);
+		}
+		const preferredModel = skipModelRewrite ? null : declaredPreference;
 
 		// If there's no preference at all, or it matches the original, no
 		// modification is needed. agentUsed is still reported for attribution.

--- a/packages/proxy/src/handlers/index.ts
+++ b/packages/proxy/src/handlers/index.ts
@@ -7,6 +7,7 @@ export {
 	getModelFamilyExhaustionInfo,
 	getXaiConvId,
 	isComboSessionFallbackDisabled,
+	isForceAccountModelEnabled,
 	type ModelFamilyExhaustionInfo,
 	recordXaiAffinitySuccess,
 	resolveEffectiveModel,

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -1,6 +1,7 @@
 import {
 	type AccountUsageSnapshot,
 	requestEvents,
+	runForceAccountModelExempt,
 	ServiceUnavailableError,
 	trackClientVersion,
 } from "@better-ccflare/core";
@@ -153,7 +154,39 @@ export function getUsageCollectorHealth(): UsageCollectorHealth {
  * @throws {ServiceUnavailableError} If all accounts fail to proxy the request
  * @throws {ProviderError} If unauthenticated proxy fails
  */
-export async function handleProxy(
+/**
+ * A verified internal probe runs with `force_account_model` treated as off for
+ * its whole lifetime.
+ *
+ * The switch promises to serve the model the *client* named or nothing, and a
+ * probe is not a client: the schedulers send a compiled-in list of Claude ids
+ * to whatever account they are probing, because the point is to touch the
+ * endpoint and read the answer. Mapping is what makes that land on a non-Claude
+ * account, so leaving the switch on here would not honour the promise — it
+ * would send `claude-haiku-4-5` to Codex, take the rejection as a refresh
+ * failure, and pause a healthy account after five of them.
+ *
+ * `isInternalProbe` verifies the process-local probe secret, so a client that
+ * copies the marker header out of a log gets nothing. Sibling of the exemptions
+ * probes already have in usage throttling and in the forced-account model
+ * check.
+ */
+export function handleProxy(
+	req: Request,
+	url: URL,
+	ctx: ProxyContext,
+	apiKeyId?: string | null,
+	apiKeyName?: string | null,
+): Promise<Response> {
+	if (isInternalProbe(req.headers, ctx)) {
+		return runForceAccountModelExempt(() =>
+			handleProxyRequest(req, url, ctx, apiKeyId, apiKeyName),
+		);
+	}
+	return handleProxyRequest(req, url, ctx, apiKeyId, apiKeyName);
+}
+
+async function handleProxyRequest(
 	req: Request,
 	url: URL,
 	ctx: ProxyContext,

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -25,6 +25,7 @@ import {
 	getUsageThrottleUntil,
 	interceptAndModifyRequest,
 	isComboSessionFallbackDisabled,
+	isForceAccountModelEnabled,
 	isInternalProbe,
 	isRefreshTokenLikelyExpired,
 	type ProxyContext,
@@ -71,6 +72,33 @@ function createComboSessionFallbackDisabledResponse(
 				message: "Service temporarily unavailable. Please try again later.",
 				code: "combo_session_fallback_disabled",
 				combo: comboName,
+			},
+		}),
+		{
+			status: 503,
+			headers: { "Content-Type": "application/json" },
+		},
+	);
+}
+
+/**
+ * No account can serve the model that was asked for, and "force account model"
+ * forbids serving a different one.
+ *
+ * 503 rather than 400: the request is well formed, and the same model may well
+ * be servable in a minute — an account may be rate-limited right now, or its
+ * model listing not yet read. The model is named in the body because that is
+ * the one thing the caller can act on.
+ */
+function createForceAccountModelResponse(model: string): Response {
+	return new Response(
+		JSON.stringify({
+			type: "error",
+			error: {
+				type: "service_unavailable_error",
+				message: `No available account can serve "${model}", and forcing the account model is enabled so no substitute was used.`,
+				code: "force_account_model_no_account",
+				model,
 			},
 		}),
 		{
@@ -353,12 +381,21 @@ export async function handleProxy(
 		}
 	};
 
-	const returnComboSessionFallbackDisabled = async (
-		comboName: string,
+	/**
+	 * Return a refusal that was decided before any upstream was contacted, and
+	 * record it as a request all the same.
+	 *
+	 * Recording matters: a routing rule that silently drops requests would make
+	 * the dashboard show a quiet, healthy proxy while clients get 503s. Shared
+	 * by every deliberate refusal so they cannot drift in what they report.
+	 */
+	const returnRefusal = async (
+		refusalResponse: Response,
+		errorCode: string,
 		failoverAttempts: number,
+		comboName: string | null,
 	): Promise<Response> => {
-		const disabledFallbackResponse =
-			createComboSessionFallbackDisabledResponse(comboName);
+		const disabledFallbackResponse = refusalResponse;
 		const collector = tryGetUsageCollector();
 		if (collector) {
 			collector.handleStart({
@@ -398,11 +435,11 @@ export async function handleProxy(
 					type: "end",
 					requestId: requestMeta.id,
 					success: false,
-					error: "combo_session_fallback_disabled",
+					error: errorCode,
 				});
 			} catch (err) {
 				log.error(
-					`handleEnd failed for combo fallback disabled request ${requestMeta.id}`,
+					`handleEnd failed for refused request ${requestMeta.id} (${errorCode})`,
 					err,
 				);
 			}
@@ -411,6 +448,17 @@ export async function handleProxy(
 		return disabledFallbackResponse;
 	};
 
+	const returnComboSessionFallbackDisabled = (
+		comboName: string,
+		failoverAttempts: number,
+	): Promise<Response> =>
+		returnRefusal(
+			createComboSessionFallbackDisabledResponse(comboName),
+			"combo_session_fallback_disabled",
+			failoverAttempts,
+			comboName,
+		);
+
 	const { available: accounts, throttled: throttledAccounts } =
 		applyUsageThrottling(selectedAccounts);
 
@@ -418,6 +466,19 @@ export async function handleProxy(
 	if (accounts.length === 0) {
 		if (requestMeta.comboName && isComboSessionFallbackDisabled(ctx)) {
 			return await returnComboSessionFallbackDisabled(requestMeta.comboName, 0);
+		}
+
+		// Nothing can serve the model that was asked for, and substituting one
+		// is exactly what this setting forbids. Answering here — rather than
+		// letting the generic pool_exhausted 503 answer — is what tells the
+		// caller which model went unserved.
+		if (effectiveModel && isForceAccountModelEnabled(ctx)) {
+			return await returnRefusal(
+				createForceAccountModelResponse(effectiveModel),
+				"force_account_model_no_account",
+				0,
+				null,
+			);
 		}
 
 		// Model-scoped capacity filter (account-selector.ts) emptied the

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -241,6 +241,7 @@ export async function handleProxy(
 		req.headers,
 		{
 			frontmatterModelFallback: ctx.config.getAgentFrontmatterModelFallback(),
+			forceAccountModel: isForceAccountModelEnabled(ctx),
 		},
 	);
 
@@ -468,19 +469,6 @@ export async function handleProxy(
 			return await returnComboSessionFallbackDisabled(requestMeta.comboName, 0);
 		}
 
-		// Nothing can serve the model that was asked for, and substituting one
-		// is exactly what this setting forbids. Answering here — rather than
-		// letting the generic pool_exhausted 503 answer — is what tells the
-		// caller which model went unserved.
-		if (effectiveModel && isForceAccountModelEnabled(ctx)) {
-			return await returnRefusal(
-				createForceAccountModelResponse(effectiveModel),
-				"force_account_model_no_account",
-				0,
-				null,
-			);
-		}
-
 		// Model-scoped capacity filter (account-selector.ts) emptied the
 		// candidate pool because every account is exhausted for this request's
 		// model family — a structured, actionable response instead of the
@@ -493,6 +481,28 @@ export async function handleProxy(
 
 		if (throttledAccounts.length > 0) {
 			return createUsageThrottledResponse(throttledAccounts);
+		}
+
+		// Nothing can serve the model that was asked for, and substituting one
+		// is exactly what this setting forbids. Answering here — rather than
+		// letting the generic pool_exhausted 503 answer — is what tells the
+		// caller which model went unserved.
+		//
+		// This comes *after* the exhaustion and throttling branches on purpose.
+		// An account that speaks the requested model but is out of quota right
+		// now is a temporary, actionable state, and those branches carry the
+		// `resetAt`/`Retry-After` that says when to come back. Answering
+		// "nothing can serve this model" over them would replace a fact with a
+		// falsehood and drop the retry time on the floor. What is left here is
+		// the case this setting is actually about: the pool emptied because the
+		// compatibility filter removed every candidate.
+		if (effectiveModel && isForceAccountModelEnabled(ctx)) {
+			return await returnRefusal(
+				createForceAccountModelResponse(effectiveModel),
+				"force_account_model_no_account",
+				0,
+				null,
+			);
 		}
 
 		// Check feature flag for backwards compatibility


### PR DESCRIPTION
Closes #426.

Adds `force_account_model`: when it is on, nothing renames a request on its way out — better-ccflare serves the model that was asked for, or it serves nothing.

Rebased onto `main` now that #427, #428 and #429 have landed, so this branch is **five commits and 23 files** — nothing borrowed from the stack it used to sit on. Everything after the first commit is a review fix, described at the end.

## Why

better-ccflare can quietly serve a different model than the one requested. A combo slot rewrites the model, an account mapping rewrites it again, and when neither applies the provider's built-in map guesses — which is how a request for Opus reached an OpenAI account and came back:

```
400 The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.
```

Every one of those substitutions is a choice made on the operator's behalf, and there was no way to decline them. The silent-success case is worse than the 400: a request answered by a different model than the one asked for is not an error at all, it just returns work of a different quality, cost and context size than the caller planned for.

## What it does

With `force_account_model` on:

- **combos are skipped**, so no slot model is applied — a slot exists precisely to send a different model, and the same sentence covers the next bullet;
- **an agent's model preference is not applied** — the agent is still attributed, but the rewrite that would send a different model does not happen. This matters more than it looks: the interceptor runs before routing, so routing sees the post-rewrite name, and without this the setting would faithfully enforce a model the client never asked for;
- **`mapModelName` returns the model untouched**, which covers every provider that funnels through it, and `CodexProvider.mapModel` returns early so the family defaults derived from an account's own listing do not apply either;
- **account selection keeps only accounts that can serve the model as written**, and a request with nothing left gets a `503` with code `force_account_model_no_account` rather than a substitute. That includes a request pinned with `x-better-ccflare-account-id`: the header still decides which account, and never gets to skip the question about the model.

## How "can this account serve this model" is answered

First-hand where possible: if the account has listed its own models, that list decides. **A borrowed listing from a sibling account deliberately does not count** — excluding an account on someone else's evidence is a guess wearing a fact's clothes.

Otherwise the provider namespace decides, since a Claude model id can only travel untranslated to a provider that speaks Claude ids. That second rule carries the weight in practice: listings are per-process and start empty after every restart, and some accounts answer 401 on the listing endpoint while serving traffic perfectly. It is coarse, and the failure it can still produce is an explicit 503 rather than a silent substitution.

**Switching accounts to serve the same model stays allowed.** The setting is about the model, not the account, so failover across accounts still works.

## Design notes

- **Off by default, deliberately.** It changes what a Claude family name means for that install: with it on, asking for a Claude model no longer reaches an OpenAI-compatible account through a mapping, so the model to name in the client is the real one. The dialog says that in as many words.
- **It ships without an environment variable**, matching the combo switches it sits next to: a variable that could override the control would force the UI to draw a switch that accepts a click and does nothing.
- **The flag lives in `core` as a plain in-memory mirror of the config**, for the same reason the provider default map does: the code that renames models sits in `core` and `providers`, and neither may depend on `@better-ccflare/config`. `apps/server` pushes it in at boot and the config `POST` pushes it again, so the switch takes effect without a restart.
- **`PROVIDERS_ACCEPTING_CLIENT_MODEL` moves into `core`.** Combo slot validation and this filter must give the same answer to "does this provider speak Claude ids", and two copies would eventually disagree.

## Testing

Run in `oven/bun:1` against `main` at `b488119`, with a baseline of that same commit measured on the same machine:

| | `main` `b488119` | this branch |
|---|---|---|
| `bunx tsc --noEmit` | exit 0 | **exit 0** |
| `bun test` | 3457 pass / 55 skip / 18 fail / 1 error | **3502 pass / 55 skip / 18 fail / 1 error** |
| `biome check .` (read-only, never `--write`) | 0 errors / 11 warnings | **0 errors / 11 warnings** |

The 18 failures are identical, name for name, to the baseline — environment-bound: the `outbound-proxy` cases need network access and the `incrementalVacuumAdaptive` cases time out on slow disk. Zero failures unique to this branch, zero fixed by it. The 45 extra passing tests are the ones added here: `force-account-model.test.ts` (config and core), `model-mapping-force-account-model.test.ts`, `account-selector-force-model.test.ts`, `force-account-model-refusal-order.test.ts`, `force-account-model-probe-exemption.test.ts`, and four cases appended to `agent-interceptor.rewrite-guard.test.ts`.

Each regression test was also run against the commit before its fix, so none of them passes either way: the reordering cases return 503 on the old ordering and 529 now, and the forced-account cases return 529 (or the wrong account) without the guard.

Verified in a live install: with the switch on, a request naming a Claude model is either served by a Claude-speaking account or refused with `force_account_model_no_account`; with it off, previous behaviour is unchanged.

## Review fixes (`bde50e5`, `638bce3`, `9669741`, `693ea10`)

Five gaps in the same promise, all from the Greptile pass.

**The refusal was masking capacity state.** It answered before the exhaustion and throttling branches, so an account that speaks the requested model but is out of quota right now came back as "nothing can serve this model" — a 503 with no `Retry-After` in place of the 529 that carries one. Capability and capacity are different claims. The refusal now answers after both, and still ahead of the generic `pool_exhausted` 503.

**Agent interception was a fourth rename path.** It ran before routing ever saw the model, so `resolveEffectiveModel` handed the substituted name to the filter and the setting enforced it faithfully. Now skipped under the setting, for the same reason combos are.

**The forced-account header skipped the filter.** I first argued this was fine — nothing renames the model on that path, so the account serves it or the provider rejects it. That argument was incomplete: with the refusal now answering *after* the capacity branches, an incompatible forced account reaches them, and the caller is handed a `Retry-After` for a wait that can never help. So it refuses now, with an empty selection that surfaces as `force_account_model_no_account`.

That is deliberately neither of the two easier answers. Falling through to normal selection would send the request to a different account than the header named — substituting the account to protect a rule about models. Letting it through leaves a false retry time standing.

**That guard then caught the auto-refresh scheduler.** I claimed probes needed no exemption because they pick a model from the account's own listing. They don't: `auto-refresh-scheduler.ts` sends a compiled-in list — `HAIKU_4_5`, then `SONNET_4_5`, then `SONNET_4` — to whatever account it is probing, provider and all. So a Codex account's own probe failed the check by construction, came back refused, counted as a refresh failure, and enough of those pause a healthy account with `pause_reason = 'failure_threshold'`. Probes are exempt now.

The exemption is keyed on `isInternalProbe`, which verifies the process-local probe secret — not on the marker header a client can copy out of a log. That was the hole the old comment was reaching for, and it isn't one here. The probe is also not a client asking for a model: it exists to touch the endpoint and read what comes back, so judging it by what the caller "asked for" was a category error rather than a tuning problem.

**And admitting the probe was only half of it.** Selection was not the only place force mode stood in its way: `mapModelName` and `CodexProvider.mapModel` still returned the model untouched, so `claude-haiku-4-5` reached Codex untranslated. That rejection is neither 404 nor 529, so the scheduler's model loop does not retry it, `recordRefreshFailure` counts it, and five ticks later the account is paused anyway — the same destination, one layer further out.

A verified internal probe now runs with the switch treated as off for its whole async lifetime: `handleProxy` opens an `AsyncLocalStorage` scope when `isInternalProbe` confirms the process-local secret, and `isForceAccountModelEnabled` reports false inside it. A scope rather than a parameter because the flag is ambient by necessity — three guards read it, and the one they share (`mapModelName`) is the funnel every provider maps through while taking no request, so threading a boolean would change six call sites, several of which hold no headers. One of the new tests interleaves a probe with client traffic to pin that the scope cannot contaminate a request beside it.

Worth naming as a separate issue rather than folding in here: the probe's model list is compiled-in and provider-agnostic, so every non-Claude provider only works because mapping papers over it. That is pre-existing — force mode merely removed the paper — and having the scheduler resolve a model the target account actually speaks would change probe behaviour for every install, force mode off included.

One last ordering case is pinned by `9669741`. `pool_exhausted` is built from a raw account sweep — every account of the provider, re-read from the DB with no compatibility filter, and always carrying a `Retry-After`. So an incompatible account that merely happens to be on cooldown is enough to produce a concrete retry time. That answer stays behind the refusal, because the wait it advertises would expire and change nothing.
