### PR TITLE
fix(proxy): fail over and bench on Anthropic 403 permission_error instead of forwarding it

### DIFF
--- a/packages/dashboard-web/src/components/overview/system-status/errorCodeMeta.ts
+++ b/packages/dashboard-web/src/components/overview/system-status/errorCodeMeta.ts
@@ -103,6 +103,22 @@ const KNOWN_ERROR_META: Record<
 			"stays in rotation and the request is passed through unchanged.",
 		severity: "error",
 	},
+	org_permission_denied: {
+		title: "Organization forbids this account",
+		description:
+			"Anthropic returned 403 `permission_error`: this account's " +
+			"organization does not allow the request — OAuth disabled org-wide, " +
+			"or Claude Code subscription access turned off by an admin. Nothing " +
+			"is wrong with the account's quota, but it cannot serve any request, " +
+			"so it was benched and the request failed over to the next account.",
+		suggestion:
+			"Ask the organization's admin to enable Claude Code access, or remove " +
+			"this account from the pool. The bench is not time-bounded upstream: " +
+			"it will expire and a single recovery probe will rediscover the same " +
+			"403 until the org setting actually changes, so a steady trickle of " +
+			"these is expected while the account stays configured.",
+		severity: "error",
+	},
 };
 
 function getModelFallbackMeta(context?: ErrorContext): ErrorMeta {

--- a/packages/http-api/src/handlers/accounts.ts
+++ b/packages/http-api/src/handlers/accounts.ts
@@ -71,6 +71,9 @@ const RATE_LIMIT_REASONS = new Set<RateLimitReason>([
 	// a faithful mirror of the union and cannot silently null the value if a
 	// future path ever persists it.
 	"windowless_429",
+	// 403 permission_error: the account's organization forbids the request. This
+	// one IS written to accounts.rate_limited_reason — the account is benched.
+	"org_permission_denied",
 ]);
 
 function toRateLimitReason(v: string | null): RateLimitReason | null {

--- a/packages/providers/src/providers/anthropic/__tests__/org-permission-denied.test.ts
+++ b/packages/providers/src/providers/anthropic/__tests__/org-permission-denied.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "bun:test";
+import {
+	isAnthropicOrgPermissionDenied,
+	ORG_PERMISSION_DENIED_REASON,
+} from "../provider";
+
+/**
+ * Body observed in production (25 occurrences) when an organization has
+ * disabled OAuth for Claude Code. Captured from `GET /api/oauth/usage`, but
+ * `/v1/messages` rejects the same account with the same status + error.type
+ * and a differently worded, Claude-Code-specific message — which is exactly
+ * why the predicate must key on `error.type`, not on the message.
+ */
+const OAUTH_NOT_ALLOWED_BODY = {
+	type: "error",
+	error: {
+		type: "permission_error",
+		message:
+			"OAuth authentication is currently not allowed for this organization.",
+		details: {
+			error_visibility: "user_facing",
+			error_code: "oauth_not_allowed_for_organization",
+		},
+	},
+	request_id: "req_011CeJWapJc7LETV42WEGiAD",
+};
+
+/** The wording Claude Code surfaces to the user on `/v1/messages`. */
+const SUBSCRIPTION_DISABLED_BODY = {
+	type: "error",
+	error: {
+		type: "permission_error",
+		message:
+			"Your organization has disabled Claude subscription access for Claude Code. Use an Anthropic API key instead, or ask your admin to enable access.",
+	},
+};
+
+function jsonResponse(
+	status: number,
+	body: unknown,
+	extraHeaders: Record<string, string> = {},
+): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json", ...extraHeaders },
+	});
+}
+
+describe("isAnthropicOrgPermissionDenied", () => {
+	it("the exported reason constant is 'org_permission_denied'", () => {
+		expect(ORG_PERMISSION_DENIED_REASON).toBe("org_permission_denied");
+	});
+
+	it("returns true for the observed 403 oauth_not_allowed_for_organization body", async () => {
+		const response = jsonResponse(403, OAUTH_NOT_ALLOWED_BODY, {
+			"x-should-retry": "false",
+		});
+
+		expect(await isAnthropicOrgPermissionDenied(response)).toBe(true);
+	});
+
+	it("returns true for the Claude-Code subscription-disabled wording (message text is not part of the match)", async () => {
+		const response = jsonResponse(403, SUBSCRIPTION_DISABLED_BODY);
+
+		expect(await isAnthropicOrgPermissionDenied(response)).toBe(true);
+	});
+
+	it("does not require the x-should-retry header to be present", async () => {
+		// The header was observed on the usage endpoint, but requiring it would
+		// fail closed — back to today's broken pass-through — if Anthropic omits
+		// it on /v1/messages. It must corroborate, never gate.
+		const response = jsonResponse(403, OAUTH_NOT_ALLOWED_BODY);
+
+		expect(await isAnthropicOrgPermissionDenied(response)).toBe(true);
+	});
+
+	it("leaves the response body readable for the caller", async () => {
+		const response = jsonResponse(403, OAUTH_NOT_ALLOWED_BODY);
+
+		expect(await isAnthropicOrgPermissionDenied(response)).toBe(true);
+		expect(response.bodyUsed).toBe(false);
+		const parsed = (await response.json()) as typeof OAUTH_NOT_ALLOWED_BODY;
+		expect(parsed.error.type).toBe("permission_error");
+	});
+
+	describe("status is an exact gate", () => {
+		for (const status of [200, 400, 401, 429, 500]) {
+			it(`returns false for ${status} even with a permission_error body`, async () => {
+				const response = jsonResponse(status, OAUTH_NOT_ALLOWED_BODY);
+
+				expect(await isAnthropicOrgPermissionDenied(response)).toBe(false);
+			});
+		}
+	});
+
+	it("returns false for a 403 whose error.type is not permission_error", async () => {
+		const response = jsonResponse(403, {
+			type: "error",
+			error: { type: "authentication_error", message: "invalid x-api-key" },
+		});
+
+		expect(await isAnthropicOrgPermissionDenied(response)).toBe(false);
+	});
+
+	it("returns false for a 403 with a non-JSON content-type (e.g. a Cloudflare block page)", async () => {
+		// Deliberately narrow: a non-JSON 403 can be an edge/network block that
+		// would reject every account identically, and benching the pool one
+		// account per attempt is the failure mode issue #301 was about. Those
+		// keep the pre-existing pass-through behaviour.
+		const response = new Response("<html>403 Forbidden</html>", {
+			status: 403,
+			headers: { "content-type": "text/html" },
+		});
+
+		expect(await isAnthropicOrgPermissionDenied(response)).toBe(false);
+	});
+
+	it("returns false for a 403 with malformed JSON (exercises the catch block)", async () => {
+		const response = new Response("{not valid json", {
+			status: 403,
+			headers: { "content-type": "application/json" },
+		});
+
+		expect(await isAnthropicOrgPermissionDenied(response)).toBe(false);
+	});
+
+	it("returns false for a 403 with no error object at all", async () => {
+		const response = jsonResponse(403, { message: "Forbidden" });
+
+		expect(await isAnthropicOrgPermissionDenied(response)).toBe(false);
+	});
+
+	it("is case-sensitive on error.type", async () => {
+		const response = jsonResponse(403, {
+			type: "error",
+			error: { type: "Permission_Error", message: "nope" },
+		});
+
+		expect(await isAnthropicOrgPermissionDenied(response)).toBe(false);
+	});
+});

