### PR TITLE
fix(providers): keep both Zai TOKENS_LIMIT windows instead of the last one

### DIFF
--- a/packages/core/src/throttle-utils.ts
+++ b/packages/core/src/throttle-utils.ts
@@ -11,7 +11,8 @@ export type SupportedWindow =
 	| "weekly"
 	| "daily"
 	| "monthly"
-	| "tokens_limit";
+	| "tokens_limit"
+	| "tokens_limit_weekly";
 
 /**
  * Fixed window durations in milliseconds.
@@ -26,6 +27,7 @@ export const FIXED_WINDOW_DURATION_MS: Record<string, number> = {
 	daily: 24 * 60 * 60 * 1000,
 	// time_limit intentionally omitted — ZAI's TIME_LIMIT window duration is unknown
 	tokens_limit: 5 * 60 * 60 * 1000,
+	tokens_limit_weekly: 7 * 24 * 60 * 60 * 1000,
 };
 
 /**

--- a/packages/dashboard-web/src/components/accounts/RateLimitProgress.test.tsx
+++ b/packages/dashboard-web/src/components/accounts/RateLimitProgress.test.tsx
@@ -43,6 +43,44 @@ describe("RateLimitProgress", () => {
 		expect(html).toContain("Usage (5-hour)");
 	});
 
+	it("renders both zai token windows, not just the last one parsed", () => {
+		const html = renderToStaticMarkup(
+			<RateLimitProgress
+				usageUtilization={2}
+				usageWindow="seven_day"
+				usageData={{
+					tokens_limit: {
+						used: 1,
+						remaining: 99,
+						percentage: 1,
+						resetAt: Date.now() + 4 * 60 * 60 * 1000,
+						type: "tokens_limit",
+					},
+					tokens_limit_weekly: {
+						used: 2,
+						remaining: 98,
+						percentage: 2,
+						resetAt: Date.now() + 6 * 24 * 60 * 60 * 1000,
+						type: "tokens_limit_weekly",
+					},
+					time_limit: {
+						used: 0,
+						remaining: 1000,
+						percentage: 0,
+						resetAt: Date.now() + 26 * 24 * 60 * 60 * 1000,
+						type: "time_limit",
+					},
+				}}
+				provider="zai"
+				showWeekly
+			/>,
+		);
+
+		expect(html).toContain("Usage (5-hour)");
+		expect(html).toContain("Usage (Weekly)");
+		expect(html).toContain("Usage (Time Quota)");
+	});
+
 	it("renders a generic seven_day_fable tier as 'Fable (Weekly)' with a 0% bar", () => {
 		const reset = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString();
 		const html = renderToStaticMarkup(

--- a/packages/dashboard-web/src/components/accounts/RateLimitProgress.tsx
+++ b/packages/dashboard-web/src/components/accounts/RateLimitProgress.tsx
@@ -367,6 +367,7 @@ export function RateLimitProgress({
 		const zaiData = usageData as {
 			time_limit?: { percentage: number; resetAt: number } | null;
 			tokens_limit?: { percentage: number; resetAt: number } | null;
+			tokens_limit_weekly?: { percentage: number; resetAt: number } | null;
 		};
 
 		// Tokens limit usage (5-hour token quota)
@@ -376,6 +377,17 @@ export function RateLimitProgress({
 				window: "tokens_limit",
 				resetTime: zaiData.tokens_limit.resetAt
 					? new Date(zaiData.tokens_limit.resetAt).toISOString()
+					: null,
+			});
+		}
+
+		// Weekly token quota (absent on single-window plans)
+		if (zaiData.tokens_limit_weekly) {
+			usages.push({
+				utilization: zaiData.tokens_limit_weekly.percentage,
+				window: "tokens_limit_weekly",
+				resetTime: zaiData.tokens_limit_weekly.resetAt
+					? new Date(zaiData.tokens_limit_weekly.resetAt).toISOString()
 					: null,
 			});
 		}

--- a/packages/dashboard-web/src/components/accounts/rate-limit-helpers.test.ts
+++ b/packages/dashboard-web/src/components/accounts/rate-limit-helpers.test.ts
@@ -225,11 +225,16 @@ describe("isUsageWindow / isWeeklyWindow / formatWindowName (legacy helpers)", (
 		expect(isWeeklyWindow("seven_day")).toBe(true);
 		expect(isWeeklyWindow("seven_day_fable")).toBe(true);
 		expect(isWeeklyWindow("five_hour")).toBe(false);
+		// Zai's long token window is weekly too; its short one is not.
+		expect(isWeeklyWindow("tokens_limit_weekly")).toBe(true);
+		expect(isWeeklyWindow("tokens_limit")).toBe(false);
 	});
 	it("formatWindowName maps generic tiers", () => {
 		expect(formatWindowName("seven_day_fable")).toBe("Fable (Weekly)");
 		expect(formatWindowName("five_hour")).toBe("5-hour");
 		expect(formatWindowName("seven_day")).toBe("Weekly");
+		expect(formatWindowName("tokens_limit")).toBe("5-hour");
+		expect(formatWindowName("tokens_limit_weekly")).toBe("Weekly");
 	});
 });
 

--- a/packages/dashboard-web/src/components/accounts/rate-limit-helpers.ts
+++ b/packages/dashboard-web/src/components/accounts/rate-limit-helpers.ts
@@ -45,7 +45,13 @@ export function isUsageWindow(
 
 /** True for the account-level weekly window and every model tier window. */
 export function isWeeklyWindow(window: string): boolean {
-	return window === "seven_day" || window.startsWith("seven_day_");
+	return (
+		window === "seven_day" ||
+		window.startsWith("seven_day_") ||
+		// Zai's long token window — weekly on current plans, so it wants the
+		// same date formatting and no-reset copy as the Anthropic ones.
+		window === "tokens_limit_weekly"
+	);
 }
 
 /**
@@ -69,6 +75,8 @@ export function formatWindowName(window: string | null): string {
 			return "Time Quota";
 		case "tokens_limit":
 			return "5-hour";
+		case "tokens_limit_weekly":
+			return "Weekly";
 		case "credits":
 			return "Grok credits";
 	}

--- a/packages/providers/src/__tests__/zai-usage-fetcher.test.ts
+++ b/packages/providers/src/__tests__/zai-usage-fetcher.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+	fetchZaiUsageData,
+	getRepresentativeZaiUtilization,
+	getRepresentativeZaiWindow,
+} from "../zai-usage-fetcher";
+
+/**
+ * Verbatim body from api.z.ai for a `pro` coding plan. The account carries TWO
+ * TOKENS_LIMIT entries — a 5-hour one (unit 3, number 5) and a weekly one
+ * (unit 6, number 1) — plus the monthly TIME_LIMIT covering the web tools.
+ */
+const PRO_PLAN_BODY = {
+	code: 200,
+	msg: "Operation successful",
+	success: true,
+	data: {
+		level: "pro",
+		limits: [
+			{
+				type: "TOKENS_LIMIT",
+				unit: 3,
+				number: 5,
+				percentage: 1,
+				nextResetTime: 1788455420775,
+			},
+			{
+				type: "TOKENS_LIMIT",
+				unit: 6,
+				number: 1,
+				percentage: 2,
+				nextResetTime: 1789005906998,
+			},
+			{
+				type: "TIME_LIMIT",
+				unit: 5,
+				number: 1,
+				usage: 1000,
+				currentValue: 0,
+				remaining: 1000,
+				percentage: 0,
+				nextResetTime: 1790733906999,
+			},
+		],
+	},
+};
+
+function stubFetch(body: unknown): void {
+	globalThis.fetch = (async () =>
+		new Response(JSON.stringify(body), {
+			status: 200,
+			headers: { "content-type": "application/json" },
+		})) as typeof fetch;
+}
+
+describe("Zai usage fetcher", () => {
+	let originalFetch: typeof fetch;
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("keeps both TOKENS_LIMIT windows instead of letting the last one win", async () => {
+		stubFetch(PRO_PLAN_BODY);
+
+		const usage = await fetchZaiUsageData("key");
+
+		// Nearest reset is the real 5-hour window.
+		expect(usage?.tokens_limit).toMatchObject({
+			percentage: 1,
+			resetAt: 1788455420775,
+		});
+		// The later one is weekly and must survive in its own field.
+		expect(usage?.tokens_limit_weekly).toMatchObject({
+			percentage: 2,
+			resetAt: 1789005906998,
+		});
+		expect(usage?.time_limit).toMatchObject({
+			percentage: 0,
+			resetAt: 1790733906999,
+		});
+	});
+
+	it("ranks the account by its most exhausted token window", async () => {
+		stubFetch(PRO_PLAN_BODY);
+
+		const usage = await fetchZaiUsageData("key");
+
+		expect(getRepresentativeZaiUtilization(usage)).toBe(2);
+		expect(getRepresentativeZaiWindow(usage)).toBe("seven_day");
+	});
+
+	it("reports the 5-hour window when it is the more exhausted one", async () => {
+		stubFetch({
+			...PRO_PLAN_BODY,
+			data: {
+				...PRO_PLAN_BODY.data,
+				limits: [
+					{ ...PRO_PLAN_BODY.data.limits[0], percentage: 80 },
+					PRO_PLAN_BODY.data.limits[1],
+					PRO_PLAN_BODY.data.limits[2],
+				],
+			},
+		});
+
+		const usage = await fetchZaiUsageData("key");
+
+		expect(getRepresentativeZaiUtilization(usage)).toBe(80);
+		expect(getRepresentativeZaiWindow(usage)).toBe("five_hour");
+	});
+
+	it("still works for plans that expose a single TOKENS_LIMIT window", async () => {
+		stubFetch({
+			...PRO_PLAN_BODY,
+			data: { ...PRO_PLAN_BODY.data, limits: [PRO_PLAN_BODY.data.limits[0]] },
+		});
+
+		const usage = await fetchZaiUsageData("key");
+
+		expect(usage?.tokens_limit?.resetAt).toBe(1788455420775);
+		expect(usage?.tokens_limit_weekly).toBeNull();
+		expect(getRepresentativeZaiWindow(usage)).toBe("five_hour");
+	});
+});

