### PR TITLE
fix(auth): close OAuth token-mutation and arbitrary-path proxy bypasses

### DIFF
--- a/__tests__/api-auth.test.ts
+++ b/__tests__/api-auth.test.ts
@@ -182,11 +182,100 @@ describe("API Authentication", () => {
 			expect(extractedKey).toBe("btr-bearer-key-456");
 		});
 
-		test("should exempt dashboard paths from authentication", async () => {
-			expect(await authService.isPathExempt("/", "GET")).toBe(true);
-			expect(await authService.isPathExempt("/dashboard", "GET")).toBe(true);
+		test("should not exempt dashboard/SPA paths at the auth-service layer", async () => {
+			// The dashboard SPA + static assets are served directly by the
+			// server (apps/server/src/server.ts) BEFORE authentication is
+			// consulted, so they never reach AuthService#isPathExempt. Any
+			// request that does reach this layer is an API or proxy request,
+			// so "/" and "/dashboard" must NOT be exempt here — exempting them
+			// in this SHARED path (also used by the proxy fallback) would
+			// let arbitrary unauthenticated paths reach the proxy whenever the
+			// dashboard is disabled or its assets are unavailable.
+			expect(await authService.isPathExempt("/", "GET")).toBe(false);
+			expect(await authService.isPathExempt("/dashboard", "GET")).toBe(false);
 			expect(await authService.isPathExempt("/health", "GET")).toBe(true);
-			expect(await authService.isPathExempt("/api/oauth/init", "POST")).toBe(true);
+		});
+
+		test("should NOT exempt token-mutating OAuth endpoints from authentication", async () => {
+			// isStaticPathExempt() used to blanket-exempt every /api/oauth*
+			// path, which let an unauthenticated caller overwrite stored
+			// account OAuth tokens whenever dashboard auth was enabled. Only
+			// read-only status polling stays exempt; init/reauth/callback now
+			// require an API key like any other /api/* route once auth is on.
+			await generateApiKey(dbOps, "oauth-guard-test", "admin");
+			expect(await authService.isAuthenticationEnabled()).toBe(true);
+
+			expect(await authService.isPathExempt("/api/oauth/init", "POST")).toBe(false);
+			expect(await authService.isPathExempt("/api/oauth/callback", "POST")).toBe(false);
+			expect(await authService.isPathExempt("/api/oauth/qwen/reauth", "POST")).toBe(false);
+			expect(await authService.isPathExempt("/api/oauth/codex/reauth", "POST")).toBe(false);
+			expect(
+				await authService.isPathExempt(
+					"/api/oauth/anthropic/reauth/callback",
+					"POST",
+				),
+			).toBe(false);
+
+			// Read-only status polling remains exempt.
+			expect(
+				await authService.isPathExempt("/api/oauth/qwen/status/acct-1", "GET"),
+			).toBe(true);
+			expect(
+				await authService.isPathExempt("/api/oauth/codex/status/acct-1", "GET"),
+			).toBe(true);
+		});
+
+		test("should still allow OAuth init/reauth for initial account setup (no keys configured)", async () => {
+			// When no API keys exist yet, authenticateRequest() allows any
+			// request through its isAuthenticationEnabled() fallback — so
+			// OAuth setup during initial install is unaffected by removing
+			// the blanket static exemption.
+			expect(await authService.isAuthenticationEnabled()).toBe(false);
+
+			const request = new Request("http://localhost:8080/api/oauth/init", {
+				method: "POST",
+			});
+			const result = await authService.authenticateRequest(
+				request,
+				"/api/oauth/init",
+				"POST",
+			);
+			expect(result.isAuthenticated).toBe(true);
+		});
+
+		test("should reject unauthenticated OAuth token mutation once auth is enabled", async () => {
+			await generateApiKey(dbOps, "oauth-enabled-test", "admin");
+			expect(await authService.isAuthenticationEnabled()).toBe(true);
+
+			const request = new Request("http://localhost:8080/api/oauth/callback", {
+				method: "POST",
+			});
+			const result = await authService.authenticateRequest(
+				request,
+				"/api/oauth/callback",
+				"POST",
+			);
+			expect(result.isAuthenticated).toBe(false);
+		});
+
+		test("should reject an arbitrary non-API proxy-fallback path once auth is enabled", async () => {
+			// isStaticPathExempt() used to treat any path not starting with
+			// /api, /v1, or /messages as exempt — intended to let the
+			// dashboard serve its SPA/static assets. But this shared path is
+			// also consulted by the proxy fallback in apps/server/src/server.ts
+			// when the dashboard is disabled/unavailable, so the broad rule
+			// let arbitrary paths (e.g. POST /foo) reach the proxy without an
+			// API key. The dashboard is now served before auth is consulted
+			// (server.ts), so nothing legitimate should reach this layer for
+			// a non-API path.
+			await generateApiKey(dbOps, "arbitrary-path-test", "admin");
+			expect(await authService.isAuthenticationEnabled()).toBe(true);
+
+			const request = new Request("http://localhost:8080/foo", {
+				method: "POST",
+			});
+			const result = await authService.authenticateRequest(request, "/foo", "POST");
+			expect(result.isAuthenticated).toBe(false);
 		});
 
 		test("should exempt /api/version/check from authentication", async () => {
@@ -215,13 +304,19 @@ describe("API Authentication", () => {
 			expect(result.error).toBeUndefined();
 		});
 
-		test("should exempt static assets from authentication", async () => {
-			expect(await authService.isPathExempt("/chunk-abc123.js", "GET")).toBe(true);
-			expect(await authService.isPathExempt("/chunk-abc123.css", "GET")).toBe(true);
-			expect(await authService.isPathExempt("/favicon-abc123.svg", "GET")).toBe(true);
-			expect(await authService.isPathExempt("/chunk-abc123.js.map", "GET")).toBe(true);
-			expect(await authService.isPathExempt("/static/logo.png", "GET")).toBe(true);
-			expect(await authService.isPathExempt("/assets/font.woff2", "GET")).toBe(true);
+		test("should not exempt static-asset-looking paths at the auth-service layer", async () => {
+			// Static assets are served directly by the server from the
+			// dashboard manifest before authentication is consulted (see
+			// apps/server/src/server.ts), so they never reach this layer.
+			// A path that merely *looks* like a static asset must still be
+			// treated as an authenticated proxy request here — this is what
+			// closes the arbitrary-path proxy bypass.
+			expect(await authService.isPathExempt("/chunk-abc123.js", "GET")).toBe(false);
+			expect(await authService.isPathExempt("/chunk-abc123.css", "GET")).toBe(false);
+			expect(await authService.isPathExempt("/favicon-abc123.svg", "GET")).toBe(false);
+			expect(await authService.isPathExempt("/chunk-abc123.js.map", "GET")).toBe(false);
+			expect(await authService.isPathExempt("/static/logo.png", "GET")).toBe(false);
+			expect(await authService.isPathExempt("/assets/font.woff2", "GET")).toBe(false);
 		});
 
 		test("should require authentication for API paths", async () => {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1424,15 +1424,21 @@ export default async function startServer(options?: {
 			async fetch(req: Request) {
 				const url = new URL(req.url);
 
-				// Try API routes first
-				const apiResponse = await apiRouter.handleRequest(url, req);
-				if (apiResponse) {
-					return apiResponse;
-				}
-
-				// Dashboard routes (only if enabled and assets are available)
+				// Serve the dashboard SPA + static assets BEFORE the
+				// authentication-gated API router. The dashboard shell is public
+				// content and the initial browser navigation cannot carry an API
+				// key, so it must be reachable without auth. Auth-exempting these
+				// paths inside the SHARED authenticateRequest() (used by both the
+				// router and the proxy fallback below) instead reopened an
+				// unauthenticated proxy-access bypass whenever the dashboard was
+				// disabled or its assets were unavailable, since GET /foo would
+				// fall through to the proxy and upstream providers accept
+				// arbitrary paths. Serving here — gated on the dashboard actually
+				// being available — means only genuine dashboard content skips
+				// auth; every other path (API and proxy) is still authenticated
+				// below.
 				if (withDashboard && dashboardManifest) {
-					// Serve dashboard static assets
+					// Serve dashboard static assets (hashed bundles, fonts, …)
 					if (dashboardManifest[url.pathname]) {
 						return serveDashboardFile(
 							url.pathname,
@@ -1441,14 +1447,28 @@ export default async function startServer(options?: {
 						);
 					}
 
-					// For all non-API routes, serve the dashboard index.html (client-side routing)
-					// This allows React Router to handle all dashboard routes without maintaining a list
+					// Client-side routing: serve index.html for SPA navigations.
+					// Limited to GET/HEAD and to non-API, non-proxy, non-/health
+					// paths so it never shadows an API route, the health endpoint,
+					// or a proxy request (which must stay authenticated).
+					const isApiOrProxyPath =
+						url.pathname.startsWith("/api/") ||
+						url.pathname === "/api" ||
+						url.pathname.startsWith("/v1/") ||
+						url.pathname.startsWith("/messages") ||
+						url.pathname === "/health";
 					if (
-						!url.pathname.startsWith("/api/") &&
-						!url.pathname.startsWith("/v1/")
+						(req.method === "GET" || req.method === "HEAD") &&
+						!isApiOrProxyPath
 					) {
 						return serveDashboardFile("/index.html", "text/html");
 					}
+				}
+
+				// API routes (authenticated inside the router)
+				const apiResponse = await apiRouter.handleRequest(url, req);
+				if (apiResponse) {
+					return apiResponse;
 				}
 
 				// All other paths go to proxy

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1450,11 +1450,14 @@ export default async function startServer(options?: {
 					// Client-side routing: serve index.html for SPA navigations.
 					// Limited to GET/HEAD and to non-API, non-proxy, non-/health
 					// paths so it never shadows an API route, the health endpoint,
-					// or a proxy request (which must stay authenticated).
+					// or a proxy request (which must stay authenticated). Prefixes
+					// mirror AuthService's own /v1, /messages classification
+					// (auth-service.ts) exactly — no trailing slash required on
+					// either — so this SPA-serving check and the auth-layer
+					// classification never drift apart.
 					const isApiOrProxyPath =
-						url.pathname.startsWith("/api/") ||
-						url.pathname === "/api" ||
-						url.pathname.startsWith("/v1/") ||
+						url.pathname.startsWith("/api") ||
+						url.pathname.startsWith("/v1") ||
 						url.pathname.startsWith("/messages") ||
 						url.pathname === "/health";
 					if (

--- a/packages/http-api/src/services/__tests__/auth-service-static-exemption-bypass.test.ts
+++ b/packages/http-api/src/services/__tests__/auth-service-static-exemption-bypass.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Regression coverage for two auth bypasses previously present in
+ * isStaticPathExempt():
+ *
+ * 1. OAuth token-mutation bypass — every /api/oauth* path was blanket-exempt,
+ *    so an unauthenticated caller could POST to init/reauth/callback and
+ *    overwrite stored account OAuth tokens even with dashboard auth enabled.
+ *
+ * 2. Arbitrary-path proxy bypass — any path not starting with /api, /v1, or
+ *    /messages was exempt (intended to let the dashboard serve its SPA/static
+ *    assets). But this exemption lives in the SAME isPathExempt() consulted
+ *    by the proxy fallback in apps/server/src/server.ts, so when the
+ *    dashboard was disabled or its assets were unavailable, an arbitrary
+ *    request (e.g. POST /foo) reached the upstream proxy handler
+ *    unauthenticated.
+ *
+ * The fix removes both blanket exemptions. OAuth read-only status polling
+ * (GET /api/oauth/{qwen,codex}/status/*) remains exempt. The dashboard SPA
+ * and static assets are now served by the server BEFORE authentication is
+ * consulted at all (server.ts), so nothing legitimate needs an exemption at
+ * this layer for non-API paths.
+ */
+import { describe, expect, it } from "bun:test";
+import type { DatabaseOperations } from "@better-ccflare/database";
+import { AuthService } from "../auth-service";
+
+function makeDbOpsNoKeys(): DatabaseOperations {
+	return {
+		countActiveApiKeys: async () => 0,
+		getActiveApiKeys: async () => [],
+	} as unknown as DatabaseOperations;
+}
+
+function makeDbOpsWithApiKeys(): DatabaseOperations {
+	return {
+		countActiveApiKeys: async () => 1,
+		getActiveApiKeys: async () => [],
+	} as unknown as DatabaseOperations;
+}
+
+describe("AuthService — static exemption bypass regression", () => {
+	describe("OAuth endpoints", () => {
+		it("isStaticPathExempt no longer blanket-exempts /api/oauth*", () => {
+			const auth = new AuthService(makeDbOpsWithApiKeys());
+			expect(auth.isStaticPathExempt("/api/oauth/init")).toBe(false);
+			expect(auth.isStaticPathExempt("/api/oauth/callback")).toBe(false);
+			expect(auth.isStaticPathExempt("/api/oauth/qwen/reauth")).toBe(false);
+		});
+
+		it("isPathExempt rejects token-mutating OAuth paths when auth is enabled", async () => {
+			const auth = new AuthService(makeDbOpsWithApiKeys());
+			expect(await auth.isPathExempt("/api/oauth/init", "POST")).toBe(false);
+			expect(await auth.isPathExempt("/api/oauth/callback", "POST")).toBe(
+				false,
+			);
+			expect(await auth.isPathExempt("/api/oauth/qwen/reauth", "POST")).toBe(
+				false,
+			);
+			expect(await auth.isPathExempt("/api/oauth/codex/reauth", "POST")).toBe(
+				false,
+			);
+			expect(
+				await auth.isPathExempt("/api/oauth/anthropic/reauth/callback", "POST"),
+			).toBe(false);
+		});
+
+		it("isPathExempt still allows read-only OAuth status polling", async () => {
+			const auth = new AuthService(makeDbOpsWithApiKeys());
+			expect(
+				await auth.isPathExempt("/api/oauth/qwen/status/acct-1", "GET"),
+			).toBe(true);
+			expect(
+				await auth.isPathExempt("/api/oauth/codex/status/acct-1", "GET"),
+			).toBe(true);
+		});
+
+		it("does not exempt a POST to the status-polling path", async () => {
+			const auth = new AuthService(makeDbOpsWithApiKeys());
+			expect(
+				await auth.isPathExempt("/api/oauth/qwen/status/acct-1", "POST"),
+			).toBe(false);
+		});
+
+		it("authenticateRequest rejects unauthenticated OAuth mutation once keys exist", async () => {
+			const auth = new AuthService(makeDbOpsWithApiKeys());
+			const req = new Request("http://localhost/api/oauth/callback", {
+				method: "POST",
+			});
+			const result = await auth.authenticateRequest(
+				req,
+				"/api/oauth/callback",
+				"POST",
+			);
+			expect(result.isAuthenticated).toBe(false);
+		});
+
+		it("authenticateRequest still allows OAuth init during initial setup (no keys yet)", async () => {
+			const auth = new AuthService(makeDbOpsNoKeys());
+			const req = new Request("http://localhost/api/oauth/init", {
+				method: "POST",
+			});
+			const result = await auth.authenticateRequest(
+				req,
+				"/api/oauth/init",
+				"POST",
+			);
+			expect(result.isAuthenticated).toBe(true);
+		});
+	});
+
+	describe("Arbitrary non-API paths", () => {
+		it("isStaticPathExempt no longer exempts an arbitrary non-API path", () => {
+			const auth = new AuthService(makeDbOpsWithApiKeys());
+			expect(auth.isStaticPathExempt("/foo")).toBe(false);
+			expect(auth.isStaticPathExempt("/dashboard")).toBe(false);
+			expect(auth.isStaticPathExempt("/")).toBe(false);
+			expect(auth.isStaticPathExempt("/static/logo.png")).toBe(false);
+		});
+
+		it("isPathExempt rejects an arbitrary non-API path when auth is enabled", async () => {
+			const auth = new AuthService(makeDbOpsWithApiKeys());
+			expect(await auth.isPathExempt("/foo", "POST")).toBe(false);
+			expect(await auth.isPathExempt("/anything/else", "GET")).toBe(false);
+		});
+
+		it("authenticateRequest rejects an unauthenticated proxy-fallback path once keys exist", async () => {
+			const auth = new AuthService(makeDbOpsWithApiKeys());
+			const req = new Request("http://localhost/foo", { method: "POST" });
+			const result = await auth.authenticateRequest(req, "/foo", "POST");
+			expect(result.isAuthenticated).toBe(false);
+		});
+
+		it("/health remains statically exempt", () => {
+			const auth = new AuthService(makeDbOpsWithApiKeys());
+			expect(auth.isStaticPathExempt("/health")).toBe(true);
+		});
+	});
+});

--- a/packages/http-api/src/services/auth-service.ts
+++ b/packages/http-api/src/services/auth-service.ts
@@ -333,10 +333,12 @@ export class AuthService {
 			return true;
 		}
 
-		// OAuth endpoints are exempt (needed for account setup)
-		if (path.startsWith("/api/oauth")) {
-			return true;
-		}
+		// NOTE: OAuth endpoints are intentionally NOT blanket-exempt here.
+		// Token-mutating endpoints (/api/oauth/**/init|reauth|callback) must
+		// require an admin API key once authentication is enabled — see the
+		// method-aware gating in isPathExempt(). A blanket static exemption
+		// allowed any unauthenticated caller to overwrite stored account
+		// OAuth tokens whenever dashboard auth was configured.
 
 		// Version check returns only the latest npm-published version. The
 		// dashboard's sidebar tile fires this on load with no API key in
@@ -353,17 +355,15 @@ export class AuthService {
 			return true;
 		}
 
-		// All other paths are dashboard routes (client-side routing) or static assets
-		// These should be exempt to allow serving the dashboard HTML and assets
-		// This matches the server logic that serves index.html for non-API routes
-		if (
-			!path.startsWith("/api") &&
-			!path.startsWith("/v1") &&
-			!path.startsWith("/messages")
-		) {
-			return true;
-		}
-
+		// IMPORTANT: do NOT blanket-exempt "any non-/api, non-/v1, non-/messages
+		// path". The dashboard SPA and its static assets are served directly by
+		// the server (apps/server/src/server.ts) *before* authentication is
+		// consulted, so they never reach this code path. Every request that
+		// actually reaches authenticateRequest() is an API or proxy request. A
+		// broad "not an API path => exempt" rule here let arbitrary proxy paths
+		// (e.g. POST /foo) through without an API key whenever the dashboard was
+		// disabled or its assets were unavailable, since upstream providers
+		// accept arbitrary paths.
 		return false;
 	}
 
@@ -388,6 +388,25 @@ export class AuthService {
 		// Static exemptions first (no DB hit)
 		if (this.isStaticPathExempt(path, method)) {
 			return true;
+		}
+
+		// OAuth endpoints.
+		// Read-only status polling (GET /api/oauth/{qwen,codex}/status/*) stays
+		// exempt — it returns transient setup progress only, no secrets or
+		// mutation, and the setup UI polls it before an API key may exist.
+		// Token-mutating endpoints (init / reauth / callback) are NOT exempt:
+		// when no API keys exist authenticateRequest() still allows them
+		// (initial account setup, via the isAuthenticationEnabled() check
+		// below); once authentication is enabled they fall through to
+		// API-key validation and authorizeEndpoint(), which only grants admin
+		// keys access to non-proxy paths. This closes the unauthenticated
+		// token-overwrite vector.
+		if (path.startsWith("/api/oauth")) {
+			const isReadOnlyStatus =
+				method === "GET" &&
+				(path.startsWith("/api/oauth/qwen/status/") ||
+					path.startsWith("/api/oauth/codex/status/"));
+			return isReadOnlyStatus;
 		}
 
 		// API key management: Only allow initial key creation without auth if no keys exist


### PR DESCRIPTION
## Summary
- `isStaticPathExempt()` blanket-exempted every `/api/oauth*` path from authentication, letting an unauthenticated caller `POST` to `init`/`reauth`/`callback` and overwrite stored account OAuth tokens even with dashboard auth enabled.
- The same function also exempted any path not starting with `/api`, `/v1`, or `/messages` — intended to let the dashboard serve its SPA/static assets, but this exemption is consulted by the shared `authenticateRequest()` also used by the proxy fallback in `server.ts`, so an arbitrary path (e.g. `POST /foo`) reached the upstream proxy handler **unauthenticated** whenever the dashboard was disabled or its assets were unavailable.
- Fix removes both blanket exemptions. OAuth read-only status polling (`GET /api/oauth/{qwen,codex}/status/*`) stays exempt; init/reauth/callback now require an API key once auth is enabled (still allowed during initial setup via the existing no-keys-configured fallback). The dashboard SPA and static assets are now served directly by the server **before** authentication is consulted at all, so no auth-layer exemption is needed for legitimate dashboard traffic.

## Test plan
- [x] New regression suite: `packages/http-api/src/services/__tests__/auth-service-static-exemption-bypass.test.ts` — covers both bypasses closed, OAuth status polling still exempt, initial setup (no keys) still works.
- [x] Updated `__tests__/api-auth.test.ts` assertions to the secure contract (dashboard/static paths no longer exempt at the `AuthService` layer; OAuth mutation paths require auth once keys exist).
- [x] `bun run lint && bun run typecheck && bun run format` all clean.
- [x] `bun test packages/http-api __tests__/api-auth.test.ts` — 619 pass / 0 fail (one pre-existing, unrelated flaky "Unhandled error" in `oauth.test.ts` confirmed present on `main` too).
- [x] GitNexus `detect_changes()` confirms blast radius is scoped to request-routing/auth/server-startup flows only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)