### PR TITLE
feat: live model discovery in account-creation wizard for openai-compatible accounts

### DIFF
--- a/packages/dashboard-web/src/api.ts
+++ b/packages/dashboard-web/src/api.ts
@@ -419,6 +419,43 @@ class API extends HttpClient {
 		}
 	}
 
+	async previewOpenAICompatibleModels(data: {
+		apiKey: string;
+		endpoint: string;
+	}): Promise<{
+		provider: string;
+		models: Array<{ id: string; displayName: string; source: string }>;
+		fetchedAt: number;
+		source: string;
+	}> {
+		const startTime = Date.now();
+		const url = "/api/models/preview";
+
+		this.logger.debug(`→ POST ${url}`, { data: { endpoint: data.endpoint } });
+
+		try {
+			const response = await this.post<{
+				provider: string;
+				models: Array<{ id: string; displayName: string; source: string }>;
+				fetchedAt: number;
+				source: string;
+			}>(url, data);
+			const duration = Date.now() - startTime;
+			this.logger.debug(`← POST ${url} - 200 (${duration}ms)`);
+			return response;
+		} catch (error) {
+			const duration = Date.now() - startTime;
+			this.logger.error(`✗ POST ${url} - ERROR (${duration}ms)`, {
+				error: error instanceof Error ? error.message : String(error),
+				stack: error instanceof Error ? error.stack : undefined,
+			});
+			if (error instanceof HttpError) {
+				throw new Error(error.message);
+			}
+			throw error;
+		}
+	}
+
 	async addNanoGPTAccount(data: {
 		name: string;
 		apiKey: string;

--- a/packages/dashboard-web/src/components/accounts/AccountAddForm.tsx
+++ b/packages/dashboard-web/src/components/accounts/AccountAddForm.tsx
@@ -222,6 +222,15 @@ export function AccountAddForm({
 	>([]);
 	const [loadingProfiles, setLoadingProfiles] = useState(false);
 
+	// openai-compatible "Fetch models" state
+	const [modelPreviewState, setModelPreviewState] = useState<
+		"idle" | "loading" | "success" | "error"
+	>("idle");
+	const [previewModels, setPreviewModels] = useState<
+		Array<{ id: string; displayName: string }>
+	>([]);
+	const [previewError, setPreviewError] = useState("");
+
 	// Cleanup Qwen polling on unmount
 	useEffect(() => {
 		return () => {
@@ -266,6 +275,47 @@ export function AccountAddForm({
 			return true;
 		} catch {
 			return false;
+		}
+	};
+
+	/**
+	 * Mirrors `deriveFamilyDefaults` in
+	 * packages/proxy/src/openai-compatible-model-catalog.ts: family defaults by
+	 * list position, since a preview fetch has no priority signal beyond the
+	 * order the endpoint returned models in.
+	 */
+	const deriveFamilyDefaults = (
+		models: Array<{ id: string; displayName: string }>,
+	): { opus: string; sonnet: string; haiku: string } => {
+		const at = (index: number) => models[Math.min(index, models.length - 1)].id;
+		return { opus: at(0), sonnet: at(1), haiku: at(2) };
+	};
+
+	const handleFetchOpenAICompatibleModels = async () => {
+		setModelPreviewState("loading");
+		setPreviewError("");
+		try {
+			const result = await api.previewOpenAICompatibleModels({
+				apiKey: newAccount.apiKey,
+				endpoint: newAccount.customEndpoint,
+			});
+			if (result.models.length === 0) {
+				throw new Error("No models returned by this endpoint");
+			}
+			setPreviewModels(result.models);
+			const defaults = deriveFamilyDefaults(result.models);
+			setNewAccount((prev) => ({
+				...prev,
+				opusModel: defaults.opus,
+				sonnetModel: defaults.sonnet,
+				haikuModel: defaults.haiku,
+			}));
+			setModelPreviewState("success");
+		} catch (err) {
+			setModelPreviewState("error");
+			setPreviewError(
+				err instanceof Error ? err.message : "Failed to fetch models",
+			);
 		}
 	};
 
@@ -909,6 +959,9 @@ export function AccountAddForm({
 				haikuModel: "",
 				fableModel: "",
 			});
+			setModelPreviewState("idle");
+			setPreviewModels([]);
+			setPreviewError("");
 			onSuccess();
 			return;
 		}
@@ -1104,6 +1157,9 @@ export function AccountAddForm({
 			haikuModel: "",
 			fableModel: "",
 		});
+		setModelPreviewState("idle");
+		setPreviewModels([]);
+		setPreviewError("");
 		onCancel();
 	};
 
@@ -2284,64 +2340,164 @@ export function AccountAddForm({
 								</p>
 							</div>
 							<div className="space-y-2">
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									disabled={
+										!newAccount.apiKey ||
+										!newAccount.customEndpoint ||
+										modelPreviewState === "loading"
+									}
+									onClick={handleFetchOpenAICompatibleModels}
+								>
+									{modelPreviewState === "loading"
+										? "Fetching…"
+										: "Fetch models"}
+								</Button>
+								{modelPreviewState === "error" && (
+									<p className="text-xs text-red-600 dark:text-red-400">
+										{previewError} — you can still enter model ids manually
+										below.
+									</p>
+								)}
+								{modelPreviewState === "success" && (
+									<p className="text-xs text-muted-foreground">
+										Found {previewModels.length} model
+										{previewModels.length === 1 ? "" : "s"} at this endpoint.
+									</p>
+								)}
+							</div>
+							<div className="space-y-2">
 								<Label>Model Mappings (Optional)</Label>
 								<p className="text-xs text-muted-foreground mb-2">
 									Map Anthropic model names to provider-specific models. Leave
 									empty to use defaults.
 								</p>
-								<div className="space-y-2 pl-4">
-									<div>
-										<Label htmlFor="opusModel" className="text-sm">
-											Opus Model
-										</Label>
-										<Input
-											id="opusModel"
-											value={newAccount.opusModel}
-											onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-												setNewAccount({
-													...newAccount,
-													opusModel: (e.target as HTMLInputElement).value,
-												})
-											}
-											placeholder="openai/gpt-5 (default)"
-											className="mt-1"
-										/>
+								{modelPreviewState === "success" ? (
+									<div className="space-y-2 pl-4">
+										<div>
+											<Label htmlFor="opusModel" className="text-sm">
+												Opus Model
+											</Label>
+											<Select
+												value={newAccount.opusModel}
+												onValueChange={(value: string) =>
+													setNewAccount({ ...newAccount, opusModel: value })
+												}
+											>
+												<SelectTrigger id="opusModel" className="mt-1">
+													<SelectValue />
+												</SelectTrigger>
+												<SelectContent>
+													{previewModels.map((model) => (
+														<SelectItem key={model.id} value={model.id}>
+															{model.displayName}
+														</SelectItem>
+													))}
+												</SelectContent>
+											</Select>
+										</div>
+										<div>
+											<Label htmlFor="sonnetModel" className="text-sm">
+												Sonnet Model
+											</Label>
+											<Select
+												value={newAccount.sonnetModel}
+												onValueChange={(value: string) =>
+													setNewAccount({ ...newAccount, sonnetModel: value })
+												}
+											>
+												<SelectTrigger id="sonnetModel" className="mt-1">
+													<SelectValue />
+												</SelectTrigger>
+												<SelectContent>
+													{previewModels.map((model) => (
+														<SelectItem key={model.id} value={model.id}>
+															{model.displayName}
+														</SelectItem>
+													))}
+												</SelectContent>
+											</Select>
+										</div>
+										<div>
+											<Label htmlFor="haikuModel" className="text-sm">
+												Haiku Model
+											</Label>
+											<Select
+												value={newAccount.haikuModel}
+												onValueChange={(value: string) =>
+													setNewAccount({ ...newAccount, haikuModel: value })
+												}
+											>
+												<SelectTrigger id="haikuModel" className="mt-1">
+													<SelectValue />
+												</SelectTrigger>
+												<SelectContent>
+													{previewModels.map((model) => (
+														<SelectItem key={model.id} value={model.id}>
+															{model.displayName}
+														</SelectItem>
+													))}
+												</SelectContent>
+											</Select>
+										</div>
 									</div>
-									<div>
-										<Label htmlFor="sonnetModel" className="text-sm">
-											Sonnet Model
-										</Label>
-										<Input
-											id="sonnetModel"
-											value={newAccount.sonnetModel}
-											onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-												setNewAccount({
-													...newAccount,
-													sonnetModel: (e.target as HTMLInputElement).value,
-												})
-											}
-											placeholder="openai/gpt-5 (default)"
-											className="mt-1"
-										/>
+								) : (
+									<div className="space-y-2 pl-4">
+										<div>
+											<Label htmlFor="opusModel" className="text-sm">
+												Opus Model
+											</Label>
+											<Input
+												id="opusModel"
+												value={newAccount.opusModel}
+												onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+													setNewAccount({
+														...newAccount,
+														opusModel: (e.target as HTMLInputElement).value,
+													})
+												}
+												placeholder="openai/gpt-5 (default)"
+												className="mt-1"
+											/>
+										</div>
+										<div>
+											<Label htmlFor="sonnetModel" className="text-sm">
+												Sonnet Model
+											</Label>
+											<Input
+												id="sonnetModel"
+												value={newAccount.sonnetModel}
+												onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+													setNewAccount({
+														...newAccount,
+														sonnetModel: (e.target as HTMLInputElement).value,
+													})
+												}
+												placeholder="openai/gpt-5 (default)"
+												className="mt-1"
+											/>
+										</div>
+										<div>
+											<Label htmlFor="haikuModel" className="text-sm">
+												Haiku Model
+											</Label>
+											<Input
+												id="haikuModel"
+												value={newAccount.haikuModel}
+												onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+													setNewAccount({
+														...newAccount,
+														haikuModel: (e.target as HTMLInputElement).value,
+													})
+												}
+												placeholder="openai/gpt-5-mini (default)"
+												className="mt-1"
+											/>
+										</div>
 									</div>
-									<div>
-										<Label htmlFor="haikuModel" className="text-sm">
-											Haiku Model
-										</Label>
-										<Input
-											id="haikuModel"
-											value={newAccount.haikuModel}
-											onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-												setNewAccount({
-													...newAccount,
-													haikuModel: (e.target as HTMLInputElement).value,
-												})
-											}
-											placeholder="openai/gpt-5-mini (default)"
-											className="mt-1"
-										/>
-									</div>
-								</div>
+								)}
 							</div>
 						</>
 					)}

