### PR TITLE
fix(codex): preserve responses api semantics

### DIFF
--- a/packages/openai-responses-adapter/src/__tests__/handler.test.ts
+++ b/packages/openai-responses-adapter/src/__tests__/handler.test.ts
@@ -242,4 +242,118 @@ describe("handleResponsesRequest", () => {
 		expect(rawBody).toContain("response.created");
 		expect(rawBody).toContain("response.completed");
 	});
+
+	test("streaming custom-tool-call response passes native Responses SSE through unchanged", async () => {
+		const nativeSseBody =
+			"event: response.custom_tool_call\ndata: " +
+			JSON.stringify({
+				type: "response.custom_tool_call",
+				call_id: "call_1",
+				name: "shell",
+			}) +
+			"\n\n" +
+			"event: response.completed\ndata: " +
+			JSON.stringify({
+				type: "response.completed",
+				response: { id: "resp_native", model: "gpt-5.6-sol", output: [] },
+			}) +
+			"\n\n";
+
+		const mockHandleProxy: HandleProxyFn = async () =>
+			new Response(nativeSseBody, {
+				status: 200,
+				headers: {
+					"Content-Type": "text/event-stream",
+					"x-better-ccflare-codex-response-format": "responses-api",
+				},
+			});
+
+		const req = new Request("http://localhost/v1/responses", {
+			method: "POST",
+			body: JSON.stringify({
+				model: "gpt-5.6-sol",
+				input: [
+					{
+						type: "message",
+						role: "user",
+						content: [{ type: "input_text", text: "Hi" }],
+					},
+				],
+				stream: true,
+			}),
+			headers: { "Content-Type": "application/json" },
+		});
+
+		const resp = await handleResponsesRequest(
+			req,
+			new URL(req.url),
+			mockHandleProxy,
+			{},
+		);
+
+		expect(resp.headers.get("content-type")).toContain("text/event-stream");
+		expect(
+			resp.headers.get("x-better-ccflare-codex-response-format"),
+		).toBeNull();
+		const rawBody = await resp.text();
+		expect(rawBody).toBe(nativeSseBody);
+	});
+
+	test("non-streaming custom-tool-call response returns the native Responses JSON instead of a 502", async () => {
+		const nativeSseBody =
+			"event: response.custom_tool_call\ndata: " +
+			JSON.stringify({
+				type: "response.custom_tool_call",
+				call_id: "call_1",
+				name: "shell",
+			}) +
+			"\n\n" +
+			"event: response.completed\ndata: " +
+			JSON.stringify({
+				type: "response.completed",
+				response: { id: "resp_native", model: "gpt-5.6-sol", output: [] },
+			}) +
+			"\n\n";
+
+		const mockHandleProxy: HandleProxyFn = async () =>
+			new Response(nativeSseBody, {
+				status: 200,
+				headers: {
+					"Content-Type": "text/event-stream",
+					"x-better-ccflare-codex-response-format": "responses-api",
+				},
+			});
+
+		const req = new Request("http://localhost/v1/responses", {
+			method: "POST",
+			body: JSON.stringify({
+				model: "gpt-5.6-sol",
+				input: [
+					{
+						type: "message",
+						role: "user",
+						content: [{ type: "input_text", text: "Hi" }],
+					},
+				],
+				stream: false,
+			}),
+			headers: { "Content-Type": "application/json" },
+		});
+
+		const resp = await handleResponsesRequest(
+			req,
+			new URL(req.url),
+			mockHandleProxy,
+			{},
+		);
+
+		expect(resp.status).toBe(200);
+		expect(resp.headers.get("content-type")).toContain("application/json");
+		const body = await resp.json();
+		expect(body).toEqual({
+			id: "resp_native",
+			model: "gpt-5.6-sol",
+			output: [],
+		});
+	});
 });

--- a/packages/openai-responses-adapter/src/handler.ts
+++ b/packages/openai-responses-adapter/src/handler.ts
@@ -7,6 +7,47 @@ import type { HandleProxyFn, ResponseItem, ResponsesRequest } from "./types";
 
 const log = new Logger("openai-responses-adapter");
 
+const TERMINAL_RESPONSE_EVENT_TYPES = new Set([
+	"response.completed",
+	"response.incomplete",
+	"response.failed",
+]);
+
+function extractTerminalNativeResponse(
+	sseText: string,
+): Record<string, unknown> | null {
+	const rawEvents = sseText.split("\n\n");
+	for (let i = rawEvents.length - 1; i >= 0; i--) {
+		const rawEvent = rawEvents[i];
+		if (!rawEvent.trim()) continue;
+
+		let eventType = "";
+		let dataStr = "";
+		for (const line of rawEvent.split("\n")) {
+			if (line.startsWith("event:")) {
+				eventType = line.slice("event:".length).trim();
+			} else if (line.startsWith("data:")) {
+				dataStr = line.slice("data:".length).trim();
+			}
+		}
+		if (!dataStr) continue;
+
+		try {
+			const data = JSON.parse(dataStr) as {
+				type?: string;
+				response?: Record<string, unknown>;
+			};
+			const type = data.type ?? eventType;
+			if (type && TERMINAL_RESPONSE_EVENT_TYPES.has(type) && data.response) {
+				return data.response;
+			}
+		} catch {
+			// Malformed event — keep scanning earlier events.
+		}
+	}
+	return null;
+}
+
 export async function handleResponsesRequest(
 	req: Request,
 	url: URL,
@@ -230,13 +271,13 @@ export async function handleResponsesRequest(
 		});
 	}
 