--- a/packages/providers/src/usage-fetcher.ts
+++ b/packages/providers/src/usage-fetcher.ts
@@ -473,6 +473,7 @@ function utilizationForProvider(
 			const candidates = [
 				zai.time_limit?.percentage ?? null,
 				zai.tokens_limit?.percentage ?? null,
+				zai.tokens_limit_weekly?.percentage ?? null,
 			].filter((v): v is number => v !== null);
 			return candidates.length > 0 ? Math.max(...candidates) : null;
 		}
@@ -688,7 +689,11 @@ export function getRepresentativeUsageSnapshotForProvider(
 ): { utilization: number; resetMs: number | null } | null {
 	if (provider === "zai") {
 		const zai = data as ZaiUsageData;
-		const candidates = [zai.time_limit, zai.tokens_limit].filter(
+		const candidates = [
+			zai.time_limit,
+			zai.tokens_limit,
+			zai.tokens_limit_weekly,
+		].filter(
 			(window): window is NonNullable<typeof window> => window !== null,
 		);
 		if (candidates.length === 0) return null;

--- a/packages/providers/src/zai-usage-fetcher.ts
+++ b/packages/providers/src/zai-usage-fetcher.ts
@@ -12,7 +12,10 @@ export interface ZaiUsageWindow {
 
 export interface ZaiUsageData {
 	time_limit: ZaiUsageWindow | null;
+	/** Short token window (5-hour on current plans) — the nearest reset. */
 	tokens_limit: ZaiUsageWindow | null;
+	/** Long token window (weekly on current plans), null on single-window plans. */
+	tokens_limit_weekly: ZaiUsageWindow | null;
 }
 
 /**
@@ -77,7 +80,16 @@ export async function fetchZaiUsageData(
 		const result: ZaiUsageData = {
 			time_limit: null,
 			tokens_limit: null,
+			tokens_limit_weekly: null,
 		};
+
+		// Zai sends MULTIPLE TOKENS_LIMIT entries (a 5-hour and a weekly cap on
+		// current plans), distinguished only by unit/number — an undocumented
+		// encoding. Ordering by reset time is the durable signal: the nearest
+		// reset is the short window, the next one the long window. Assigning
+		// them in loop order would let the weekly entry overwrite the 5-hour
+		// one, which is what made the dashboard label a weekly cap "5-hour".
+		const tokenWindows: ZaiUsageWindow[] = [];
 
 		// Parse each limit type
 		for (const limit of limits) {
@@ -90,15 +102,25 @@ export async function fetchZaiUsageData(
 					type: "time_limit",
 				};
 			} else if (limit.type === "TOKENS_LIMIT") {
-				result.tokens_limit = {
+				tokenWindows.push({
 					used: limit.currentValue ?? 0,
 					remaining: limit.remaining ?? 0,
 					percentage: limit.percentage ?? 0,
 					resetAt: limit.nextResetTime ?? null,
 					type: "tokens_limit",
-				};
+				});
 			}
 		}
+
+		tokenWindows.sort(
+			(a, b) =>
+				(a.resetAt ?? Number.POSITIVE_INFINITY) -
+				(b.resetAt ?? Number.POSITIVE_INFINITY),
+		);
+		result.tokens_limit = tokenWindows[0] ?? null;
+		result.tokens_limit_weekly = tokenWindows[1]
+			? { ...tokenWindows[1], type: "tokens_limit_weekly" }
+			: null;
 
 		return result;
 	} catch (error) {
@@ -108,43 +130,55 @@ export async function fetchZaiUsageData(
 }
 
 /**
+ * Both token windows, named in Claude terminology so the shared window helpers
+ * (throttle pacing, weekly formatting) can size them without a zai special case.
+ * time_limit is excluded: it caps the web tools, not model traffic.
+ */
+function tokenWindows(
+	usage: ZaiUsageData,
+): Array<{ name: string; percentage: number }> {
+	const windows: Array<{ name: string; percentage: number }> = [];
+	if (usage.tokens_limit && usage.tokens_limit.percentage !== undefined) {
+		windows.push({ name: "five_hour", percentage: usage.tokens_limit.percentage });
+	}
+	if (
+		usage.tokens_limit_weekly &&
+		usage.tokens_limit_weekly.percentage !== undefined
+	) {
+		windows.push({
+			name: "seven_day",
+			percentage: usage.tokens_limit_weekly.percentage,
+		});
+	}
+	return windows;
+}
+
+/**
  * Get the representative utilization percentage (0-100)
- * Returns the tokens_limit utilization (5-hour token quota)
+ * Returns the most exhausted token window — an account capped weekly is just as
+ * unavailable as one capped for the hour.
  */
 export function getRepresentativeZaiUtilization(
 	usage: ZaiUsageData | null,
 ): number | null {
 	if (!usage) return null;
 
-	// Only consider tokens_limit (5-hour token quota)
-	// time_limit is not displayed to users
-	if (usage.tokens_limit && usage.tokens_limit.percentage !== undefined) {
-		return usage.tokens_limit.percentage;
-	}
+	const windows = tokenWindows(usage);
+	if (windows.length === 0) return null;
 
-	return null;
+	return Math.max(...windows.map((w) => w.percentage));
 }
 
 /**
  * Determine which limit is the most restrictive (highest utilization)
- * Returns "five_hour" (for tokens_limit) to match Claude terminology
+ * Returns "five_hour" or "seven_day" to match Claude terminology
  */
 export function getRepresentativeZaiWindow(
 	usage: ZaiUsageData | null,
 ): string | null {
 	if (!usage) return null;
 
-	const windows: Array<{ name: string; percentage: number }> = [];
-
-	// Only consider tokens_limit (5-hour token quota)
-	// time_limit is not displayed to users
-	if (usage.tokens_limit && usage.tokens_limit.percentage !== undefined) {
-		windows.push({
-			name: "five_hour", // Map to "5-hour" to match Claude terminology
-			percentage: usage.tokens_limit.percentage,
-		});
-	}
-
+	const windows = tokenWindows(usage);
 	if (windows.length === 0) return null;
 
 	const max = windows.reduce((prev, current) =>

--- a/packages/types/src/account.ts
+++ b/packages/types/src/account.ts
@@ -111,7 +111,10 @@ export interface ZaiUsageWindow {
 
 export interface ZaiUsageData {
 	time_limit: ZaiUsageWindow | null;
+	/** Short token window (5-hour on current plans) — the nearest reset. */
 	tokens_limit: ZaiUsageWindow | null;
+	/** Long token window (weekly on current plans), null on single-window plans. */
+	tokens_limit_weekly: ZaiUsageWindow | null;
 }
 
 // Usage data types for Kilo accounts


### PR DESCRIPTION
## Problem

Zai's quota endpoint returns **two** `TOKENS_LIMIT` entries for current coding plans — a 5-hour cap and a weekly one — distinguished only by an undocumented `unit`/`number` encoding. Verbatim from `GET https://api.z.ai/api/monitor/usage/quota/limit` on a `pro` plan:

```json
{"type":"TOKENS_LIMIT","unit":3,"number":5,"percentage":1,"nextResetTime":1788455420775}
{"type":"TOKENS_LIMIT","unit":6,"number":1,"percentage":2,"nextResetTime":1789005906998}
{"type":"TIME_LIMIT","unit":5,"number":1,"currentValue":0,"remaining":1000,"percentage":0,"nextResetTime":1790733906999}
```

That is +4.9h, +157.8h and +637.8h from the time of the call. `fetchZaiUsageData` assigns them in loop order, so the weekly entry overwrites the 5-hour one and the 5-hour window is lost entirely.

Three consequences, all from that one assignment:

- **the dashboard mislabels the cap.** `formatWindowName` maps `tokens_limit` to `"5-hour"`, so the card reads `Usage (5-hour) 2% · 157h 56m until refresh · Resets Sep 10`. That is the weekly cap wearing the 5-hour label;
- **ranking ignores the 5-hour window.** `getRepresentativeZaiUtilization` returns whatever survived, so an account capped for the hour can still rank as idle;
- **throttle pacing is sized against the wrong window.** `FIXED_WINDOW_DURATION_MS.tokens_limit` is 5h, but the surviving reset is a week out, so `computeWindowStartMs` puts the window start ~152h in the *future* and the pace marker with it.

## Fix

Order the `TOKENS_LIMIT` entries by reset time — nearest is the short window, the next one is the weekly cap — rather than trusting loop order or decoding `unit`/`number`, which is undocumented and has no stable meaning I could confirm.

The weekly cap is exposed as `tokens_limit_weekly` and gets its own row, a real 7-day pacing length, and weekly reset formatting. Representative utilization/window now consider both windows, so whichever is more exhausted governs.

Plans that expose a single `TOKENS_LIMIT` window are unaffected: `tokens_limit_weekly` stays `null` and no extra row renders — covered by a test.

## Test

`packages/providers/src/__tests__/zai-usage-fetcher.test.ts`, built on the verbatim payload above, plus label/classification cases in the dashboard helper tests and a render test asserting all three rows appear. Verified red before the change and green after.

Running this in production against the account the payload came from:

```
tokens_limit (5h)  : 4% -> in 4.7h
tokens_limit_weekly: 3% -> in 157.6h
time_limit         : 0% -> in 637.6h
```