### PR TITLE
chore: add a token usage report for diagnosing token consumption

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,17 @@ Comprehensive documentation of the OAuth re-authentication system that allows us
 - Usage examples
 - Troubleshooting guide
 
+### [Token Usage Report](token-usage-report.md)
+How to compare token consumption across days or weeks and find what caused a
+jump, using `scripts/token-usage-report.ts` against local Claude Code
+transcripts — the history the retention-pruned `requests` table cannot provide.
+
+**Topics covered:**
+- Why the proxy database cannot answer week-over-week questions
+- Running the report and reading its columns
+- Attributing a period to models, projects or subagent types
+- Limits of transcript-based accounting
+
 ## For Developers
 
 These documents provide in-depth technical details for developers working on the better-ccflare codebase. For user-facing documentation, see the main [CLAUDE.md](../CLAUDE.md) file.

--- a/docs/token-usage-report.md
+++ b/docs/token-usage-report.md
@@ -74,12 +74,25 @@ All options:
 | `--dir <path>` | `~/.claude/projects` | transcript root |
 | `--since <date>` | 8 weeks ago | ignore entries before this date |
 | `--group day\|week` | `week` | period length (ISO week, Mon–Sun) |
-| `--by <dimension>` | none | breakdown per period: `model`, `project`, `agent`, `kind` |
+| `--by <dimension>` | none | breakdown per period (see below) |
 | `--top <n>` | `5` | breakdown rows per period |
 | `--json` | off | machine-readable output |
 
-`--by kind` splits main sessions from subagent runs — the fastest way to see
-whether fan-outs are driving the bill.
+The breakdown dimensions:
+
+| `--by` | Splits each period by | Answers |
+| --- | --- | --- |
+| `kind` | main session vs. subagent run | are fan-outs driving the bill? |
+| `agent` | subagent type (`agentType` from the meta file) | which fan-out, and since when? |
+| `project` | project directory | which work caused it |
+| `model` | model id | did the model mix shift? |
+| `version` | Claude Code CLI version | did an update change anything? |
+| `context` | context size per call (`<50k`, `50–200k`, `200–500k`, `>500k`) | how much of the bill comes from oversized contexts |
+
+Every breakdown row carries its own `k/call`, which is what makes the
+comparison honest: a period's overall `tok/call` can fall while every single
+row inside it rises, simply because cheap rows grew faster than expensive
+ones.
 
 ## Reading the output
 
@@ -109,15 +122,39 @@ week (Mon)     calls    in M   out M  cacheRd M  cacheCr M   total M  tok/call  
 
 ## Finding the cause
 
-A workflow that gets there in three commands:
+A rise in **calls** and a rise in **tokens per call** are different problems.
+Split them first, then follow the matching branch:
 
 1. `--by kind` — main sessions or subagents?
-2. `--by agent --top 5` — if subagents: which agent type, and since when?
-3. `--by project --group day --since <the day it started>` — which work
-   caused it.
+2. More calls → `--by agent --top 5` (which fan-out, since when), then
+   `--by project --group day --since <that day>` (which work caused it).
+   Fan-outs are the usual answer: one agent type running many parallel lanes
+   for a few days can outweigh every interactive session combined.
+3. More tokens per call → `--by context` (how much comes from oversized
+   contexts) and `--by model` (did the mix shift toward expensive models?).
 
-Fan-outs are the usual answer: one agent type running many parallel lanes for
-a few days can outweigh every interactive session combined.
+### Correlating with a CLI update
+
+`--by version` tags every call with the Claude Code version that produced it,
+so a suspected regression can be tested instead of assumed. **Compare versions
+*within* one day, never across days.** Across days the work itself changes —
+different projects, models and session lengths — and that variation dwarfs any
+version effect.
+
+The test is simple: on days when two versions ran side by side, do their
+`k/call` values differ consistently in the same direction? If the gap between
+versions on one day is smaller than the day-to-day swing, the version is not
+the cause, whatever the calendar suggests.
+
+Two independent records help date the updates themselves: the `version` field
+in the transcripts (what actually ran) and the history of
+`CLAUDE_CLI_VERSION` in `packages/core/src/version.ts`, which a pre-push hook
+keeps current:
+
+```bash
+git log --format='%h %ad %s' --date=short -p origin/main -- packages/core/src/version.ts \
+  | grep -E '^[0-9a-f]{8} |^\+export const CLAUDE_CLI_VERSION'
+```
 
 ## What it does not see
 

