### PR TITLE
improve(adapter): avoid redundant buffer scan in SSE frame boundary discovery

### DIFF
--- a/packages/openai-responses-adapter/src/__tests__/stream-translator.test.ts
+++ b/packages/openai-responses-adapter/src/__tests__/stream-translator.test.ts
@@ -424,4 +424,69 @@ describe("translateAnthropicStreamToResponses", () => {
 		const delta = got.find((e) => e.event === "response.output_text.delta");
 		expect((delta?.data as { delta?: string })?.delta).toBe("hello");
 	});
+
+	test("flushes a final frame with no trailing delimiter", async () => {
+		// Every other fixture's body ends with "\n\n", so the last frame is
+		// always drained by transform(). Omit it here so the last frame stays
+		// in lineBuffer until flush() and exercises the flush-only code path.
+		// End on message_delta (not message_stop): message_stop carries no
+		// data of its own, so a broken flush would still pass by falling back
+		// to emitDone()'s defaults. message_delta's output_tokens only reaches
+		// the final usage if this trailing, undelimited frame is actually
+		// parsed and processed rather than silently dropped.
+		const events = [
+			sseEvent("message_start", {
+				type: "message_start",
+				message: {
+					id: "msg_noeof",
+					usage: { input_tokens: 5, output_tokens: 0 },
+				},
+			}),
+			sseEvent("content_block_start", {
+				type: "content_block_start",
+				index: 0,
+				content_block: { type: "text", text: "" },
+			}),
+			sseEvent("content_block_delta", {
+				type: "content_block_delta",
+				index: 0,
+				delta: { type: "text_delta", text: "hi" },
+			}),
+			sseEvent("content_block_stop", { type: "content_block_stop", index: 0 }),
+			sseEvent("message_delta", {
+				type: "message_delta",
+				delta: { stop_reason: "end_turn" },
+				usage: { output_tokens: 7 },
+			}),
+		];
+
+		// No trailing "\n\n" after the last event.
+		const body = events.join("\n\n");
+		const upstream = new Response(body, {
+			headers: { "Content-Type": "text/event-stream" },
+		});
+
+		const translated = translateAnthropicStreamToResponses(upstream, "gpt-5");
+		const got = await collectSseEvents(translated);
+		const types = got.map((e) => e.event);
+
+		expect(types).toContain("response.created");
+		expect(types).toContain("response.output_text.delta");
+		expect(types).toContain("response.completed");
+
+		const delta = got.find((e) => e.event === "response.output_text.delta");
+		expect((delta?.data as { delta?: string })?.delta).toBe("hi");
+
+		// Proves the trailing, undelimited message_delta frame was actually
+		// parsed by flush() rather than dropped — output_tokens would be 0
+		// (emitDone()'s default) if that frame never reached processEvent().
+		const doneEvent = got.find((e) => e.event === "response.completed");
+		const usage = (
+			(doneEvent?.data as Record<string, unknown>).response as Record<
+				string,
+				unknown
+			>
+		).usage as Record<string, number>;
+		expect(usage.output_tokens).toBe(7);
+	});
 });

--- a/packages/openai-responses-adapter/src/stream-translator.ts
+++ b/packages/openai-responses-adapter/src/stream-translator.ts
@@ -373,14 +373,10 @@ function processEvent(
 }
 
 function parseAndProcessChunk(
-	chunk: string,
+	rawEvents: string[],
 	controller: TransformStreamDefaultController,
 	state: State,
 ): void {
-	// Split on double newline to get complete SSE events. Accept CRLF framing:
-	// an upstream that terminates frames with \r\n\r\n has no literal "\n\n".
-	const rawEvents = chunk.split(/\r?\n\r?\n/);
-
 	for (const rawEvent of rawEvents) {
 		if (!rawEvent.trim()) continue;
 
@@ -445,20 +441,22 @@ export function translateAnthropicStreamToResponses(
 				try {
 					state.lineBuffer += decoder.decode(chunk, { stream: true });
 
-					// Process complete events (delimited by \r?\n\r?\n), keep the
-					// remainder in the buffer. The delimiter is two or four bytes
-					// depending on framing, so consume its matched length instead of
-					// assuming 2 — otherwise a CRLF stream leaks "\r\n" into the
-					// next event.
-					const boundaries = [...state.lineBuffer.matchAll(/\r?\n\r?\n/g)];
-					const last = boundaries[boundaries.length - 1];
-					if (!last || last.index === undefined) return;
+					// Split into frames (delimited by \r?\n\r?\n), keep the trailing
+					// partial frame buffered. The delimiter is two or four bytes
+					// depending on framing, so track each match's own length rather
+					// than assuming 2 — otherwise a CRLF stream leaks "\r\n" into the
+					// next frame. Reuses this single scan for both boundary discovery
+					// and frame extraction instead of re-splitting the same text.
+					const rawEvents: string[] = [];
+					let cursor = 0;
+					for (const match of state.lineBuffer.matchAll(/\r?\n\r?\n/g)) {
+						rawEvents.push(state.lineBuffer.slice(cursor, match.index));
+						cursor = match.index + match[0].length;
+					}
+					if (cursor === 0) return;
 
-					const cut = last.index + last[0].length;
-					const complete = state.lineBuffer.slice(0, cut);
-					state.lineBuffer = state.lineBuffer.slice(cut);
-
-					parseAndProcessChunk(complete, controller, state);
+					state.lineBuffer = state.lineBuffer.slice(cursor);
+					parseAndProcessChunk(rawEvents, controller, state);
 				} catch (err) {
 					log.warn(`Stream transform error: ${String(err)}`);
 				}
@@ -472,7 +470,7 @@ export function translateAnthropicStreamToResponses(
 
 					// Process any remaining buffered content
 					if (state.lineBuffer.trim()) {
-						parseAndProcessChunk(`${state.lineBuffer}\n\n`, controller, state);
+						parseAndProcessChunk([state.lineBuffer], controller, state);
 						state.lineBuffer = "";
 					}
 					// Ensure done event is always emitted


### PR DESCRIPTION
## Summary
Addresses the P2 Greptile flagged on #454: `transform()`'s `matchAll()` collected every frame boundary in the buffered SSE text, then `parseAndProcessChunk()` immediately re-split the same text on the identical `/\r?\n\r?\n/` regex. This reuses the single `matchAll` scan to slice frames directly, so the buffer is only scanned once per chunk instead of twice.

- `parseAndProcessChunk` now takes pre-split `rawEvents: string[]` instead of a raw chunk string it re-splits itself.
- `transform()` builds `rawEvents` by walking the `matchAll` iterator once, slicing between consecutive boundaries.
- `flush()` passes its single remaining buffered frame as a one-element array.

No behavior change — same frames, same events, same buffering semantics.

## Test plan
- [x] `bun test packages/openai-responses-adapter` — 59 pass, 0 fail (including the CRLF regression test from #454)
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run lint` — clean (no new warnings)