### PR TITLE
fix(providers): read cloned request bodies as text, not json()

### DIFF
--- a/bench/request-clone-json-leak.ts
+++ b/bench/request-clone-json-leak.ts
@@ -26,9 +26,6 @@
  * numbers are allocator noise and do not grow with N.
  */
 
-const MODE = (process.argv[2] ?? "json") as "json" | "text" | "none";
-const N = Number(process.argv[3] ?? 300);
-const BODY_KIB = Number(process.argv[4] ?? 800);
 const CONCURRENCY = 4;
 const WARMUP = 20;
 
@@ -40,6 +37,21 @@ if (process.argv[2] === "--client") {
 	);
 	process.exit(0);
 }
+
+// Reject unknown modes instead of silently measuring the no-read baseline: a
+// typo such as "jsno" would otherwise print a plausible non-leaking result.
+const MODES = ["json", "text", "none"] as const;
+type Mode = (typeof MODES)[number];
+const modeArg = process.argv[2] ?? "json";
+if (!(MODES as readonly string[]).includes(modeArg)) {
+	console.error(
+		`Unknown mode "${modeArg}". Usage: bun run bench/request-clone-json-leak.ts [json|text|none] [N] [bodyKiB]`,
+	);
+	process.exit(2);
+}
+const MODE = modeArg as Mode;
+const N = Number(process.argv[3] ?? 300);
+const BODY_KIB = Number(process.argv[4] ?? 800);
 
 const encoder = new TextEncoder();
 