--- a/docs/token-usage-report.md
+++ b/docs/token-usage-report.md
@@ -1,0 +1,141 @@
+# Token Usage Report
+
+How to find out **why token consumption jumped** — which period, which model,
+which project, which subagent type — by comparing Claude Code transcripts
+across days or weeks.
+
+Script: [`scripts/token-usage-report.ts`](../scripts/token-usage-report.ts)
+
+## The question this answers
+
+> "We are burning far more tokens than a few days ago. More requests than the
+> weeks before, or just more expensive ones?"
+
+The report separates those two causes. It buckets every API call into periods,
+shows the delta against the previous period, and can attribute each period to
+the models, projects or subagent types behind it.
+
+## Why not the proxy database
+
+better-ccflare records every request, but it cannot answer a *week-over-week*
+question:
+
+| Table | Holds | Why it does not answer this |
+| --- | --- | --- |
+| `requests` | full per-request token counts | retention-pruned — a busy instance keeps only a couple of days |
+| `usage_snapshots` | rate-limit utilization per account | months of history, but **no token counts** — only how full the 5-hour and 7-day windows were |
+
+`usage_snapshots` is still worth a look as an independent cross-check: rising
+average utilization confirms a consumption trend without touching transcripts.
+
+The one local source that reaches back weeks *with* token counts is the Claude
+Code transcript tree in `~/.claude/projects`. That is what this script reads.
+
+## Prerequisites
+
+- Bun (already required by this repo)
+- Claude Code transcripts on the machine you run it on — by default
+  `~/.claude/projects`, override with `--dir`
+
+The script only reads files. It never writes to the transcripts and never
+contacts the proxy or any API.
+
+## Run it
+
+Week-over-week overview, the default:
+
+```bash
+bun run scripts/token-usage-report.ts
+```
+
+A specific window, day by day:
+
+```bash
+bun run scripts/token-usage-report.ts --since 2026-08-01 --group day
+```
+
+Attribution — the step that usually finds the cause:
+
+```bash
+bun run scripts/token-usage-report.ts --by agent --top 5
+bun run scripts/token-usage-report.ts --by project --group day --since 2026-09-01
+```
+
+Machine-readable, for a chart or a diff between two runs:
+
+```bash
+bun run scripts/token-usage-report.ts --json > usage.json
+```
+
+All options:
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `--dir <path>` | `~/.claude/projects` | transcript root |
+| `--since <date>` | 8 weeks ago | ignore entries before this date |
+| `--group day\|week` | `week` | period length (ISO week, Mon–Sun) |
+| `--by <dimension>` | none | breakdown per period: `model`, `project`, `agent`, `kind` |
+| `--top <n>` | `5` | breakdown rows per period |
+| `--json` | off | machine-readable output |
+
+`--by kind` splits main sessions from subagent runs — the fastest way to see
+whether fan-outs are driving the bill.
+
+## Reading the output
+
+Example shape (numbers illustrative):
+
+```
+week (Mon)     calls    in M   out M  cacheRd M  cacheCr M   total M  tok/call  vs prev
+2026-08-17    33,290     0.5     3.2      10,300        220     10,522      316k       —
+2026-08-24    53,495     6.4     4.7      16,300        350     16,652      311k     +58%
+2026-08-31    88,904     2.4     6.9      25,400        700     25,971      292k     +56%
+2026-09-07 *  12,000     0.2     1.4       3,500         90      3,600      300k     -86%
+```
+
+- **`calls` vs `tok/call`** is the whole point of the comparison. Rising calls
+  at a flat `tok/call` means *more work*, not more expensive work; a rising
+  `tok/call` at flat calls means longer contexts (bigger prompts, longer
+  sessions, larger context windows).
+- **`cacheRd` dominates everything.** In agent-heavy usage the cache-read
+  column is routinely 90–95 % of all tokens: every turn re-reads the whole
+  context from the prompt cache. Session length therefore costs roughly
+  quadratically — a worker with twice the turns reads its context twice as
+  often at twice the size.
+- **`*` marks a period that has not finished yet.** Its `vs prev` value is
+  meaningless — never compare a running week against a completed one.
+- **`vs prev`** compares total tokens against the previous row, not against
+  the same weekday or the same calendar period last month.
+
+## Finding the cause
+
+A workflow that gets there in three commands:
+
+1. `--by kind` — main sessions or subagents?
+2. `--by agent --top 5` — if subagents: which agent type, and since when?
+3. `--by project --group day --since <the day it started>` — which work
+   caused it.
+
+Fan-outs are the usual answer: one agent type running many parallel lanes for
+a few days can outweigh every interactive session combined.
+
+## What it does not see
+
+- **Only this machine.** Sessions on other hosts, other clients, and any
+  non-Claude-Code traffic through the proxy are missing entirely.
+- **Fewer entries than the proxy counts.** Retries and token-counting requests
+  never reach a transcript, so proxy request counts run well above the call
+  counts here. Compare trends between the two, not absolute numbers.
+- **No costs.** Token counts only — pricing is deliberately not hardcoded.
+
+## How it works
+
+- Walks `--dir` for `*.jsonl`, skipping files whose mtime predates `--since`
+  (a file cannot contain entries newer than itself).
+- Keeps every assistant message carrying a `usage` block, deduped by message
+  id — resumed and forked sessions copy earlier history into new files, and
+  without dedupe those turns would be counted twice.
+- Attributes subagent transcripts
+  (`<project>/<session>/subagents/agent-*.jsonl`) to their parent project and
+  to the `agentType` recorded in the sibling `.meta.json`.
+- Buckets timestamps in the machine's local timezone.

