### PR TITLE
fix(proxy): stop gating the reset-less 529 retry on isRateLimited

### DIFF
--- a/packages/proxy/src/handlers/__tests__/proxy-operations-529-retry-gate.test.ts
+++ b/packages/proxy/src/handlers/__tests__/proxy-operations-529-retry-gate.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Regression test: the in-place 529 retry must not be gated on
+ * `rlInfo.isRateLimited`.
+ *
+ * BaseProvider.parseRateLimit only reports isRateLimited from the unified
+ * rate-limit headers or a 429 status. A provider that sends neither — zai is
+ * one — therefore always answers `false` on a 529, so the reset-less-529
+ * branch was unreachable for exactly the overload case it exists for, and the
+ * inner loop broke out after a single attempt regardless of the configured
+ * budget. Both sites are already inside `response.status === 529`, so the
+ * reset hint alone decides in-place retry vs. cooldown.
+ *
+ * Static/structural check, same convention as the issue #354 and #382 tests
+ * in this directory — proxy-operations.ts is not imported directly because its
+ * transitive dependency chain loads @better-ccflare/database, which can fail to
+ * initialise in worktrees where `bun install` has not run.
+ *
+ * Run: bun test packages/proxy/src/handlers/__tests__/proxy-operations-529-retry-gate.test.ts
+ */
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const SOURCE_PATH = "packages/proxy/src/handlers/proxy-operations.ts";
+
+function readSource(): string {
+	return readFileSync(SOURCE_PATH, "utf-8");
+}
+
+describe("529 in-place retry gating", () => {
+	it("enters the retry branch on reset-less 529 without consulting isRateLimited", () => {
+		const source = readSource();
+		expect(source).toMatch(/if \(!rlInfo\.resetTime\) \{/);
+		expect(source).not.toMatch(/rlInfo\.isRateLimited && !rlInfo\.resetTime/);
+	});
+
+	it("stops retrying only on a reset hint, not on isRateLimited", () => {
+		const source = readSource();
+		expect(source).toMatch(/if \(retryRlInfo\.resetTime\) \{/);
+		expect(source).not.toMatch(
+			/!retryRlInfo\.isRateLimited \|\| retryRlInfo\.resetTime/,
+		);
+	});
+});

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -1404,7 +1404,12 @@ export async function proxyWithAccount(
 			// disposed of — one orphan per 529, plus one per in-place retry
 			// below. See issue #354.
 			const rlInfo = provider.parseRateLimit(response);
-			if (rlInfo.isRateLimited && !rlInfo.resetTime) {
+			// Do NOT gate on rlInfo.isRateLimited: ZaiProvider.parseRateLimit
+			// returns isRateLimited only for 429, so on a 529 it always answers
+			// false and this whole branch was dead for zai accounts — the very
+			// overload case it exists for. We are already inside `status === 529`;
+			// resetTime alone decides in-place retry vs. cooldown.
+			if (!rlInfo.resetTime) {
 				const retryCfg = getOverloadRetryConfig();
 				if (retryCfg.enabled && retryCfg.maxAttempts > 1) {
 					for (let attempt = 1; attempt < retryCfg.maxAttempts; attempt++) {
@@ -1498,7 +1503,11 @@ export async function proxyWithAccount(
 						// Header-only read, see the note on the first parseRateLimit
 						// call above — the retry response must not be teed either.
 						const retryRlInfo = provider.parseRateLimit(retryResponse);
-						if (!retryRlInfo.isRateLimited || retryRlInfo.resetTime) {
+						// Same reason as the entry guard above: isRateLimited is
+						// always false here for zai, so this broke out after a
+						// single retry and silently capped the budget at 1.
+						// Status is known to be 529 here — only a reset hint stops us.
+						if (retryRlInfo.resetTime) {
 							// Got a reset hint on retry — stop; let processProxyResponse apply cooldown
 							break;
 						}


### PR DESCRIPTION
## Problem

`BaseProvider.parseRateLimit` reports `isRateLimited` only from the unified `anthropic-ratelimit-*` headers or a 429 status. A provider that sends neither — zai is one — always answers `false` on a 529.

That makes the reset-less-529 branch in `proxyWithAccount` unreachable for exactly the overload case it was written for:

```ts
if (rlInfo.isRateLimited && !rlInfo.resetTime) {   // never true on a zai 529
```

The account skips the in-place retries entirely and goes straight to cooldown on the first 529.

The inner loop has the mirrored bug:

```ts
if (!retryRlInfo.isRateLimited || retryRlInfo.resetTime) break;   // always true
```

so even when the branch is entered it breaks out after one attempt, silently capping the budget at 1 regardless of `CCFLARE_OVERLOAD_RETRY_MAX_ATTEMPTS`.

## Fix

Both sites already sit inside `response.status === 529 && !isSyntheticInternal`, so the reset hint alone is the meaningful signal: no reset time means retry in place, a reset time means let `processProxyResponse` apply the cooldown.

## Behaviour change worth flagging

This widens behaviour beyond zai: any provider whose 529 carries no reset hint now gets the in-place retries that `getOverloadRetryConfig` already advertises (enabled by default, 2 attempts). That is the branch's stated purpose — it was simply dead. Say the word if you would rather scope it to providers that opt in.

## Test

Structural test following the convention of the #354 / #382 tests in the same directory (`proxy-operations.ts` is not importable in a bare worktree — it pulls in `@better-ccflare/database`). Verified it fails against the old condition and passes against the new one.

Running this in production against a zai `pro` account.