### PR TITLE
fix(alerts): catch aggregate-query rejections to prevent proxy crash

### DIFF
--- a/packages/http-api/src/services/__tests__/auth-failure-alert.test.ts
+++ b/packages/http-api/src/services/__tests__/auth-failure-alert.test.ts
@@ -330,4 +330,29 @@ describe("AlertService aggregate-query timeout (issue #451)", () => {
 			service.stop();
 		}
 	});
+
+	it("does not leak an unhandled rejection when the auth-failure listener's cooldown check times out", async () => {
+		// persistAndEmit's cooldown pre-check (`SELECT id FROM alerts`) runs
+		// outside its own try/catch, and handleAuthFailure awaits persistAndEmit
+		// with no catch of its own — so this exercises a third fire-and-forget
+		// call site (authFailureListener) distinct from the two above.
+		const adapter = new TimingOutPgAdapter();
+		const service = new AlertService(
+			adapter as unknown as BunSqlAdapterType,
+			makeAggregateConfig(),
+		);
+		service.start();
+		try {
+			authFailureEvents.emit("event", {
+				accountId: "account-1",
+				accountName: "Backup account",
+				provider: "anthropic",
+				reason: "invalid_grant",
+			});
+			await Bun.sleep(20);
+			expect(unhandled).toHaveLength(0);
+		} finally {
+			service.stop();
+		}
+	});
 });

--- a/packages/http-api/src/services/__tests__/auth-failure-alert.test.ts
+++ b/packages/http-api/src/services/__tests__/auth-failure-alert.test.ts
@@ -2,7 +2,11 @@ import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { EventEmitter } from "node:events";
 import type { Config } from "@better-ccflare/config";
-import { alertEvents, authFailureEvents } from "@better-ccflare/core";
+import {
+	alertEvents,
+	authFailureEvents,
+	requestEvents,
+} from "@better-ccflare/core";
 import type { BunSqlAdapter as BunSqlAdapterType } from "@better-ccflare/database";
 import { BunSqlAdapter, ensureSchema } from "@better-ccflare/database";
 import type { RequestResponse } from "@better-ccflare/types";
