### PR TITLE
fix(proxy): detect Zai's in-stream 1305 overload and retry instead of streaming it

### DIFF
--- a/packages/proxy/src/handlers/__tests__/zai-1305.test.ts
+++ b/packages/proxy/src/handlers/__tests__/zai-1305.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Zai returns HTTP 200 with a text/event-stream body whose first chunk carries
+ * error code 1305 ("service overloaded"). These cover the detector that spots
+ * it; the retry/fallback wiring around it lives in proxy-operations.ts, which
+ * is not importable from tests (it pulls in @better-ccflare/database).
+ */
+import { describe, expect, it } from "bun:test";
+import { hasZai1305Error } from "../zai-1305";
+
+describe("hasZai1305Error", () => {
+	it("detects the overload error in a first SSE chunk", () => {
+		const chunk =
+			'data: {"error":{"code":1305,"message":"The service is overloaded, please try again later"}}\n\n';
+		expect(hasZai1305Error(chunk)).toBe(true);
+	});
+
+	it("ignores a normal stream opener", () => {
+		const chunk =
+			'data: {"id":"chatcmpl-1305","choices":[{"delta":{"content":"hi"}}]}\n\n';
+		expect(hasZai1305Error(chunk)).toBe(false);
+	});
+
+	it("ignores an overload error that is not 1305", () => {
+		const chunk =
+			'data: {"error":{"code":1302,"message":"The service is overloaded"}}\n\n';
+		expect(hasZai1305Error(chunk)).toBe(false);
+	});
+
+	it("is false for an empty chunk", () => {
+		expect(hasZai1305Error("")).toBe(false);
+	});
+});

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -42,6 +42,7 @@ import { handleProxyError, processProxyResponse } from "./response-processor";
 import { isRetryable429 } from "./retryable-429";
 import { getValidAccessToken } from "./token-manager";
 import { collectWindows } from "./usage-throttling";
+import { hasZai1305Error } from "./zai-1305";
 
 const log = new Logger("ProxyOperations");
 
@@ -473,6 +474,122 @@ export async function isModelUnavailableError(
 	}
 
 	return false;