--- a/packages/dashboard-web/src/components/accounts/AccountAddForm.tsx
+++ b/packages/dashboard-web/src/components/accounts/AccountAddForm.tsx
@@ -230,10 +230,11 @@ export function AccountAddForm({
 		Array<{ id: string; displayName: string }>
 	>([]);
 	const [previewError, setPreviewError] = useState("");
-	// The apiKey/endpoint a successful preview was fetched for, so a later
-	// edit to either field can invalidate stale results instead of letting
-	// the user submit model ids that were never validated against the
-	// endpoint they're now pointing at.
+	// The apiKey/endpoint the current (in-flight or last-settled) preview
+	// request was started for, so a later edit to either field can invalidate
+	// it — including while it's still loading — instead of letting a stale
+	// response apply model ids that were never validated against the
+	// endpoint the user is now pointing at.
 	const previewSourceRef = useRef<{ apiKey: string; endpoint: string } | null>(
 		null,
 	);
@@ -321,6 +322,10 @@ export function AccountAddForm({
 	const handleFetchOpenAICompatibleModels = async () => {
 		const requestId = ++previewRequestIdRef.current;
 		const { apiKey, customEndpoint: endpoint } = newAccount;
+		// Recorded at request start, not just on success — so an edit made
+		// while this request is still loading is visible to the invalidation
+		// effect below immediately, not only after the response comes back.
+		previewSourceRef.current = { apiKey, endpoint };
 		setModelPreviewState("loading");
 		setPreviewError("");
 		try {
@@ -335,7 +340,6 @@ export function AccountAddForm({
 				throw new Error("No models returned by this endpoint");
 			}
 			setPreviewModels(result.models);
-			previewSourceRef.current = { apiKey, endpoint };
 			const defaults = deriveFamilyDefaults(result.models);
 			setNewAccount((prev) => ({
 				...prev,

--- a/packages/dashboard-web/src/components/accounts/AccountAddForm.tsx
+++ b/packages/dashboard-web/src/components/accounts/AccountAddForm.tsx
@@ -230,6 +230,14 @@ export function AccountAddForm({
 		Array<{ id: string; displayName: string }>
 	>([]);
 	const [previewError, setPreviewError] = useState("");
+	// The apiKey/endpoint a successful preview was fetched for, so a later
+	// edit to either field can invalidate stale results instead of letting
+	// the user submit model ids that were never validated against the
+	// endpoint they're now pointing at.
+	const previewSourceRef = useRef<{ apiKey: string; endpoint: string } | null>(
+		null,
+	);
+	const previewRequestIdRef = useRef(0);
 
 	// Cleanup Qwen polling on unmount
 	useEffect(() => {
@@ -268,6 +276,25 @@ export function AccountAddForm({
 		}
 	}, [newAccount.mode]);
 
+	// Invalidate a fetched model preview once its source apiKey/endpoint no
+	// longer matches what's in the form — otherwise editing either field
+	// after a successful fetch would silently submit model ids from a
+	// different endpoint than the one being saved.
+	useEffect(() => {
+		const source = previewSourceRef.current;
+		if (!source) return;
+		if (
+			source.apiKey !== newAccount.apiKey ||
+			source.endpoint !== newAccount.customEndpoint
+		) {
+			previewSourceRef.current = null;
+			previewRequestIdRef.current += 1;
+			setModelPreviewState("idle");
+			setPreviewModels([]);
+			setPreviewError("");
+		}
+	}, [newAccount.apiKey, newAccount.customEndpoint]);
+
 	const validateCustomEndpoint = (endpoint: string): boolean => {
 		if (!endpoint) return true; // Empty is fine (use default)
 		try {
@@ -292,17 +319,23 @@ export function AccountAddForm({
 	};
 
 	const handleFetchOpenAICompatibleModels = async () => {
+		const requestId = ++previewRequestIdRef.current;
+		const { apiKey, customEndpoint: endpoint } = newAccount;
 		setModelPreviewState("loading");
 		setPreviewError("");
 		try {
 			const result = await api.previewOpenAICompatibleModels({
-				apiKey: newAccount.apiKey,
-				endpoint: newAccount.customEndpoint,
+				apiKey,
+				endpoint,
 			});
+			// A newer fetch (or an edit that invalidated this one) landed first —
+			// applying this response now would overwrite it with stale results.
+			if (requestId !== previewRequestIdRef.current) return;
 			if (result.models.length === 0) {
 				throw new Error("No models returned by this endpoint");
 			}
 			setPreviewModels(result.models);
+			previewSourceRef.current = { apiKey, endpoint };
 			const defaults = deriveFamilyDefaults(result.models);
 			setNewAccount((prev) => ({
 				...prev,
@@ -312,6 +345,7 @@ export function AccountAddForm({
 			}));
 			setModelPreviewState("success");
 		} catch (err) {
+			if (requestId !== previewRequestIdRef.current) return;
 			setModelPreviewState("error");
 			setPreviewError(
 				err instanceof Error ? err.message : "Failed to fetch models",
@@ -959,6 +993,8 @@ export function AccountAddForm({
 				haikuModel: "",
 				fableModel: "",
 			});
+			previewSourceRef.current = null;
+			previewRequestIdRef.current += 1;
 			setModelPreviewState("idle");
 			setPreviewModels([]);
 			setPreviewError("");
@@ -1157,6 +1193,8 @@ export function AccountAddForm({
 			haikuModel: "",
 			fableModel: "",
 		});
+		previewSourceRef.current = null;
+		previewRequestIdRef.current += 1;
 		setModelPreviewState("idle");
 		setPreviewModels([]);
 		setPreviewError("");

--- a/packages/http-api/src/handlers/__tests__/models-preview.test.ts
+++ b/packages/http-api/src/handlers/__tests__/models-preview.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { createModelsPreviewHandler } from "../models";
+
+/**
+ * `POST /api/models/preview` answers the same question as the `accountId`
+ * branch of `GET /api/models` — which models can this endpoint serve — but
+ * for the account wizard, before an account row exists to read api_key /
+ * custom_endpoint from. It takes the raw apiKey/endpoint the user just typed
+ * instead of an accountId.
+ */
+
+const LIVE_BODY = {
+	data: [{ id: "gpt-oss-120b" }, { id: "gpt-oss-20b" }],
+};
+
+let originalFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+	originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+function request(body: unknown): Request {
+	return new Request("http://local/api/models/preview", {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify(body),
+	});
+}
+
+describe("POST /api/models/preview", () => {
+	it("returns the live listing for a valid apiKey/endpoint", async () => {
+		globalThis.fetch = (async () =>
+			new Response(JSON.stringify(LIVE_BODY), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			})) as typeof globalThis.fetch;
+
+		const handler = createModelsPreviewHandler();
+		const response = await handler(
+			request({
+				apiKey: "sk-test-1234567890",
+				endpoint: "https://api.example.com/v1",
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as {
+			provider: string;
+			models: Array<{ id: string; displayName: string; source: string }>;
+			source: string;
+			fetchedAt: number;
+		};
+		expect(body.provider).toBe("openai-compatible");
+		expect(body.source).toBe("preview");
+		expect(body.models).toEqual([
+			{ id: "gpt-oss-120b", displayName: "gpt-oss-120b", source: "preview" },
+			{ id: "gpt-oss-20b", displayName: "gpt-oss-20b", source: "preview" },
+		]);
+		expect(body.fetchedAt).toBeGreaterThan(0);
+	});
+
+	it("rejects a missing apiKey with 400", async () => {
+		const handler = createModelsPreviewHandler();
+		const response = await handler(
+			request({ endpoint: "https://api.example.com/v1" }),
+		);
+
+		expect(response.status).toBe(400);
+	});
+
+	it("rejects a missing endpoint with 400", async () => {
+		const handler = createModelsPreviewHandler();
+		const response = await handler(request({ apiKey: "sk-test-1234567890" }));
+
+		expect(response.status).toBe(400);
+	});
+
+	it("rejects a non-string apiKey with 400", async () => {
+		const handler = createModelsPreviewHandler();
+		const response = await handler(
+			request({ apiKey: 12345, endpoint: "https://api.example.com/v1" }),
+		);
+
+		expect(response.status).toBe(400);
+	});
+
+	// The wizard has no cache to fall back to, so a failed underlying fetch
+	// must surface as an error response rather than degrading silently.
+	it("returns a non-200 error response when the endpoint rejects the credentials, and never echoes the apiKey", async () => {
+		const secretApiKey = "sk-super-secret-should-not-leak";
+		globalThis.fetch = (async () =>
+			new Response("unauthorized", {
+				status: 401,
+			})) as typeof globalThis.fetch;
+
+		const handler = createModelsPreviewHandler();
+		const response = await handler(
+			request({
+				apiKey: secretApiKey,
+				endpoint: "https://api.example.com/v1",
+			}),
+		);
+
+		expect(response.status).not.toBe(200);
+		const text = await response.text();
+		expect(text).not.toContain(secretApiKey);
+	});
+
+	it("returns a non-200 error response when the endpoint is unreachable, and never echoes the apiKey", async () => {
+		const secretApiKey = "sk-another-secret-value";
+		globalThis.fetch = (async () => {
+			throw new Error("fetch failed: network error");
+		}) as typeof globalThis.fetch;
+
+		const handler = createModelsPreviewHandler();
+		const response = await handler(
+			request({
+				apiKey: secretApiKey,
+				endpoint: "https://api.example.com/v1",
+			}),
+		);
+
+		expect(response.status).not.toBe(200);
+		const text = await response.text();
+		expect(text).not.toContain(secretApiKey);
+	});
+
+	it("rejects an invalid JSON body with 400", async () => {
+		const handler = createModelsPreviewHandler();
+		const response = await handler(
+			new Request("http://local/api/models/preview", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: "not json",
+			}),
+		);
+
+		expect(response.status).toBe(400);
+	});
+});

--- a/packages/http-api/src/handlers/models.ts
+++ b/packages/http-api/src/handlers/models.ts
@@ -1,5 +1,14 @@
-import { listCatalogueModels } from "@better-ccflare/core";
-import { errorResponse, jsonResponse } from "@better-ccflare/http-common";
+import {
+	listCatalogueModels,
+	validateApiKey,
+	validateEndpointUrl,
+} from "@better-ccflare/core";
+import {
+	BadRequest,
+	errorResponse,
+	jsonResponse,
+} from "@better-ccflare/http-common";
+import { fetchOpenAICompatibleModelsPreview } from "@better-ccflare/proxy";
 import type { APIContext } from "../types";
 
 /**
@@ -206,6 +215,54 @@ export function createModelsHandler(context: APIContext) {
 						warning: `No reference models for "${section}" in the models.dev catalogue (unknown provider, catalogue offline, or fetch failed)`,
 					}),
 		});
+	};
+}
+
+/**
+ * POST /api/models/preview — live model discovery for the account wizard,
+ * before an account row exists to read api_key/custom_endpoint from. Takes
+ * the apiKey/endpoint the user just typed instead of an accountId.
+ *
+ * Same shape as the `accountId` branch above (`source: "account"` there
+ * becomes `source: "preview"` here — there is no account row yet to call it
+ * "account"). Errors propagate as 4xx/5xx rather than degrading to a cached
+ * listing: unlike the account-backed path, a preview has no cache to fall
+ * back to.
+ */
+export function createModelsPreviewHandler() {
+	return async (req: Request): Promise<Response> => {
+		let body: unknown;
+		try {
+			body = await req.json();
+		} catch {
+			return errorResponse(BadRequest("Request body must be valid JSON"));
+		}
+		const { apiKey, endpoint } = body as Record<string, unknown>;
+
+		try {
+			const validApiKey = validateApiKey(apiKey);
+			const validEndpoint = validateEndpointUrl(endpoint);
+			const preview = await fetchOpenAICompatibleModelsPreview(
+				validApiKey,
+				validEndpoint,
+			);
+			return jsonResponse({
+				provider: "openai-compatible",
+				models: preview.models.map((model) => ({
+					id: model.id,
+					displayName: model.displayName,
+					source: "preview" as const,
+				})),
+				fetchedAt: preview.fetchedAt,
+				source: preview.source,
+			});
+		} catch (error) {
+			// Never let the raw error surface the apiKey the caller sent — the
+			// thrown errors from fetchOpenAICompatibleModelsPreview never include
+			// it, but errorResponse's own request-body logging redaction (see
+			// http-common/responses.ts) is the backstop if that ever changes.
+			return errorResponse(error);
+		}
 	};
 }
 

--- a/packages/http-api/src/router.ts
+++ b/packages/http-api/src/router.ts
@@ -91,6 +91,7 @@ import { createLogsHistoryHandler } from "./handlers/logs-history";
 import { createCleanupHandler } from "./handlers/maintenance";
 import {
 	createModelsHandler,
+	createModelsPreviewHandler,
 	createModelsRefreshHandler,
 } from "./handlers/models";
 import {
@@ -519,8 +520,12 @@ export class APIRouter {
 		// Model catalog routes
 		const modelsHandler = createModelsHandler(this.context);
 		const modelsRefreshHandler = createModelsRefreshHandler(this.context);
+		const modelsPreviewHandler = createModelsPreviewHandler();
 		this.handlers.set("GET:/api/models", (_req, url) => modelsHandler(url));
 		this.handlers.set("POST:/api/models/refresh", () => modelsRefreshHandler());
+		this.handlers.set("POST:/api/models/preview", (req) =>
+			modelsPreviewHandler(req),
+		);
 	}
 
 	/**

--- a/packages/proxy/src/__tests__/openai-compatible-model-catalog.test.ts
+++ b/packages/proxy/src/__tests__/openai-compatible-model-catalog.test.ts
@@ -8,6 +8,7 @@ import type { ProxyContext } from "../handlers/proxy-types";
 import {
 	clearOpenAICompatibleModelCacheForTests,
 	deriveFamilyDefaults,
+	fetchOpenAICompatibleModelsPreview,
 	getOpenAICompatibleModels,
 } from "../openai-compatible-model-catalog";
 
@@ -249,6 +250,71 @@ describe("getOpenAICompatibleModels", () => {
 
 	it("returns nothing for an account that does not exist", async () => {
 		expect(await getOpenAICompatibleModels("ghost", makeCtx(null))).toBeNull();
+	});
+});
+
+describe("fetchOpenAICompatibleModelsPreview", () => {
+	// The wizard has no accountId yet, only the apiKey/endpoint the user just
+	// typed — this is the same live fetch as getOpenAICompatibleModels, minus
+	// the accountId-keyed cache and derived-defaults side effects.
+	it("returns the account's own listing for raw apiKey/endpoint", async () => {
+		globalThis.fetch = (async () =>
+			new Response(JSON.stringify(LIVE_BODY), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			})) as typeof globalThis.fetch;
+
+		const preview = await fetchOpenAICompatibleModelsPreview(
+			"sk-test",
+			"https://api.example.com/v1",
+		);
+
+		expect(preview.source).toBe("preview");
+		expect(preview.models.map((m) => m.id)).toEqual([
+			"gpt-oss-120b",
+			"gpt-oss-20b",
+			"gpt-oss-8b",
+		]);
+		expect(preview.fetchedAt).toBeGreaterThan(0);
+	});
+
+	it("throws for an empty API key", async () => {
+		await expect(
+			fetchOpenAICompatibleModelsPreview("", "https://api.example.com/v1"),
+		).rejects.toThrow();
+	});
+
+	it("throws on an HTTP error from the endpoint", async () => {
+		globalThis.fetch = (async () =>
+			new Response("unauthorized", { status: 401 })) as typeof globalThis.fetch;
+
+		await expect(
+			fetchOpenAICompatibleModelsPreview(
+				"sk-test",
+				"https://api.example.com/v1",
+			),
+		).rejects.toThrow("HTTP 401");
+	});
+
+	it("throws when the listing came back with no usable models", async () => {
+		globalThis.fetch = (async () =>
+			new Response(JSON.stringify({ data: [] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			})) as typeof globalThis.fetch;
+
+		await expect(
+			fetchOpenAICompatibleModelsPreview(
+				"sk-test",
+				"https://api.example.com/v1",
+			),
+		).rejects.toThrow("no usable models");
+	});
+
+	it("throws for an invalid endpoint URL", async () => {
+		await expect(
+			fetchOpenAICompatibleModelsPreview("sk-test", "not-a-url"),
+		).rejects.toThrow();
 	});
 });
 

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -87,9 +87,11 @@ export {
 export type {
 	OpenAICompatibleModelEntry,
 	OpenAICompatibleModelListing,
+	OpenAICompatibleModelPreview,
 } from "./openai-compatible-model-catalog";
 export {
 	clearOpenAICompatibleModelCacheForAccount,
+	fetchOpenAICompatibleModelsPreview,
 	getOpenAICompatibleModels,
 } from "./openai-compatible-model-catalog";
 export {

--- a/packages/proxy/src/openai-compatible-model-catalog.ts
+++ b/packages/proxy/src/openai-compatible-model-catalog.ts
@@ -65,14 +65,21 @@ function normalize(body: OpenAIModelsResponse): OpenAICompatibleModelEntry[] {
 	return entries;
 }
 
-async function fetchLive(
-	account: Account,
+/**
+ * The HTTP call shared by the account-backed path and the pre-save preview:
+ * GET `<endpoint>/v1/models` with a bearer token, normalized into entries.
+ * Takes raw strings rather than an `Account` so the wizard can call this
+ * before an account row exists to read `api_key`/`custom_endpoint` from.
+ */
+async function fetchLiveModels(
+	apiKey: string,
+	endpoint: string,
 ): Promise<OpenAICompatibleModelEntry[]> {
-	if (!account.api_key) {
+	if (!apiKey) {
 		throw new Error("no API key for this account");
 	}
-	const endpoint = validateEndpointUrl(getEndpointUrl(account), "endpoint");
-	const url = `${endpoint}${endpoint.endsWith("/v1") ? "" : "/v1"}/models`;
+	const validEndpoint = validateEndpointUrl(endpoint, "endpoint");
+	const url = `${validEndpoint}${validEndpoint.endsWith("/v1") ? "" : "/v1"}/models`;
 
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
@@ -80,7 +87,7 @@ async function fetchLive(
 		const response = await fetch(url, {
 			method: "GET",
 			headers: {
-				authorization: `Bearer ${account.api_key}`,
+				authorization: `Bearer ${apiKey}`,
 				accept: "application/json",
 			},
 			signal: controller.signal,
@@ -92,6 +99,10 @@ async function fetchLive(
 	} finally {
 		clearTimeout(timeout);
 	}
+}
+
+function fetchLive(account: Account): Promise<OpenAICompatibleModelEntry[]> {
+	return fetchLiveModels(account.api_key ?? "", getEndpointUrl(account));
 }
 
 /**
@@ -169,4 +180,30 @@ export async function getOpenAICompatibleModels(
 		);
 		return cached;
 	}
+}
+
+export interface OpenAICompatibleModelPreview {
+	models: OpenAICompatibleModelEntry[];
+	fetchedAt: number;
+	source: "preview";
+}
+
+/**
+ * Same live listing `getOpenAICompatibleModels` reads, but for the account
+ * wizard: before a row exists there is no `accountId` to look up, only the
+ * `apiKey`/`endpoint` the user just typed. No cache, no derived defaults —
+ * both of those are keyed by `accountId`, which does not exist yet — so a
+ * failure here has nothing to fall back to and must propagate to the caller
+ * rather than degrade to a cached listing the way the account-backed path
+ * does.
+ */
+export async function fetchOpenAICompatibleModelsPreview(
+	apiKey: string,
+	endpoint: string,
+): Promise<OpenAICompatibleModelPreview> {
+	const models = await fetchLiveModels(apiKey, endpoint);
+	if (models.length === 0) {
+		throw new Error("the listing came back with no usable models");
+	}
+	return { models, fetchedAt: Date.now(), source: "preview" };
 }


### PR DESCRIPTION
## Summary
- Adds a "Fetch models" step to the dashboard's Add Account form for `openai-compatible` accounts, calling a new `POST /api/models/preview` endpoint that queries the endpoint's own `/v1/models` listing using the just-entered `apiKey`/`endpoint` — before the account exists in the DB.
- Family model pickers (opus/sonnet/haiku) default from the fetched list, using the same position-based logic as the existing account-backed catalog (`deriveFamilyDefaults`), instead of requiring hand-typed model ids.
- Falls back to the original free-text inputs if fetch fails or hasn't been triggered — never blocks account creation.

This is the deferred wizard-time piece of #434 (items 1–3 already shipped via #439/#440/#441). Scoped to the dashboard only: `packages/cli-commands` has no dependency on `packages/proxy` today, so the CLI wizard keeps its existing hardcoded-default flow rather than adding a new cross-package dependency for this.

## Changes
- `packages/proxy/src/openai-compatible-model-catalog.ts` — extracted `fetchLiveModels(apiKey, endpoint)` from `fetchLive(account)` (now a thin wrapper); added `fetchOpenAICompatibleModelsPreview(apiKey, endpoint)` — a pure preview fetch with no caching/DB dependency. Existing account-backed path (`getOpenAICompatibleModels`) is behavior-preserving, confirmed by its original tests passing unchanged.
- `packages/http-api/src/handlers/models.ts` + `router.ts` — new `POST /api/models/preview` endpoint. Never logs the API key.
- `packages/dashboard-web/src/api.ts` + `AccountAddForm.tsx` — "Fetch models" button, `Select` dropdowns populated on success, free-text fallback preserved on failure.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run lint` / `bun run format` — clean (no unrelated file churn in final diff)
- [x] `bun test` on touched suites — 31/31 passing (catalog extraction + preview handler + existing provider regression)
- [x] `bun run build` — dashboard + CLI build succeeds
- [x] Manually verified `/api/models/preview` returns 400 on bad input and a non-2xx JSON error on unreachable endpoints, which the dashboard's fallback path handles

🤖 Generated with [Claude Code](https://claude.com/claude-code)