--- a/bench/request-clone-json-leak.ts
+++ b/bench/request-clone-json-leak.ts
@@ -1,0 +1,206 @@
+/**
+ * Request.clone().json() leak measurement for issue #382.
+ *
+ * On Bun 1.3.x a cloned, body-bearing Request read with `.json()` never frees
+ * the clone's native body buffer, so a proxy that inspects the client body
+ * that way leaks ~1x the body size on every request — off-heap, so heapUsed
+ * stays flat while RSS climbs. Reading the same clone with `.text()` is
+ * released normally, and Bun 1.4.0+ frees both.
+ *
+ * The measured process runs an upstream that streams a small SSE body and a
+ * proxy mirroring proxy-operations.ts / model-mapping.ts: buffer the client
+ * body with arrayBuffer(), build the provider Request from a Uint8Array, read
+ * its JSON through a clone (json | text | none), forward with fetch through a
+ * `new Request(providerRequest, { headers, signal })`, and pump the SSE back
+ * through a ReadableStream. The client runs in a child process so its own
+ * fetch allocations do not pollute the measurement. RSS is sampled after a
+ * forced GC before and after N requests.
+ *
+ * Run:  bun run bench/request-clone-json-leak.ts [json|text|none] [N] [bodyKiB]
+ *
+ * Measured with this harness, N=300, 800 KiB body, 4 concurrent clients:
+ *   Bun 1.3.11   json ~950 KiB/req    text ~17 KiB/req    none ~12 KiB/req
+ *   Bun 1.4.1    json  ~18 KiB/req    text ~20 KiB/req    (fixed by Bun 1.4.0's
+ *                                                          body/stream rewrite)
+ * Bun 1.3.12 through 1.3.14 measure the same as 1.3.11. The non-leaking
+ * numbers are allocator noise and do not grow with N.
+ */
+
+const MODE = (process.argv[2] ?? "json") as "json" | "text" | "none";
+const N = Number(process.argv[3] ?? 300);
+const BODY_KIB = Number(process.argv[4] ?? 800);
+const CONCURRENCY = 4;
+const WARMUP = 20;
+
+if (process.argv[2] === "--client") {
+	await runClient(
+		process.argv[3],
+		Number(process.argv[4]),
+		Number(process.argv[5]),
+	);
+	process.exit(0);
+}
+
+const encoder = new TextEncoder();
+
+// ---- upstream: consume the body, stream ~10 KiB of SSE back
+const upstream = Bun.serve({
+	hostname: "127.0.0.1",
+	port: 0,
+	async fetch(req) {
+		await req.arrayBuffer();
+		const stream = new ReadableStream<Uint8Array>({
+			async start(controller) {
+				controller.enqueue(
+					encoder.encode(
+						'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":1}}}\n\n',
+					),
+				);
+				for (let i = 0; i < 20; i++) {
+					await Bun.sleep(1);
+					controller.enqueue(
+						encoder.encode(
+							`event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"${"x".repeat(400)}"}}\n\n`,
+						),
+					);
+				}
+				controller.enqueue(
+					encoder.encode(
+						'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+					),
+				);
+				controller.close();
+			},
+		});
+		return new Response(stream, {
+			headers: { "content-type": "text/event-stream" },
+		});
+	},
+});
+const upstreamUrl = `http://127.0.0.1:${upstream.port}/v1/messages`;
+
+// ---- proxy: the request-body path of proxy-operations.ts + model-mapping.ts
+const proxy = Bun.serve({
+	hostname: "127.0.0.1",
+	port: 0,
+	maxRequestBodySize: 64 * 1024 * 1024,
+	async fetch(req) {
+		const buffer = await req.arrayBuffer(); // prepareRequestBody
+		const providerRequest = new Request(upstreamUrl, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: new Uint8Array(buffer),
+			duplex: "half",
+			signal: req.signal,
+		} as RequestInit);
+
+		// transformRequestBodyModel: inspect the JSON body without consuming it
+		if (MODE === "json") {
+			await providerRequest.clone().json();
+		} else if (MODE === "text") {
+			JSON.parse(await providerRequest.clone().text());
+		}
+
+		// makeProxyRequest
+		const response = await fetch(
+			new Request(providerRequest, {
+				headers: new Headers(providerRequest.headers),
+				signal: req.signal,
+			}),
+		);
+
+		// teeStream-style pump
+		const reader = response.body?.getReader();
+		if (!reader) return new Response(null, { status: 502 });
+		const body = new ReadableStream<Uint8Array>({
+			async pull(controller) {
+				const { done, value } = await reader.read();
+				if (done) {
+					reader.releaseLock();
+					controller.close();
+					return;
+				}
+				controller.enqueue(value);
+			},
+		});
+		return new Response(body, {
+			status: response.status,
+			headers: { "content-type": "text/event-stream" },
+		});
+	},
+});
+const proxyUrl = `http://127.0.0.1:${proxy.port}/v1/messages`;
+
+async function settledRssKiB(): Promise<number> {
+	Bun.gc(true);
+	await Bun.sleep(100);
+	Bun.gc(true);
+	return Math.round(process.memoryUsage().rss / 1024);
+}
+
+async function drive(count: number): Promise<void> {
+	const child = Bun.spawn(
+		[
+			"bun",
+			import.meta.path,
+			"--client",
+			proxyUrl,
+			String(count),
+			String(BODY_KIB),
+		],
+		{ stdout: "inherit", stderr: "inherit" },
+	);
+	const code = await child.exited;
+	if (code !== 0) throw new Error(`client exited with ${code}`);
+}
+
+await drive(WARMUP);
+const before = await settledRssKiB();
+const startedAt = performance.now();
+await drive(N);
+const elapsedMs = performance.now() - startedAt;
+const after = await settledRssKiB();
+
+console.log(
+	JSON.stringify({
+		bun: Bun.version,
+		mode: MODE,
+		requests: N,
+		body_kib: BODY_KIB,
+		rss_before_kib: before,
+		rss_after_kib: after,
+		kib_per_request: Math.round((after - before) / N),
+		ms_per_request: Math.round(elapsedMs / N),
+	}),
+);
+upstream.stop(true);
+proxy.stop(true);
+
+// ---- child process: the client
+async function runClient(url: string, count: number, bodyKiB: number) {
+	const filler =
+		"Lorem ipsum — dolor sit amet, consectetur → adipiscing elit. ";
+	const text = filler.repeat(
+		Math.ceil((bodyKiB * 1024) / Buffer.byteLength(filler)),
+	);
+	const body = JSON.stringify({
+		model: "claude-opus-5",
+		messages: [{ role: "user", content: [{ type: "text", text }] }],
+		max_tokens: 1024,
+		stream: true,
+	});
+	let started = 0;
+	await Promise.all(
+		Array.from({ length: CONCURRENCY }, async () => {
+			while (started < count) {
+				started++;
+				const res = await fetch(url, {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body,
+				});
+				await res.text();
+			}
+		}),
+	);
+}

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -212,12 +212,19 @@ export NO_PROXY=localhost,127.0.0.1
 If RSS grows into multiple GB while `process.memoryUsage().heapUsed` stays
 flat at tens of MB, this is native (off-heap) memory retention, not a JS
 object leak — clearing history or caches will not help. This was tracked as