@@ -203,6 +207,122 @@ describe("AlertService persistAndEmit (issue #326)", () => {
 			await expect(
 				service.evaluateRequest(makeHighTokenRequest()),
 			).resolves.toBeUndefined();
+		} finally {
+			service.stop();
+		}
+	});
+});
+
+/**
+ * Fake adapter whose `.get()` rejects, simulating a PG statement-timeout on
+ * the aggregate-threshold query (e.g. the tokens-per-hour SUM query,
+ * issue #451, "PG query timeout after 8000ms").
+ */
+class TimingOutPgAdapter implements BunSqlAdapterType {
+	readonly isSQLite = false;
+
+	async get<T>(_sql: string, _params?: unknown[]): Promise<T | null> {
+		throw new Error("PG query timeout after 8000ms: SELECT SUM(...)");
+	}
+	async query<T>(_sql: string, _params?: unknown[]): Promise<T[]> {
+		throw new Error("PG query timeout after 8000ms: SELECT ...");
+	}
+	async run(_sql: string, _params?: unknown[]): Promise<void> {}
+}
+
+function makeAggregateConfig(): Config {
+	return Object.assign(new EventEmitter(), {
+		getAlertDailySpendUsd: () => 0,
+		getAlertTokensPerHour: () => 1,
+		getAlertRequestTokens: () => 0,
+		getAlertAnomalyEnabled: () => true,
+		getAlertAnomalyIntervalMinutes: () => 15,
+		getAlertAnomalyBaselineWindowMinutes: () => 1440,
+		getAlertAnomalyLoopMinRequests: () => 25,
+		getAlertCooldownMinutes: () => 60,
+		getAlertWebhookUrl: () => "",
+	}) as unknown as Config;
+}
+
+describe("AlertService aggregate-query timeout (issue #451)", () => {
+	let originalUnhandledRejectionListeners: NodeJS.UnhandledRejectionListener[];
+	let unhandled: unknown[];
+
+	function makeHighTokenRequest(): RequestResponse {
+		return {
+			id: "req-timeout",
+			timestamp: new Date().toISOString(),
+			method: "POST",
+			path: "/v1/messages",
+			accountUsed: "account-1",
+			statusCode: 200,
+			success: true,
+			errorMessage: null,
+			responseTimeMs: 100,
+			failoverAttempts: 0,
+			model: "claude-3",
+			totalTokens: 10,
+			inputTokens: 10,
+			cacheReadInputTokens: 0,
+			cacheCreationInputTokens: 0,
+			outputTokens: 0,
+			costUsd: 0,
+			project: null,
+		};
+	}
+
+	beforeEach(() => {
+		originalUnhandledRejectionListeners = process.listeners(
+			"unhandledRejection",
+		) as NodeJS.UnhandledRejectionListener[];
+		process.removeAllListeners("unhandledRejection");
+		unhandled = [];
+		process.on("unhandledRejection", (reason) => {
+			unhandled.push(reason);
+		});
+	});
+
+	afterEach(() => {
+		process.removeAllListeners("unhandledRejection");
+		for (const listener of originalUnhandledRejectionListeners) {
+			process.on("unhandledRejection", listener);
+		}
+	});
+
+	it("does not leak an unhandled rejection when the request listener's aggregate query times out", async () => {
+		const adapter = new TimingOutPgAdapter();
+		const service = new AlertService(
+			adapter as unknown as BunSqlAdapterType,
+			makeAggregateConfig(),
+		);
+		service.start();
+		try {
+			requestEvents.emit("event", {
+				type: "summary",
+				payload: makeHighTokenRequest(),
+			});
+			await Bun.sleep(20);
+			expect(unhandled).toHaveLength(0);
+		} finally {
+			service.stop();
+		}
+	});
+
+	it("does not leak an unhandled rejection when the anomaly timer's query times out", async () => {
+		const adapter = new TimingOutPgAdapter();
+		const service = new AlertService(
+			adapter as unknown as BunSqlAdapterType,
+			makeAggregateConfig(),
+		);
+		service.start();
+		try {
+			// evaluateAnomalies is invoked directly here (rather than waiting for
+			// the interval timer) so the test isn't tied to
+			// anomalyIntervalMinutes, but it exercises the exact rejecting
+			// `.query()` call the timer callback fires-and-forgets.
+			service.evaluateAnomalies().catch(() => {});
+			await Bun.sleep(20);
+			expect(unhandled).toHaveLength(0);
 		} finally {
 			service.stop();
 		}

--- a/packages/http-api/src/services/__tests__/auth-failure-alert.test.ts
+++ b/packages/http-api/src/services/__tests__/auth-failure-alert.test.ts
@@ -230,13 +230,16 @@ class TimingOutPgAdapter implements BunSqlAdapterType {
 	async run(_sql: string, _params?: unknown[]): Promise<void> {}
 }
 
-function makeAggregateConfig(): Config {
+function makeAggregateConfig(
+	overrides: Partial<{ anomalyIntervalMinutes: number }> = {},
+): Config {
 	return Object.assign(new EventEmitter(), {
 		getAlertDailySpendUsd: () => 0,
 		getAlertTokensPerHour: () => 1,
 		getAlertRequestTokens: () => 0,
 		getAlertAnomalyEnabled: () => true,
-		getAlertAnomalyIntervalMinutes: () => 15,
+		getAlertAnomalyIntervalMinutes: () =>
+			overrides.anomalyIntervalMinutes ?? 15,
 		getAlertAnomalyBaselineWindowMinutes: () => 1440,
 		getAlertAnomalyLoopMinRequests: () => 25,
 		getAlertCooldownMinutes: () => 60,
@@ -310,17 +313,17 @@ describe("AlertService aggregate-query timeout (issue #451)", () => {
 
 	it("does not leak an unhandled rejection when the anomaly timer's query times out", async () => {
 		const adapter = new TimingOutPgAdapter();
+		// A sub-millisecond interval so the real setInterval callback in
+		// restartAnomalyTimer fires during the test wait below — this exercises
+		// the timer's own .catch() wrapper directly, rather than calling
+		// evaluateAnomalies() and catching it ourselves (which would still pass
+		// even if the production .catch() were removed).
 		const service = new AlertService(
 			adapter as unknown as BunSqlAdapterType,
-			makeAggregateConfig(),
+			makeAggregateConfig({ anomalyIntervalMinutes: 1 / 6_000_000 }),
 		);
 		service.start();
 		try {
-			// evaluateAnomalies is invoked directly here (rather than waiting for
-			// the interval timer) so the test isn't tied to
-			// anomalyIntervalMinutes, but it exercises the exact rejecting
-			// `.query()` call the timer callback fires-and-forgets.
-			service.evaluateAnomalies().catch(() => {});
 			await Bun.sleep(20);
 			expect(unhandled).toHaveLength(0);
 		} finally {

--- a/packages/http-api/src/services/alerts.ts
+++ b/packages/http-api/src/services/alerts.ts
@@ -254,7 +254,16 @@ export class AlertService {
 		this.config = config;
 		this.requestListener = (event) => {
 			if (event.type === "summary") {
-				void this.evaluateRequest(event.payload);
+				// Alert evaluation runs the aggregate-threshold queries below,
+				// which can reject (e.g. a PG statement-timeout during a DB
+				// slowdown, #451). This listener is invoked from an async event
+				// handler, so an unhandled rejection here would crash the proxy
+				// with exit code 1 — catch and log instead.
+				this.evaluateRequest(event.payload).catch((error) => {
+					log.error(
+						`Alert evaluation failed for request ${event.payload.id}: ${(error as Error).message}`,
+					);
+				});
 			}
 		};
 		this.authFailureListener = (event) => {
@@ -322,7 +331,13 @@ export class AlertService {
 		if (!config.anomalyEnabled) return;
 		this.anomalyTimer = setInterval(
 			() => {
-				void this.evaluateAnomalies();
+				// Same rationale as evaluateRequest above: this timer callback
+				// fires an async function with no caller to await it, so an
+				// unhandled rejection (e.g. a PG timeout on the anomaly window
+				// query, #451) would otherwise crash the proxy.
+				this.evaluateAnomalies().catch((error) => {
+					log.error(`Anomaly evaluation failed: ${(error as Error).message}`);
+				});
 			},
 			config.anomalyIntervalMinutes * 60 * 1000,
 		);

--- a/packages/http-api/src/services/alerts.ts
+++ b/packages/http-api/src/services/alerts.ts
@@ -267,7 +267,17 @@ export class AlertService {
 			}
 		};
 		this.authFailureListener = (event) => {
-			void this.handleAuthFailure(event);
+			// Same rationale as the requestListener above: handleAuthFailure
+			// calls persistAndEmit, whose cooldown pre-check (`SELECT id FROM
+			// alerts`) runs outside persistAndEmit's own try/catch and can
+			// reject on a PG timeout (#451). This listener is invoked from an
+			// async event handler, so an unhandled rejection here would crash
+			// the proxy with exit code 1 — catch and log instead.
+			this.handleAuthFailure(event).catch((error) => {
+				log.error(
+					`Auth-failure alert evaluation failed for account ${event.accountId}: ${(error as Error).message}`,
+				);
+			});
 		};
 		this.configChangeListener = ({ key }: { key: string }) => {
 			if (


### PR DESCRIPTION
## Summary
- Fixes #451 — a PG statement-timeout on the usage-aggregation query (e.g. a transient Supabase stall at the 00:00 UTC day rollover) was escaping as an unhandled promise rejection and crashing the whole Bun process with exit code 1.
- `AlertService` fired two async methods without awaiting or catching them: `this.evaluateRequest(...)` in the request-summary listener, and `this.evaluateAnomalies()` in the anomaly interval timer. Both run unguarded aggregate SQL (`SELECT SUM(...)`, and the anomaly-window `SELECT`) that can reject on a PG timeout.
- This mirrors the exact fix already applied to `persistAndEmit` for issue #326 (see the comment there: "the listener is invoked from an async event handler, so an unhandled rejection crashes Bun with exit code 1") — that fix covered persistence failures but missed these two upstream call sites.

## Changes
- `packages/http-api/src/services/alerts.ts`: wrap both fire-and-forget call sites with `.catch()` that logs via the existing `Logger` instead of letting the rejection escape.
- `packages/http-api/src/services/__tests__/auth-failure-alert.test.ts`: added regression tests using a fake adapter whose `.get()`/`.query()` reject with a simulated `PG query timeout after 8000ms` error (matching the issue's log), asserting via a `process.on("unhandledRejection")` listener that neither the request-summary path nor the anomaly-timer path leaks an unhandled rejection. Confirmed these tests fail against the pre-fix code and reproduce the exact crash stack from the issue.

## Not included (open question for feedback)
The issue and its automated triage comment also suggested (2) auditing other background jobs for the same pattern, and (3) a top-level `process.on("unhandledRejection")` safety net across the whole server as defense-in-depth. I scoped this PR to the two concrete, confirmed call sites in `AlertService` rather than adding a blanket top-level handler, since silently swallowing *all* unhandled rejections server-wide could mask unrelated bugs rather than just this one. Happy to add a scoped top-level handler (e.g. one that logs-and-continues rather than exits) if that's wanted — flagging for discussion rather than deciding unilaterally.

## Test plan
- [x] `bun run lint && bun run typecheck && bun run format` — clean
- [x] New regression tests fail on pre-fix code (reproduce the crash stack) and pass after the fix
- [x] Full `packages/http-api` test suite passes (575 pass, 51 skip, 0 fail — pre-existing unrelated `oauth.test.ts` unhandled-error noise confirmed present on unmodified code too)