### PR TITLE
fix(adapter): harden SSE frame parsing for CRLF in the stream translator

### DIFF
--- a/packages/openai-responses-adapter/src/__tests__/stream-translator.test.ts
+++ b/packages/openai-responses-adapter/src/__tests__/stream-translator.test.ts
@@ -7,10 +7,12 @@ async function collectSseEvents(
 ): Promise<Array<{ event: string; data: unknown }>> {
 	const text = await response.text();
 	const events: Array<{ event: string; data: unknown }> = [];
-	const rawEvents = text.split("\n\n").filter((s) => s.trim().length > 0);
+	const rawEvents = text
+		.split(/\r?\n\r?\n/)
+		.filter((s) => s.trim().length > 0);
 
 	for (const rawEvent of rawEvents) {
-		const lines = rawEvent.split("\n");
+		const lines = rawEvent.split(/\r?\n/);
 		let eventType = "message";
 		let dataStr = "";
 		for (const line of lines) {
@@ -373,5 +375,53 @@ describe("translateAnthropicStreamToResponses", () => {
 			"Failed to parse upstream SSE event data",
 		);
 		expect(JSON.stringify(logs)).not.toContain(payloadMarker);
+	});
+	test("translates a CRLF-framed upstream stream", async () => {
+		// An upstream that terminates SSE frames with \r\n\r\n contains no
+		// literal "\n\n", so a literal split finds no boundary: every event
+		// stays buffered until flush and only the last one survives.
+		const events = [
+			sseEvent("message_start", {
+				type: "message_start",
+				message: {
+					id: "msg_crlf",
+					model: "claude-3-5-sonnet",
+					usage: { input_tokens: 11, output_tokens: 0 },
+				},
+			}),
+			sseEvent("content_block_start", {
+				type: "content_block_start",
+				index: 0,
+				content_block: { type: "text", text: "" },
+			}),
+			sseEvent("content_block_delta", {
+				type: "content_block_delta",
+				index: 0,
+				delta: { type: "text_delta", text: "hello" },
+			}),
+			sseEvent("content_block_stop", { type: "content_block_stop", index: 0 }),
+			sseEvent("message_delta", {
+				type: "message_delta",
+				delta: { stop_reason: "end_turn" },
+				usage: { output_tokens: 3 },
+			}),
+			sseEvent("message_stop", { type: "message_stop" }),
+		].map((e) => e.replace(/\n/g, "\r\n"));
+
+		const body = `${events.join("\r\n\r\n")}\r\n\r\n`;
+		const upstream = new Response(body, {
+			headers: { "Content-Type": "text/event-stream" },
+		});
+
+		const translated = translateAnthropicStreamToResponses(upstream, "gpt-5");
+		const got = await collectSseEvents(translated);
+		const types = got.map((e) => e.event);
+
+		expect(types).toContain("response.created");
+		expect(types).toContain("response.output_text.delta");
+		expect(types).toContain("response.completed");
+
+		const delta = got.find((e) => e.event === "response.output_text.delta");
+		expect((delta?.data as { delta?: string })?.delta).toBe("hello");
 	});
 });

--- a/packages/openai-responses-adapter/src/stream-translator.ts
+++ b/packages/openai-responses-adapter/src/stream-translator.ts
@@ -377,13 +377,14 @@ function parseAndProcessChunk(
 	controller: TransformStreamDefaultController,
 	state: State,
 ): void {
-	// Split on double newline to get complete SSE events
-	const rawEvents = chunk.split("\n\n");
+	// Split on double newline to get complete SSE events. Accept CRLF framing:
+	// an upstream that terminates frames with \r\n\r\n has no literal "\n\n".
+	const rawEvents = chunk.split(/\r?\n\r?\n/);
 
 	for (const rawEvent of rawEvents) {
 		if (!rawEvent.trim()) continue;
 
-		const lines = rawEvent.split("\n");
+		const lines = rawEvent.split(/\r?\n/);
 		let eventType = "";
 		let dataStr = "";
 
@@ -444,12 +445,18 @@ export function translateAnthropicStreamToResponses(
 				try {
 					state.lineBuffer += decoder.decode(chunk, { stream: true });
 
-					// Process complete events (delimited by \n\n), keep remainder in buffer
-					const lastDoubleNewline = state.lineBuffer.lastIndexOf("\n\n");
-					if (lastDoubleNewline === -1) return;
+					// Process complete events (delimited by \r?\n\r?\n), keep the
+					// remainder in the buffer. The delimiter is two or four bytes
+					// depending on framing, so consume its matched length instead of
+					// assuming 2 — otherwise a CRLF stream leaks "\r\n" into the
+					// next event.
+					const boundaries = [...state.lineBuffer.matchAll(/\r?\n\r?\n/g)];
+					const last = boundaries[boundaries.length - 1];
+					if (!last || last.index === undefined) return;
 
-					const complete = state.lineBuffer.slice(0, lastDoubleNewline + 2);
-					state.lineBuffer = state.lineBuffer.slice(lastDoubleNewline + 2);
+					const cut = last.index + last[0].length;
+					const complete = state.lineBuffer.slice(0, cut);
+					state.lineBuffer = state.lineBuffer.slice(cut);
 
 					parseAndProcessChunk(complete, controller, state);
 				} catch (err) {


### PR DESCRIPTION
Follow-up to `4cdd64fc`. That commit hardened the two remaining literal-newline parsers in the Codex provider; the same bug class survives in `packages/openai-responses-adapter/src/stream-translator.ts`, which is the last SSE parser in the adapter package still splitting on literals.

Three sites:

- `transform()` searched for the frame boundary with `lastIndexOf("\n\n")`
- `parseAndProcessChunk()` split frames on `"\n\n"` and lines on `"\n"`

## Why it is a different failure shape

CRLF framing terminates a frame with `\r\n\r\n`, which contains no adjacent `"\n\n"`, so the boundary search never matches. Unlike the provider's live transform you fixed, this one does not hang. `lineBuffer` grows until flush, the whole buffer is then parsed as a single event, and the per-line loop overwrites `eventType`/`dataStr` on each iteration — so only the final event survives and every earlier one is dropped silently. This translator also carries `inputTokens`/`outputTokens` in its own state, so usage goes with them.

`transform()` now consumes the matched delimiter's own length instead of a hardcoded `+2`. Under CRLF a fixed 2 would leave a stray `\r\n` at the head of the next frame even once the boundary is found.

## Proof

The added test feeds a fully CRLF-framed stream through the translator. Against the unfixed source it fails with:

```
expect(received).toContain(expected)
Expected to contain: "response.created"
Received: [ "response.completed" ]
```

That single surviving event is exactly the silent-loss shape above. I also made the test file's own SSE collector CRLF-tolerant, so the assertion exercises the translator rather than the harness.

278 tests across the adapter and codex suites pass.

To be clear about scope: I have no upstream that frames with CRLF, so this is defensive hardening for consistency with `4cdd64fc`, not a fix for an observed production failure.