-issue [#382](https://github.com/tombii/better-ccflare/issues/382): stream
-reader locks were never released on normal stream completion, and a few
-response paths cloned bodies whose tee branches were never consumed. Fixed
-upstream — upgrade to the latest version. If it still reproduces on a recent
-release, report your provider mix and an idle-vs-traffic RSS comparison on
-the issue.
+issue [#382](https://github.com/tombii/better-ccflare/issues/382). Three
+causes were fixed in turn: stream reader locks were never released on normal
+stream completion, a few response paths cloned bodies whose tee branches were
+never consumed, and — the dominant one — the model-mapping transform read the
+client request through `request.clone().json()`, which on Bun 1.3.x never
+frees the clone's native body buffer. That last one leaked about 1x the
+request body (~1 MiB per Claude Code request, roughly 0.5 GB/hour under normal
+load) on every proxied request for every provider, and only the request side,
+so it survived the response-side fixes. The clone is now read as text
+(`readRequestJson` in `packages/providers`); Bun 1.4.0+ also fixes it at the
+runtime level. `bench/request-clone-json-leak.ts` reproduces the measurement.
+If it still reproduces on a recent release, report your provider mix and an
+idle-vs-traffic RSS comparison on the issue.
 
 **Solutions**:
 1. Check log file size (auto-rotates at 10MB):

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -33,6 +33,8 @@ export {
 export * from "./types";
 // Export usage fetcher
 export * from "./usage-fetcher";
+// Export shared request-body helper (Bun 1.3.x clone().json() leak, #382)
+export * from "./utils/request-json";
 // Export shared stream-drain helpers
 export * from "./utils/stream-drain";
 // Export xAI usage fetcher

--- a/packages/providers/src/utils/model-mapping.ts
+++ b/packages/providers/src/utils/model-mapping.ts
@@ -5,6 +5,7 @@ import {
 } from "@better-ccflare/core";
 import { Logger } from "@better-ccflare/logger";
 import type { Account } from "@better-ccflare/types";
+import { readRequestJson } from "./request-json";
 
 const log = new Logger("ModelMappingUtils");
 
@@ -112,8 +113,9 @@ export async function transformRequestBodyModel<T extends TransformRequestBody>(
 	providerSpecificMapping?: (model: string, account?: Account) => string,
 ): Promise<Request> {
 	try {
-		const clonedRequest = request.clone();
-		const body: T = await clonedRequest.json();
+		// Not `request.clone().json()` — that leaks the whole body on Bun 1.3.x
+		// (#382); see readRequestJson.
+		const body = await readRequestJson<T>(request);
 		let bodyChanged = false;
 
 		// Codex-only passthrough metadata; strip it in case failover ever
@@ -185,8 +187,8 @@ export async function transformRequestBodyModelForce(
 	targetModel: string,
 ): Promise<Request> {
 	try {
-		const clonedRequest = request.clone();
-		const body = await clonedRequest.json();
+		// Not `request.clone().json()` — see readRequestJson (#382).
+		const body = await readRequestJson<Record<string, unknown> | null>(request);
 
 		// Direct body mutation for performance - avoids object spreading overhead
 		if (body && typeof body === "object" && body.model) {

--- a/packages/providers/src/utils/request-json.test.ts
+++ b/packages/providers/src/utils/request-json.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, spyOn } from "bun:test";
+import {
+	transformRequestBodyModel,
+	transformRequestBodyModelForce,
+} from "./model-mapping";
+import { readRequestJson } from "./request-json";
+
+const body = {
+	model: "claude-sonnet-4-5",
+	messages: [{ role: "user", content: "hello" }],
+	max_tokens: 16,
+};
+
+function makeRequest(): Request {
+	return new Request("http://test.com/v1/messages", {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify(body),
+	});
+}
+
+describe("readRequestJson", () => {
+	it("returns the parsed body and leaves the original request unconsumed", async () => {
+		const request = makeRequest();
+
+		expect(await readRequestJson(request)).toEqual(body);
+		expect(request.bodyUsed).toBe(false);
+		expect(await request.json()).toEqual(body);
+	});
+
+	it("rejects a non-JSON body", async () => {
+		const request = new Request("http://test.com/v1/messages", {
+			method: "POST",
+			body: "not json",
+		});
+
+		await expect(readRequestJson(request)).rejects.toThrow();
+		expect(request.bodyUsed).toBe(false);
+	});
+
+	// Regression guard for #382. The leak is specific to `.json()` on a cloned
+	// Request under Bun 1.3.x; the parsed output is identical either way, so the
+	// transform tests cannot tell the two reads apart. This one can: it fails if
+	// any request-body inspection path goes back to `clone().json()`.
+	it("never reads a cloned Request through .json()", async () => {
+		const jsonSpy = spyOn(Request.prototype, "json");
+		const textSpy = spyOn(Request.prototype, "text");
+		try {
+			await readRequestJson(makeRequest());
+			await transformRequestBodyModel(makeRequest(), undefined, (model) =>
+				model === body.model ? "mapped-model" : model,
+			);
+			await transformRequestBodyModelForce(makeRequest(), "forced-model");
+
+			expect(jsonSpy).not.toHaveBeenCalled();
+			expect(textSpy).toHaveBeenCalledTimes(3);
+		} finally {
+			jsonSpy.mockRestore();
+			textSpy.mockRestore();
+		}
+	});
+});

--- a/packages/providers/src/utils/request-json.ts
+++ b/packages/providers/src/utils/request-json.ts
@@ -1,0 +1,20 @@
+/**
+ * Read a Request's JSON body without consuming the Request.
+ *
+ * Do NOT write `request.clone().json()` for this. On Bun 1.3.x (measured on
+ * 1.3.11 through 1.3.14) the `.json()` read of a cloned, body-bearing Request
+ * never frees the clone's native body buffer: every call leaks the full
+ * request body off-heap, invisible to `heapUsed`, heap snapshots and
+ * `/api/debug/heap`. On a proxy fronting Claude Code that is ~1 MiB per
+ * request — the multi-GB RSS growth in issue #382, which survived the earlier
+ * reader-lock and response-clone fixes because it sits on the request side.
+ *
+ * Reading the same clone with `.text()` (or `.arrayBuffer()`) releases the
+ * buffer normally, and Bun 1.4.0+ frees both. bench/request-clone-json-leak.ts
+ * reproduces the measurement.
+ */
+export async function readRequestJson<T = unknown>(
+	request: Request,
+): Promise<T> {
+	return JSON.parse(await request.clone().text()) as T;
+}


### PR DESCRIPTION
…1.3.x leaks the body (#382)

transformRequestBodyModel and transformRequestBodyModelForce inspected the client body with `request.clone().json()`. On Bun 1.3.x (measured 1.3.11 through 1.3.14) that `.json()` read never frees the clone's native body buffer, so every proxied request leaked ~1x its body off-heap — about 1 MiB per Claude Code request, 9 GB in 18 h on a production proxy, while heapUsed stayed flat at tens of MB. The earlier #382 fixes were all on the response side, which is why the leak survived them.

Reading the same clone with `.text()` releases the buffer normally, and Bun 1.4.0+ frees both. Both call sites now go through a small documented helper, readRequestJson(), exported from @better-ccflare/providers.

Reproduction: bench/request-clone-json-leak.ts (N=300, 800 KiB body):
  Bun 1.3.11  json ~950 KiB/req   text ~17 KiB/req   none ~12 KiB/req
  Bun 1.4.1   json  ~18 KiB/req   text ~20 KiB/req

Verified in production: a 3.5.72 build with this patch stayed at ~200 MB RSS over 400+ requests where the published binary retained ~1 MiB each.