### PR TITLE
fix(proxy): clear stale rate_limit_reset on out-of-band weekly reset

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -576,19 +576,25 @@ function startUsagePollingWithRefresh(
 					// an earlier 429 — this blocks AutoRefreshScheduler's probe gate and
 					// pins the account last in strict drain-soonest ranking forever (#443).
 					// Clear it so the account gets probed on the next scheduler tick.
+					//
+					// clearStaleRateLimitReset is a compare-and-swap: it only clears the
+					// field if it still matches the value we just read, so a genuinely
+					// newer rate_limit_reset recorded by a concurrent proxy response
+					// (e.g. a fresh 429) between the read and write below is preserved
+					// instead of being clobbered.
 					proxyContext.dbOps
 						.getAccount(accountId)
 						.then((acc) => {
-							if (
-								acc?.rate_limit_reset &&
-								Number(acc.rate_limit_reset) > Date.now()
-							) {
+							const staleReset = Number(acc?.rate_limit_reset);
+							if (acc?.rate_limit_reset && staleReset > Date.now()) {
 								return proxyContext.dbOps
-									.updateAccountRateLimitMeta(accountId, "allowed", null)
-									.then(() => {
-										logger.info(
-											`Cleared stale rate_limit_reset for account ${acc.name} (${accountId}): usage polling shows fresh weekly window (out-of-band reset)`,
-										);
+									.clearStaleRateLimitReset(accountId, staleReset)
+									.then((cleared) => {
+										if (cleared) {
+											logger.info(
+												`Cleared stale rate_limit_reset for account ${acc.name} (${accountId}): usage polling shows fresh weekly window (out-of-band reset)`,
+											);
+										}
 									});
 							}
 						})

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -570,25 +570,33 @@ function startUsagePollingWithRefresh(
 							),
 						);
 				},
-				(accountId) => {
+				(accountId, observedAt) => {
 					// Usage API shows a fresh weekly window (0% utilization, resets_at
 					// unknown) but rate_limit_reset is still a stale future timestamp from
 					// an earlier 429 — this blocks AutoRefreshScheduler's probe gate and
 					// pins the account last in strict drain-soonest ranking forever (#443).
 					// Clear it so the account gets probed on the next scheduler tick.
 					//
-					// clearStaleRateLimitReset is a compare-and-swap: it only clears the
-					// field if it still matches the value we just read, so a genuinely
-					// newer rate_limit_reset recorded by a concurrent proxy response
-					// (e.g. a fresh 429) between the read and write below is preserved
-					// instead of being clobbered.
+					// clearStaleRateLimitReset guards on two things:
+					//   1. value match — rate_limit_reset still equals the value we just
+					//      read, so a write that lands between our read and this write
+					//      simply misses the WHERE clause instead of being clobbered.
+					//   2. write-time ≤ observation-time — rate_limit_reset_at (stamped
+					//      whenever rate_limit_reset is written) must be no newer than
+					//      observedAt, the instant the poller saw this contradiction. This
+					//      closes a second race Greptile flagged in round 2: a *genuine*
+					//      429 can land after observedAt but before getAccount() below
+					//      resolves, so its value alone would satisfy guard #1 even though
+					//      it's a brand new legitimate rate limit, not the stale one we
+					//      observed. The write-time check rejects that case regardless of
+					//      read/write ordering.
 					proxyContext.dbOps
 						.getAccount(accountId)
 						.then((acc) => {
 							const staleReset = Number(acc?.rate_limit_reset);
 							if (acc?.rate_limit_reset && staleReset > Date.now()) {
 								return proxyContext.dbOps
-									.clearStaleRateLimitReset(accountId, staleReset)
+									.clearStaleRateLimitReset(accountId, staleReset, observedAt)
 									.then((cleared) => {
 										if (cleared) {
 											logger.info(

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -570,6 +570,34 @@ function startUsagePollingWithRefresh(
 							),
 						);
 				},
+				(accountId) => {
+					// Usage API shows a fresh weekly window (0% utilization, resets_at
+					// unknown) but rate_limit_reset is still a stale future timestamp from
+					// an earlier 429 — this blocks AutoRefreshScheduler's probe gate and
+					// pins the account last in strict drain-soonest ranking forever (#443).
+					// Clear it so the account gets probed on the next scheduler tick.
+					proxyContext.dbOps
+						.getAccount(accountId)
+						.then((acc) => {
+							if (
+								acc?.rate_limit_reset &&
+								Number(acc.rate_limit_reset) > Date.now()
+							) {
+								return proxyContext.dbOps
+									.updateAccountRateLimitMeta(accountId, "allowed", null)
+									.then(() => {
+										logger.info(
+											`Cleared stale rate_limit_reset for account ${acc.name} (${accountId}): usage polling shows fresh weekly window (out-of-band reset)`,
+										);
+									});
+							}
+						})
+						.catch((err) =>
+							logger.warn(
+								`Failed to check/clear rate_limit_reset for account ${accountId} on weekly reset detection: ${err}`,
+							),
+						);
+				},
 				(accountId, data) => {
 					proxyContext.dbOps
 						.recordUsageSnapshot(accountId, data, Date.now())

--- a/packages/database/src/database-operations.ts
+++ b/packages/database/src/database-operations.ts
@@ -934,6 +934,17 @@ OAuth tokens will need to be re-authenticated.
 		);
 	}
 
+	async clearStaleRateLimitReset(
+		accountId: string,
+		expectedReset: number,
+	): Promise<boolean> {
+		return withDatabaseRetry(
+			() => this.accounts.clearStaleRateLimitReset(accountId, expectedReset),
+			this.retryConfig,
+			"clearStaleRateLimitReset",
+		);
+	}
+
 	// Usage-history operations delegated to repository
 	getUsageHistoryRepository(): UsageHistoryRepository {
 		return this.usageHistory;

--- a/packages/database/src/database-operations.ts
+++ b/packages/database/src/database-operations.ts
@@ -937,9 +937,15 @@ OAuth tokens will need to be re-authenticated.
 	async clearStaleRateLimitReset(
 		accountId: string,
 		expectedReset: number,
+		observedAt: number,
 	): Promise<boolean> {
 		return withDatabaseRetry(
-			() => this.accounts.clearStaleRateLimitReset(accountId, expectedReset),
+			() =>
+				this.accounts.clearStaleRateLimitReset(
+					accountId,
+					expectedReset,
+					observedAt,
+				),
 			this.retryConfig,
 			"clearStaleRateLimitReset",
 		);

--- a/packages/database/src/migrations-pg.ts
+++ b/packages/database/src/migrations-pg.ts
@@ -86,6 +86,7 @@ export async function ensureSchemaPg(adapter: BunSqlAdapter): Promise<void> {
 			session_request_count INTEGER DEFAULT 0,
 			paused INTEGER DEFAULT 0,
 			rate_limit_reset BIGINT,
+			rate_limit_reset_at BIGINT,
 			rate_limit_status TEXT,
 			rate_limit_remaining INTEGER,
 			auto_fallback_enabled INTEGER DEFAULT 0,
@@ -736,6 +737,11 @@ export async function runMigrationsPg(adapter: BunSqlAdapter): Promise<void> {
 			table: "accounts",
 			column: "rate_limited_at",
 			definition: "ALTER TABLE accounts ADD COLUMN rate_limited_at BIGINT",
+		},
+		{
+			table: "accounts",
+			column: "rate_limit_reset_at",
+			definition: "ALTER TABLE accounts ADD COLUMN rate_limit_reset_at BIGINT",
 		},
 		{
 			table: "accounts",

--- a/packages/database/src/migrations.ts
+++ b/packages/database/src/migrations.ts
@@ -921,6 +921,14 @@ export function runMigrations(db: Database, dbPath?: string): void {
 			log.info("Added rate_limit_reset column to accounts table");
 		}
 
+		// Add rate_limit_reset_at column if it doesn't exist
+		if (!initialAccountsColumnNames.includes("rate_limit_reset_at")) {
+			db.prepare(
+				"ALTER TABLE accounts ADD COLUMN rate_limit_reset_at INTEGER",
+			).run();
+			log.info("Added rate_limit_reset_at column to accounts table");
+		}
+
 		// Add rate_limit_status column if it doesn't exist
 		if (!initialAccountsColumnNames.includes("rate_limit_status")) {
 			db.prepare(

--- a/packages/database/src/repositories/__tests__/account-rate-limit-reset-cas.test.ts
+++ b/packages/database/src/repositories/__tests__/account-rate-limit-reset-cas.test.ts
@@ -1,0 +1,274 @@
+import "@better-ccflare/core";
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { BunSqlAdapter } from "../../adapters/bun-sql-adapter";
+import { AccountRepository } from "../account.repository";
+
+interface RawRateLimitRow {
+	rate_limit_status: string | null;
+	rate_limit_reset: number | null;
+	rate_limit_reset_at: number | null;
+}
+
+// Regression coverage for PR #445's round-2 review finding: the original
+// clearStaleRateLimitReset CAS only compared the stored rate_limit_reset
+// value against the one the caller had just read, which protects the
+// read→write gap but not the poll-observation→read gap. A genuine 429
+// landing between "the poller observed the fresh-window contradiction" and
+// "the callback's getAccount() read the row" would write a new, legitimate
+// rate_limit_reset that happens to be read back and value-matched by the old
+// CAS — incorrectly clearing a real rate limit. Threading rate_limit_reset_at
+// (the write-time of rate_limit_reset) and requiring it to be no newer than
+// the poll's observedAt timestamp closes that gap.
+describe("AccountRepository.clearStaleRateLimitReset — write-time CAS guard (#445 round-2 fix)", () => {
+	let db: Database;
+	let repository: AccountRepository;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		db.run(`
+			CREATE TABLE accounts (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				provider TEXT DEFAULT 'anthropic',
+				api_key TEXT,
+				refresh_token TEXT DEFAULT '',
+				access_token TEXT,
+				expires_at INTEGER,
+				created_at INTEGER NOT NULL,
+				last_used INTEGER,
+				request_count INTEGER DEFAULT 0,
+				total_requests INTEGER DEFAULT 0,
+				rate_limited_until INTEGER,
+				rate_limited_reason TEXT,
+				rate_limited_at INTEGER,
+				session_start INTEGER,
+				session_request_count INTEGER DEFAULT 0,
+				paused INTEGER DEFAULT 0,
+				requires_reauth INTEGER DEFAULT 0,
+				rate_limit_reset INTEGER,
+				rate_limit_reset_at INTEGER,
+				rate_limit_status TEXT,
+				rate_limit_remaining INTEGER,
+				priority INTEGER DEFAULT 0,
+				auto_fallback_enabled INTEGER DEFAULT 0,
+				auto_refresh_enabled INTEGER DEFAULT 0,
+				auto_pause_on_overage_enabled INTEGER DEFAULT 0,
+				peak_hours_pause_enabled INTEGER DEFAULT 0,
+				custom_endpoint TEXT,
+				model_mappings TEXT,
+				cross_region_mode TEXT,
+				model_fallbacks TEXT,
+				billing_type TEXT,
+				pause_reason TEXT,
+				refresh_token_issued_at INTEGER,
+				consecutive_rate_limits INTEGER DEFAULT 0
+			)
+		`);
+		repository = new AccountRepository(new BunSqlAdapter(db));
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	function insertAccount(
+		id: string,
+		rateLimitReset: number | null,
+		rateLimitResetAt: number | null,
+	): void {
+		db.run(
+			`INSERT INTO accounts (id, name, provider, refresh_token, access_token, expires_at, created_at, rate_limit_status, rate_limit_reset, rate_limit_reset_at)
+			 VALUES (?, ?, 'anthropic', '', 'at', 1, 1, 'rate_limited', ?, ?)`,
+			[id, id, rateLimitReset, rateLimitResetAt],
+		);
+	}
+
+	function getRaw(id: string): RawRateLimitRow {
+		return db
+			.query<RawRateLimitRow, [string]>(
+				"SELECT rate_limit_status, rate_limit_reset, rate_limit_reset_at FROM accounts WHERE id = ?",
+			)
+			.get(id) as RawRateLimitRow;
+	}
+
+	it("clears when rate_limit_reset_at <= observedAt", async () => {
+		const futureReset = Date.now() + 60_000;
+		const writtenAt = 1_000_000;
+		const observedAt = 2_000_000; // observed strictly after the stale write
+		insertAccount("acct-clears", futureReset, writtenAt);
+
+		const cleared = await repository.clearStaleRateLimitReset(
+			"acct-clears",
+			futureReset,
+			observedAt,
+		);
+
+		expect(cleared).toBe(true);
+		const row = getRaw("acct-clears");
+		expect(row.rate_limit_status).toBe("allowed");
+		expect(row.rate_limit_reset).toBeNull();
+		expect(row.rate_limit_reset_at).toBeNull();
+	});
+
+	it("does NOT clear when rate_limit_reset_at > observedAt (fresh legitimate write landed after observation)", async () => {
+		const futureReset = Date.now() + 60_000;
+		const observedAt = 1_000_000;
+		const writtenAt = 2_000_000; // a genuine 429 wrote this AFTER the poll observed the contradiction
+		insertAccount("acct-race", futureReset, writtenAt);
+
+		const cleared = await repository.clearStaleRateLimitReset(
+			"acct-race",
+			futureReset,
+			observedAt,
+		);
+
+		expect(cleared).toBe(false);
+		const row = getRaw("acct-race");
+		expect(row.rate_limit_status).toBe("rate_limited");
+		expect(row.rate_limit_reset).toBe(futureReset);
+		expect(row.rate_limit_reset_at).toBe(writtenAt);
+	});
+
+	it("still clears when rate_limit_reset_at IS NULL (legacy rows predating the column)", async () => {
+		const futureReset = Date.now() + 60_000;
+		const observedAt = 1_000_000;
+		insertAccount("acct-legacy", futureReset, null);
+
+		const cleared = await repository.clearStaleRateLimitReset(
+			"acct-legacy",
+			futureReset,
+			observedAt,
+		);
+
+		expect(cleared).toBe(true);
+		const row = getRaw("acct-legacy");
+		expect(row.rate_limit_status).toBe("allowed");
+		expect(row.rate_limit_reset).toBeNull();
+		expect(row.rate_limit_reset_at).toBeNull();
+	});
+
+	it("does not clear when the value no longer matches expectedReset (original read→write CAS)", async () => {
+		const originalReset = Date.now() + 60_000;
+		const newerReset = Date.now() + 120_000;
+		const observedAt = 2_000_000;
+		insertAccount("acct-value-mismatch", newerReset, 1_000_000);
+
+		const cleared = await repository.clearStaleRateLimitReset(
+			"acct-value-mismatch",
+			originalReset,
+			observedAt,
+		);
+
+		expect(cleared).toBe(false);
+		const row = getRaw("acct-value-mismatch");
+		expect(row.rate_limit_reset).toBe(newerReset);
+	});
+
+	it("returns false when the account id does not exist", async () => {
+		const cleared = await repository.clearStaleRateLimitReset(
+			"missing-account",
+			12345,
+			1_000_000,
+		);
+
+		expect(cleared).toBe(false);
+	});
+});
+
+describe("AccountRepository — rate_limit_reset_at stamping", () => {
+	let db: Database;
+	let repository: AccountRepository;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		db.run(`
+			CREATE TABLE accounts (
+				id TEXT PRIMARY KEY,
+				name TEXT NOT NULL,
+				provider TEXT DEFAULT 'anthropic',
+				api_key TEXT,
+				refresh_token TEXT DEFAULT '',
+				access_token TEXT,
+				expires_at INTEGER,
+				created_at INTEGER NOT NULL,
+				last_used INTEGER,
+				request_count INTEGER DEFAULT 0,
+				total_requests INTEGER DEFAULT 0,
+				rate_limited_until INTEGER,
+				rate_limited_reason TEXT,
+				rate_limited_at INTEGER,
+				session_start INTEGER,
+				session_request_count INTEGER DEFAULT 0,
+				paused INTEGER DEFAULT 0,
+				requires_reauth INTEGER DEFAULT 0,
+				rate_limit_reset INTEGER,
+				rate_limit_reset_at INTEGER,
+				rate_limit_status TEXT,
+				rate_limit_remaining INTEGER,
+				priority INTEGER DEFAULT 0,
+				auto_fallback_enabled INTEGER DEFAULT 0,
+				auto_refresh_enabled INTEGER DEFAULT 0,
+				auto_pause_on_overage_enabled INTEGER DEFAULT 0,
+				peak_hours_pause_enabled INTEGER DEFAULT 0,
+				custom_endpoint TEXT,
+				model_mappings TEXT,
+				cross_region_mode TEXT,
+				model_fallbacks TEXT,
+				billing_type TEXT,
+				pause_reason TEXT,
+				refresh_token_issued_at INTEGER,
+				consecutive_rate_limits INTEGER DEFAULT 0
+			)
+		`);
+		db.run(
+			`INSERT INTO accounts (id, name, provider, refresh_token, access_token, expires_at, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			["acct-1", "Account 1", "anthropic", "", "at", 1, 1],
+		);
+		repository = new AccountRepository(new BunSqlAdapter(db));
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	function getRaw(id: string): RawRateLimitRow {
+		return db
+			.query<RawRateLimitRow, [string]>(
+				"SELECT rate_limit_status, rate_limit_reset, rate_limit_reset_at FROM accounts WHERE id = ?",
+			)
+			.get(id) as RawRateLimitRow;
+	}
+
+	it("stamps rate_limit_reset_at to now when updateRateLimitMeta sets a reset value", async () => {
+		const before = Date.now();
+		await repository.updateRateLimitMeta("acct-1", "rate_limited", 999_999);
+		const after = Date.now();
+
+		const row = getRaw("acct-1");
+		expect(row.rate_limit_reset).toBe(999_999);
+		expect(row.rate_limit_reset_at).not.toBeNull();
+		expect(row.rate_limit_reset_at as number).toBeGreaterThanOrEqual(before);
+		expect(row.rate_limit_reset_at as number).toBeLessThanOrEqual(after);
+	});
+
+	it("nulls rate_limit_reset_at when updateRateLimitMeta clears the reset (reset === null)", async () => {
+		await repository.updateRateLimitMeta("acct-1", "rate_limited", 999_999);
+		await repository.updateRateLimitMeta("acct-1", "allowed", null);
+
+		const row = getRaw("acct-1");
+		expect(row.rate_limit_reset).toBeNull();
+		expect(row.rate_limit_reset_at).toBeNull();
+	});
+
+	it("clearRateLimitState nulls rate_limit_reset_at along with rate_limit_reset", async () => {
+		await repository.updateRateLimitMeta("acct-1", "rate_limited", 999_999);
+
+		await repository.clearRateLimitState("acct-1");
+
+		const row = getRaw("acct-1");
+		expect(row.rate_limit_reset).toBeNull();
+		expect(row.rate_limit_reset_at).toBeNull();
+		expect(row.rate_limit_status).toBeNull();
+	});
+});

--- a/packages/database/src/repositories/__tests__/account-rate-limit-reset-cas.test.ts
+++ b/packages/database/src/repositories/__tests__/account-rate-limit-reset-cas.test.ts
@@ -92,7 +92,7 @@ describe("AccountRepository.clearStaleRateLimitReset — write-time CAS guard (#
 			.get(id) as RawRateLimitRow;
 	}
 
-	it("clears when rate_limit_reset_at <= observedAt", async () => {
+	it("clears when rate_limit_reset_at < observedAt", async () => {
 		const futureReset = Date.now() + 60_000;
 		const writtenAt = 1_000_000;
 		const observedAt = 2_000_000; // observed strictly after the stale write
@@ -128,6 +128,24 @@ describe("AccountRepository.clearStaleRateLimitReset — write-time CAS guard (#
 		expect(row.rate_limit_status).toBe("rate_limited");
 		expect(row.rate_limit_reset).toBe(futureReset);
 		expect(row.rate_limit_reset_at).toBe(writtenAt);
+	});
+
+	it("does NOT clear when rate_limit_reset_at === observedAt (same-millisecond write, strict guard)", async () => {
+		const futureReset = Date.now() + 60_000;
+		const sameInstant = 1_500_000;
+		insertAccount("acct-same-ms", futureReset, sameInstant);
+
+		const cleared = await repository.clearStaleRateLimitReset(
+			"acct-same-ms",
+			futureReset,
+			sameInstant,
+		);
+
+		expect(cleared).toBe(false);
+		const row = getRaw("acct-same-ms");
+		expect(row.rate_limit_status).toBe("rate_limited");
+		expect(row.rate_limit_reset).toBe(futureReset);
+		expect(row.rate_limit_reset_at).toBe(sameInstant);
 	});
 
 	it("still clears when rate_limit_reset_at IS NULL (legacy rows predating the column)", async () => {

--- a/packages/database/src/repositories/account.repository.ts
+++ b/packages/database/src/repositories/account.repository.ts
@@ -337,6 +337,24 @@ export class AccountRepository extends BaseRepository<Account> {
 		);
 	}
 
+	/**
+	 * Clear rate_limit_reset/rate_limit_status only if rate_limit_reset still
+	 * equals expectedReset — a compare-and-swap guard against a proxy response
+	 * recording a newer, legitimate rate limit between the caller's read and
+	 * this write (#443 fix's race window). Returns true if the row was
+	 * cleared, false if it had already changed (no-op).
+	 */
+	async clearStaleRateLimitReset(
+		accountId: string,
+		expectedReset: number,
+	): Promise<boolean> {
+		const changes = await this.runWithChanges(
+			`UPDATE accounts SET rate_limit_status = 'allowed', rate_limit_reset = NULL WHERE id = ? AND rate_limit_reset = ?`,
+			[accountId, expectedReset],
+		);
+		return changes > 0;
+	}
+
 	async clearRateLimitState(accountId: string): Promise<number> {
 		return this.runWithChanges(
 			`UPDATE accounts

--- a/packages/database/src/repositories/account.repository.ts
+++ b/packages/database/src/repositories/account.repository.ts
@@ -332,25 +332,48 @@ export class AccountRepository extends BaseRepository<Account> {
 		remaining?: number | null,
 	): Promise<void> {
 		await this.run(
-			`UPDATE accounts SET rate_limit_status = ?, rate_limit_reset = ?, rate_limit_remaining = ? WHERE id = ?`,
-			[status, reset, remaining ?? null, accountId],
+			`UPDATE accounts SET rate_limit_status = ?, rate_limit_reset = ?, rate_limit_reset_at = ?, rate_limit_remaining = ? WHERE id = ?`,
+			[
+				status,
+				reset,
+				reset !== null ? Date.now() : null,
+				remaining ?? null,
+				accountId,
+			],
 		);
 	}
 
 	/**
 	 * Clear rate_limit_reset/rate_limit_status only if rate_limit_reset still
-	 * equals expectedReset — a compare-and-swap guard against a proxy response
-	 * recording a newer, legitimate rate limit between the caller's read and
-	 * this write (#443 fix's race window). Returns true if the row was
-	 * cleared, false if it had already changed (no-op).
+	 * equals expectedReset AND rate_limit_reset_at (the write-time of that
+	 * value) is no newer than observedAt (the moment the poller observed the
+	 * fresh-window contradiction that triggered this clear). This two-part
+	 * guard closes both race windows from the #443 fix:
+	 *   - value match: protects the read→write gap (a concurrent write
+	 *     between our read and this write changes the value, so the WHERE
+	 *     clause simply misses).
+	 *   - write-time ≤ observation-time: protects the poll-observation→read
+	 *     gap. A genuine 429 landing *after* observedAt but *before* our
+	 *     read would otherwise be read back and "matched" by the CAS above,
+	 *     even though it's a brand new legitimate rate limit rather than the
+	 *     stale one the poll observed. Stamping rate_limit_reset_at at write
+	 *     time lets us tell those apart: a legitimate post-observation write
+	 *     always has rate_limit_reset_at > observedAt, so the guard rejects it.
+	 * rate_limit_reset_at IS NULL is treated as eligible to clear (legacy
+	 * rows written before this column existed, or by paths that predate the
+	 * stamping) so pre-migration data doesn't regress.
+	 * Returns true if the row was cleared, false if it had already changed
+	 * or the write-time guard rejected the clear (no-op).
 	 */
 	async clearStaleRateLimitReset(
 		accountId: string,
 		expectedReset: number,
+		observedAt: number,
 	): Promise<boolean> {
 		const changes = await this.runWithChanges(
-			`UPDATE accounts SET rate_limit_status = 'allowed', rate_limit_reset = NULL WHERE id = ? AND rate_limit_reset = ?`,
-			[accountId, expectedReset],
+			`UPDATE accounts SET rate_limit_status = 'allowed', rate_limit_reset = NULL, rate_limit_reset_at = NULL
+			 WHERE id = ? AND rate_limit_reset = ? AND (rate_limit_reset_at IS NULL OR rate_limit_reset_at <= ?)`,
+			[accountId, expectedReset, observedAt],
 		);
 		return changes > 0;
 	}
@@ -363,6 +386,7 @@ export class AccountRepository extends BaseRepository<Account> {
 			 	rate_limited_reason = NULL,
 			 	rate_limited_at = NULL,
 			 	rate_limit_reset = NULL,
+			 	rate_limit_reset_at = NULL,
 			 	rate_limit_status = NULL,
 			 	rate_limit_remaining = NULL
 			 WHERE id = ?`,

--- a/packages/database/src/repositories/account.repository.ts
+++ b/packages/database/src/repositories/account.repository.ts
@@ -352,13 +352,14 @@ export class AccountRepository extends BaseRepository<Account> {
 	 *   - value match: protects the read→write gap (a concurrent write
 	 *     between our read and this write changes the value, so the WHERE
 	 *     clause simply misses).
-	 *   - write-time ≤ observation-time: protects the poll-observation→read
-	 *     gap. A genuine 429 landing *after* observedAt but *before* our
+	 *   - write-time < observation-time: protects the poll-observation→read
+	 *     gap. A genuine 429 landing at or after observedAt but before our
 	 *     read would otherwise be read back and "matched" by the CAS above,
 	 *     even though it's a brand new legitimate rate limit rather than the
 	 *     stale one the poll observed. Stamping rate_limit_reset_at at write
-	 *     time lets us tell those apart: a legitimate post-observation write
-	 *     always has rate_limit_reset_at > observedAt, so the guard rejects it.
+	 *     time lets us tell those apart: a legitimate write at/after the
+	 *     observation instant always has rate_limit_reset_at >= observedAt,
+	 *     so the guard uses a strict "<" to reject same-millisecond writes too.
 	 * rate_limit_reset_at IS NULL is treated as eligible to clear (legacy
 	 * rows written before this column existed, or by paths that predate the
 	 * stamping) so pre-migration data doesn't regress.
@@ -372,7 +373,7 @@ export class AccountRepository extends BaseRepository<Account> {
 	): Promise<boolean> {
 		const changes = await this.runWithChanges(
 			`UPDATE accounts SET rate_limit_status = 'allowed', rate_limit_reset = NULL, rate_limit_reset_at = NULL
-			 WHERE id = ? AND rate_limit_reset = ? AND (rate_limit_reset_at IS NULL OR rate_limit_reset_at <= ?)`,
+			 WHERE id = ? AND rate_limit_reset = ? AND (rate_limit_reset_at IS NULL OR rate_limit_reset_at < ?)`,
 			[accountId, expectedReset, observedAt],
 		);
 		return changes > 0;

--- a/packages/providers/src/__tests__/window-reset-detection.test.ts
+++ b/packages/providers/src/__tests__/window-reset-detection.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, mock } from "bun:test";
 import type { AnyUsageData, UsageData } from "../usage-fetcher";
 import {
 	extractWeeklyResetTime,
+	extractWeeklyUtilization,
 	extractWindowResetTime,
 	usageCache,
 } from "../usage-fetcher";
@@ -120,6 +121,50 @@ describe("extractWeeklyResetTime", () => {
 		expect(extractWeeklyResetTime({} as any, "zai")).toBeNull();
 		expect(extractWeeklyResetTime({} as any, "xai")).toBeNull();
 		expect(extractWeeklyResetTime({} as any, "nanogpt")).toBeNull();
+	});
+});
+
+// ── extractWeeklyUtilization ───────────────────────────────────────────────
+// Regression coverage for #443 review feedback: the out-of-band-reset
+// detector must read the seven_day window specifically, not the
+// account-wide max utilization (which a busy five_hour session window would
+// keep non-zero even while seven_day silently resets).
+
+describe("extractWeeklyUtilization", () => {
+	it("returns seven_day utilization for anthropic provider", () => {
+		const data: UsageData = {
+			five_hour: { utilization: 90, resets_at: "2030-01-01T12:00:00Z" },
+			seven_day: { utilization: 42, resets_at: "2030-01-08T12:00:00Z" },
+		};
+		expect(extractWeeklyUtilization(data, "anthropic")).toBe(42);
+	});
+
+	it("reads 0% seven_day utilization even when five_hour is busy", () => {
+		const data: UsageData = {
+			five_hour: { utilization: 88, resets_at: "2030-01-01T12:00:00Z" },
+			seven_day: { utilization: 0, resets_at: null },
+		};
+		expect(extractWeeklyUtilization(data, "anthropic")).toBe(0);
+	});
+
+	it("falls back to limits[] weekly_all percent for limits-only payloads", () => {
+		const data = {
+			limits: [
+				{ kind: "session", percent: 90, resets_at: null, scope: null },
+				{ kind: "weekly_all", percent: 0, resets_at: null, scope: null },
+			],
+		} as unknown as UsageData;
+		expect(extractWeeklyUtilization(data, "codex")).toBe(0);
+	});
+
+	it("returns null for providers without a weekly_all window (zai, xai, unsupported)", () => {
+		expect(extractWeeklyUtilization({} as any, "zai")).toBeNull();
+		expect(extractWeeklyUtilization({} as any, "xai")).toBeNull();
+		expect(extractWeeklyUtilization({} as any, "nanogpt")).toBeNull();
+	});
+
+	it("returns null when neither seven_day nor limits[] weekly_all is present", () => {
+		expect(extractWeeklyUtilization({} as UsageData, "anthropic")).toBeNull();
 	});
 });
 

--- a/packages/providers/src/usage-fetcher.ts
+++ b/packages/providers/src/usage-fetcher.ts
@@ -742,7 +742,7 @@ class UsageCache {
 	>();
 	private staleWeeklyResetCallbacks = new Map<
 		string,
-		(accountId: string) => void
+		(accountId: string, observedAt: number) => void
 	>();
 	private snapshotCallbacks = new Map<
 		string,
@@ -829,7 +829,7 @@ class UsageCache {
 		customEndpoint?: string | null,
 		onWindowReset?: (accountId: string) => void,
 		onCapacityRestored?: (accountId: string) => void,
-		onStaleWeeklyReset?: (accountId: string) => void,
+		onStaleWeeklyReset?: (accountId: string, observedAt: number) => void,
 		onSnapshot?: (accountId: string, data: UsageData) => void,
 	) {
 		// Check if provider supports usage tracking
@@ -1196,7 +1196,7 @@ class UsageCache {
 					);
 					if (weeklyUtilization === 0 && weeklyResetAt === null) {
 						const staleCb = this.staleWeeklyResetCallbacks.get(accountId);
-						if (staleCb) staleCb(accountId);
+						if (staleCb) staleCb(accountId, Date.now());
 					}
 					const window = getRepresentativeWindow(result.data as UsageData);
 					log.debug(

--- a/packages/providers/src/usage-fetcher.ts
+++ b/packages/providers/src/usage-fetcher.ts
@@ -189,6 +189,27 @@ export function extractWeeklyResetTime(
 }
 
 /**
+ * Extract the weekly_all (all-models weekly) window utilization percentage.
+ * Mirrors {@link extractWeeklyResetTime}'s field precedence so both read the
+ * same window — unlike {@link getRepresentativeUtilization}, which returns
+ * the max across ALL windows (five_hour included) and so cannot be used to
+ * detect a weekly-window-specific reset.
+ */
+export function extractWeeklyUtilization(
+	data: AnyUsageData,
+	provider: string,
+): number | null {
+	if (provider !== "anthropic" && provider !== "codex") return null;
+	const d = data as UsageData;
+	return (
+		d.seven_day?.utilization ??
+		(Array.isArray(d.limits)
+			? (d.limits.find((l) => l?.kind === "weekly_all")?.percent ?? null)
+			: null)
+	);
+}
+
+/**
  * Fetch usage data from Anthropic's OAuth usage endpoint
  */
 export interface UsageFetchResult {
@@ -1157,16 +1178,23 @@ class UsageCache {
 							this.capacityRestoredCallbacks.get(accountId);
 						if (capacityCallback) capacityCallback(accountId);
 					}
-					// Detect an out-of-band weekly reset: usage shows a fresh window
-					// (0% utilization, resets_at unknown) while the DB's rate_limit_reset
+					// Detect an out-of-band weekly reset: the seven_day window shows 0%
+					// utilization with resets_at unknown while the DB's rate_limit_reset
 					// may still hold a stale future timestamp from an earlier 429. That
 					// stale value defeats AutoRefreshScheduler's probe gate and pins the
 					// account last in strict drain-soonest ranking indefinitely (#443).
+					// Scoped to the weekly window specifically (not the account-wide max
+					// utilization) so a busy five_hour session window doesn't mask a
+					// reset seven_day window.
 					const weeklyResetAt = extractWeeklyResetTime(
 						result.data as UsageData,
 						"anthropic",
 					);
-					if (utilization === 0 && weeklyResetAt === null) {
+					const weeklyUtilization = extractWeeklyUtilization(
+						result.data as UsageData,
+						"anthropic",
+					);
+					if (weeklyUtilization === 0 && weeklyResetAt === null) {
 						const staleCb = this.staleWeeklyResetCallbacks.get(accountId);
 						if (staleCb) staleCb(accountId);
 					}

--- a/packages/providers/src/usage-fetcher.ts
+++ b/packages/providers/src/usage-fetcher.ts
@@ -719,6 +719,10 @@ class UsageCache {
 		string,
 		(accountId: string) => void
 	>();
+	private staleWeeklyResetCallbacks = new Map<
+		string,
+		(accountId: string) => void
+	>();
 	private snapshotCallbacks = new Map<
 		string,
 		(accountId: string, data: UsageData) => void
@@ -804,6 +808,7 @@ class UsageCache {
 		customEndpoint?: string | null,
 		onWindowReset?: (accountId: string) => void,
 		onCapacityRestored?: (accountId: string) => void,
+		onStaleWeeklyReset?: (accountId: string) => void,
 		onSnapshot?: (accountId: string, data: UsageData) => void,
 	) {
 		// Check if provider supports usage tracking
@@ -849,6 +854,11 @@ class UsageCache {
 			this.capacityRestoredCallbacks.set(accountId, onCapacityRestored);
 		} else {
 			this.capacityRestoredCallbacks.delete(accountId);
+		}
+		if (onStaleWeeklyReset) {
+			this.staleWeeklyResetCallbacks.set(accountId, onStaleWeeklyReset);
+		} else {
+			this.staleWeeklyResetCallbacks.delete(accountId);
 		}
 		if (onSnapshot) {
 			this.snapshotCallbacks.set(accountId, onSnapshot);
@@ -918,6 +928,7 @@ class UsageCache {
 			this.failureCounts.delete(accountId);
 			this.windowResetCallbacks.delete(accountId);
 			this.capacityRestoredCallbacks.delete(accountId);
+			this.staleWeeklyResetCallbacks.delete(accountId);
 			this.snapshotCallbacks.delete(accountId);
 			// Clean up cache entry when polling stops to prevent memory leaks
 			this.cache.delete(accountId);
@@ -1145,6 +1156,19 @@ class UsageCache {
 						const capacityCallback =
 							this.capacityRestoredCallbacks.get(accountId);
 						if (capacityCallback) capacityCallback(accountId);
+					}
+					// Detect an out-of-band weekly reset: usage shows a fresh window
+					// (0% utilization, resets_at unknown) while the DB's rate_limit_reset
+					// may still hold a stale future timestamp from an earlier 429. That
+					// stale value defeats AutoRefreshScheduler's probe gate and pins the
+					// account last in strict drain-soonest ranking indefinitely (#443).
+					const weeklyResetAt = extractWeeklyResetTime(
+						result.data as UsageData,
+						"anthropic",
+					);
+					if (utilization === 0 && weeklyResetAt === null) {
+						const staleCb = this.staleWeeklyResetCallbacks.get(accountId);
+						if (staleCb) staleCb(accountId);
 					}
 					const window = getRepresentativeWindow(result.data as UsageData);
 					log.debug(

--- a/packages/proxy/src/auto-refresh-scheduler.ts
+++ b/packages/proxy/src/auto-refresh-scheduler.ts
@@ -637,8 +637,8 @@ export class AutoRefreshScheduler {
 				// Update rate limit fields from unified headers
 				if (rateLimitInfo.resetTime) {
 					await this.db.run(
-						"UPDATE accounts SET rate_limit_reset = ?, rate_limited_until = NULL WHERE id = ?",
-						[rateLimitInfo.resetTime, accountRow.id],
+						"UPDATE accounts SET rate_limit_reset = ?, rate_limit_reset_at = ?, rate_limited_until = NULL WHERE id = ?",
+						[rateLimitInfo.resetTime, Date.now(), accountRow.id],
 					);
 
 					// Update our tracking with the NEW rate_limit_reset from the API


### PR DESCRIPTION
## Summary
- Fixes #443: `session-drain-soonest-strict` deadlock where an account whose weekly window was reset out-of-band (usage 0%, `resets_at: null`) but which still holds a stale future-dated `rate_limit_reset` from an earlier 429 gets ranked last forever and is never probed, because `AutoRefreshScheduler`'s probe gate refuses to touch accounts with a future `rate_limit_reset`.
- Adds a new `onStaleWeeklyReset` callback in `UsageCache`, fired from `_doFetchAndCache`'s Anthropic branch when `utilization === 0 && extractWeeklyResetTime(...) === null`, mirroring the existing `onCapacityRestored` pattern used for the seat-reassignment case.
- Wires it in `apps/server/src/server.ts`: when fired, checks if the account's `rate_limit_reset` is still in the future and clears it via the existing `dbOps.updateAccountRateLimitMeta(accountId, "allowed", null)` helper — the same narrow fields the reporter cleared manually as a workaround.
- Leaves `compareAccountsStrict` and `AutoRefreshScheduler`'s gate untouched, per the issue's preferred fix direction (detect the contradiction at the source instead of changing ranking/probing logic).

## Test plan
- [x] `bun run lint && bun run typecheck && bun run format`
- [x] `bun test packages/providers` (766 pass)
- [x] `bun test apps/server` (29 pass)
- [x] `bun test packages/load-balancer packages/database` (409 pass, 4 skip)
- [x] GitNexus `detect_changes()` — LOW risk, changes confined to the expected `startPolling`/`_doFetchAndCache` chain
- [ ] No integration test against real Anthropic accounts (per repo policy — real accounts must only be exercised via actual Claude Code, not scripted). This is a pure DB/callback-wiring change with no proxy request-path involvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)