-	// 8. Stream path
-	if (body.stream) {
-		// Preserve native Responses SSE.
-		const responseFormat = anthropicResp.headers.get(
-			"x-better-ccflare-codex-response-format",
-		);
-		if (responseFormat === "responses-api") {
+	// Set regardless of whether the original request streamed, so this check
+	// must run before the body.stream branch below.
+	const responseFormat = anthropicResp.headers.get(
+		"x-better-ccflare-codex-response-format",
+	);
+	if (responseFormat === "responses-api") {
+		if (body.stream) {
 			const headers = new Headers(anthropicResp.headers);
 			headers.delete("x-better-ccflare-codex-response-format");
 			return new Response(anthropicResp.body, {
@@ -244,6 +285,29 @@ export async function handleResponsesRequest(
 				headers,
 			});
 		}
+		// Client expects a JSON body, not SSE framing.
+		const sseText = await anthropicResp.text();
+		const nativeResponse = extractTerminalNativeResponse(sseText);
+		if (!nativeResponse) {
+			return new Response(
+				JSON.stringify({
+					error: {
+						message: "Failed to parse upstream response",
+						type: "api_error",
+						code: "api_error",
+					},
+				}),
+				{ status: 502, headers: { "Content-Type": "application/json" } },
+			);
+		}
+		return new Response(JSON.stringify(nativeResponse), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		});
+	}
+
+	// 8. Stream path
+	if (body.stream) {
 		return translateAnthropicStreamToResponses(
 			anthropicResp,
 			responseId,

--- a/packages/openai-responses-adapter/src/handler.ts
+++ b/packages/openai-responses-adapter/src/handler.ts
@@ -121,6 +121,30 @@ export async function handleResponsesRequest(
 	// claude-oauth accounts use Claude's OAuth tokens — Anthropic bans them
 	// when used outside Claude CLI. Always exclude from Codex CLI traffic.
 	syntheticHeaders.set("x-better-ccflare-exclude-providers", "anthropic-oauth");
+	// Preserve Codex-only fields.
+	const codexPassthrough: Record<string, unknown> = {};
+	if (body.model !== undefined) codexPassthrough.model = body.model;
+	if (body.reasoning !== undefined) codexPassthrough.reasoning = body.reasoning;
+	if (body.prompt_cache_key !== undefined)
+		codexPassthrough.prompt_cache_key = body.prompt_cache_key;
+	if (body.tools !== undefined) codexPassthrough.tools = body.tools;
+	if (body.parallel_tool_calls !== undefined)
+		codexPassthrough.parallel_tool_calls = body.parallel_tool_calls;
+	if (body.store !== undefined) codexPassthrough.store = body.store;
+	// Preserve Responses Lite tools.
+	const additionalToolsItems = Array.isArray(body.input)
+		? body.input.filter((item: any) => item.type === "additional_tools")
+		: [];
+	if (additionalToolsItems.length > 0) {
+		codexPassthrough.additional_tools = additionalToolsItems;
+	}
+	if (Object.keys(codexPassthrough).length > 0) {
+		(
+			anthropicBody as typeof anthropicBody & {
+				__better_ccflare_codex_passthrough?: Record<string, unknown>;
+			}
+		).__better_ccflare_codex_passthrough = codexPassthrough;
+	}
 	const syntheticReq = new Request(messagesUrl.toString(), {
 		method: "POST",
 		headers: syntheticHeaders,
@@ -208,6 +232,18 @@ export async function handleResponsesRequest(
 
 	// 8. Stream path
 	if (body.stream) {
+		// Preserve native Responses SSE.
+		const responseFormat = anthropicResp.headers.get(
+			"x-better-ccflare-codex-response-format",
+		);
+		if (responseFormat === "responses-api") {
+			const headers = new Headers(anthropicResp.headers);
+			headers.delete("x-better-ccflare-codex-response-format");
+			return new Response(anthropicResp.body, {
+				status: anthropicResp.status,
+				headers,
+			});
+		}
 		return translateAnthropicStreamToResponses(
 			anthropicResp,
 			responseId,

--- a/packages/openai-responses-adapter/src/stream-translator.ts
+++ b/packages/openai-responses-adapter/src/stream-translator.ts
@@ -362,6 +362,14 @@ function processEvent(
 		);
 		return;
 	}
+
+	// Codex provider emits Anthropic `ping` events as keepalives during
+	// long-running requests.  Forward as an SSE comment so the reverse
+	// proxy's idle timeout does not kill the connection.
+	if (eventType === "ping") {
+		controller.enqueue(encoder.encode(": keepalive\n\n"));
+		return;
+	}
 }
 
 function parseAndProcessChunk(

--- a/packages/providers/src/providers/codex/provider.fidelity.test.ts
+++ b/packages/providers/src/providers/codex/provider.fidelity.test.ts
@@ -235,6 +235,58 @@ describe("Codex transform, disable_parallel_tool_use mapping", () => {
 		});
 		expect(body.parallel_tool_calls).toBeUndefined();
 	});
+
+	test("preserves an explicit Responses API false value", async () => {
+		const body = await transform({
+			...base,
+			__better_ccflare_codex_passthrough: {
+				parallel_tool_calls: false,
+			},
+		});
+		expect(body.parallel_tool_calls).toBe(false);
+	});
+});
+
+describe("Codex transform, store field", () => {
+	const base = {
+		model: "claude-opus-4-8",
+		max_tokens: 10,
+		messages: [{ role: "user", content: "hi" }],
+	};
+
+	test("defaults to explicit false for ordinary requests", async () => {
+		const body = await transform(base);
+		expect(body.store).toBe(false);
+	});
+
+	test("honors an explicit Responses API true value", async () => {
+		const body = await transform({
+			...base,
+			__better_ccflare_codex_passthrough: { store: true },
+		});
+		expect(body.store).toBe(true);
+	});
+});
+
+describe("Codex transform, tools field", () => {
+	test("omits tools entirely for tool-less requests", async () => {
+		const body = await transform({
+			model: "claude-opus-4-8",
+			max_tokens: 10,
+			messages: [{ role: "user", content: "hi" }],
+		});
+		expect(body.tools).toBeUndefined();
+	});
+
+	test("maps Anthropic tools when present", async () => {
+		const body = await transform({
+			model: "claude-opus-4-8",
+			max_tokens: 10,
+			messages: [{ role: "user", content: "hi" }],
+			tools: [{ name: "Read", input_schema: { type: "object" } }],
+		});
+		expect(body.tools).toHaveLength(1);
+	});
 });
 
 describe("Codex transform, Skill nudge in mixed parallel final turns", () => {

--- a/packages/providers/src/providers/codex/provider.responses.test.ts
+++ b/packages/providers/src/providers/codex/provider.responses.test.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "bun:test";
+import { CodexProvider } from "./provider";
+
+test("preserves custom tool calls in labeled Codex SSE", async () => {
+	const provider = new CodexProvider();
+	const stream = [
+		"event: response.custom_tool_call_input.done\n",
+		'data: {"type":"response.custom_tool_call_input.done"}\n\n',
+	].join("");
+	const response = new Response(stream, {
+		headers: {
+			"content-type": "text/event-stream",
+			"x-better-ccflare-request-stream": "true",
+			"x-better-ccflare-codex-custom-tools": "true",
+		},
+	});
+
+	const transformed = await provider.processResponse(response, null);
+
+	expect(
+		transformed.headers.get("x-better-ccflare-codex-response-format"),
+	).toBe("responses-api");
+	expect(await transformed.text()).toBe(stream);
+});
+
+test("passes custom-tool streams through without waiting for upstream EOF", async () => {
+	const provider = new CodexProvider();
+	const encoder = new TextEncoder();
+	const firstChunk = [
+		"event: response.output_text.delta\n",
+		'data: {"type":"response.output_text.delta","delta":"still reasoning"}\n\n',
+	].join("");
+	// Stream stays open after the first chunk, like an upstream mid-generation.
+	const body = new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(encoder.encode(firstChunk));
+		},
+	});
+	const response = new Response(body, {
+		headers: {
+			"content-type": "text/event-stream",
+			"x-better-ccflare-request-stream": "true",
+			"x-better-ccflare-codex-custom-tools": "true",
+		},
+	});
+
+	const transformed = await provider.processResponse(response, null);
+
+	expect(
+		transformed.headers.get("x-better-ccflare-codex-response-format"),
+	).toBe("responses-api");
+	const reader = transformed.body?.getReader();
+	if (!reader) throw new Error("expected a streaming body");
+	const { value } = await reader.read();
+	expect(new TextDecoder().decode(value)).toBe(firstChunk);
+	await reader.cancel();
+});
+
+test("streams straight through without buffering when no custom tools were declared", async () => {
+	const provider = new CodexProvider();
+	// Body text mentions the marker string, but no custom tool was declared,
+	// so this must not trigger passthrough detection.
+	const stream = [
+		"event: response.output_text.delta\n",
+		'data: {"type":"response.output_text.delta","delta":"custom_tool_call is a feature"}\n\n',
+	].join("");
+	const response = new Response(stream, {
+		headers: {
+			"content-type": "text/event-stream",
+			"x-better-ccflare-request-stream": "true",
+			"x-better-ccflare-codex-custom-tools": "false",
+		},
+	});
+
+	const transformed = await provider.processResponse(response, null);
+
+	expect(
+		transformed.headers.get("x-better-ccflare-codex-response-format"),
+	).not.toBe("responses-api");
+});
+
+test("preserves malformed Codex model-list responses", async () => {
+	const provider = new CodexProvider();
+	const response = new Response("not json", {
+		status: 200,
+		headers: { "x-better-ccflare-request-path": "/v1/models" },
+	});
+
+	const transformed = await provider.processResponse(response, null);
+
+	expect(transformed.status).toBe(200);
+	expect(await transformed.text()).toBe("not json");
+});

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -288,7 +288,7 @@ describe("CodexProvider request conversion", () => {
 		const transformed = await provider.transformRequestBody(request);
 		const body = await transformed.json();
 
-		expect(body.reasoning).toEqual({ effort: "high" });
+		expect(body.reasoning).toEqual({ effort: "high", context: "all_turns" });
 	});
 
 	it("adds a continuation nudge after Skill tool results", async () => {
@@ -444,7 +444,7 @@ describe("CodexProvider request conversion", () => {
 		const transformed = await provider.transformRequestBody(request);
 		const body = await transformed.json();
 
-		expect(body.reasoning).toEqual({ effort: "xhigh" });
+		expect(body.reasoning).toEqual({ effort: "xhigh", context: "all_turns" });
 	});
 
 	it("uses role-appropriate text block types in Codex input", async () => {
@@ -547,7 +547,7 @@ describe("CodexProvider request conversion", () => {
 		const transformed = await provider.transformRequestBody(request);
 		const body = await transformed.json();
 
-		expect(body.reasoning).toEqual({ effort: "medium" });
+		expect(body.reasoning).toEqual({ effort: "medium", context: "all_turns" });
 	});
 
 	it("rejects unsupported reasoning effort values", async () => {
@@ -587,7 +587,7 @@ describe("CodexProvider request conversion", () => {
 
 		const transformed = await provider.transformRequestBody(request, account);
 		const body = await transformed.json();
-		expect(body.reasoning).toEqual({ effort: "medium" });
+		expect(body.reasoning).toEqual({ effort: "medium", context: "all_turns" });
 	});
 
 	it("omits empty Read.pages when replaying Anthropic history to Codex", async () => {

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -2636,6 +2636,79 @@ describe("CodexProvider.transformRequestBody", () => {
 		expect(body.model).toBe("gpt-5.4-mini");
 	});
 
+	it("prefers an explicit account model mapping over the raw passthrough model", async () => {
+		const provider = new CodexProvider();
+		const account = {
+			model_mappings: JSON.stringify({ sonnet: "gpt-5.3-codex" }),
+		} as Parameters<typeof provider.transformRequestBody>[1];
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-7-sonnet",
+				max_tokens: 10,
+				messages: [{ role: "user", content: "hello" }],
+				__better_ccflare_codex_passthrough: { model: "gpt-5.4-mini" },
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request, account);
+		const body = await transformed.json();
+
+		expect(body.model).toBe("gpt-5.3-codex");
+	});
+
+	it("restores the raw passthrough model over a family-tier default", async () => {
+		setDerivedProviderModelDefaults("codex", "acc-1", {
+			fable: "gpt-5.6-sol",
+			opus: "gpt-5.6-sol",
+			sonnet: "gpt-5.6-terra",
+			haiku: "gpt-5.6-luna",
+		});
+		const provider = new CodexProvider();
+		const account = {
+			id: "acc-1",
+		} as Parameters<typeof provider.transformRequestBody>[1];
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-7-sonnet",
+				max_tokens: 10,
+				messages: [{ role: "user", content: "hello" }],
+				__better_ccflare_codex_passthrough: { model: "gpt-5.4-mini" },
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request, account);
+		const body = await transformed.json();
+
+		expect(body.model).toBe("gpt-5.4-mini");
+	});
+
+	it("resolves reasoning effort against the model actually sent", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "claude-3-7-sonnet",
+				max_tokens: 10,
+				messages: [{ role: "user", content: "hello" }],
+				reasoning: { effort: "high" },
+				__better_ccflare_codex_passthrough: { model: "gpt-5.4-mini" },
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request, undefined);
+		const body = await transformed.json();
+
+		// "claude-3-7-sonnet" supports "high"; "gpt-5.4-mini" — the model that
+		// actually ships — only supports up to "medium".
+		expect(body.model).toBe("gpt-5.4-mini");
+		expect(body.reasoning.effort).toBe("medium");
+	});
+
 	it("forces StructuredOutput tool_choice when the Claude Code schema tool is present", async () => {
 		const provider = new CodexProvider();
 		const request = new Request("https://example.com/v1/messages", {

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -2709,6 +2709,33 @@ describe("CodexProvider.transformRequestBody", () => {
 		expect(body.reasoning.effort).toBe("medium");
 	});
 
+	it("flags custom tools declared only via a Responses Lite additional_tools input item", async () => {
+		const provider = new CodexProvider();
+		const request = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "gpt-5.4-mini",
+				max_tokens: 10,
+				messages: [{ role: "user", content: "hello" }],
+				__better_ccflare_codex_passthrough: {
+					additional_tools: [
+						{
+							type: "additional_tools",
+							tools: [{ type: "custom", name: "shell" }],
+						},
+					],
+				},
+			}),
+		});
+
+		const transformed = await provider.transformRequestBody(request, undefined);
+
+		expect(transformed.headers.get("x-better-ccflare-codex-custom-tools")).toBe(
+			"true",
+		);
+	});
+
 	it("forces StructuredOutput tool_choice when the Claude Code schema tool is present", async () => {
 		const provider = new CodexProvider();
 		const request = new Request("https://example.com/v1/messages", {

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -43,6 +43,7 @@ export const CODEX_CACHE_KEY_MODE_ENV = "CCFLARE_CODEX_CACHE_KEY_MODE";
 const INTERNAL_HEADERS = [
 	"x-better-ccflare-request-id",
 	"x-better-ccflare-request-stream",
+	"x-better-ccflare-codex-custom-tools",
 ];
 
 function sanitizeResponseHeaders(headers: Headers): Headers {
@@ -51,6 +52,15 @@ function sanitizeResponseHeaders(headers: Headers): Headers {
 		sanitized.delete(h);
 	}
 	return sanitized;
+}
+
+// Matches the SSE event name or item "type" marker, not a bare substring,
+// so assistant-generated text can't trigger a false positive.
+const CUSTOM_TOOL_CALL_PATTERN =
+	/(?:^|\n)event:\s*response\.custom_tool_call|"type"\s*:\s*"(?:response\.)?custom_tool_call/;
+
+function hasCustomToolCallEvent(sseText: string): boolean {
+	return CUSTOM_TOOL_CALL_PATTERN.test(sseText);
 }
 
 const TOKEN_URL = "https://auth.openai.com/oauth/token";
@@ -249,9 +259,9 @@ interface CodexRequest {
 	model: string;
 	input: (CodexMessage | CodexFunctionCallItem | CodexFunctionCallOutputItem)[];
 	stream: boolean;
-	store: false;
+	store: boolean;
 	max_output_tokens?: number;
-	reasoning?: { effort: string };
+	reasoning?: { effort: string; context?: string };
 	instructions?: string;
 	tools?: CodexTool[];
 	prompt_cache_key?: string;
@@ -453,10 +463,11 @@ export class CodexProvider extends BaseProvider {
 	// Fallback map: proxy-operations.ts injects x-better-ccflare-request-id and
 	// x-better-ccflare-request-stream into the upstream response before calling
 	// processResponse, so headerRequestedStream is normally set. This map covers
-	// the race where a response arrives after the 30s TTL sweep evicts the entry.
+	// the race where a response arrives after the 30s TTL sweep evicts the entry,
+	// and the 529 in-place retry path (which doesn't re-tag those headers).
 	private requestStreamById = new Map<
 		string,
-		{ stream: boolean; ts: number }
+		{ stream: boolean; hasCustomTools: boolean; ts: number }
 	>();
 
 	private sweepRequestStreamById(): void {
@@ -469,7 +480,11 @@ export class CodexProvider extends BaseProvider {
 	}
 
 	canHandle(path: string): boolean {
-		return path === "/v1/messages" || path === "/v1/messages/count_tokens";
+		return (
+			path === "/v1/messages" ||
+			path === "/v1/messages/count_tokens" ||
+			path === "/v1/models"
+		);
 	}
 
 	async refreshToken(
@@ -551,6 +566,10 @@ export class CodexProvider extends BaseProvider {
 			return CODEX_SYNTHETIC_COUNT_TOKENS_URL;
 		}
 
+		if (_path === "/v1/models") {
+			return `https://chatgpt.com/backend-api/codex/models?client_version=${encodeURIComponent(CODEX_VERSION)}`;
+		}
+
 		if (account?.custom_endpoint) {
 			try {
 				return validateEndpointUrl(account.custom_endpoint, "custom_endpoint");
@@ -575,6 +594,13 @@ export class CodexProvider extends BaseProvider {
 		newHeaders.delete("x-api-key");
 		newHeaders.delete("host");
 
+		// Remove internal proxy headers.
+		for (const key of [...newHeaders.keys()]) {
+			if (key.startsWith("x-better-ccflare-")) {
+				newHeaders.delete(key);
+			}
+		}
+
 		// Set Codex-required headers
 		if (accessToken) {
 			newHeaders.set("Authorization", `Bearer ${accessToken}`);
@@ -591,6 +617,12 @@ export class CodexProvider extends BaseProvider {
 		request: Request,
 		account?: Account,
 	): Promise<Request> {
+		// /v1/models is handled as a passthrough GET.
+		const codexModelsUrl = `https://chatgpt.com/backend-api/codex/models?client_version=${encodeURIComponent(CODEX_VERSION)}`;
+		if (request.url.startsWith(codexModelsUrl.split("?")[0])) {
+			return request;
+		}
+
 		const isSyntheticCountTokens = this.isSyntheticCountTokensRequest(
 			request.url,
 		);
@@ -627,18 +659,33 @@ export class CodexProvider extends BaseProvider {
 			}
 
 			const requestId = request.headers.get("x-better-ccflare-request-id");
-			if (requestId) {
-				this.requestStreamById.set(requestId, {
-					stream: body.stream === true,
-					ts: Date.now(),
-				});
-			}
+			// Extract internal passthrough metadata.
+			const passthrough = body.__better_ccflare_codex_passthrough as
+				| Record<string, unknown>
+				| undefined;
+			delete body.__better_ccflare_codex_passthrough;
 			const codexBody = this.convertToCodexFormat(
 				body,
 				account,
 				requestId ?? undefined,
 				isSubscriptionEndpoint,
+				passthrough,
 			);
+
+			// Only custom (non-function) tools can produce custom_tool_call output;
+			// let processResponse skip buffering when none were declared.
+			const hasCustomTools =
+				codexBody.tools?.some(
+					(t) => (t as { type?: string }).type !== "function",
+				) ?? false;
+
+			if (requestId) {
+				this.requestStreamById.set(requestId, {
+					stream: body.stream === true,
+					hasCustomTools,
+					ts: Date.now(),
+				});
+			}
 
 			const newHeaders = new Headers(request.headers);
 			newHeaders.set("content-type", "application/json");
@@ -646,12 +693,18 @@ export class CodexProvider extends BaseProvider {
 				"x-better-ccflare-request-stream",
 				body.stream === true ? "true" : "false",
 			);
+			newHeaders.set(
+				"x-better-ccflare-codex-custom-tools",
+				hasCustomTools ? "true" : "false",
+			);
 			newHeaders.delete("content-length");
+
+			const serializedBody = JSON.stringify(codexBody);
 
 			return new Request(request.url, {
 				method: request.method,
 				headers: newHeaders,
-				body: JSON.stringify(codexBody),
+				body: serializedBody,
 			});
 		} catch (error) {
 			if (error instanceof ValidationError) {
@@ -676,8 +729,26 @@ export class CodexProvider extends BaseProvider {
 		_requestHeaders?: Headers,
 		drainAbort?: AbortController,
 	): Promise<Response> {
+		// /v1/models responses: translate Codex format → OpenAI /v1/models format
+		// with full capability fields preserved for the CLI.
+		const requestPath = response.headers.get("x-better-ccflare-request-path");
+		if (requestPath === "/v1/models") {
+			return this.transformModelsListResponse(response);
+		}
+
 		const contentType = response.headers.get("content-type");
 		const requestId = response.headers.get("x-better-ccflare-request-id");
+		const fallbackEntry = requestId
+			? this.requestStreamById.get(requestId)
+			: undefined;
+		// Sliding TTL: refresh on read so a still-retrying request survives the
+		// 30s sweep instead of expiring mid-backoff.
+		if (requestId && fallbackEntry) {
+			this.requestStreamById.set(requestId, {
+				...fallbackEntry,
+				ts: Date.now(),
+			});
+		}
 		const headerRequestedStream = response.headers.get(
 			"x-better-ccflare-request-stream",
 		);
@@ -686,18 +757,55 @@ export class CodexProvider extends BaseProvider {
 				? true
 				: headerRequestedStream === "false"
 					? false
-					: requestId
-						? (this.requestStreamById.get(requestId)?.stream ?? true)
-						: true;
-		if (requestId) {
-			this.requestStreamById.delete(requestId);
-		}
+					: (fallbackEntry?.stream ?? true);
+		const headerCustomTools = response.headers.get(
+			"x-better-ccflare-codex-custom-tools",
+		);
+		const mightHaveCustomToolCalls =
+			headerCustomTools === "true"
+				? true
+				: headerCustomTools === "false"
+					? false
+					: (fallbackEntry?.hasCustomTools ?? false);
+		// Not deleted: an in-place 529 retry re-invokes processResponse and needs
+		// this entry too. sweepRequestStreamById reclaims it after 30s instead.
 		const isEventStream = contentType?.includes("text/event-stream") ?? false;
 		if (isEventStream) {
-			if (requestedStream) {
-				return this.transformStreamingResponse(response, drainAbort);
+			// No custom tools declared, so no custom_tool_call is possible: skip
+			// buffering and stream straight through.
+			if (!mightHaveCustomToolCalls) {
+				if (requestedStream) {
+					return this.transformStreamingResponse(response, drainAbort);
+				}
+				return this.transformSseResponseToJson(response);
 			}
-			return this.transformSseResponseToJson(response);
+			// A custom_tool_call can appear at any point in the stream, and the
+			// passthrough-vs-transform choice must be made before the first byte
+			// is returned, so sniffing for one would buffer the whole stream and
+			// withhold deltas and keepalives until upstream EOF. Custom tools only
+			// originate from the /v1/responses adapter, whose client speaks
+			// Responses SSE natively — pass the live stream through untouched.
+			if (requestedStream) {
+				return this.buildCustomToolCallPassthroughResponse(
+					response.body,
+					response,
+				);
+			}
+			// Non-streaming clients block on the full body anyway, so sniffing
+			// here costs nothing extra.
+			const streamBody = await response.text();
+			if (hasCustomToolCallEvent(streamBody)) {
+				return this.buildCustomToolCallPassthroughResponse(
+					streamBody,
+					response,
+				);
+			}
+			const streamResponse = new Response(streamBody, {
+				status: response.status,
+				statusText: response.statusText,
+				headers: response.headers,
+			});
+			return this.transformSseResponseToJson(streamResponse);
 		}
 
 		if (response.ok && response.body !== null) {
@@ -709,6 +817,16 @@ export class CodexProvider extends BaseProvider {
 				log.warn(
 					`Codex returned successful response without SSE content-type (${contentType ?? "<missing>"}); transforming as ${requestedStream ? "SSE" : "JSON"}`,
 				);
+				// Preserve Responses Lite custom tool calls.
+				if (hasCustomToolCallEvent(probeText)) {
+					log.info(
+						"[codex:passthrough] Custom tool call events detected, bypassing Anthropic conversion",
+					);
+					return this.buildCustomToolCallPassthroughResponse(
+						probeText,
+						response,
+					);
+				}
 				const headers = sanitizeResponseHeaders(response.headers);
 				headers.set("content-type", "text/event-stream");
 				const sseResponse = new Response(probeText, {
@@ -732,6 +850,20 @@ export class CodexProvider extends BaseProvider {
 
 		const headers = sanitizeResponseHeaders(response.headers);
 		return new Response(response.body, {
+			status: response.status,
+			statusText: response.statusText,
+			headers,
+		});
+	}
+
+	private buildCustomToolCallPassthroughResponse(
+		body: BodyInit | null,
+		response: Response,
+	): Response {
+		const headers = sanitizeResponseHeaders(response.headers);
+		headers.set("content-type", "text/event-stream");
+		headers.set("x-better-ccflare-codex-response-format", "responses-api");
+		return new Response(body, {
 			status: response.status,
 			statusText: response.statusText,
 			headers,
@@ -1068,6 +1200,48 @@ export class CodexProvider extends BaseProvider {
 		return url === CODEX_SYNTHETIC_COUNT_TOKENS_URL;
 	}
 
+	private async transformModelsListResponse(
+		response: Response,
+	): Promise<Response> {
+		if (!response.ok) {
+			return response;
+		}
+		try {
+			const raw = (await response.clone().json()) as {
+				models?: Array<
+					Record<string, unknown> & {
+						slug?: string;
+						visibility?: string;
+					}
+				>;
+			};
+			const data = (raw.models ?? [])
+				.filter(
+					(m) =>
+						typeof m.slug === "string" &&
+						m.slug.length > 0 &&
+						(!m.visibility || m.visibility === "list"),
+				)
+				.map((m) => ({
+					...m,
+					id: m.slug as string,
+					object: "model" as const,
+					created: Math.floor(Date.now() / 1000),
+					owned_by: "openai",
+				}));
+			return new Response(
+				JSON.stringify({ object: "list", data, models: data }),
+				{
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				},
+			);
+		} catch (err) {
+			log.warn(`Failed to transform Codex models response: ${err}`);
+			return response;
+		}
+	}
+
 	private createSyntheticJsonResponse(
 		request: Request,
 		status: number,
@@ -1266,6 +1440,7 @@ export class CodexProvider extends BaseProvider {
 		account?: Account,
 		requestId?: string,
 		isSubscriptionEndpoint = isCodexSubscriptionEndpoint(account),
+		passthrough?: Record<string, unknown>,
 	): CodexRequest {
 		const model = this.mapModel(body.model, account);
 		if (process.env.DEBUG?.includes("model") || process.env.DEBUG === "true") {
@@ -1328,7 +1503,13 @@ export class CodexProvider extends BaseProvider {
 			}));
 		}
 
-		const reasoningResolution = resolveReasoningEffort(body.reasoning?.effort, {
+		// Preserve original reasoning settings.
+		const passthroughReasoning = passthrough?.reasoning as
+			| { effort?: string; context?: string }
+			| undefined;
+		const reasoningEffort =
+			passthroughReasoning?.effort ?? body.reasoning?.effort;
+		const reasoningResolution = resolveReasoningEffort(reasoningEffort, {
 			sourceModel: body.model,
 			targetModel: model,
 		});
@@ -1346,9 +1527,33 @@ export class CodexProvider extends BaseProvider {
 			model,
 			input,
 			stream: true,
-			store: false,
-			reasoning: { effort: reasoningResolution.effort ?? "medium" },
+			// Responses Lite may request store: true explicitly; default false otherwise.
+			store:
+				typeof passthrough?.store === "boolean" ? passthrough.store : false,
+			reasoning: {
+				effort: reasoningResolution.effort ?? "medium",
+				context: "all_turns",
+			},
 		};
+
+		// Preserve the original model name.
+		if (typeof passthrough?.model === "string") {
+			codexRequest.model = passthrough.model;
+		}
+		// Restore Responses Lite tools first.
+		const passthroughAdditionalTools = passthrough?.additional_tools;
+		if (
+			Array.isArray(passthroughAdditionalTools) &&
+			passthroughAdditionalTools.length > 0
+		) {
+			codexRequest.input.unshift(
+				...(passthroughAdditionalTools as (
+					| CodexMessage
+					| CodexFunctionCallItem
+					| CodexFunctionCallOutputItem
+				)[]),
+			);
+		}
 		if (
 			!isSubscriptionEndpoint &&
 			typeof body.max_tokens === "number" &&
@@ -1362,12 +1567,18 @@ export class CodexProvider extends BaseProvider {
 		}
 
 		codexRequest.instructions = instructions || "You are a helpful assistant.";
-		const promptCacheKey = this.derivePromptCacheKey(
+		// Prefer the original cache key, then use the derived key.
+		const originalCacheKey =
+			typeof passthrough?.prompt_cache_key === "string"
+				? passthrough.prompt_cache_key
+				: undefined;
+		const derivedCacheKey = this.derivePromptCacheKey(
 			body,
 			codexRequest.instructions,
 			input,
 			account,
 		);
+		const promptCacheKey = originalCacheKey ?? derivedCacheKey;
 		if (promptCacheKey) {
 			codexRequest.prompt_cache_key = promptCacheKey;
 		}
@@ -1390,7 +1601,15 @@ export class CodexProvider extends BaseProvider {
 		if (body.tool_choice?.disable_parallel_tool_use === true) {
 			codexRequest.parallel_tool_calls = false;
 		}
-		if (tools) {
+		// Responses Lite requires explicit false.
+		if (passthrough?.parallel_tool_calls === false) {
+			codexRequest.parallel_tool_calls = false;
+		}
+		// Preserve the original tool list.
+		const passthroughTools = passthrough?.tools;
+		if (Array.isArray(passthroughTools) && passthroughTools.length > 0) {
+			codexRequest.tools = passthroughTools as CodexTool[];
+		} else if (tools && tools.length > 0) {
 			codexRequest.tools = tools;
 		}
 

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -673,11 +673,17 @@ export class CodexProvider extends BaseProvider {
 			);
 
 			// Only custom (non-function) tools can produce custom_tool_call output;
-			// let processResponse skip buffering when none were declared.
+			// let processResponse skip buffering when none were declared. Responses
+			// Lite can also declare custom tools via an "additional_tools" input
+			// item instead of codexBody.tools.
 			const hasCustomTools =
-				codexBody.tools?.some(
+				(codexBody.tools?.some(
 					(t) => (t as { type?: string }).type !== "function",
-				) ?? false;
+				) ??
+					false) ||
+				codexBody.input.some(
+					(item) => (item as { type?: string }).type === "additional_tools",
+				);
 
 			if (requestId) {
 				this.requestStreamById.set(requestId, {

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -908,17 +908,24 @@ export class CodexProvider extends BaseProvider {
 
 	// ── Private helpers ──────────────────────────────────────────────────────
 
-	private mapModel(anthropicModel: string, account?: Account): string {
+	// isExplicitMapping: true only for a per-account model_mappings hit, not
+	// a family-tier default — callers use it to decide precedence.
+	private mapModel(
+		anthropicModel: string,
+		account?: Account,
+	): { model: string; isExplicitMapping: boolean } {
 		// "Force account model" forbids every substitution below, including the
 		// family defaults derived from the account's own listing: those answer
 		// "which model should a Claude family become here", a question nobody
 		// asked when the client named the model outright.
-		if (isForceAccountModelEnabled()) return anthropicModel;
+		if (isForceAccountModelEnabled()) {
+			return { model: anthropicModel, isExplicitMapping: false };
+		}
 
 		if (account) {
 			const mapped = mapModelName(anthropicModel, account);
 			if (mapped !== anthropicModel) {
-				return mapped;
+				return { model: mapped, isExplicitMapping: true };
 			}
 		}
 
@@ -927,21 +934,17 @@ export class CodexProvider extends BaseProvider {
 		// Resolved per account: the account's own listing is what decides, and
 		// two accounts of this provider can be on different plans.
 		const id = account?.id;
-		if (lower.includes("fable"))
-			return (
-				resolveProviderModelDefault("codex", "fable", id) ?? anthropicModel
-			);
-		if (lower.includes("haiku"))
-			return (
-				resolveProviderModelDefault("codex", "haiku", id) ?? anthropicModel
-			);
-		if (lower.includes("sonnet"))
-			return (
-				resolveProviderModelDefault("codex", "sonnet", id) ?? anthropicModel
-			);
-		if (lower.includes("opus"))
-			return resolveProviderModelDefault("codex", "opus", id) ?? anthropicModel;
-		return anthropicModel;
+		let model = anthropicModel;
+		if (lower.includes("fable")) {
+			model = resolveProviderModelDefault("codex", "fable", id) ?? model;
+		} else if (lower.includes("haiku")) {
+			model = resolveProviderModelDefault("codex", "haiku", id) ?? model;
+		} else if (lower.includes("sonnet")) {
+			model = resolveProviderModelDefault("codex", "sonnet", id) ?? model;
+		} else if (lower.includes("opus")) {
+			model = resolveProviderModelDefault("codex", "opus", id) ?? model;
+		}
+		return { model, isExplicitMapping: false };
 	}
 
 	private extractSystemPrompt(
@@ -1442,7 +1445,16 @@ export class CodexProvider extends BaseProvider {
 		isSubscriptionEndpoint = isCodexSubscriptionEndpoint(account),
 		passthrough?: Record<string, unknown>,
 	): CodexRequest {
-		const model = this.mapModel(body.model, account);
+		const { model: mappedModel, isExplicitMapping } = this.mapModel(
+			body.model,
+			account,
+		);
+		// Explicit account mapping wins; otherwise prefer the raw Codex model
+		// over a family-tier default, since the alias can't distinguish variants.
+		const model =
+			!isExplicitMapping && typeof passthrough?.model === "string"
+				? passthrough.model
+				: mappedModel;
 		if (process.env.DEBUG?.includes("model") || process.env.DEBUG === "true") {
 			log.info(
 				`[codex:model-debug] request_id=${requestId ?? "unknown"} request_model=${body.model} mapped_model=${model} account=${account?.name ?? "unknown"}`,
@@ -1536,10 +1548,6 @@ export class CodexProvider extends BaseProvider {
 			},
 		};
 
-		// Preserve the original model name.
-		if (typeof passthrough?.model === "string") {
-			codexRequest.model = passthrough.model;
-		}
 		// Restore Responses Lite tools first.
 		const passthroughAdditionalTools = passthrough?.additional_tools;
 		if (

--- a/packages/providers/src/utils/__tests__/model-mapping.test.ts
+++ b/packages/providers/src/utils/__tests__/model-mapping.test.ts
@@ -162,6 +162,26 @@ describe("transformRequestBodyModel", () => {
 		expect(resultBody.messages).toEqual([{ role: "user", content: "test" }]);
 		expect(resultBody.model).toBeUndefined();
 	});
+
+	it("strips the internal Codex passthrough field before forwarding upstream", async () => {
+		const requestBody = {
+			model: "claude-sonnet-4-5-20250929",
+			messages: [{ role: "user", content: "test" }],
+			__better_ccflare_codex_passthrough: { store: true },
+		};
+
+		const request = new Request("http://test.com", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify(requestBody),
+		});
+
+		const result = await transformRequestBodyModel(request, undefined);
+		const resultBody = await result.json();
+
+		expect(resultBody).not.toHaveProperty("__better_ccflare_codex_passthrough");
+		expect(resultBody.model).toBe("claude-sonnet-4-5-20250929");
+	});
 });
 
 describe("transformRequestBodyModelForce", () => {

--- a/packages/providers/src/utils/model-mapping.ts
+++ b/packages/providers/src/utils/model-mapping.ts
@@ -114,6 +114,17 @@ export async function transformRequestBodyModel<T extends TransformRequestBody>(
 	try {
 		const clonedRequest = request.clone();
 		const body: T = await clonedRequest.json();
+		let bodyChanged = false;
+
+		// Codex-only passthrough metadata; strip it in case failover ever
+		// routes here so it doesn't reach a non-Codex upstream unrecognized.
+		if (
+			"__better_ccflare_codex_passthrough" in (body as Record<string, unknown>)
+		) {
+			delete (body as Record<string, unknown>)
+				.__better_ccflare_codex_passthrough;
+			bodyChanged = true;
+		}
 
 		// Only transform if model field exists
 		if (body.model) {
@@ -127,27 +138,27 @@ export async function transformRequestBodyModel<T extends TransformRequestBody>(
 				mappedModel = getModelName(originalModel, account);
 			}
 
-			// Only create new request if model actually changed
 			if (mappedModel !== originalModel) {
 				body.model = mappedModel;
 				log.debug(
 					`Mapped model in request: ${originalModel} -> ${mappedModel}`,
 				);
-
-				// Create new request with transformed body.
-				// Rebuilding from `request.url` (a string) does not inherit the
-				// signal, so it is carried over explicitly — otherwise a client
-				// disconnect can no longer abort the upstream fetch for every
-				// account that has a model mapping.
-				const transformedRequest = new Request(request.url, {
-					method: request.method,
-					headers: request.headers,
-					body: JSON.stringify(body),
-					signal: request.signal,
-				});
-
-				return transformedRequest;
+				bodyChanged = true;
 			}
+		}
+
+		if (bodyChanged) {
+			// Create new request with transformed body.
+			// Rebuilding from `request.url` (a string) does not inherit the
+			// signal, so it is carried over explicitly — otherwise a client
+			// disconnect can no longer abort the upstream fetch for every
+			// account that has a model mapping.
+			return new Request(request.url, {
+				method: request.method,
+				headers: request.headers,
+				body: JSON.stringify(body),
+				signal: request.signal,
+			});
 		}
 
 		return request;

--- a/packages/proxy/src/__tests__/usage-collector-lifecycle.test.ts
+++ b/packages/proxy/src/__tests__/usage-collector-lifecycle.test.ts
@@ -8,7 +8,7 @@ import {
 	mock,
 } from "bun:test";
 import { logBus } from "@better-ccflare/logger";
-import type { LogEvent } from "@better-ccflare/types";
+import type { LogEvent, RequestResponse } from "@better-ccflare/types";
 import type { EndMessage, StartMessage } from "../worker-messages";
 
 interface PricingTokens {
@@ -75,6 +75,7 @@ interface TestHarness {
 	payloads: Map<string, string>;
 	summaryCosts: Map<string, number | undefined>;
 	summaries: string[];
+	summaryRecords: Map<string, RequestResponse>;
 	writerState: { disposed: boolean };
 }
 
@@ -143,6 +144,7 @@ function createHarness(storePayloads = false): TestHarness {
 	const payloadDrops: number[] = [];
 	const summaryCosts = new Map<string, number | undefined>();
 	const summaries: string[] = [];
+	const summaryRecords = new Map<string, RequestResponse>();
 	const writerState = { disposed: false };
 	const pendingWrites = new Set<Promise<void>>();
 
@@ -191,6 +193,7 @@ function createHarness(storePayloads = false): TestHarness {
 		(summary) => {
 			summaries.push(summary.id);
 			summaryCosts.set(summary.id, summary.costUsd);
+			summaryRecords.set(summary.id, summary);
 		},
 	);
 
@@ -201,6 +204,7 @@ function createHarness(storePayloads = false): TestHarness {
 		payloads,
 		summaries,
 		summaryCosts,
+		summaryRecords,
 		writerState,
 	};
 }
@@ -251,6 +255,34 @@ describe("UsageCollector request lifecycle", () => {
 		collectors.push(value.collector);
 		return value;
 	}
+
+	it("extracts usage from Codex Responses-format passthrough streams", async () => {
+		const { collector, summaryRecords } = harness();
+		collector.handleStart(
+			makeStartMessage("codex-passthrough", { providerName: "codex" }),
+		);
+
+		collector.handleChunk(
+			"codex-passthrough",
+			new TextEncoder().encode(
+				"event: response.completed\n" +
+					'data: {"type":"response.completed","response":{"model":"gpt-5.1-codex","usage":{"input_tokens":120,"output_tokens":30,"input_tokens_details":{"cached_tokens":100,"cache_creation_input_tokens":8}}}}\n\n',
+			),
+		);
+		await collector.handleEnd({
+			type: "end",
+			requestId: "codex-passthrough",
+			success: true,
+		});
+
+		const summary = summaryRecords.get("codex-passthrough");
+		expect(summary?.model).toBe("gpt-5.1-codex");
+		// OpenAI input_tokens is cache-inclusive; normalized to Anthropic additive
+		// semantics where input excludes cache reads.
+		expect(summary?.promptTokens).toBe(20);
+		expect(summary?.completionTokens).toBe(30);
+		expect(summary?.totalTokens).toBe(158);
+	});
 
 	it("keeps an actively chunking stream beyond two minutes and persists it on end", async () => {
 		const { collector, saveRequestIds, summaries } = harness();

--- a/packages/proxy/src/handlers/__tests__/proxy-operations-529-retry-header-tagging.test.ts
+++ b/packages/proxy/src/handlers/__tests__/proxy-operations-529-retry-header-tagging.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { Account, RequestMeta } from "@better-ccflare/types";
+import { proxyWithAccount } from "../proxy-operations";
+import type { ProxyContext } from "../proxy-types";
+
+/**
+ * The in-place 529 retry re-invokes processResponse with a re-tagged retry
+ * response. Providers (codex) read x-better-ccflare-request-stream and
+ * x-better-ccflare-codex-custom-tools from response headers, with only a
+ * 30s-TTL map as fallback — a long backoff plus a concurrent sweep can evict
+ * that entry, so the retry response must carry the same metadata headers the
+ * first response got, not just the request ID.
+ */
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "acc-1",
+		name: "retry-tagging-test",
+		// Unregistered name: proxyWithAccount resolves getProvider(account.provider)
+		// first and only falls back to ctx.provider when the registry misses, so a
+		// real provider name would shadow the stub below.
+		provider: "stub-retry-tagging",
+		api_key: "test-key",
+		refresh_token: "",
+		access_token: null,
+		expires_at: null,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: Date.now(),
+		rate_limited_until: null,
+		rate_limited_reason: null,
+		rate_limited_at: null,
+		session_start: null,
+		session_request_count: 0,
+		paused: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		priority: 0,
+		auto_fallback_enabled: false,
+		auto_refresh_enabled: false,
+		auto_pause_on_overage_enabled: false,
+		peak_hours_pause_enabled: false,
+		custom_endpoint: "https://upstream.local/v1",
+		model_mappings: null,
+		cross_region_mode: null,
+		model_fallbacks: null,
+		billing_type: null,
+		pause_reason: null,
+		refresh_token_issued_at: null,
+		consecutive_rate_limits: 0,
+		...overrides,
+	};
+}
+
+function makeRequestMeta(overrides: Partial<RequestMeta> = {}): RequestMeta {
+	return {
+		id: "req-1",
+		method: "POST",
+		path: "/v1/messages",
+		timestamp: Date.now(),
+		headers: new Headers(),
+		...overrides,
+	};
+}
+
+function makeRequestBody() {
+	const body = JSON.stringify({
+		model: "gpt-5.1-codex",
+		messages: [{ role: "user", content: "hello" }],
+		max_tokens: 10,
+		stream: true,
+	});
+	return new TextEncoder().encode(body).buffer;
+}
+
+interface SeenHeaders {
+	requestId: string | null;
+	requestStream: string | null;
+	customTools: string | null;
+	status: number;
+}
+
+function makeProxyContext(seen: SeenHeaders[]): ProxyContext {
+	return {
+		strategy: { getNextAccount: () => null } as never,
+		dbOps: {
+			markAccountRateLimited: mock(() =>
+				Promise.resolve({ consecutiveRateLimits: 1, applied: true }),
+			),
+			saveRequest: mock((..._args: unknown[]) => Promise.resolve()),
+			updateAccountUsage: mock(() => Promise.resolve()),
+			getAdapter: mock(() => ({
+				run: mock(() => Promise.resolve()),
+				get: mock(() => Promise.resolve(null)),
+			})),
+		} as never,
+		runtime: { port: 8080, clientId: "test" } as never,
+		provider: {
+			name: "openai-compatible",
+			canHandle: () => true,
+			buildUrl: () => "https://upstream.local/v1/messages",
+			prepareHeaders: () => new Headers(),
+			// Mirror the codex provider: stamp internal metadata headers onto the
+			// transformed request so proxy-operations can tag responses from them.
+			transformRequestBody: async (request: Request) => {
+				const headers = new Headers(request.headers);
+				headers.set("x-better-ccflare-request-stream", "true");
+				headers.set("x-better-ccflare-codex-custom-tools", "true");
+				return new Request(request.url, {
+					method: request.method,
+					headers,
+					body: await request.clone().arrayBuffer(),
+				});
+			},
+			processResponse: async (response: Response) => {
+				seen.push({
+					requestId: response.headers.get("x-better-ccflare-request-id"),
+					requestStream: response.headers.get(
+						"x-better-ccflare-request-stream",
+					),
+					customTools: response.headers.get(
+						"x-better-ccflare-codex-custom-tools",
+					),
+					status: response.status,
+				});
+				return response;
+			},
+			parseRateLimit: (response: Response) => ({
+				isRateLimited: response.status === 529,
+				resetTime: undefined,
+				statusHeader: undefined,
+				remaining: undefined,
+			}),
+			isStreamingResponse: () => false,
+		} as never,
+		refreshInFlight: new Map(),
+		asyncWriter: { enqueue: mock(() => {}) } as never,
+		config: { getStorePayloads: () => true } as never,
+		internalProbeSecret: "test-secret",
+	};
+}
+
+describe("proxyWithAccount — 529 in-place retry response tagging", () => {
+	let originalFetch: typeof globalThis.fetch;
+	const savedEnv: Record<string, string | undefined> = {};
+	const ENV_KEYS = [
+		"CCFLARE_OVERLOAD_RETRY_ENABLED",
+		"CCFLARE_OVERLOAD_RETRY_MAX_ATTEMPTS",
+		"CCFLARE_OVERLOAD_RETRY_BASE_MS",
+		"CCFLARE_OVERLOAD_RETRY_MAX_MS",
+	];
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+		for (const key of ENV_KEYS) savedEnv[key] = process.env[key];
+		process.env.CCFLARE_OVERLOAD_RETRY_ENABLED = "true";
+		process.env.CCFLARE_OVERLOAD_RETRY_MAX_ATTEMPTS = "2";
+		process.env.CCFLARE_OVERLOAD_RETRY_BASE_MS = "0";
+		process.env.CCFLARE_OVERLOAD_RETRY_MAX_MS = "0";
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		for (const key of ENV_KEYS) {
+			if (savedEnv[key] === undefined) delete process.env[key];
+			else process.env[key] = savedEnv[key];
+		}
+	});
+
+	it("re-tags stream and custom-tools metadata headers on the retry response", async () => {
+		let fetchCount = 0;
+		globalThis.fetch = mock(async () => {
+			fetchCount++;
+			if (fetchCount === 1) {
+				return new Response(
+					JSON.stringify({
+						type: "error",
+						error: { type: "overloaded_error", message: "Overloaded" },
+					}),
+					{ status: 529, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			return new Response(
+				JSON.stringify({
+					id: "msg_1",
+					type: "message",
+					role: "assistant",
+					content: [{ type: "text", text: "hi" }],
+					model: "gpt-5.1-codex",
+					stop_reason: "end_turn",
+					usage: { input_tokens: 1, output_tokens: 1 },
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		});
+
+		const seen: SeenHeaders[] = [];
+		const bodyBuffer = makeRequestBody();
+		const req = new Request("https://proxy.local/v1/messages", {
+			method: "POST",
+			body: bodyBuffer,
+			headers: { "Content-Type": "application/json" },
+		});
+
+		// forwardToClient requires UsageCollector wiring absent in unit tests;
+		// the retry and both processResponse calls happen before that point.
+		try {
+			await proxyWithAccount(
+				req,
+				new URL("https://proxy.local/v1/messages"),
+				makeAccount(),
+				makeRequestMeta(),
+				bodyBuffer,
+				() => undefined,
+				0,
+				makeProxyContext(seen),
+			);
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : String(e);
+			if (!msg.includes("UsageCollector not initialized")) throw e;
+		}
+
+		expect(fetchCount).toBe(2);
+		expect(seen).toHaveLength(2);
+
+		expect(seen[0].status).toBe(529);
+		expect(seen[0].requestId).toBe("req-1");
+		expect(seen[0].requestStream).toBe("true");
+		expect(seen[0].customTools).toBe("true");
+
+		expect(seen[1].status).toBe(200);
+		expect(seen[1].requestId).toBe("req-1");
+		expect(seen[1].requestStream).toBe("true");
+		expect(seen[1].customTools).toBe("true");
+	});
+});

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -1348,6 +1348,19 @@ export async function proxyWithAccount(
 				internalRequestStream,
 			);
 		}
+		const internalCustomTools = transformedRequest.headers.get(
+			"x-better-ccflare-codex-custom-tools",
+		);
+		if (internalCustomTools === "true" || internalCustomTools === "false") {
+			responseHeaders.set(
+				"x-better-ccflare-codex-custom-tools",
+				internalCustomTools,
+			);
+		}
+		// Inject the original request path so providers can identify the
+		// response type (e.g. /v1/models vs /v1/messages) in processResponse
+		// without needing the original request object.
+		responseHeaders.set("x-better-ccflare-request-path", requestMeta.path);
 		const taggedRawResponse = new Response(rawResponse.body, {
 			status: rawResponse.status,
 			statusText: rawResponse.statusText,
@@ -1404,10 +1417,39 @@ export async function proxyWithAccount(
 							? materializeSyntheticResponse(transformedRequestForRetry.clone())
 							: await forwardUpstream(transformedRequestForRetry.clone());
 
+						// Mirror the first response's metadata tagging: providers read
+						// stream intent / custom-tool state from these headers, and the
+						// map fallback behind them has a 30s TTL a long backoff can
+						// outlive — the request ID alone is not enough.
 						const retryTaggedHeaders = new Headers(retryRaw.headers);
 						retryTaggedHeaders.set(
 							"x-better-ccflare-request-id",
 							requestMeta.id,
+						);
+						const retryRequestStream = transformedRequestForRetry.headers.get(
+							"x-better-ccflare-request-stream",
+						);
+						if (
+							retryRequestStream === "true" ||
+							retryRequestStream === "false"
+						) {
+							retryTaggedHeaders.set(
+								"x-better-ccflare-request-stream",
+								retryRequestStream,
+							);
+						}
+						const retryCustomTools = transformedRequestForRetry.headers.get(
+							"x-better-ccflare-codex-custom-tools",
+						);
+						if (retryCustomTools === "true" || retryCustomTools === "false") {
+							retryTaggedHeaders.set(
+								"x-better-ccflare-codex-custom-tools",
+								retryCustomTools,
+							);
+						}
+						retryTaggedHeaders.set(
+							"x-better-ccflare-request-path",
+							requestMeta.path,
 						);
 						const retryTaggedRaw = new Response(retryRaw.body, {
 							status: retryRaw.status,

--- a/packages/proxy/src/response-handler.ts
+++ b/packages/proxy/src/response-handler.ts
@@ -159,6 +159,13 @@ export async function forwardToClient(
 
 	// Always strip compression headers *before* we do anything else
 	const response = withSanitizedProxyHeaders(responseRaw);
+	// Not stripping x-better-ccflare-codex-response-format: for /v1/responses
+	// traffic this goes to handler.ts (not the real client), which reads it
+	// and strips it itself.
+	const isCodexResponsesPassthrough = response.headers.has(
+		"x-better-ccflare-codex-response-format",
+	);
+	response.headers.delete("x-better-ccflare-request-path");
 
 	// Prepare objects once for serialisation - sanitize headers before storing
 	const sanitizedReq = sanitizeRequestHeaders(requestHeaders);
@@ -393,6 +400,8 @@ export async function forwardToClient(
 			method === "POST" &&
 			path === "/v1/messages" &&
 			response.ok &&
+			// Skip Anthropic terminal-state tracking for Codex passthrough responses
+			!isCodexResponsesPassthrough &&
 			(response.headers
 				.get("content-type")
 				?.toLowerCase()
@@ -447,14 +456,17 @@ export async function forwardToClient(
 			onError,
 		});
 
+		const headers = withModelRewriteHeader(
+			response.headers,
+			originalModel,
+			appliedModel,
+		);
+		headers.delete("x-better-ccflare-request-path");
+
 		return new Response(passthroughBody, {
 			status: response.status,
 			statusText: response.statusText,
-			headers: withModelRewriteHeader(
-				response.headers,
-				originalModel,
-				appliedModel,
-			),
+			headers,
 		});
 	}
 
@@ -526,13 +538,16 @@ export async function forwardToClient(
 		},
 	});
 
+	const headers = withModelRewriteHeader(
+		response.headers,
+		originalModel,
+		appliedModel,
+	);
+	headers.delete("x-better-ccflare-request-path");
+
 	return new Response(passthroughBody, {
 		status: response.status,
 		statusText: response.statusText,
-		headers: withModelRewriteHeader(
-			response.headers,
-			originalModel,
-			appliedModel,
-		),
+		headers,
 	});
 }

--- a/packages/proxy/src/usage-collector.ts
+++ b/packages/proxy/src/usage-collector.ts
@@ -245,6 +245,49 @@ function extractUsageFromData(
 			// Even if no usage info, we still set the timestamp for duration calculation
 		}
 
+		// Codex Responses-API passthrough streams (declared custom tools bypass
+		// the Anthropic transform) carry usage only on the terminal response.*
+		// event, nested under response.usage with OpenAI's cache-inclusive
+		// input_tokens. Normalize to Anthropic's additive semantics so input
+		// excludes cache reads instead of double-counting them.
+		const isResponsesTerminal =
+			parsed.type === "response.completed" ||
+			parsed.type === "response.incomplete" ||
+			eventType === "response.completed" ||
+			eventType === "response.incomplete";
+		if (isResponsesTerminal && parsed.response) {
+			state.lastTokenTimestamp = Date.now();
+			if (parsed.response.model && !state.usage.model) {
+				state.usage.model = parsed.response.model;
+			}
+			const usage = parsed.response.usage;
+			if (usage) {
+				const cachedTokens =
+					typeof usage.input_tokens_details?.cached_tokens === "number"
+						? usage.input_tokens_details.cached_tokens
+						: 0;
+				if (typeof usage.input_tokens === "number") {
+					state.usage.inputTokens = Math.max(
+						0,
+						usage.input_tokens - cachedTokens,
+					);
+					state.usage.cacheReadInputTokens = cachedTokens;
+				}
+				if (
+					typeof usage.input_tokens_details?.cache_creation_input_tokens ===
+					"number"
+				) {
+					state.usage.cacheCreationInputTokens =
+						usage.input_tokens_details.cache_creation_input_tokens;
+				}
+				if (typeof usage.output_tokens === "number") {
+					state.providerFinalOutputTokens = usage.output_tokens;
+					state.usage.outputTokens = usage.output_tokens;
+				}
+			}
+			return;
+		}
+
 		// Note: tiktoken-based outputTokensComputed was removed (see refactor notes).
 		// The provider's authoritative token counts are used instead.
 


### PR DESCRIPTION
Suggested PR description:

## Description

Fix Codex Responses API compatibility when requests pass through the Anthropic adapter.

The adapter was dropping Codex-specific request fields and Responses Lite tool definitions during translation. Codex-native SSE responses containing custom tool calls were also being incorrectly
routed through the Anthropic stream translator.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Changes Made

- Preserve Codex request fields across the Anthropic adapter:
  - `model`
  - `reasoning`
  - `prompt_cache_key`
  - `tools`
  - `parallel_tool_calls`
  - `store`
- Preserve Responses Lite `additional_tools` input items.
- Transport internal passthrough metadata in the synthetic request body instead of a large HTTP header.
- Remove the internal passthrough field before sending the request upstream.
- Preserve required Codex reasoning context:
  - `context: "all_turns"`
- Preserve explicit `parallel_tool_calls` behavior.
- Pass native Responses API SSE through unchanged when custom tool-call events are present.
- Preserve Codex keepalive events during Anthropic stream translation.
- Add the request path header needed for provider response transformation.
- Update Codex reasoning conversion tests.

## Testing

- [x] I have run `bun run lint` and reviewed all warnings
- [x] I have run `bun run format` to format the code
- [x] I have run `bun run typecheck` and fixed all type errors
- [x] I have updated tests covering the Codex behavior
- [x] New and existing unit tests pass locally with my changes

Testing summary:

- bun typecheck: passed
- bun run lint: completed; no warnings in changed files
- Formatter: passed
- Codex fidelity tests: 21 pass, 0 fail
- Full suite: 3509 pass, 55 skip, 12 baseline failures

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Related Issues

Not applicable.