--- a/scripts/token-usage-report.ts
+++ b/scripts/token-usage-report.ts
@@ -1,0 +1,388 @@
+/**
+ * token-usage-report.ts — compare Claude Code token usage across time periods.
+ *
+ * WHY THIS SCRIPT EXISTS
+ *   "We are burning far more tokens than last week — why?" cannot be answered
+ *   from the proxy database. `requests` is retention-pruned (a busy instance
+ *   keeps only a couple of days), and `usage_snapshots` stores rate-limit
+ *   *utilization*, not token counts. The only local record that reaches back
+ *   weeks is the Claude Code transcript tree in ~/.claude/projects.
+ *
+ *   This script aggregates those transcripts into period buckets (day or ISO
+ *   week), shows the delta against the previous period, and — with --by —
+ *   attributes each period to the models, projects or subagent types that
+ *   caused it. That last part usually holds the answer: a single fan-out agent
+ *   type can dominate a whole week.
+ *
+ * WHAT IT COUNTS
+ *   Every assistant message that carries a `usage` block: one API call each,
+ *   with input, output, cache-read and cache-creation tokens. Messages are
+ *   deduped by message id, because resumed and forked sessions copy earlier
+ *   history into a new transcript file.
+ *
+ *   Subagent transcripts live in <project>/<session>/subagents/agent-*.jsonl
+ *   with a sibling .meta.json naming the agentType; they are attributed to
+ *   their parent project and to that agent type.
+ *
+ * LIMITS
+ *   * Local transcripts only — sessions on other machines, other clients and
+ *     non-Claude-Code traffic through the proxy are invisible here.
+ *   * The proxy counts more HTTP requests than this counts calls: retries and
+ *     token-counting requests never appear in a transcript.
+ *   * Periods are bucketed in the machine's local timezone.
+ *
+ * Usage:
+ *   bun run scripts/token-usage-report.ts
+ *   bun run scripts/token-usage-report.ts --group day --since 2026-08-01
+ *   bun run scripts/token-usage-report.ts --by agent --top 5
+ *   bun run scripts/token-usage-report.ts --json > usage.json
+ */
+import { createReadStream, readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import { createInterface } from "node:readline";
+
+type Counters = {
+	calls: number;
+	input: number;
+	output: number;
+	cacheRead: number;
+	cacheCreate: number;
+};
+
+type Options = {
+	dir: string;
+	since: Date;
+	group: "day" | "week";
+	by: "model" | "project" | "agent" | "kind" | null;
+	top: number;
+	json: boolean;
+};
+
+const USAGE_MARKER = '"cache_read_input_tokens"';
+
+function emptyCounters(): Counters {
+	return { calls: 0, input: 0, output: 0, cacheRead: 0, cacheCreate: 0 };
+}
+
+function total(c: Counters): number {
+	return c.input + c.output + c.cacheRead + c.cacheCreate;
+}
+
+function add(target: Map<string, Counters>, key: string, c: Counters): void {
+	let bucket = target.get(key);
+	if (!bucket) {
+		bucket = emptyCounters();
+		target.set(key, bucket);
+	}
+	bucket.calls += c.calls;
+	bucket.input += c.input;
+	bucket.output += c.output;
+	bucket.cacheRead += c.cacheRead;
+	bucket.cacheCreate += c.cacheCreate;
+}
+
+function parseArgs(argv: string[]): Options {
+	const opts: Options = {
+		dir: join(homedir(), ".claude", "projects"),
+		since: new Date(Date.now() - 56 * 86400_000),
+		group: "week",
+		by: null,
+		top: 5,
+		json: false,
+	};
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		const next = () => {
+			const value = argv[++i];
+			if (value === undefined) {
+				console.error(`${arg} needs a value`);
+				process.exit(2);
+			}
+			return value;
+		};
+		switch (arg) {
+			case "--dir":
+				opts.dir = next();
+				break;
+			case "--since": {
+				const value = next();
+				const parsed = new Date(value);
+				if (Number.isNaN(parsed.getTime())) {
+					console.error(`--since: not a date: ${value}`);
+					process.exit(2);
+				}
+				opts.since = parsed;
+				break;
+			}
+			case "--group": {
+				const value = next();
+				if (value !== "day" && value !== "week") {
+					console.error("--group must be day or week");
+					process.exit(2);
+				}
+				opts.group = value;
+				break;
+			}
+			case "--by": {
+				const value = next();
+				if (!["model", "project", "agent", "kind"].includes(value)) {
+					console.error("--by must be model, project, agent or kind");
+					process.exit(2);
+				}
+				opts.by = value as Options["by"];
+				break;
+			}
+			case "--top":
+				opts.top = Number.parseInt(next(), 10);
+				break;
+			case "--json":
+				opts.json = true;
+				break;
+			case "--help":
+			case "-h":
+				console.log(
+					[
+						"Usage: bun run scripts/token-usage-report.ts [options]",
+						"",
+						"  --dir <path>      transcript root (default ~/.claude/projects)",
+						"  --since <date>    ignore entries before this date (default: 8 weeks ago)",
+						"  --group day|week  period length (default week, ISO Mon-Sun)",
+						"  --by <dimension>  breakdown per period: model | project | agent | kind",
+						"  --top <n>         breakdown rows per period (default 5)",
+						"  --json            machine-readable output",
+					].join("\n"),
+				);
+				process.exit(0);
+				break;
+			default:
+				console.error(`unknown option: ${arg} (try --help)`);
+				process.exit(2);
+		}
+	}
+	return opts;
+}
+
+/** All *.jsonl below root whose mtime is at or after `since`. */
+function collectTranscripts(root: string, since: Date): string[] {
+	const found: string[] = [];
+	const walk = (dir: string): void => {
+		let entries: ReturnType<typeof readdirSync>;
+		try {
+			entries = readdirSync(dir, { withFileTypes: true });
+		} catch {
+			return;
+		}
+		for (const entry of entries) {
+			const path = join(dir, entry.name);
+			if (entry.isDirectory()) {
+				walk(path);
+			} else if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+				// A file cannot hold entries newer than its own mtime, so an
+				// older file can be skipped without reading it.
+				try {
+					if (statSync(path).mtimeMs >= since.getTime()) found.push(path);
+				} catch {
+					// vanished between readdir and stat — ignore
+				}
+			}
+		}
+	};
+	walk(root);
+	return found;
+}
+
+/**
+ * Attribution of one transcript file: which project it belongs to, whether it
+ * is a subagent run, and (for subagents) which agent type produced it.
+ */
+function attribute(
+	path: string,
+	root: string,
+): { project: string; kind: "main" | "subagent"; agent: string } {
+	const relative = path.slice(root.length).replace(/^\/+/, "");
+	const parts = relative.split("/");
+	const project = parts[0] ?? "?";
+	if (!parts.includes("subagents")) {
+		return { project, kind: "main", agent: "(main session)" };
+	}
+	let agent = "?";
+	try {
+		const meta = JSON.parse(
+			readFileSync(path.replace(/\.jsonl$/, ".meta.json"), "utf8"),
+		);
+		if (typeof meta?.agentType === "string") agent = meta.agentType;
+	} catch {
+		// no meta file (older transcripts) — fall back to the file name
+		agent = basename(path).replace(/^agent-/, "").replace(/\.jsonl$/, "");
+	}
+	return { project, kind: "subagent", agent };
+}
+
+function dayKey(d: Date): string {
+	const month = `${d.getMonth() + 1}`.padStart(2, "0");
+	const day = `${d.getDate()}`.padStart(2, "0");
+	return `${d.getFullYear()}-${month}-${day}`;
+}
+
+/** Monday of the ISO week containing `d`, in local time. */
+function weekKey(d: Date): string {
+	const start = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+	const mondayOffset = (start.getDay() + 6) % 7;
+	start.setDate(start.getDate() - mondayOffset);
+	return dayKey(start);
+}
+
+/** True while the period starting at `key` has not finished yet. */
+function isPartial(key: string, group: "day" | "week"): boolean {
+	const start = new Date(`${key}T00:00:00`);
+	const end = new Date(start);
+	end.setDate(end.getDate() + (group === "week" ? 7 : 1));
+	return end.getTime() > Date.now();
+}
+
+async function main(): Promise<void> {
+	const opts = parseArgs(process.argv.slice(2));
+	const files = collectTranscripts(opts.dir, opts.since);
+	process.stderr.write(
+		`scanning ${files.length} transcripts in ${opts.dir}\n`,
+	);
+
+	const periods = new Map<string, Counters>();
+	const breakdown = new Map<string, Map<string, Counters>>();
+	const seen = new Set<string>();
+	let scanned = 0;
+
+	for (const path of files) {
+		if (++scanned % 500 === 0) {
+			process.stderr.write(`  ${scanned}/${files.length}\n`);
+		}
+		const where = attribute(path, opts.dir);
+		const lines = createInterface({
+			input: createReadStream(path, { encoding: "utf8" }),
+			crlfDelay: Number.POSITIVE_INFINITY,
+		});
+		for await (const line of lines) {
+			// Cheap pre-filter: only usage blocks carry this key, and they are a
+			// small minority of the lines in a transcript.
+			if (!line.includes(USAGE_MARKER)) continue;
+			let record: {
+				timestamp?: string;
+				uuid?: string;
+				message?: {
+					id?: string;
+					model?: string;
+					usage?: Record<string, number>;
+				};
+			};
+			try {
+				record = JSON.parse(line);
+			} catch {
+				continue;
+			}
+			const usage = record.message?.usage;
+			if (!usage || !record.timestamp) continue;
+			const id = record.message?.id ?? record.uuid;
+			if (!id || seen.has(id)) continue;
+			seen.add(id);
+
+			const at = new Date(record.timestamp);
+			if (Number.isNaN(at.getTime()) || at < opts.since) continue;
+
+			const counters: Counters = {
+				calls: 1,
+				input: usage.input_tokens ?? 0,
+				output: usage.output_tokens ?? 0,
+				cacheRead: usage.cache_read_input_tokens ?? 0,
+				cacheCreate: usage.cache_creation_input_tokens ?? 0,
+			};
+			const period = opts.group === "week" ? weekKey(at) : dayKey(at);
+			add(periods, period, counters);
+
+			if (opts.by) {
+				const dimension =
+					opts.by === "model"
+						? (record.message?.model ?? "?")
+						: opts.by === "project"
+							? where.project
+							: opts.by === "agent"
+								? where.agent
+								: where.kind;
+				let inner = breakdown.get(period);
+				if (!inner) {
+					inner = new Map();
+					breakdown.set(period, inner);
+				}
+				add(inner, dimension, counters);
+			}
+		}
+	}
+
+	const keys = [...periods.keys()].sort();
+
+	if (opts.json) {
+		console.log(
+			JSON.stringify(
+				{
+					group: opts.group,
+					since: opts.since.toISOString(),
+					periods: keys.map((key) => ({
+						period: key,
+						partial: isPartial(key, opts.group),
+						...periods.get(key),
+						total: total(periods.get(key) as Counters),
+						breakdown: opts.by
+							? Object.fromEntries(breakdown.get(key) ?? [])
+							: undefined,
+					})),
+				},
+				null,
+				2,
+			),
+		);
+		return;
+	}
+
+	const M = 1_000_000;
+	const fmt = (n: number) => n.toLocaleString("en-US");
+	console.log(
+		`\n${opts.group === "week" ? "week (Mon)" : "day".padEnd(10)}   ${"calls".padStart(8)} ${"in M".padStart(7)} ${"out M".padStart(7)} ${"cacheRd M".padStart(10)} ${"cacheCr M".padStart(10)} ${"total M".padStart(9)} ${"tok/call".padStart(9)}  vs prev`,
+	);
+	let previous: number | null = null;
+	for (const key of keys) {
+		const c = periods.get(key) as Counters;
+		const sum = total(c);
+		const perCall = c.calls ? Math.round(sum / c.calls / 1000) : 0;
+		const delta =
+			previous && previous > 0
+				? `${sum >= previous ? "+" : ""}${Math.round(((sum - previous) / previous) * 100)}%`
+				: "—";
+		const flag = isPartial(key, opts.group) ? " *" : "  ";
+		console.log(
+			`${key}${flag} ${fmt(c.calls).padStart(9)} ${(c.input / M).toFixed(1).padStart(7)} ${(c.output / M).toFixed(1).padStart(7)} ${(c.cacheRead / M).toFixed(0).padStart(10)} ${(c.cacheCreate / M).toFixed(0).padStart(10)} ${(sum / M).toFixed(0).padStart(9)} ${`${perCall}k`.padStart(9)}  ${delta.padStart(6)}`,
+		);
+		if (opts.by) {
+			const rows = [...(breakdown.get(key) ?? new Map())]
+				.sort((a, b) => total(b[1]) - total(a[1]))
+				.slice(0, opts.top);
+			for (const [name, c2] of rows) {
+				const share = sum ? Math.round((total(c2) / sum) * 100) : 0;
+				console.log(
+					`             ${name.slice(0, 38).padEnd(38)} ${fmt(c2.calls).padStart(8)} calls ${(total(c2) / M).toFixed(0).padStart(7)}M ${`${share}%`.padStart(5)}`,
+				);
+			}
+		}
+		previous = sum;
+	}
+	console.log(
+		"\n* period still running — not comparable to the completed ones.",
+	);
+	console.log(
+		`${fmt(seen.size)} distinct calls, ${fmt(files.length)} transcripts scanned.`,
+	);
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/scripts/token-usage-report.ts
+++ b/scripts/token-usage-report.ts
@@ -50,16 +50,46 @@ type Counters = {
 	cacheCreate: number;
 };
 
+type Dimension =
+	| "model"
+	| "project"
+	| "agent"
+	| "kind"
+	| "version"
+	| "context";
+
 type Options = {
 	dir: string;
 	since: Date;
 	group: "day" | "week";
-	by: "model" | "project" | "agent" | "kind" | null;
+	by: Dimension | null;
 	top: number;
 	json: boolean;
 };
 
+const DIMENSIONS: Dimension[] = [
+	"model",
+	"project",
+	"agent",
+	"kind",
+	"version",
+	"context",
+];
+
 const USAGE_MARKER = '"cache_read_input_tokens"';
+
+/**
+ * Context size of one call: everything the model had to read, output excluded.
+ * The buckets matter because anything above ~200k can only happen in an
+ * extended context window — the share of those calls is what makes a session
+ * expensive per turn.
+ */
+function contextBucket(tokens: number): string {
+	if (tokens > 500_000) return "ctx >500k";
+	if (tokens > 200_000) return "ctx 200-500k";
+	if (tokens > 50_000) return "ctx 50-200k";
+	return "ctx <50k";
+}
 
 function emptyCounters(): Counters {
 	return { calls: 0, input: 0, output: 0, cacheRead: 0, cacheCreate: 0 };
@@ -126,11 +156,11 @@ function parseArgs(argv: string[]): Options {
 			}
 			case "--by": {
 				const value = next();
-				if (!["model", "project", "agent", "kind"].includes(value)) {
-					console.error("--by must be model, project, agent or kind");
+				if (!DIMENSIONS.includes(value as Dimension)) {
+					console.error(`--by must be one of: ${DIMENSIONS.join(", ")}`);
 					process.exit(2);
 				}
-				opts.by = value as Options["by"];
+				opts.by = value as Dimension;
 				break;
 			}
 			case "--top":
@@ -148,7 +178,7 @@ function parseArgs(argv: string[]): Options {
 						"  --dir <path>      transcript root (default ~/.claude/projects)",
 						"  --since <date>    ignore entries before this date (default: 8 weeks ago)",
 						"  --group day|week  period length (default week, ISO Mon-Sun)",
-						"  --by <dimension>  breakdown per period: model | project | agent | kind",
+						`  --by <dimension>  breakdown per period: ${DIMENSIONS.join(" | ")}`,
 						"  --top <n>         breakdown rows per period (default 5)",
 						"  --json            machine-readable output",
 					].join("\n"),
@@ -269,6 +299,7 @@ async function main(): Promise<void> {
 			let record: {
 				timestamp?: string;
 				uuid?: string;
+				version?: string;
 				message?: {
 					id?: string;
 					model?: string;
@@ -300,14 +331,28 @@ async function main(): Promise<void> {
 			add(periods, period, counters);
 
 			if (opts.by) {
-				const dimension =
-					opts.by === "model"
-						? (record.message?.model ?? "?")
-						: opts.by === "project"
-							? where.project
-							: opts.by === "agent"
-								? where.agent
-								: where.kind;
+				let dimension: string;
+				switch (opts.by) {
+					case "model":
+						dimension = record.message?.model ?? "?";
+						break;
+					case "project":
+						dimension = where.project;
+						break;
+					case "agent":
+						dimension = where.agent;
+						break;
+					case "version":
+						dimension = record.version ?? "?";
+						break;
+					case "context":
+						dimension = contextBucket(
+							counters.input + counters.cacheRead + counters.cacheCreate,
+						);
+						break;
+					default:
+						dimension = where.kind;
+				}
 				let inner = breakdown.get(period);
 				if (!inner) {
 					inner = new Map();
@@ -367,8 +412,13 @@ async function main(): Promise<void> {
 				.slice(0, opts.top);
 			for (const [name, c2] of rows) {
 				const share = sum ? Math.round((total(c2) / sum) * 100) : 0;
+				// tokens per call per row: comparing rows WITHIN one period is what
+				// separates a real effect from a shifted mix.
+				const rowPerCall = c2.calls
+					? Math.round(total(c2) / c2.calls / 1000)
+					: 0;
 				console.log(
-					`             ${name.slice(0, 38).padEnd(38)} ${fmt(c2.calls).padStart(8)} calls ${(total(c2) / M).toFixed(0).padStart(7)}M ${`${share}%`.padStart(5)}`,
+					`             ${name.slice(0, 34).padEnd(34)} ${fmt(c2.calls).padStart(8)} calls ${(total(c2) / M).toFixed(0).padStart(7)}M ${`${share}%`.padStart(5)} ${`${rowPerCall}k/call`.padStart(11)}`,
 				);
 			}
 		}


### PR DESCRIPTION
**Why:** When token consumption jumps, this repo's own data cannot say what
changed. `requests` is retention-pruned and keeps only a couple of days on a
busy instance, and `usage_snapshots` stores rate-limit utilization rather than
token counts — so neither table can compare this week against the one before
it. The one local record that reaches back weeks with token counts is the
Claude Code transcript tree, which nothing in the repo reads today.

**Changes:**
- `scripts/token-usage-report.ts` aggregates transcripts into day or ISO-week
  buckets and prints calls, token classes, tokens per call and the delta
  against the previous period — separating "more calls" from "more expensive
  calls", which demand opposite responses.
- `--by model|project|agent|kind|version|context` attributes a period to what
  caused it. Fan-outs usually explain a volume spike; oversized contexts
  usually explain a per-call spike.
- Every breakdown row carries its own tokens-per-call figure, because an
  aggregate can fall while every group inside it rises — a shifted mix reads
  as a real change otherwise.
- Messages are deduped by id: resumed and forked sessions copy earlier history
  into new transcript files, and counting those turns twice would inflate long
  sessions by whole multiples.
- A period that has not finished yet is marked, so its delta is not read as a
  collapse.
- `docs/token-usage-report.md` documents the workflow, the columns, and the
  limits — transcript accounting sees only the local machine and fewer entries
  than the proxy counts, since retries and token-counting requests never reach
  a transcript.

**Verification:** Ported from a throwaway Python aggregate written for the
same question; both were run over the same 16,921 transcripts and the
TypeScript version reproduces its per-week figures exactly (88,904 calls /
25,971M tokens for one week, 53,495 / 16,652M for the previous one). Ran
`--group week`, `--group day --by agent`, `--by context` and `--by version`
end to end (71 s for the full tree). `bunx tsc --noEmit` reports no errors for
the new file; the two `apps/server/src/server.ts` errors in a fresh worktree
are the pre-existing missing `dashboard-web/dist` artifacts. `scripts/` is
excluded from biome in `biome.json`, so no lint gate applies there.

Used in practice for a real diagnosis: a suspected regression from a CLI
update did not survive `--by version` — comparing two versions that ran on the
same day showed no consistent difference, while the day-to-day swing was much
larger.
