### PR TITLE
fix: eliminate unread clone branches retaining native body buffers (#382)

### DIFF
--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -15,7 +15,7 @@ import type { Account } from "@better-ccflare/types";
 import { BaseProvider } from "../../base";
 import { resolveProviderModelDefault } from "../../provider-model-defaults";
 import type { RateLimitInfo, TokenRefreshResult } from "../../types";
-import { drainReaderWithDeadline } from "../../utils/stream-drain";
+import { drainReader, drainReaderWithDeadline } from "../../utils/stream-drain";
 import {
 	CodexStreamLiveness,
 	type CodexStreamLivenessOptions,
@@ -1496,6 +1496,12 @@ export class CodexProvider extends BaseProvider {
 					}
 				}
 				if (pending) processLine(pending);
+			} catch (readError) {
+				// releaseLock() alone doesn't free the native buffer backing the
+				// stream on Bun (#382) — drain to `done` first, which also
+				// releases the lock.
+				await drainReader(reader);
+				throw readError;
 			} finally {
 				reader.releaseLock();
 			}

--- a/packages/providers/src/providers/openai/provider.ts
+++ b/packages/providers/src/providers/openai/provider.ts
@@ -250,17 +250,19 @@ export class OpenAICompatibleProvider extends BaseProvider {
 		outputTokens?: number;
 	} | null> {
 		try {
-			const clone = response.clone();
 			const contentType = response.headers.get("content-type");
 
 			// Handle streaming responses (SSE)
 			if (contentType?.includes("text/event-stream")) {
-				// For streaming, we can only extract usage from the final chunk
-				// This is complex to implement properly, so we'll return null for now
-				// In a full implementation, we'd need to buffer the entire stream
+				// For streaming, we can only extract usage from the final chunk.
+				// This is complex to implement properly, so we return null for
+				// now — deliberately not cloning the body here: an unread clone
+				// leaves its tee branch open, retaining the native buffer for a
+				// body nobody will ever consume (#382).
 				return null;
 			} else {
 				// Handle non-streaming JSON responses
+				const clone = response.clone();
 				const json = (await clone.json()) as {
 					model?: string;
 					usage?: {

--- a/packages/providers/src/providers/vertex-ai/provider.ts
+++ b/packages/providers/src/providers/vertex-ai/provider.ts
@@ -284,8 +284,6 @@ export class VertexAIProvider extends BaseAnthropicCompatibleProvider {
 		}
 
 		try {
-			// Clone response to read body
-			const clonedResponse = response.clone();
 			const contentType = response.headers.get("content-type") || "";
 
 			console.log(`[Vertex AI] Response content-type: ${contentType}`);
@@ -297,6 +295,11 @@ export class VertexAIProvider extends BaseAnthropicCompatibleProvider {
 				);
 				return super.processResponse(response, account);
 			}
+
+			// Clone only on the JSON path — cloning before the gate leaves the
+			// clone's tee branch unread on every SSE response, retaining its
+			// native buffer (#382).
+			const clonedResponse = response.clone();
 
 			const text = await clonedResponse.text();
 			const data = JSON.parse(text);

--- a/packages/providers/src/providers/zai/provider.ts
+++ b/packages/providers/src/providers/zai/provider.ts
@@ -27,6 +27,12 @@ export class ZaiProvider extends BaseAnthropicCompatibleProvider {
 		response: Response,
 	): Promise<number | undefined> {
 		try {
+			// Only JSON bodies carry the Zai rate-limit payload; cloning an SSE
+			// body here leaves the clone's tee branch unread (#382).
+			const contentType = response.headers.get("content-type") || "";
+			if (!contentType.includes("application/json")) {
+				return undefined;
+			}
 			const clone = response.clone();
 			const body = await clone.json();
 

--- a/packages/providers/src/utils/stream-drain.ts
+++ b/packages/providers/src/utils/stream-drain.ts
@@ -4,8 +4,8 @@
  * native buffer; draining actually releases it. Errors are swallowed since
  * this is best-effort cleanup, not part of the caller's control flow (#382).
  */
-export async function drainReader(
-	reader: ReadableStreamDefaultReader<Uint8Array>,
+export async function drainReader<T>(
+	reader: ReadableStreamDefaultReader<T>,
 ): Promise<void> {
 	try {
 		while (true) {

--- a/packages/proxy/src/__tests__/stream-reader-lock-release-382.test.ts
+++ b/packages/proxy/src/__tests__/stream-reader-lock-release-382.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Regression test for issue #382 — the teeStream and
+ * createAnthropicTerminalRecoveryStream done/error paths must release the
+ * upstream reader's lock once the wrapper stream completes normally. A reader
+ * left locked keeps the source stream pinned (no other consumer can
+ * getReader() it) and, in production, retains the fetch body's native
+ * off-heap buffer.
+ *
+ * Runtime check: consume the readable side to `done` (no cancel), then
+ * assert source.getReader() succeeds — it throws TypeError if the stream is
+ * still locked to the wrapper's reader.
+ *
+ * Run: bun test packages/proxy/src/__tests__/stream-reader-lock-release-382.test.ts
+ */
+import { describe, expect, it } from "bun:test";
+import { createAnthropicTerminalRecoveryStream } from "../anthropic-terminal-recovery";
+import { teeStream } from "../stream-tee";
+
+const encoder = new TextEncoder();
+
+function immediateStream(
+	chunks: readonly Uint8Array[],
+): ReadableStream<Uint8Array> {
+	return new ReadableStream<Uint8Array>({
+		start(controller) {
+			for (const chunk of chunks) controller.enqueue(chunk);
+			controller.close();
+		},
+	});
+}
+
+async function drainToDone(stream: ReadableStream<Uint8Array>): Promise<void> {
+	const reader = stream.getReader();
+	while (true) {
+		const { done } = await reader.read();
+		if (done) return;
+	}
+}
+
+describe("issue #382 — reader lock release on normal completion", () => {
+	it("teeStream releases the upstream reader lock after done", async () => {
+		const source = immediateStream([
+			encoder.encode("hello "),
+			encoder.encode("world"),
+		]);
+		const teed = teeStream(source);
+		await drainToDone(teed);
+		expect(() => source.getReader()).not.toThrow();
+	});
+
+	it("terminal-recovery stream releases the upstream reader lock after done", async () => {
+		const source = immediateStream([
+			encoder.encode(
+				'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":42}}\n\n',
+			),
+			encoder.encode('event: message_stop\ndata: {"type":"message_stop"}\n\n'),
+		]);
+		const wrapped = createAnthropicTerminalRecoveryStream(source);
+		await drainToDone(wrapped);
+		expect(() => source.getReader()).not.toThrow();
+	});
+});

--- a/packages/proxy/src/anthropic-terminal-recovery.ts
+++ b/packages/proxy/src/anthropic-terminal-recovery.ts
@@ -614,6 +614,7 @@ export function createAnthropicTerminalRecoveryStream(
 					}
 					fireTerminalState();
 					controller.close();
+					reader.releaseLock();
 					return;
 				}
 
@@ -635,6 +636,7 @@ export function createAnthropicTerminalRecoveryStream(
 				markTerminalFailure();
 				fireTerminalState();
 				controller.error(error);
+				reader.releaseLock();
 			}
 		},
 

--- a/packages/proxy/src/handlers/__tests__/proxy-operations-529-retry-clone-regression.test.ts
+++ b/packages/proxy/src/handlers/__tests__/proxy-operations-529-retry-clone-regression.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Regression test for issue #382 — the in-place 529 retry previously sent a
+ * pre-cloned `transformedRequestForRetry` Request whose tee branch was never
+ * read, retaining its native off-heap buffer. The retry must instead rebuild
+ * its Request from the buffered `retryBodyText`.
+ *
+ * Static/structural check, same convention as the issue #354 test
+ * (proxy-operations-529-parselimit-clones.test.ts) — proxy-operations.ts is
+ * not imported directly because its transitive dependency chain loads
+ * @better-ccflare/database, which can fail to initialise in worktrees where
+ * `bun install` has not run.
+ *
+ * Run: bun test packages/proxy/src/handlers/__tests__/proxy-operations-529-retry-clone-regression.test.ts
+ */
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const SOURCE_PATH = "packages/proxy/src/handlers/proxy-operations.ts";
+
+function readSource(): string {
+	return readFileSync(SOURCE_PATH, "utf-8");
+}
+
+describe("issue #382 — 529 in-place retry Request clone", () => {
+	it("no longer contains the unread transformedRequestForRetry clone", () => {
+		const source = readSource();
+		expect(source).not.toMatch(/transformedRequestForRetry/);
+	});
+
+	it("rebuilds the retry Request from retryBodyText instead of a clone", () => {
+		const source = readSource();
+		expect(source).toMatch(
+			/const retryRequest = new Request\(transformedRequest\.url, \{[\s\S]*?body: retryBodyText \|\| undefined,/,
+		);
+	});
+});

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -745,8 +745,13 @@ export async function proxyWithAccount(
 			? await provider.transformRequestBody(providerRequest, account)
 			: providerRequest;
 
-		// Pre-strip cache_control for (account, model) pairs known to reject it
+		// Pre-strip cache_control for (account, model) pairs known to reject it.
+		// Also doubles as the buffered body for in-place 529 retries below —
+		// cloning the Request for retries tees the body into a branch nothing
+		// reads on the no-retry path, retaining its native buffer per request
+		// (#382).
 		const transformedBodyText = await transformedRequest.clone().text();
+		let retryBodyText = transformedBodyText;
 		let transformedBodyJson: Record<string, unknown> | null = null;
 		try {
 			transformedBodyJson = JSON.parse(transformedBodyText);
@@ -774,13 +779,11 @@ export async function proxyWithAccount(
 				// A URL-based rebuild drops the signal — carry it over.
 				signal: req.signal,
 			});
+			retryBodyText = JSON.stringify(transformedBodyJson);
 			log.debug(
 				`Pre-stripped cache_control for known rejector: account=${account.name} model=${transformedModel}`,
 			);
 		}
-
-		// Capture a clone for in-place 529 retries before the body is consumed.
-		const transformedRequestForRetry = transformedRequest.clone();
 
 		// Make the request (or unwrap a synthetic provider response)
 		let rawResponse = isSyntheticProviderResponse(transformedRequest)
@@ -1398,11 +1401,18 @@ export async function proxyWithAccount(
 							`Account ${account.name}: in-place retry ${attempt}/${retryCfg.maxAttempts - 1} after ${Math.round(delayMs)}ms for 529 overloaded_error`,
 						);
 
-						const retryRaw = isSyntheticProviderResponse(
-							transformedRequestForRetry,
-						)
-							? materializeSyntheticResponse(transformedRequestForRetry.clone())
-							: await forwardUpstream(transformedRequestForRetry.clone());
+						// Rebuild from the buffered body text instead of a
+						// pre-cloned Request — an unread clone branch retains
+						// its native buffer (#382).
+						const retryRequest = new Request(transformedRequest.url, {
+							method: transformedRequest.method,
+							headers: transformedRequest.headers,
+							body: retryBodyText || undefined,
+							signal: req.signal,
+						});
+						const retryRaw = isSyntheticProviderResponse(retryRequest)
+							? materializeSyntheticResponse(retryRequest)
+							: await forwardUpstream(retryRequest);
 
 						const retryTaggedHeaders = new Headers(retryRaw.headers);
 						retryTaggedHeaders.set(

--- a/packages/proxy/src/stream-tee.ts
+++ b/packages/proxy/src/stream-tee.ts
@@ -32,6 +32,7 @@ export function teeStream(
 				if (done) {
 					onClose?.(buffered);
 					controller.close();
+					reader.releaseLock();
 					return;
 				}
 
@@ -57,6 +58,7 @@ export function teeStream(
 			} catch (error) {
 				onError?.(error as Error);
 				controller.error(error);
+				reader.releaseLock();
 			}
 		},
 


### PR DESCRIPTION
## Summary
- Removes the per-request `transformedRequestForRetry` clone in the 529 in-place retry path (`proxy-operations.ts`) — the clone's tee branch was never read on the ~100% no-retry path, retaining its native buffer for every proxied request regardless of provider. Retries now rebuild the `Request` from the body text already buffered for cache_control pre-stripping.
- Moves the `response.clone()` in vertex-ai `processResponse` after the `application/json` gate, so SSE responses no longer leave an unread clone branch (same pattern as the openai `extractUsage` fix already on this branch).
- Adds a JSON content-type gate in zai `parseRateLimitFromBody` before cloning.
- Drains (via `drainReader`) instead of bare `releaseLock()` when codex `transformSseResponseToJson`'s read loop throws — releaseLock alone doesn't free the native buffer on Bun.
- Loosens `drainReader` to a generic reader type to accept decoder-stream readers.
- Retains the earlier fixes on this branch: openai `extractUsage` clone gate, `releaseLock()` on normal completion in `stream-tee.ts` / `anthropic-terminal-recovery.ts`.

## Context
Issue #382: RSS grows unbounded while JS heap stays flat — native, off-heap, request-driven retention. The `.cancel()`-on-discard sites and the Bun 1.4.0 runtime fix were both falsified as explanations. The unread-clone class (tee branch never consumed → native buffer retained) matches the evidence: it leaks on the normal completion path, invisibly to JSC heap stats.

## Test plan
- [x] `bun run lint && bun run typecheck && bun run format`
- [x] codex provider + stream-drain test suites (154 pass)
- [x] proxy handler test suite (508 pass)
- [ ] Reporter verification on a real deployment: RSS should stop climbing per-request on v3.5.6x

Closes nothing yet — awaiting reporter confirmation per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)