+}
+
+/**
+ * Detects ZAI error 1305 ("service overloaded") inside an SSE stream.
+ * ZAI returns HTTP 200 with content-type: text/event-stream, but the SSE body
+ * contains an error event with code 1305. This function:
+ *   1. Peeks at the first chunk of the SSE stream (via clone, original preserved)
+ *   2. If 1305 + "overloaded" found - retries the request with backoff (up to 2 attempts)
+ *   3. If retries also return 1305 - converts to a synthetic 429 so isModelUnavailableError
+ *      triggers model fallback (e.g. glm-5.2 -> glm-4.7)
+ *   4. If no 1305 - returns the original response unchanged
+ */
+async function checkZai1305(
+	response: Response,
+	account: Account,
+	requestClone: Request,
+	log: Logger,
+): Promise<Response> {
+	if (
+		response.status !== 200 ||
+		account.provider !== "zai" ||
+		!response.headers.get("content-type")?.includes("text/event-stream")
+	) {
+		return response;
+	}
+
+	// Peek at first chunk of SSE stream
+	let has1305 = false;
+	try {
+		const peek = response.clone();
+		const reader = peek.body?.getReader();
+		if (reader) {
+			const { value } = await reader.read();
+			reader.releaseLock();
+			const text = value ? new TextDecoder().decode(value) : "";
+			if (hasZai1305Error(text)) {
+				has1305 = true;
+			}
+		}
+	} catch {
+		// If we can't read the stream, pass through
+	}
+
+	if (!has1305) {
+		return response;
+	}
+
+	log.warn(
+		`Account ${account.name}: detected 1305 overloaded in SSE stream, retrying`,
+	);
+
+	// Retry with backoff (same config as 529 retry)
+	const retryCfg = getOverloadRetryConfig();
+	if (retryCfg.enabled && retryCfg.maxAttempts > 1) {
+		for (let attempt = 1; attempt < retryCfg.maxAttempts; attempt++) {
+			const cap = Math.min(retryCfg.baseMs * 2 ** attempt, retryCfg.maxMs);
+			const delayMs = Math.random() * cap;
+			await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+
+			log.info(
+				`Account ${account.name}: 1305 retry ${attempt}/${retryCfg.maxAttempts - 1} after ${Math.round(delayMs)}ms`,
+			);
+
+			const retryRaw = await makeProxyRequest(requestClone.clone());
+			const retryHeaders = new Headers(retryRaw.headers);
+			retryHeaders.set(
+				"x-better-ccflare-request-id",
+				response.headers.get("x-better-ccflare-request-id") || "",
+			);
+
+			const retryResponse = new Response(retryRaw.body, {
+				status: retryRaw.status,
+				statusText: retryRaw.statusText,
+				headers: retryHeaders,
+			});
+
+			// Check if retry succeeded (no 1305 in stream)
+			try {
+				const retryPeek = retryResponse.clone();
+				const retryReader = retryPeek.body?.getReader();
+				if (retryReader) {
+					const { value: retryValue } = await retryReader.read();
+					retryReader.releaseLock();
+					const retryText = retryValue
+						? new TextDecoder().decode(retryValue)
+						: "";
+					if (!hasZai1305Error(retryText)) {
+						log.info(
+							`Account ${account.name}: 1305 resolved on retry ${attempt}`,
+						);
+						return retryResponse;
+					}
+				} else {
+					return retryResponse;
+				}
+			} catch {
+				return retryResponse;
+			}
+		}
+	}
+
+	log.warn(
+		`Account ${account.name}: all 1305 retries exhausted, converting to 429 for model fallback`,
+	);
+
+	// Convert to synthetic 429 so isModelUnavailableError triggers model cycling
+	return new Response(
+		JSON.stringify({
+			error: { type: "overloaded", message: "ZAI service overloaded (1305)" },
+		}),
+		{
+			status: 429,
+			statusText: "Too Many Requests",
+			headers: { "content-type": "application/json" },
+		},
+	);
 }
 
 /**
@@ -934,6 +1051,14 @@ export async function proxyWithAccount(
 			return withSanitizedProxyHeaders(rawResponse);
 		}
 
+		// Check for ZAI 1305 overloaded error in SSE stream and retry/fallback
+		rawResponse = await checkZai1305(
+			rawResponse,
+			account,
+			transformedRequest,
+			log,
+		);
+
 		// On model unavailable / rate-limited: cycle through the model list for
 		// this account. getModelList returns [primary, ...fallbacks] merged from
 		// model_mappings arrays and legacy model_fallbacks. We already tried index 0
@@ -1266,6 +1391,12 @@ export async function proxyWithAccount(
 						? materializeSyntheticResponse(retryTransformedRequest)
 						: await forwardUpstream(retryTransformedRequest);
 
+					rawResponse = await checkZai1305(
+						rawResponse,
+						account,
+						retryTransformedRequest,
+						log,
+					);
 					if (!(await isModelUnavailableError(rawResponse.clone()))) {
 						break; // Success — stop cycling
 					}
@@ -1275,6 +1406,12 @@ export async function proxyWithAccount(
 			// If still unavailable/rate-limited after exhausting the model list,
 			// failover to the next account. OpenAI-compatible providers never set
 			// isRateLimited:true in parseRateLimit, so we must handle it here.
+			rawResponse = await checkZai1305(
+				rawResponse,
+				account,
+				transformedRequest,
+				log,
+			);
 			if (await isModelUnavailableError(rawResponse)) {
 				log.warn(
 					`All models exhausted on account ${account.name}, failing over to next account`,

--- a/packages/proxy/src/handlers/zai-1305.ts
+++ b/packages/proxy/src/handlers/zai-1305.ts
@@ -1,0 +1,21 @@
+/**
+ * Zai signals "service overloaded" (code 1305) *inside* a successful SSE
+ * stream: HTTP 200, content-type text/event-stream, and an error event in the
+ * body. Nothing in the status line or headers says the request failed, so the
+ * proxy has to look at the first chunk to notice.
+ *
+ * Kept in its own module so it can be unit-tested — proxy-operations.ts pulls
+ * in @better-ccflare/database transitively and is not importable from tests.
+ */
+
+/**
+ * True when an SSE chunk carries Zai's 1305 overload error.
+ *
+ * Deliberately a substring match rather than an SSE parse: the error arrives
+ * as the very first chunk of the stream, before any model output, and its
+ * exact envelope has changed across Zai releases. Both markers must be present
+ * so an unrelated "1305" (a token count, an id) does not trip it.
+ */
+export function hasZai1305Error(chunk: string): boolean {
+	return chunk.includes("1305") && chunk.includes("overloaded");
+}


### PR DESCRIPTION
## Problem

Zai reports "service overloaded" (code 1305) **inside a successful response**: HTTP 200, `content-type: text/event-stream`, and the error as the first SSE event. Nothing in the status line or headers marks it as a failure, so the proxy forwards the error stream straight to the client — no retry, no model fallback, no cooldown, and the request is recorded as a success.

## Fix

Peek at the first chunk of a zai SSE response (via `clone()`, so the original stream is untouched). On a 1305 hit, retry with the existing `getOverloadRetryConfig` backoff; if the retries also come back 1305, synthesise a 429 so `isModelUnavailableError` triggers the normal model-fallback path (e.g. `glm-5.2` -> `glm-4.7`) instead of handing the caller a broken stream. Anything that is not a zai 200 `text/event-stream` returns untouched.

## Notes for review

- **The detector is a substring match** on the first chunk (`"1305"` and `"overloaded"` must both be present). I split it into `handlers/zai-1305.ts` so it is unit-testable — `proxy-operations.ts` pulls in `@better-ccflare/database` transitively and cannot be imported from tests. Happy to swap it for a real SSE parse if you would rather not depend on the envelope shape; I kept the loose match because the envelope has moved across Zai releases.
- **`clone()` on the response** buffers whatever the slower branch has not consumed. Here only the first chunk is read from the clone and it is dropped immediately, but given #382 I would rather you look at that explicitly than have it slip in unnoticed.
- Stacks cleanly with #447, which fixes the 529 path in the same file — different hunks, no conflict.

## Test

`packages/proxy/src/handlers/__tests__/zai-1305.test.ts` covers the detector: a real 1305 error event, a normal stream opener whose id happens to contain `1305`, an overload error with a different code, and an empty chunk.

Running this in production against a zai `pro` account.