### PR TITLE
fix(core): build the force-account-model exempt scope lazily

### DIFF
--- a/packages/core/src/force-account-model-browser-bundle.test.ts
+++ b/packages/core/src/force-account-model-browser-bundle.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+
+/**
+ * The dashboard imports the `@better-ccflare/core` barrel, which re-exports
+ * force-account-model, so this module ships inside the browser bundle. Bun's
+ * browser target has no `node:async_hooks`: it rewrites the import into a
+ * destructure from an empty stub, leaving `AsyncLocalStorage` undefined. Any
+ * module-scope `new AsyncLocalStorage()` then throws "is not a constructor"
+ * while the chunk is still initialising, and because that chunk carries the
+ * dashboard's React bootstrap, the entire UI fails to mount.
+ *
+ * Bundling the module the same way the dashboard does and running it is the
+ * only faithful reproduction — `mock.module("node:async_hooks", () => ({}))`
+ * cannot stand in for it, because a named ESM import of a missing export fails
+ * to link instead of yielding undefined.
+ */
+const ENTRY = new URL("./force-account-model.ts", import.meta.url).pathname;
+
+async function bundleForBrowser(): Promise<string> {
+	const built = await Bun.build({
+		entrypoints: [ENTRY],
+		target: "browser",
+		format: "iife",
+	});
+	if (!built.success) {
+		throw new AggregateError(built.logs, "browser bundle failed");
+	}
+	return await built.outputs[0].text();
+}
+
+describe("force-account-model in a browser bundle", () => {
+	it("evaluates with node:async_hooks stubbed out", async () => {
+		const code = await bundleForBrowser();
+		expect(() => {
+			new Function(code)();
+		}).not.toThrow();
+	});
+});

--- a/packages/core/src/force-account-model.ts
+++ b/packages/core/src/force-account-model.ts
@@ -38,7 +38,32 @@ let forceAccountModel = false;
  * already verified — and every guard that reads the flag then answers
  * correctly, including ones added later.
  */
-const exemptScope = new AsyncLocalStorage<true>();
+let exemptScope: AsyncLocalStorage<true> | null = null;
+
+/**
+ * Build the scope on first use rather than at import time.
+ *
+ * This module reaches the browser: `core/src/index.ts` re-exports it, the
+ * dashboard imports that barrel, and a browser bundle has no
+ * `node:async_hooks` — Bun's browser target replaces the import with an empty
+ * stub, leaving `AsyncLocalStorage` undefined. Constructing at module scope
+ * therefore threw "AsyncLocalStorage is not a constructor" while the chunk was
+ * still initialising, and since that chunk carries the dashboard's React
+ * bootstrap, the whole UI failed to mount.
+ *
+ * Nothing in the browser calls the functions below — only the proxy and the
+ * providers do — so deferring the construction keeps the module importable
+ * there while server behaviour stays exactly the same: the first caller builds
+ * the one scope, every later caller reuses it. The null branch is reachable in
+ * the browser bundle only, where "no scope" is the correct answer: an
+ * exemption is something the proxy opens around a verified probe, and there
+ * are no probes in a browser.
+ */
+function getExemptScope(): AsyncLocalStorage<true> | null {
+	if (typeof AsyncLocalStorage !== "function") return null;
+	exemptScope ??= new AsyncLocalStorage<true>();
+	return exemptScope;
+}
 
 /** Mirror the config value here. Called at boot and after a successful write. */
 export function setForceAccountModel(value: boolean): void {
@@ -53,7 +78,7 @@ export function setForceAccountModel(value: boolean): void {
  * on the operator's behalf while this is on.
  */
 export function isForceAccountModelEnabled(): boolean {
-	return forceAccountModel && exemptScope.getStore() !== true;
+	return forceAccountModel && getExemptScope()?.getStore() !== true;
 }
 
 /**
@@ -64,7 +89,8 @@ export function isForceAccountModelEnabled(): boolean {
  * opting itself out of the operator's setting.
  */
 export function runForceAccountModelExempt<T>(fn: () => T): T {
-	return exemptScope.run(true, fn);
+	const scope = getExemptScope();
+	return scope ? scope.run(true, fn) : fn();
 }
 
 /**
@@ -73,5 +99,5 @@ export function runForceAccountModelExempt<T>(fn: () => T): T {
  * reading `isForceAccountModelEnabled`, which already accounts for it.
  */
 export function isForceAccountModelExempt(): boolean {
-	return exemptScope.getStore() === true;
+	return getExemptScope()?.getStore() === true;
 }


### PR DESCRIPTION
## What breaks

Since v3.5.62 the dashboard never mounts — the page loads and `#root` stays empty. Browser console:

```
Uncaught TypeError: Yb is not a constructor
    at force-account-model.ts:41
```

The proxy itself is fine, which is why this is easy to miss: `POST /v1/messages` keeps being served normally, only the UI is dead.

## Cause

693ea10d added a module-scope `AsyncLocalStorage` to `packages/core/src/force-account-model.ts`:

```ts
import { AsyncLocalStorage } from "node:async_hooks";
// ...
const exemptScope = new AsyncLocalStorage<true>();
```

`packages/core/src/index.ts:38` re-exports that module (`export * from "./force-account-model"`), and `packages/dashboard-web` imports the `@better-ccflare/core` barrel in 14 files, so the module ships inside the browser bundle. Bun's browser target has no `node:async_hooks` and rewrites the import into a destructure from an empty stub — the built chunk contains:

```js
var{AsyncLocalStorage:Yb}=(()=>({}));var XG6=new Yb;
```

`Yb` is `undefined`, so module initialisation throws, and that chunk carries the dashboard's React bootstrap (`StrictMode`, `QueryClientProvider`) — nothing mounts.

Affected: v3.5.62 only; v3.5.61 and earlier do not contain 693ea10d. Reproduced identically on `ghcr.io/tombii/better-ccflare:latest` and on a local source build — same chunk, same md5.

## Fix

Build the scope on first use. Nothing in the browser calls these functions — only the proxy and the providers do — so the browser constructs nothing, while on the server the first caller builds the one scope that every later caller reuses. Behaviour is unchanged.

## Test

`packages/core/src/force-account-model-browser-bundle.test.ts` bundles the module with Bun's browser target and evaluates it. That is the only faithful reproduction: `mock.module("node:async_hooks", () => ({}))` cannot stand in, because a named ESM import of a missing export fails to *link* (`SyntaxError: Export named 'AsyncLocalStorage' not found in module 'node:async_hooks'`) rather than yielding `undefined`.

The test fails on the parent commit and passes with the fix.

## Verification

- `bun test` on the four force-account-model suites: identical before and after — 15 pass, 2 failures that are pre-existing in this environment (`Cannot find module './inline-integrity-check-worker'`, which is generated by a build).
- `bunx biome check` clean on both files; `bunx tsc --noEmit` clean after `bun run build:dashboard`.
- Built bundle after the fix: the stub destructure remains, the construction is gone.
- Headless Chrome against a rebuilt container: the dashboard renders (Overview / Accounts / Analytics / Requests / Logs / Agents) instead of an empty `#root`.