--- a/packages/providers/src/providers/anthropic/index.ts
+++ b/packages/providers/src/providers/anthropic/index.ts
@@ -3,6 +3,8 @@ export {
 	AnthropicProvider,
 	EXTRA_USAGE_EXHAUSTED_REASON,
 	isAnthropicExtraUsageExhausted,
+	isAnthropicOrgPermissionDenied,
 	isAnthropicOutOfCredits,
+	ORG_PERMISSION_DENIED_REASON,
 	OUT_OF_CREDITS_REASON,
 } from "./provider";

--- a/packages/providers/src/providers/anthropic/provider.ts
+++ b/packages/providers/src/providers/anthropic/provider.ts
@@ -96,6 +96,57 @@ export async function isAnthropicExtraUsageExhausted(
 	}
 }
 
+/**
+ * Anthropic returns 403 `permission_error` when the account's ORGANIZATION —
+ * not the account's quota — forbids the request: OAuth disabled org-wide,
+ * Claude Code subscription access turned off by an admin, and the like. The
+ * account cannot serve ANY request until someone changes a setting upstream,
+ * so it must be benched and the request failed over, exactly like an exhausted
+ * quota window. Distinct from `out_of_credits` / `extra_usage_exhausted`,
+ * which are scoped to a model or surface and leave the account routable.
+ */
+export const ORG_PERMISSION_DENIED_REASON = "org_permission_denied";
+
+/**
+ * Returns true iff the response is a 403 carrying Anthropic's
+ * `error.type: "permission_error"`.
+ *
+ * KEYED ON `error.type`, DELIBERATELY NOT ON THE MESSAGE. Two different
+ * wordings of the same condition were observed on one organization within the
+ * same hour — `/api/oauth/usage` answers "OAuth authentication is currently
+ * not allowed for this organization." (with
+ * `details.error_code: oauth_not_allowed_for_organization`), while
+ * `/v1/messages` tells Claude Code "Your organization has disabled Claude
+ * subscription access for Claude Code…". Anthropic owns that copy and can
+ * reword it without notice; `error.type` is the machine-readable field and the
+ * only part stable enough to route on. `x-should-retry: false` accompanied
+ * every observed instance and corroborates the classification, but is not
+ * required here: gating on it would fail closed — straight back to forwarding
+ * the 403 to the client — the moment a variant omits it.
+ *
+ * Narrow by construction in two ways:
+ *   - A non-JSON 403 (edge/WAF block page) does NOT match. Such a block
+ *     usually rejects every account identically, and benching the pool one
+ *     account per attempt is the pool-drain failure mode of issue #301.
+ *   - The content-type gate runs BEFORE `.clone()`. Cloning first tees the
+ *     body and then returns early for every non-JSON 403, stranding that copy
+ *     unread while the tee keeps buffering for whoever consumes the original
+ *     (issue #356) — same ordering as `isAnthropicExtraUsageExhausted` above.
+ */
+export async function isAnthropicOrgPermissionDenied(
+	response: Response,
+): Promise<boolean> {
+	if (response.status !== 403) return false;
+	try {
+		const contentType = response.headers.get("content-type");
+		if (!contentType?.includes("application/json")) return false;
+		const json = await response.clone().json();
+		return json?.error?.type === "permission_error";
+	} catch {
+		return false;
+	}
+}
+
 const log = new Logger("AnthropicProvider");
 
 export class AnthropicProvider extends BaseProvider {

--- a/packages/providers/src/providers/index.ts
+++ b/packages/providers/src/providers/index.ts
@@ -4,7 +4,9 @@ export {
 	AnthropicProvider,
 	EXTRA_USAGE_EXHAUSTED_REASON,
 	isAnthropicExtraUsageExhausted,
+	isAnthropicOrgPermissionDenied,
 	isAnthropicOutOfCredits,
+	ORG_PERMISSION_DENIED_REASON,
 	OUT_OF_CREDITS_REASON,
 } from "./anthropic/index";
 export {

--- a/packages/proxy/src/__tests__/bun-leak-273-regression.test.ts
+++ b/packages/proxy/src/__tests__/bun-leak-273-regression.test.ts
@@ -105,16 +105,19 @@ describe("issue #273 — Group A: helper contract", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Group B — call-site coverage. Static check that the 13 drain sites the
-// spec calls out (429/529/401 failover return-null + retry-loop overwrite)
+// Group B — call-site coverage. Static check that the 14 drain sites the
+// spec calls out (429/529/401/403 failover return-null + retry-loop overwrite)
 // are wired into proxy-operations.ts. The negative-control run removes
 // these lines; this check fails if any are missing.
+//
+// Went from 13 to 14 with the org_permission_denied branch (403
+// `permission_error`), which is a new discard-then-return-null failover site.
 // ---------------------------------------------------------------------------
 
-const EXPECTED_SITE_COUNT = 13;
+const EXPECTED_SITE_COUNT = 14;
 
 describe("issue #273 — Group B: call-site coverage in proxy-operations.ts", () => {
-	it("proxy-operations.ts has exactly 13 cancelDiscardedResponseBody call sites", () => {
+	it("proxy-operations.ts has exactly 14 cancelDiscardedResponseBody call sites", () => {
 		const source = readFileSync(
 			"packages/proxy/src/handlers/proxy-operations.ts",
 			"utf-8",

--- a/packages/proxy/src/circuit-breaker.ts
+++ b/packages/proxy/src/circuit-breaker.ts
@@ -211,10 +211,17 @@ interface CircuitEntry {
  * `org_permission_denied` (403 `permission_error` — the org forbids OAuth /
  * Claude Code access) is the opposite of the scoped kinds above: the account
  * cannot serve ANY request, and it stays that way until an admin changes a
- * setting upstream. Since the breaker is keyed per `(provider, accountId)`,
- * opening it here is exactly the desired effect — the account is skipped
- * fail-fast, without an upstream round-trip per request — and it cannot take
- * healthy accounts of the same provider down with it.
+ * setting upstream. So it counts, on the same grounds as account-wide
+ * exhaustion.
+ *
+ * What counting it does NOT do is change routing. Nothing in the request path
+ * calls `shouldAllow` or `isProviderWideOpen` today — see the "Wiring is
+ * deferred" note at the top of this file — so what actually takes the account
+ * out of rotation is the cooldown bench `applyRateLimitCooldown` applies at the
+ * call site, not this predicate. Counting here keeps the breaker's failure
+ * accounting truthful for whenever admission is wired up; and because the
+ * breaker is keyed per `(provider, accountId)`, it can never take healthy
+ * accounts of the same provider down with it.
  *
  * Every other `RateLimitReason` — account/provider-wide exhaustion,
  * 529 overload — counts as a circuit failure.
@@ -253,8 +260,9 @@ export function shouldCountAsCircuitFailure(kind: FailureKind): boolean {
 		case "all_models_exhausted_429":
 		case "upstream_529_overloaded_with_reset":
 		case "upstream_529_overloaded_no_reset":
-		// Account-wide and admin-gated: fail-fast is strictly better than
-		// re-discovering the same 403 on every request.
+		// Account-wide and admin-gated, so it belongs with account-wide
+		// exhaustion here. The cooldown bench, not this, is what removes the
+		// account from rotation.
 		case "org_permission_denied":
 			return true;
 		default:

--- a/packages/proxy/src/circuit-breaker.ts
+++ b/packages/proxy/src/circuit-breaker.ts
@@ -208,6 +208,14 @@ interface CircuitEntry {
  * in rotation — so counting it would open the breaker on an account that is
  * still serving traffic.
  *
+ * `org_permission_denied` (403 `permission_error` — the org forbids OAuth /
+ * Claude Code access) is the opposite of the scoped kinds above: the account
+ * cannot serve ANY request, and it stays that way until an admin changes a
+ * setting upstream. Since the breaker is keyed per `(provider, accountId)`,
+ * opening it here is exactly the desired effect — the account is skipped
+ * fail-fast, without an upstream round-trip per request — and it cannot take
+ * healthy accounts of the same provider down with it.
+ *
  * Every other `RateLimitReason` — account/provider-wide exhaustion,
  * 529 overload — counts as a circuit failure.
  *
@@ -245,6 +253,9 @@ export function shouldCountAsCircuitFailure(kind: FailureKind): boolean {
 		case "all_models_exhausted_429":
 		case "upstream_529_overloaded_with_reset":
 		case "upstream_529_overloaded_no_reset":
+		// Account-wide and admin-gated: fail-fast is strictly better than
+		// re-discovering the same 403 on every request.
+		case "org_permission_denied":
 			return true;
 		default:
 			return assertNever(kind);

--- a/packages/proxy/src/handlers/__tests__/proxy-operations-org-permission-denied.test.ts
+++ b/packages/proxy/src/handlers/__tests__/proxy-operations-org-permission-denied.test.ts
@@ -1,0 +1,344 @@
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	mock,
+	spyOn,
+} from "bun:test";
+import { usageCache } from "@better-ccflare/providers";
+import type { Account, RequestMeta } from "@better-ccflare/types";
+import { resetDefaultCircuitBreaker } from "../../circuit-breaker";
+import * as usageCollectorModule from "../../usage-collector";
+import { clearFamilyExhaustionCache } from "../model-capacity";
+import { proxyWithAccount } from "../proxy-operations";
+import type { ProxyContext } from "../proxy-types";
+import { resetRateLimitProbeGatesForTests } from "../rate-limit-cooldown";
+
+function stubUsageCollector() {
+	return spyOn(usageCollectorModule, "getUsageCollector").mockReturnValue({
+		handleStart: mock(() => {}),
+		handleChunk: mock(() => {}),
+		handleEnd: mock(() => Promise.resolve()),
+	} as unknown as usageCollectorModule.UsageCollector);
+}
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "acc-anthropic-1",
+		name: "claude-pro",
+		provider: "anthropic",
+		api_key: null,
+		refresh_token: "refresh-token",
+		access_token: "access-token",
+		expires_at: Date.now() + 3 * 60 * 60 * 1000,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: Date.now(),
+		rate_limited_until: null,
+		rate_limited_reason: null,
+		rate_limited_at: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		peak_hours_pause_enabled: false,
+		custom_endpoint: null,
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		billing_type: null,
+		pause_reason: null,
+		refresh_token_issued_at: null,
+		consecutive_rate_limits: 0,
+		...overrides,
+	};
+}
+
+function makeRequestMeta(): RequestMeta {
+	return {
+		id: "req-1",
+		method: "POST",
+		path: "/v1/messages",
+		timestamp: Date.now(),
+		headers: new Headers(),
+		clientSessionId: "sess-1",
+	};
+}
+
+function makeRequestBody(model = "claude-sonnet-4-5") {
+	const body = JSON.stringify({
+		model,
+		messages: [{ role: "user", content: "hello" }],
+		max_tokens: 10,
+	});
+	return new TextEncoder().encode(body).buffer;
+}
+
+function makeRequest(body: ArrayBuffer, headers: Record<string, string> = {}) {
+	return new Request("https://proxy.local/v1/messages", {
+		method: "POST",
+		body,
+		headers: { "Content-Type": "application/json", ...headers },
+	});
+}
+
+/**
+ * The 403 captured verbatim from Anthropic on 2026-08-22 (25 occurrences across
+ * three accounts of one organization within the hour). `x-should-retry: false`
+ * accompanied every instance.
+ */
+function orgPermissionDenied403(
+	extraHeaders: Record<string, string> = {},
+): Response {
+	return new Response(
+		JSON.stringify({
+			type: "error",
+			error: {
+				type: "permission_error",
+				message:
+					"OAuth authentication is currently not allowed for this organization.",
+				details: {
+					error_visibility: "user_facing",
+					error_code: "oauth_not_allowed_for_organization",
+				},
+			},
+			request_id: "req_011CeJWapJc7LETV42WEGiAD",
+		}),
+		{
+			status: 403,
+			headers: {
+				"content-type": "application/json",
+				"x-should-retry": "false",
+				...extraHeaders,
+			},
+		},
+	);
+}
+
+function makeCtx(): ProxyContext {
+	return {
+		strategy: { getNextAccount: () => null } as never,
+		dbOps: {
+			markAccountRateLimited: mock(
+				(_id: string, _until: number, _reason: string) =>
+					Promise.resolve({ consecutiveRateLimits: 1, applied: true }),
+			),
+			saveRequest: mock((..._args: unknown[]) => Promise.resolve()),
+			updateAccountUsage: mock(() => Promise.resolve()),
+			getAdapter: mock(() => ({
+				run: mock(() => Promise.resolve()),
+				get: mock(() => Promise.resolve(null)),
+			})),
+		} as never,
+		runtime: { port: 8080, clientId: "test" } as never,
+		// getProvider("anthropic") from the registry wins over this, by design —
+		// the real parseRateLimit and processResponse run.
+		provider: { name: "anthropic" } as never,
+		refreshInFlight: new Map(),
+		asyncWriter: {
+			enqueue: mock(async (job: () => void | Promise<void>) => {
+				await job();
+			}),
+		} as never,
+		config: { getStorePayloads: () => true } as never,
+		internalProbeSecret: "test-secret",
+	};
+}
+
+async function runProxy(
+	account: Account,
+	ctx: ProxyContext,
+	req: Request,
+	body: ArrayBuffer,
+) {
+	return proxyWithAccount(
+		req,
+		new URL("https://proxy.local/v1/messages"),
+		account,
+		makeRequestMeta(),
+		body,
+		() => undefined,
+		0,
+		ctx,
+	);
+}
+
+const saveCalls = (ctx: ProxyContext) =>
+	(ctx.dbOps.saveRequest as ReturnType<typeof mock>).mock
+		.calls as unknown as unknown[][];
+/** markAccountRateLimited(accountId, until, reason, incrementStreak) */
+const markCalls = (ctx: ProxyContext) =>
+	(ctx.dbOps.markAccountRateLimited as ReturnType<typeof mock>).mock
+		.calls as unknown as [string, number, string, boolean][];
+
+describe("proxyWithAccount — org_permission_denied (403 permission_error)", () => {
+	let originalFetch: typeof globalThis.fetch;
+	let collectorSpy: ReturnType<typeof stubUsageCollector>;
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+		collectorSpy = stubUsageCollector();
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		collectorSpy.mockRestore();
+		usageCache.clear();
+		clearFamilyExhaustionCache();
+		resetRateLimitProbeGatesForTests();
+		resetDefaultCircuitBreaker();
+	});
+
+	it("benches the account and fails over instead of forwarding the 403", async () => {
+		globalThis.fetch = mock(async () => orgPermissionDenied403());
+
+		const ctx = makeCtx();
+		const account = makeAccount();
+		const body = makeRequestBody();
+
+		const result = await runProxy(account, ctx, makeRequest(body), body);
+
+		// Failed over to the next account rather than handing the client a 403.
+		expect(result).toBeNull();
+
+		// Benched, exactly like an exhausted window.
+		expect(typeof account.rate_limited_until).toBe("number");
+		expect(account.rate_limited_reason).toBe("org_permission_denied");
+		expect(markCalls(ctx)).toHaveLength(1);
+		expect(markCalls(ctx)[0][2]).toBe("org_permission_denied");
+		// Fourth arg is incrementStreak: this is not an overload reason, so the
+		// consecutive counter must ramp the backoff on repeat offences.
+		expect(markCalls(ctx)[0][3]).toBe(true);
+		expect(account.consecutive_rate_limits).toBe(1);
+	});
+
+	it("records one audit row carrying status 403 and the org_permission_denied reason", async () => {
+		globalThis.fetch = mock(async () => orgPermissionDenied403());
+
+		const ctx = makeCtx();
+		const account = makeAccount();
+		const body = makeRequestBody();
+
+		await runProxy(account, ctx, makeRequest(body), body);
+
+		expect(saveCalls(ctx)).toHaveLength(1);
+		const args = saveCalls(ctx)[0];
+		// 5th positional arg is statusCode, 7th is reason, 10th is usage.
+		expect(args[4]).toBe(403);
+		expect(args[6]).toBe("org_permission_denied");
+		expect(args[9]).toEqual({ model: "claude-sonnet-4-5" });
+		// The tail arguments are easy to drop when copying a sibling branch.
+		expect(args[args.length - 1]).toBe("sess-1");
+	});
+
+	it("matches on error.type, not on the message wording", async () => {
+		// The wording Claude Code shows the user on /v1/messages differs from the
+		// usage endpoint's. Anthropic owns that copy; the routing must not.
+		globalThis.fetch = mock(
+			async () =>
+				new Response(
+					JSON.stringify({
+						type: "error",
+						error: {
+							type: "permission_error",
+							message:
+								"Your organization has disabled Claude subscription access for Claude Code. Use an Anthropic API key instead, or ask your admin to enable access.",
+						},
+					}),
+					{ status: 403, headers: { "content-type": "application/json" } },
+				),
+		);
+
+		const ctx = makeCtx();
+		const account = makeAccount();
+		const body = makeRequestBody();
+
+		const result = await runProxy(account, ctx, makeRequest(body), body);
+
+		expect(result).toBeNull();
+		expect(markCalls(ctx)[0][2]).toBe("org_permission_denied");
+	});
+
+	it("benches on a keepalive probe but records no audit row", async () => {
+		// A 403 from the organization is authoritative no matter who asked, so the
+		// bench is real information — unlike a keepalive 429, which can be a
+		// synthetic per-IP burst artifact. The history row is still suppressed:
+		// no client ever saw this request.
+		globalThis.fetch = mock(async () => orgPermissionDenied403());
+
+		const ctx = makeCtx();
+		const account = makeAccount();
+		const body = makeRequestBody();
+		const req = makeRequest(body, {
+			"x-better-ccflare-keepalive": "true",
+			"x-better-ccflare-internal-probe-secret": "test-secret",
+		});
+
+		const result = await runProxy(account, ctx, req, body);
+
+		expect(result).toBeNull();
+		expect(markCalls(ctx)).toHaveLength(1);
+		expect(markCalls(ctx)[0][2]).toBe("org_permission_denied");
+		expect(saveCalls(ctx)).toHaveLength(0);
+	});
+
+	it("leaves a 403 whose error.type is not permission_error untouched", async () => {
+		globalThis.fetch = mock(
+			async () =>
+				new Response(
+					JSON.stringify({
+						type: "error",
+						error: {
+							type: "authentication_error",
+							message: "invalid x-api-key",
+						},
+					}),
+					{ status: 403, headers: { "content-type": "application/json" } },
+				),
+		);
+
+		const ctx = makeCtx();
+		const account = makeAccount();
+		const body = makeRequestBody();
+
+		const result = await runProxy(account, ctx, makeRequest(body), body);
+
+		// Unchanged pre-existing behaviour: forwarded to the client, no bench.
+		expect(result).not.toBeNull();
+		expect(result?.status).toBe(403);
+		expect(markCalls(ctx)).toHaveLength(0);
+		expect(account.rate_limited_until).toBeNull();
+	});
+
+	it("leaves a non-JSON 403 untouched (edge/WAF block pages must not drain the pool)", async () => {
+		// Such a block typically rejects every account identically. Benching one
+		// account per attempt is the pool-drain failure mode of issue #301.
+		globalThis.fetch = mock(
+			async () =>
+				new Response("<html>403 Forbidden</html>", {
+					status: 403,
+					headers: { "content-type": "text/html" },
+				}),
+		);
+
+		const ctx = makeCtx();
+		const account = makeAccount();
+		const body = makeRequestBody();
+
+		const result = await runProxy(account, ctx, makeRequest(body), body);
+
+		expect(result).not.toBeNull();
+		expect(result?.status).toBe(403);
+		expect(markCalls(ctx)).toHaveLength(0);
+		expect(account.rate_limited_until).toBeNull();
+	});
+});

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -16,6 +16,7 @@ import {
 	applyXaiConvIdHeader,
 	getProvider,
 	isAnthropicExtraUsageExhausted,
+	isAnthropicOrgPermissionDenied,
 	isAnthropicOutOfCredits,
 	usageCache,
 } from "@better-ccflare/providers";
@@ -923,6 +924,95 @@ export async function proxyWithAccount(
 			// Do not bench the account or fail over — pass Anthropic's real error
 			// through to the client unchanged, same as any other 400 today.
 			return withSanitizedProxyHeaders(rawResponse);
+		}
+
+		// ── org_permission_denied: the ORGANIZATION forbids this account ──
+		// Anthropic answers 403 `permission_error` when an account's org has
+		// OAuth — or Claude Code specifically — turned off by an admin. Measured
+		// on a live pool: three accounts of one organization returned it 25 times
+		// within the hour, every one carrying `x-should-retry: false`, while the
+		// usage poller had independently racked up 49 consecutive failures per
+		// account. That signal existed in-process the whole time and never
+		// reached the router.
+		//
+		// Before this branch, a 403 matched none of the failover guards (401 /
+		// 429 / 529 / model-unavailable) and fell through to forwardToClient, so
+		// the client saw the error even with healthy accounts still in the pool.
+		// Worse, `processProxyResponse` classifies any non-429 as "not rate
+		// limited" and unconditionally clears `rate_limited_until`, so the
+		// offending account also lost any existing bench and stayed pinned at the
+		// front of the priority order for every following request. Returning null
+		// here short-circuits both halves of that.
+		//
+		// The account is benched exactly like an exhausted quota window: it
+		// cannot serve anything at all, so it must leave the rotation, and the
+		// exponential ramp plus the single-flight recovery probe (see
+		// rate-limit-cooldown.ts) means at most one request per cooldown expiry
+		// is spent rediscovering a block only an admin can lift.
+		if (
+			isClaudeProvider &&
+			rawResponse.status === 403 &&
+			// Passed un-cloned on purpose: the predicate clones internally and
+			// never consumes its argument, so wrapping it in another clone here
+			// would strand a tee branch for every non-matching 403 (issue #356).
+			(await isAnthropicOrgPermissionDenied(rawResponse))
+		) {
+			let requestedModel: string | null = null;
+			if (effectiveBodyBuffer) requestedModel = effectiveBodyContext.getModel();
+
+			const reason: RateLimitReason = "org_permission_denied";
+			log.warn(
+				`Account ${account.name} org_permission_denied (403${requestedModel ? `, model=${requestedModel}` : ""}) — ` +
+					`organization forbids OAuth/Claude Code access for this account; ` +
+					`benching account and failing over to next account`,
+			);
+
+			// Benched even for synthetic probes. Unlike a 429 — where a keepalive
+			// burst can trip Anthropic's per-IP limit and produce a cooldown no
+			// real user earned — a 403 from the organization is authoritative
+			// regardless of who asked, so learning it from a probe is genuine
+			// information and throwing it away would only delay the bench until a
+			// real request pays for it.
+			applyRateLimitCooldown(account, { reason }, ctx);
+
+			// The audit row, however, stays real-traffic-only: a synthetic probe's
+			// rejection was never a client-visible request, and recording it would
+			// just be history noise. Same rationale as the out_of_credits path.
+			if (!isSyntheticInternal) {
+				const responseTime = Date.now() - requestMeta.timestamp;
+				const modelRewrite = isModelRewrite(
+					requestMeta.originalModel,
+					requestMeta.appliedModel,
+				);
+				ctx.asyncWriter.enqueue(() =>
+					ctx.dbOps.saveRequest(
+						crypto.randomUUID(),
+						req.method,
+						url.pathname,
+						account.id,
+						403,
+						false,
+						reason,
+						responseTime,
+						failoverAttempts,
+						requestedModel ? { model: requestedModel } : undefined,
+						requestMeta.agentUsed ?? undefined,
+						apiKeyId ?? undefined,
+						apiKeyName ?? undefined,
+						requestMeta.project ?? null,
+						undefined,
+						requestMeta.comboName ?? null,
+						modelRewrite ? (requestMeta.originalModel ?? null) : null,
+						modelRewrite ? (requestMeta.appliedModel ?? null) : null,
+						requestMeta.projectAttributionSource ?? null,
+						requestMeta.agentAttributionSource ?? null,
+						null,
+						requestMeta.clientSessionId ?? null,
+					),
+				);
+			}
+			cancelDiscardedResponseBody(rawResponse);
+			return null;
 		}
 
 		// On model unavailable / rate-limited: cycle through the model list for

--- a/packages/types/src/account.ts
+++ b/packages/types/src/account.ts
@@ -30,7 +30,17 @@ export type RateLimitReason =
 	 *  request identically, and retries spanning 11s never once cleared it. The
 	 *  account is NOT benched — the request fails over and the account stays in
 	 *  rotation. */
-	| "windowless_429";
+	| "windowless_429"
+	/** Anthropic 403 `permission_error` — the account's ORGANIZATION forbids the
+	 *  request (OAuth disabled org-wide, Claude Code subscription access turned
+	 *  off by an admin). Nothing about the account's own quota is wrong, but it
+	 *  cannot serve any request until an admin changes a setting upstream, so it
+	 *  is benched like an exhausted window and the request fails over. Unlike
+	 *  `out_of_credits` / `extra_usage_exhausted` this is account-wide, not
+	 *  scoped to a model or surface, so it DOES count as a circuit failure.
+	 *  Not time-bounded: the bench will expire and the single-flight recovery
+	 *  probe will rediscover the 403 until the org setting actually changes. */
+	| "org_permission_denied";
 
 // Usage data types for Anthropic accounts
 export interface UsageWindowData {

--- a/packages/types/src/rate-limit-reason.ts
+++ b/packages/types/src/rate-limit-reason.ts
@@ -39,6 +39,11 @@
  * - `windowless_429` — 429 reporting no rate-limit window at all; measured
  *   as request-scoped, so the account is never benched. Does NOT trip the
  *   breaker.
+ * - `org_permission_denied` — 403 `permission_error`: the account's
+ *   organization forbids the request (OAuth disabled org-wide, Claude Code
+ *   subscription access turned off). Account-wide and not quota-related, but
+ *   the account cannot serve anything, so it is benched and DOES trip the
+ *   breaker.
  */
 import type { RateLimitReason } from "./account";
 
@@ -53,6 +58,7 @@ export const RATE_LIMIT_REASONS: readonly RateLimitReason[] = [
 	"out_of_credits",
 	"extra_usage_exhausted",
 	"windowless_429",
+	"org_permission_denied",
 ] as const;
 
 export function isRateLimitReason(value: string): value is RateLimitReason {


### PR DESCRIPTION
## Problem

Anthropic answers **403 `permission_error`** when an account's *organization* forbids the request — OAuth disabled org-wide, or Claude Code subscription access turned off by an admin. Claude Code shows the user:

> Your organization has disabled Claude subscription access for Claude Code · Use an Anthropic API key instead, or ask your admin to enable access

That status matched **none** of the failover guards in `proxyWithAccount` (401 / 429 / 529 / model-unavailable), so it fell straight through to `forwardToClient`. The client saw the error even with healthy accounts still in the pool.

Two things made it stick rather than pass once:

1. `processProxyResponse` classifies any non-429 as "not rate limited" and then **unconditionally clears `rate_limited_until`** (`response-processor.ts`). So the offending account also lost any existing bench and stayed pinned at the front of the priority order for every following request.
2. **The usage poller already knew.** `UsageFetcher` had logged the identical 403 with *49 consecutive failures per account*, and that signal never reached the router.

Evidence from a production install: three accounts of one organization returned this 403 **25 times within an hour**, every one carrying `x-should-retry: false`, while **97** such 403s across the request history all recorded `failover_attempts = 0`.

```json
403 Forbidden   x-should-retry: false
{"type":"error","error":{
  "type":"permission_error",
  "message":"OAuth authentication is currently not allowed for this organization.",
  "details":{"error_visibility":"user_facing",
             "error_code":"oauth_not_allowed_for_organization"}}}
```

## Fix

New `isAnthropicOrgPermissionDenied` predicate plus a failover branch that benches the account **exactly like an exhausted quota window** (`applyRateLimitCooldown` + `return null`). The exponential ramp and the single-flight recovery probe mean at most one request per cooldown expiry is spent rediscovering a block that only an admin can lift.

### Why it keys on `error.type`, not the message

One organization produced **two different wordings of the same condition within the same hour** — `/api/oauth/usage` says "OAuth authentication is currently not allowed for this organization." while `/v1/messages` tells Claude Code "Your organization has disabled Claude subscription access for Claude Code…". Anthropic owns that copy and can reword it without notice. `error.type` is the machine-readable field.

`x-should-retry: false` accompanied every observed instance and corroborates the classification, but does **not** gate it: requiring it would fail closed — straight back to forwarding the 403 — the moment a variant omits it.

### Deliberately narrow

- **Non-JSON 403s keep the existing pass-through.** An edge/WAF block page usually rejects every account identically, and benching the pool one account per attempt is the drain failure mode of #301.
- **Gated to `anthropic` / `claude-oauth`.** Codex has the same gap (`usage_not_included` → `permission_error` → 403, `codex/provider.ts`) and is left as a follow-up rather than widened here.
- `org_permission_denied` **does** count as a circuit failure, unlike the scoped `out_of_credits` / `extra_usage_exhausted` / `model_fallback_429` — an account-wide, admin-gated block belongs with account-wide exhaustion. To be precise about what that does and does not do: the breaker is still the state machine only (nothing in the request path calls `shouldAllow` / `isProviderWideOpen`), so what actually removes the account from rotation here is the cooldown bench, not the breaker. Counting it just keeps the failure accounting truthful for whenever admission gets wired up.

## Verification

Unit + integration tests, both new: 21 tests. The integration test was confirmed to discriminate — reverting only the `proxy-operations.ts` branch fails 4 of 6, with the failure output being the bug itself (a 403 `Response` handed back instead of `null`).

Full-suite delta against a clean-tree baseline: **zero regressions** (identical pre-existing failure count, +21 passing).

Verified live on a production install against real Claude Code traffic (not a script — the repo forbids curling Anthropic):

```
23:52:47.749  Selected 3 accounts: Zygmunt, Monika, Stanislaw
23:52:47.749  Attempting request with account: Zygmunt
23:52:48.034  WARN Account Zygmunt org_permission_denied (403, model=claude-opus-5) —
              organization forbids OAuth/Claude Code access; benching account and failing over
23:52:48.055  WARN cooldown_applied reason=org_permission_denied until=23:53:18 consecutive=1
23:52:52.589  Selected 2 accounts: Monika, Stanislaw          <- benched, out of rotation
```

Request history for the same run — every 403 is now immediately followed by a 200 on the next account with `failover_attempts=1`, on the same model:

```
01:52:48  Zygmunt  403  fail  org_permission_denied  failover=0  claude-opus-5
01:52:52  Monika   200  ok                           failover=1  claude-opus-5
01:53:25  Zygmunt  403  fail  org_permission_denied  failover=0  claude-sonnet-5
01:53:27  Monika   200  ok                           failover=1  claude-sonnet-5
```

Before this change those 403 rows existed with `failover_attempts = 0` and no follow-up: the client just got the error.

## Note for a possible follow-up (not in this PR)

`response-processor.ts` clears `rate_limited_until` on *any* non-rate-limited response, gated only on "not 429" — not on `response.ok`. So a 500 or an unmatched 4xx still wipes an active bench. This PR does not depend on that (the new branch returns before `processProxyResponse` runs) and I left it alone to keep the change focused, but it looks like a real latent bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
