### PR TITLE
fix(codex): preserve controlled continuation for Claude Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,3 +841,42 @@ MIT - See [LICENSE](LICENSE) for details
 <p align="center">
   Built with ❤️ for developers who ship
 </p>
+
+### Claude Messages continuation on Codex (opt-in)
+
+Set `CCFLARE_CODEX_MESSAGES_CONTINUATION=1` to let the Codex provider retain
+server-owned Responses continuation while serving `/v1/messages` clients. It
+requires an authenticated API key, a selected account, and a nonempty prompt
+cache key (normally derived from Claude session metadata on OpenAI endpoints).
+The first request sends the full translated history, implicit GPT cache options
+with a 30-minute TTL, and a developer-prefix breakpoint. Subsequent exact
+history/configuration matches send only new input and the stored response ID.
+Claude cache markers and signatures never become GPT input artifacts.
+
+State is separated by account, model, authenticated caller, session, and client
+protocol. Changed history/tools, expiration, process restart, unknown output,
+failed or ambiguous terminal events, and cancellation cannot create a reusable
+checkpoint. Streaming remains incremental, but checkpoint promotion requires
+clean upstream EOF. Opaque GPT reasoning remains upstream; the proxy retains
+only bounded in-memory response IDs and replay digests. Public responses remain
+Claude-compatible and cache telemetry continues to label this ingress `legacy`.
+
+This switch does not change model selection or fallback policy. It defaults off;
+disabling it restores the prior Messages request format. It does not transfer
+Anthropic caches or guarantee a cache-hit percentage. Custom endpoints must
+support these Responses controls when this bridge is enabled; authenticated
+Messages requests may then derive cache keys from ordinary session metadata.
+Caller-provided native input, identity, and response IDs remain untrusted.
+
+HTTP continuation requires the endpoint to retain the referenced response. If it
+returns `previous_response_not_found` (or a typed invalid previous-response ID),
+the bridge retries the original full history once on the same account and model,
+then suspends continuation for that chain for 30 minutes. GPT cache controls
+remain active. This does not change `store:false` or enable provider-side
+retention. Backend retention and actual cache reuse need endpoint-specific
+validation; local response-ID existence is not proof of backend availability.
+
+Optionally set `CCFLARE_CODEX_MESSAGES_CONTINUATION_MODELS` to a comma-separated
+list of exact resolved model names to limit this feature to validated models.
+Unset means all models when enabled; an empty list enables none. This scope
+controls adapter features, not model selection or fallback routes.

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -81,3 +81,5 @@ registry.registerProvider(new OllamaProvider());
 registry.registerProvider(new OllamaCloudProvider());
 registry.registerProvider(new AnthropicCompatibleProvider());
 registry.registerProvider(new MetaProvider());
+
+export { recoverCodexMessagesContinuation } from "./providers/codex/provider";

--- a/packages/providers/src/providers/codex/provider.messages-continuation.test.ts
+++ b/packages/providers/src/providers/codex/provider.messages-continuation.test.ts
@@ -1,0 +1,585 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Account } from "@better-ccflare/types";
+import { CodexProvider } from "./provider";
+
+const old = process.env.CCFLARE_CODEX_MESSAGES_CONTINUATION;
+const oldModels = process.env.CCFLARE_CODEX_MESSAGES_CONTINUATION_MODELS;
+beforeEach(() => {
+	delete process.env.CCFLARE_CODEX_MESSAGES_CONTINUATION_MODELS;
+	process.env.CCFLARE_CODEX_MESSAGES_CONTINUATION = "1";
+});
+afterEach(() => {
+	if (oldModels === undefined)
+		delete process.env.CCFLARE_CODEX_MESSAGES_CONTINUATION_MODELS;
+	else process.env.CCFLARE_CODEX_MESSAGES_CONTINUATION_MODELS = oldModels;
+	if (old === undefined) delete process.env.CCFLARE_CODEX_MESSAGES_CONTINUATION;
+	else process.env.CCFLARE_CODEX_MESSAGES_CONTINUATION = old;
+});
+const account = { id: "fixture-account", provider: "codex" } as Account;
+const history = [
+	{ role: "user", content: "original task" },
+	{
+		role: "assistant",
+		content: [
+			{ type: "thinking", thinking: "Claude state", signature: "claude-only" },
+			{ type: "text", text: "prior Claude answer" },
+		],
+	},
+	{ role: "user", content: "continue after switching" },
+];
+const textOutput = [
+	{ type: "reasoning", id: "rs_opaque", encrypted_content: "opaque-gpt-state" },
+	{
+		type: "message",
+		role: "assistant",
+		id: "msg_upstream",
+		status: "completed",
+		content: [{ type: "output_text", text: "GPT answer" }],
+	},
+];
+const replay = [
+	...history,
+	{ role: "assistant", content: [{ type: "text", text: "GPT answer" }] },
+	{ role: "user", content: "next turn" },
+];
+async function request(
+	provider: CodexProvider,
+	id: string,
+	messages: unknown[] = history,
+	extra: Record<string, unknown> = {},
+	caller = "a".repeat(64),
+	selectedAccount = account,
+) {
+	const headers = new Headers({
+		"content-type": "application/json",
+		"x-better-ccflare-request-id": id,
+	});
+	if (caller) headers.set("x-better-ccflare-authenticated-caller", caller);
+	const result = await provider.transformRequestBody(
+		new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers,
+			body: JSON.stringify({
+				model: "gpt-6-astra",
+				stream: false,
+				system: [
+					{
+						type: "text",
+						text: "stable system",
+						cache_control: { type: "ephemeral" },
+					},
+				],
+				metadata: {
+					user_id: JSON.stringify({
+						session_id: "11111111-1111-4111-8111-111111111111",
+					}),
+				},
+				messages,
+				...extra,
+			}),
+		}),
+		selectedAccount,
+	);
+	expect(result.headers.has("x-better-ccflare-authenticated-caller")).toBe(
+		false,
+	);
+	return (await result.json()) as {
+		model: string;
+		instructions?: string;
+		prompt_cache_options?: unknown;
+		previous_response_id?: string;
+		input: Array<{
+			type?: string;
+			content: Array<{ prompt_cache_breakpoint?: unknown }>;
+		}>;
+	};
+}
+function event(type: string, fields: Record<string, unknown>) {
+	return `event: ${type}\ndata: ${JSON.stringify({ type, ...fields })}\n\n`;
+}
+async function complete(
+	provider: CodexProvider,
+	id: string,
+	output: unknown[] = textOutput,
+	tail = "",
+	stream = false,
+) {
+	let wire = event("response.created", {
+		response: { id: `resp_${id}`, model: "gpt-6-astra" },
+	});
+	wire += event("response.content_part.added", {
+		part: { type: "output_text", text: "" },
+	});
+	wire += event("response.output_text.delta", { delta: "GPT answer" });
+	wire += event("response.completed", {
+		response: {
+			id: `resp_${id}`,
+			model: "gpt-6-astra",
+			status: "completed",
+			output,
+			usage: { input_tokens: 100, output_tokens: 5 },
+		},
+	});
+	const response = await provider.processResponse(
+		new Response(wire + tail, {
+			headers: {
+				"content-type": "text/event-stream",
+				"x-better-ccflare-request-id": id,
+				"x-better-ccflare-request-stream": String(stream),
+			},
+		}),
+		null,
+	);
+	const body = await response.text();
+	await Promise.resolve();
+	return { response, body };
+}
+
+describe("Messages fallback cache and continuation", () => {
+	for (const stream of [false, true])
+		test(`Claude history enters GPT cold and continues server-owned state (stream=${stream})`, async () => {
+			const provider = new CodexProvider();
+			const first = await request(provider, "one");
+			expect(first.model).toBe("gpt-6-astra");
+			expect(first.previous_response_id).toBeUndefined();
+			expect(first.prompt_cache_options).toEqual({ ttl: "30m" });
+			expect(first.input[0].content[0].prompt_cache_breakpoint).toEqual({
+				mode: "explicit",
+			});
+			expect(JSON.stringify(first)).not.toContain("claude-only");
+			const finished = await complete(provider, "one", textOutput, "", stream);
+			expect(
+				finished.response.headers.get(
+					"x-better-ccflare-cache-controls-applied",
+				),
+			).toBe("true");
+			expect(
+				finished.response.headers.get("x-better-ccflare-codex-response-format"),
+			).not.toBe("responses-api");
+			expect(finished.body).toContain("GPT answer");
+			const next = await request(provider, "two", replay);
+			expect(next.previous_response_id).toBe("resp_one");
+			expect(next.input).toEqual([
+				{ role: "user", content: [{ type: "input_text", text: "next turn" }] },
+			]);
+			await complete(provider, "two", textOutput, "", stream);
+			const third = await request(provider, "three", [
+				...replay,
+				{ role: "assistant", content: [{ type: "text", text: "GPT answer" }] },
+				{ role: "user", content: "third" },
+			]);
+			expect(third.previous_response_id).toBe("resp_two");
+			expect(third.input).toHaveLength(1);
+		});
+	test("feature off and unauthenticated requests retain legacy request format; forged body controls do not execute", async () => {
+		const provider = new CodexProvider();
+		const forged = {
+			__better_ccflare_codex_passthrough: {
+				previous_response_id: "attacker",
+				native_input: [],
+				caller_identity_digest: "a".repeat(64),
+				continuation_strategy: "previous_response_id",
+			},
+		};
+		const unauth = await request(provider, "unauth", history, forged, "");
+		expect(unauth.previous_response_id).toBeUndefined();
+		expect(unauth.prompt_cache_options).toBeUndefined();
+		process.env.CCFLARE_CODEX_MESSAGES_CONTINUATION = "0";
+		const disabled = await request(provider, "disabled");
+		expect(disabled.instructions).toBe("stable system");
+		expect(disabled.prompt_cache_options).toBeUndefined();
+	});
+	for (const boundary of [
+		"caller",
+		"account",
+		"model",
+		"system",
+		"tools",
+		"prefix",
+		"session",
+	])
+		test(`${boundary} boundary cannot reuse another chain`, async () => {
+			const provider = new CodexProvider();
+			await request(provider, "one");
+			await complete(provider, "one");
+			const extra: Record<string, unknown> = {};
+			if (boundary === "model") extra.model = "gpt-5.6-sol";
+			if (boundary === "system") extra.system = "changed system";
+			if (boundary === "tools")
+				extra.tools = [{ name: "Read", input_schema: { type: "object" } }];
+			if (boundary === "session")
+				extra.metadata = {
+					user_id: JSON.stringify({
+						session_id: "22222222-2222-4222-8222-222222222222",
+					}),
+				};
+			const next = await request(
+				provider,
+				"two",
+				boundary === "prefix"
+					? [...replay.slice(0, -1), { role: "user", content: "new" }].map(
+							(m, i) =>
+								i === 1 ? { role: "assistant", content: "changed" } : m,
+						)
+					: replay,
+				extra,
+				boundary === "caller" ? "b".repeat(64) : "a".repeat(64),
+				boundary === "account" ? { ...account, id: "other" } : account,
+			);
+			expect(next.previous_response_id).toBeUndefined();
+			expect(next.input.length).toBeGreaterThan(1);
+		});
+	for (const tail of [
+		"partial",
+		event("response.failed", { response: { status: "failed" } }),
+		event("response.completed", {
+			response: { id: "second", status: "completed", output: textOutput },
+		}),
+	])
+		test(`ambiguous terminal state stays cold: ${tail.slice(0, 24)}`, async () => {
+			const provider = new CodexProvider();
+			await request(provider, "one");
+			await complete(provider, "one", textOutput, tail);
+			expect(
+				(await request(provider, "two", replay)).previous_response_id,
+			).toBeUndefined();
+		});
+	test("unknown output cannot be silently dropped to match a continuation", async () => {
+		const provider = new CodexProvider();
+		await request(provider, "one");
+		await complete(provider, "one", [...textOutput, { type: "unknown_state" }]);
+		expect(
+			(await request(provider, "two", replay)).previous_response_id,
+		).toBeUndefined();
+	});
+	test("tool output is projected through the existing Messages translator", async () => {
+		const provider = new CodexProvider();
+		await request(provider, "tool");
+		const call = {
+			type: "function_call",
+			id: "fc_native",
+			call_id: "call_read",
+			name: "Read",
+			arguments: '{ "file_path": "fixture.txt" }',
+			status: "completed",
+		};
+		const wire =
+			event("response.created", {
+				response: { id: "resp_tool", model: "gpt-6-astra" },
+			}) +
+			event("response.output_item.added", { item: call, output_index: 0 }) +
+			event("response.function_call_arguments.delta", {
+				delta: call.arguments,
+				output_index: 0,
+			}) +
+			event("response.function_call_arguments.done", {
+				arguments: call.arguments,
+				output_index: 0,
+			}) +
+			event("response.output_item.done", { item: call, output_index: 0 }) +
+			event("response.completed", {
+				response: {
+					id: "resp_tool",
+					status: "completed",
+					output: [textOutput[0], call],
+				},
+			});
+		const response = await provider.processResponse(
+			new Response(wire, {
+				headers: {
+					"content-type": "text/event-stream",
+					"x-better-ccflare-request-id": "tool",
+					"x-better-ccflare-request-stream": "false",
+				},
+			}),
+			null,
+		);
+		const returned = (await response.json()) as { content: unknown[] };
+		expect(returned.content[0]).toEqual({
+			type: "tool_use",
+			id: "call_read",
+			name: "Read",
+			input: { file_path: "fixture.txt" },
+		});
+		const next = await request(provider, "tool-next", [
+			...history,
+			{ role: "assistant", content: returned.content },
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "call_read",
+						content: "fixture result",
+					},
+				],
+			},
+		]);
+		expect(next.previous_response_id).toBe("resp_tool");
+		expect(next.input).toHaveLength(1);
+		expect(next.input[0].type).toBe("function_call_output");
+	});
+	test("late concurrent completion cannot roll a chain backward", async () => {
+		const provider = new CodexProvider();
+		await request(provider, "slow");
+		await request(provider, "fast");
+		await complete(provider, "fast");
+		await complete(provider, "slow");
+		expect((await request(provider, "next", replay)).previous_response_id).toBe(
+			"resp_fast",
+		);
+	});
+	test("expiry and process restart discard continuation", async () => {
+		let now = 1000;
+		const provider = new CodexProvider({
+			now: () => now,
+			continuationTtlMs: 10,
+		});
+		await request(provider, "one");
+		await complete(provider, "one");
+		now += 11;
+		expect(
+			(await request(provider, "two", replay)).previous_response_id,
+		).toBeUndefined();
+		expect(
+			(await request(new CodexProvider(), "restart", replay))
+				.previous_response_id,
+		).toBeUndefined();
+	});
+	test("cancellation cannot promote even a buffered completion candidate", async () => {
+		const provider = new CodexProvider();
+		await request(provider, "cancel");
+		let source: ReadableStreamDefaultController<Uint8Array>;
+		const upstream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				source = controller;
+				controller.enqueue(
+					new TextEncoder().encode(
+						event("response.created", {
+							response: { id: "resp_cancel", model: "gpt-6-astra" },
+						}),
+					),
+				);
+			},
+		});
+		const response = await provider.processResponse(
+			new Response(upstream, {
+				headers: {
+					"content-type": "text/event-stream",
+					"x-better-ccflare-request-id": "cancel",
+					"x-better-ccflare-request-stream": "true",
+				},
+			}),
+			null,
+		);
+		if (!response.body) throw new Error("missing response stream");
+		const reader = response.body.getReader();
+		await reader.read();
+		await reader.cancel();
+		source.enqueue(
+			new TextEncoder().encode(
+				event("response.completed", {
+					response: {
+						id: "resp_cancel",
+						status: "completed",
+						output: textOutput,
+					},
+				}),
+			),
+		);
+		source.close();
+		await new Promise((resolve) => setTimeout(resolve, 5));
+		expect(
+			(await request(provider, "next", replay)).previous_response_id,
+		).toBeUndefined();
+	});
+	test("HTTP error carrying a completed event cannot create a checkpoint", async () => {
+		const provider = new CodexProvider();
+		await request(provider, "error");
+		const response = await provider.processResponse(
+			new Response(
+				event("response.completed", {
+					response: {
+						id: "resp_error",
+						status: "completed",
+						output: textOutput,
+					},
+				}),
+				{
+					status: 500,
+					headers: {
+						"content-type": "text/event-stream",
+						"x-better-ccflare-request-id": "error",
+						"x-better-ccflare-request-stream": "false",
+					},
+				},
+			),
+			null,
+		);
+		await response.text();
+		expect(
+			(await request(provider, "next", replay)).previous_response_id,
+		).toBeUndefined();
+	});
+	test("Claude client can cancel on message_stop and immediately continue", async () => {
+		const provider = new CodexProvider();
+		await request(provider, "stop");
+		const wire =
+			event("response.created", {
+				response: { id: "resp_stop", model: "gpt-6-astra" },
+			}) +
+			event("response.content_part.added", {
+				part: { type: "output_text", text: "" },
+			}) +
+			event("response.output_text.delta", { delta: "GPT answer" }) +
+			event("response.completed", {
+				response: { id: "resp_stop", status: "completed", output: textOutput },
+			});
+		const response = await provider.processResponse(
+			new Response(wire, {
+				headers: {
+					"content-type": "text/event-stream",
+					"x-better-ccflare-request-id": "stop",
+					"x-better-ccflare-request-stream": "true",
+				},
+			}),
+			null,
+		);
+		if (!response.body) throw new Error("missing response body");
+		const reader = response.body.getReader();
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) throw new Error("missing message_stop");
+			if (new TextDecoder().decode(value).includes("event: message_stop")) {
+				await reader.cancel();
+				break;
+			}
+		}
+		expect((await request(provider, "next", replay)).previous_response_id).toBe(
+			"resp_stop",
+		);
+	});
+	test("custom endpoints use ordinary session metadata only when explicitly enabled", async () => {
+		const custom = {
+			...account,
+			custom_endpoint: "http://fixture.local/responses",
+		};
+		const provider = new CodexProvider();
+		const enabled = await request(
+			provider,
+			"custom",
+			history,
+			{},
+			"a".repeat(64),
+			custom,
+		);
+		expect(enabled.prompt_cache_options).toEqual({ ttl: "30m" });
+		process.env.CCFLARE_CODEX_MESSAGES_CONTINUATION = "0";
+		const disabled = await request(
+			provider,
+			"custom-off",
+			history,
+			{},
+			"a".repeat(64),
+			custom,
+		);
+		expect(disabled.prompt_cache_options).toBeUndefined();
+	});
+	for (const status of [400, 404])
+		test(`missing upstream response ID retries full history once (${status})`, async () => {
+			const provider = new CodexProvider();
+			await request(provider, "one");
+			await complete(provider, "one");
+			expect(
+				(await request(provider, "retry", replay)).previous_response_id,
+			).toBe("resp_one");
+			const original = new Request("https://example.com/v1/messages", {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					"x-better-ccflare-request-id": "retry",
+					"x-better-ccflare-authenticated-caller": "a".repeat(64),
+				},
+				body: JSON.stringify({
+					model: "gpt-6-astra",
+					stream: false,
+					system: "stable system",
+					metadata: {
+						user_id: JSON.stringify({
+							session_id: "11111111-1111-4111-8111-111111111111",
+						}),
+					},
+					messages: replay,
+				}),
+			});
+			const rejected = new Response(
+				JSON.stringify({
+					error: {
+						type: "invalid_request_error",
+						code: "previous_response_not_found",
+					},
+				}),
+				{ status },
+			);
+			const recovered = await provider.recoverMessagesContinuation(
+				rejected,
+				original,
+				account,
+			);
+			if (!recovered) throw new Error("missing full-history recovery");
+			const full = (await recovered.json()) as {
+				model: string;
+				input: unknown[];
+				previous_response_id?: string;
+				store: boolean;
+			};
+			expect(full.model).toBe("gpt-6-astra");
+			expect(full.input).toHaveLength(6);
+			expect(full.previous_response_id).toBeUndefined();
+			expect(full.store).toBe(false);
+			await complete(provider, "retry");
+			const third = await request(provider, "third", [
+				...replay,
+				{ role: "assistant", content: [{ type: "text", text: "GPT answer" }] },
+				{ role: "user", content: "third turn" },
+			]);
+			expect(third.previous_response_id).toBeUndefined();
+			expect(third.input.length).toBeGreaterThan(1);
+		});
+	test("unrelated HTTP errors do not trigger continuation recovery", async () => {
+		const provider = new CodexProvider();
+		await request(provider, "one");
+		await complete(provider, "one");
+		await request(provider, "two", replay);
+		const original = new Request("https://example.com/v1/messages", {
+			method: "POST",
+			headers: { "x-better-ccflare-request-id": "two" },
+			body: "{}",
+		});
+		expect(
+			await provider.recoverMessagesContinuation(
+				new Response(JSON.stringify({ error: { code: "invalid_model" } }), {
+					status: 400,
+				}),
+				original,
+				account,
+			),
+		).toBeNull();
+	});
+	test("optional exact model scope leaves other models unchanged", async () => {
+		process.env.CCFLARE_CODEX_MESSAGES_CONTINUATION_MODELS = "gpt-6-astra";
+		const provider = new CodexProvider();
+		expect((await request(provider, "astra")).prompt_cache_options).toEqual({
+			ttl: "30m",
+		});
+		const other = await request(provider, "sol", history, {
+			model: "gpt-5.6-sol",
+		});
+		expect(other.model).toBe("gpt-5.6-sol");
+		expect(other.prompt_cache_options).toBeUndefined();
+		process.env.CCFLARE_CODEX_MESSAGES_CONTINUATION_MODELS = "";
+		expect(
+			(await request(provider, "empty")).prompt_cache_options,
+		).toBeUndefined();
+	});
+});

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -339,6 +339,8 @@ interface ContinuationState {
 }
 
 interface PendingContinuation {
+	legacyProjection?: boolean;
+	continuationSuppressed?: boolean;
 	laneKey: string;
 	inputDigests: string[];
 	configDigest: string;
@@ -556,6 +558,7 @@ export class CodexProvider extends BaseProvider {
 	private readonly now: () => number;
 	private readonly continuationByLane = new Map<string, ContinuationState>();
 	private continuationGeneration = 0;
+	private readonly messagesContinuationRejected = new Map<string, number>();
 	private readonly pendingContinuationByRequest = new Map<
 		string,
 		PendingContinuation
@@ -912,6 +915,70 @@ export class CodexProvider extends BaseProvider {
 				}
 			}
 
+			const messagesModels =
+				process.env.CCFLARE_CODEX_MESSAGES_CONTINUATION_MODELS;
+			if (
+				!nativeResponses &&
+				process.env.CCFLARE_CODEX_MESSAGES_CONTINUATION === "1" &&
+				(messagesModels === undefined ||
+					messagesModels
+						.split(",")
+						.map((model) => model.trim())
+						.includes(codexBody.model))
+			) {
+				const caller = request.headers.get(
+					"x-better-ccflare-authenticated-caller",
+				);
+				// Opting a custom Responses endpoint into this bridge also opts it
+				// into GPT cache controls; ordinary custom-endpoint traffic is unchanged.
+				if (
+					caller &&
+					/^[0-9a-f]{64}$/.test(caller) &&
+					codexBody.prompt_cache_key === undefined
+				) {
+					codexBody.prompt_cache_key = this.derivePromptCacheKey(
+						body,
+						codexBody.instructions ?? "",
+						codexBody.input,
+						account,
+						true,
+					);
+				}
+				if (
+					requestId &&
+					caller &&
+					/^[0-9a-f]{64}$/.test(caller) &&
+					account?.id &&
+					codexBody.prompt_cache_key
+				) {
+					// The serving adapter owns the cache standard. Claude signatures and
+					// cache_control objects never enter the Responses request.
+					codexBody.prompt_cache_options = { ttl: "30m" };
+					if (codexBody.instructions) {
+						codexBody.input.unshift({
+							role: "developer",
+							content: [
+								{
+									type: "input_text",
+									text: codexBody.instructions,
+									prompt_cache_breakpoint: { mode: "explicit" },
+								},
+							],
+						} as unknown as CodexMessage);
+						codexBody.instructions = "";
+					}
+					this.prepareNativeContinuation(
+						codexBody,
+						request.headers,
+						account,
+						requestId,
+						caller,
+						true,
+						true,
+					);
+				}
+			}
+
 			// Only custom (non-function) tools can produce custom_tool_call output;
 			// let processResponse skip buffering when none were declared. Responses
 			// Lite can also declare custom tools via an "additional_tools" input
@@ -938,6 +1005,7 @@ export class CodexProvider extends BaseProvider {
 			// Proxy-owned correlation is needed only while preparing the transformed
 			// request. Do not disclose it to the upstream Responses service.
 			newHeaders.delete("x-better-ccflare-request-id");
+			newHeaders.delete("x-better-ccflare-authenticated-caller");
 			newHeaders.set("content-type", "application/json");
 			newHeaders.set(
 				"x-better-ccflare-request-stream",
@@ -1321,6 +1389,14 @@ export class CodexProvider extends BaseProvider {
 	}
 
 	private sweepContinuationState(now: number): void {
+		for (const [lane, expires] of this.messagesContinuationRejected) {
+			if (expires <= now) this.messagesContinuationRejected.delete(lane);
+		}
+		while (this.messagesContinuationRejected.size > this.continuationMaxLanes) {
+			const oldest = this.messagesContinuationRejected.keys().next().value;
+			if (oldest === undefined) break;
+			this.messagesContinuationRejected.delete(oldest);
+		}
 		for (const [key, state] of this.continuationByLane) {
 			if (state.expiresAt <= now) this.continuationByLane.delete(key);
 		}
@@ -1351,6 +1427,7 @@ export class CodexProvider extends BaseProvider {
 		requestId: string,
 		callerIdentityDigest: unknown,
 		cacheControlsApplied: unknown,
+		legacyProjection = false,
 	): void {
 		// On a controlled request the gateway, not the caller, owns the chain.
 		// Never let a caller-provided response ID survive an inability to prepare
@@ -1373,6 +1450,7 @@ export class CodexProvider extends BaseProvider {
 		});
 		const laneKey = this.digest({
 			accountId: account.id,
+			protocol: legacyProjection ? "messages" : "responses",
 			model: body.model,
 			callerIdentityDigest,
 			sessionDigest,
@@ -1389,7 +1467,11 @@ export class CodexProvider extends BaseProvider {
 		// so measure it before any continuation slicing occurs.
 		const originalBreakpointIsExact =
 			this.hasExactlyOneExplicitPromptCacheBreakpoint(body.input);
-		const previous = this.continuationByLane.get(laneKey);
+		const continuationSuppressed =
+			legacyProjection && this.messagesContinuationRejected.has(laneKey);
+		const previous = continuationSuppressed
+			? undefined
+			: this.continuationByLane.get(laneKey);
 		let result: ContinuationResult = "cold";
 		let suffixStart = 0;
 		if (previousExpired) {
@@ -1421,6 +1503,8 @@ export class CodexProvider extends BaseProvider {
 				? previous.replayPrefixDigests
 				: inputDigests;
 		this.pendingContinuationByRequest.set(requestId, {
+			continuationSuppressed,
+			legacyProjection,
 			laneKey,
 			inputDigests,
 			configDigest,
@@ -1446,6 +1530,106 @@ export class CodexProvider extends BaseProvider {
 			inputItemCount: inputDigests.length,
 			suffixItemCount: inputDigests.length - suffixStart,
 		});
+	}
+
+	async recoverMessagesContinuation(
+		response: Response,
+		originalRequest: Request,
+		account: Account,
+	): Promise<Request | null> {
+		const requestId = originalRequest.headers.get(
+			"x-better-ccflare-request-id",
+		);
+		const pending = requestId
+			? this.pendingContinuationByRequest.get(requestId)
+			: undefined;
+		if (
+			!requestId ||
+			!pending?.legacyProjection ||
+			pending.result !== "hit" ||
+			![400, 404].includes(response.status)
+		)
+			return null;
+		let error: { code?: unknown; param?: unknown; type?: unknown } | undefined;
+		try {
+			error = ((await response.clone().json()) as { error?: typeof error })
+				.error;
+		} catch {
+			return null;
+		}
+		if (
+			error?.code !== "previous_response_not_found" &&
+			error?.code !== "invalid_previous_response_id" &&
+			!(
+				error?.param === "previous_response_id" &&
+				error?.type === "invalid_request_error"
+			)
+		)
+			return null;
+		// The endpoint may not retain store=false responses over HTTP. Preserve
+		// the session with one full-history retry, without changing retention,
+		// account, model, or attempting the same rejected chain on every turn.
+		const current = this.continuationByLane.get(pending.laneKey);
+		if ((current?.generation ?? null) === pending.baseGeneration) {
+			this.continuationByLane.delete(pending.laneKey);
+			this.messagesContinuationRejected.set(
+				pending.laneKey,
+				this.now() + this.continuationTtlMs,
+			);
+		}
+		this.pendingContinuationByRequest.delete(requestId);
+		log.info("Codex Messages continuation rejected; retrying full history", {
+			result: "previous_response_not_found",
+		});
+		return this.transformRequestBody(originalRequest, account);
+	}
+
+	private projectedOutputDigests(
+		output: unknown[],
+		legacy: boolean,
+	): string[] | null {
+		if (!legacy) return output.map((item) => this.replayItemDigest(item));
+		const content: AnthropicContentBlock[] = [];
+		for (const raw of output) {
+			if (!raw || typeof raw !== "object") return null;
+			const item = raw as Record<string, unknown>;
+			if (item.type === "reasoning") continue; // retained by upstream response ID
+			if (
+				item.type === "message" &&
+				item.role === "assistant" &&
+				Array.isArray(item.content)
+			) {
+				for (const rawBlock of item.content) {
+					const block = rawBlock as Record<string, unknown>;
+					if (
+						!block ||
+						block.type !== "output_text" ||
+						typeof block.text !== "string"
+					)
+						return null;
+					content.push({ type: "text", text: block.text });
+				}
+			} else if (
+				item.type === "function_call" &&
+				typeof item.call_id === "string" &&
+				typeof item.name === "string" &&
+				typeof item.arguments === "string"
+			) {
+				try {
+					content.push({
+						type: "tool_use",
+						id: item.call_id,
+						name: item.name,
+						input: JSON.parse(item.arguments),
+					});
+				} catch {
+					return null;
+				}
+			} else return null;
+		}
+		return this.convertMessage({ role: "assistant", content }).map((item) =>
+			this.replayItemDigest(item),
+		);
 	}
 
 	private commitNativeContinuation(
@@ -1479,6 +1663,11 @@ export class CodexProvider extends BaseProvider {
 		const pending = this.pendingContinuationByRequest.get(requestId);
 		if (!pending) return;
 		this.pendingContinuationByRequest.delete(requestId);
+		if (
+			pending.continuationSuppressed ||
+			this.messagesContinuationRejected.has(pending.laneKey)
+		)
+			return;
 		const current = this.continuationByLane.get(pending.laneKey);
 		if ((current?.generation ?? null) !== pending.baseGeneration) {
 			// Another request advanced/replaced this lane after preparation. A late
@@ -1577,10 +1766,15 @@ export class CodexProvider extends BaseProvider {
 			this.pendingContinuationByRequest.delete(requestId);
 			return;
 		}
-		pending.terminalCandidate = {
-			responseId,
-			outputDigests: output.map((item) => this.replayItemDigest(item)),
-		};
+		const outputDigests = this.projectedOutputDigests(
+			output,
+			pending.legacyProjection === true,
+		);
+		if (!outputDigests) {
+			this.pendingContinuationByRequest.delete(requestId);
+			return;
+		}
+		pending.terminalCandidate = { responseId, outputDigests };
 	}
 
 	private finalizeNativeContinuationStream(
@@ -1677,7 +1871,7 @@ export class CodexProvider extends BaseProvider {
 				diagnostics.cacheControlsApplied ? "true" : "false",
 			);
 		}
-		log.info("Codex native response diagnostics", {
+		log.info("Codex continuation response diagnostics", {
 			transportUsed,
 			continuationUsed: diagnostics?.result === "hit",
 			previousResponsePresent: diagnostics?.previousResponsePresent ?? false,
@@ -2303,9 +2497,11 @@ export class CodexProvider extends BaseProvider {
 		instructions: string,
 		input: readonly unknown[],
 		account?: Account,
+		controlledMessagesEndpoint = false,
 	): string | undefined {
 		if (process.env[CODEX_PROMPT_CACHE_KEY_ENV] === "0") return undefined;
-		if (!isOpenAiPromptCacheEndpoint(account)) return undefined;
+		if (!controlledMessagesEndpoint && !isOpenAiPromptCacheEndpoint(account))
+			return undefined;
 		const sessionId = this.extractSessionId(body);
 		if (!sessionId) return undefined;
 		// Digests are truncated to 48 hex chars so the full key fits the API's
@@ -2762,7 +2958,7 @@ export class CodexProvider extends BaseProvider {
 			stop_sequence: null,
 			usage,
 		};
-		const headers = sanitizeResponseHeaders(response.headers);
+		const headers = sanitizeResponseHeaders(transformed.headers);
 		headers.set("content-type", "application/json");
 		return new Response(JSON.stringify(jsonPayload), {
 			status: response.status,
@@ -2782,6 +2978,12 @@ export class CodexProvider extends BaseProvider {
 				`[codex:model-debug] request_id=${requestId} transformStreamingResponse initial fallback model=gpt-5.4 until response.created arrives`,
 			);
 		}
+		const controlledMessages =
+			response.ok &&
+			this.pendingContinuationByRequest.get(requestId)?.legacyProjection ===
+				true;
+		if (!response.ok && response.status !== 529)
+			this.pendingContinuationByRequest.delete(requestId);
 		const state: StreamState = {
 			buffer: "",
 			messageId: `msg_${crypto.randomUUID().replace(/-/g, "").substring(0, 24)}`,
@@ -2799,7 +3001,19 @@ export class CodexProvider extends BaseProvider {
 			sawToolUse: false,
 		};
 
-		const headers = sanitizeResponseHeaders(response.headers);
+		const headers = controlledMessages
+			? new Headers(
+					this.buildNativeResponsesPassthroughResponse(
+						new Response(null, {
+							status: response.status,
+							headers: response.headers,
+						}),
+						requestId,
+						false,
+					).headers,
+				)
+			: sanitizeResponseHeaders(response.headers);
+		headers.delete("x-better-ccflare-codex-response-format");
 		headers.set("content-type", "text/event-stream");
 
 		const { readable, writable } = new TransformStream<
@@ -2811,6 +3025,9 @@ export class CodexProvider extends BaseProvider {
 		const decoder = new TextDecoder();
 		const streamLiveness = new CodexStreamLiveness(this.streamLivenessOptions);
 
+		// Hold only the two terminal frames until upstream EOF. Claude clients may
+		// cancel at message_stop, so emitting it earlier would lose every checkpoint.
+		const terminalFrames: Uint8Array[] = [];
 		const writeSSE = async (event: string, data: unknown) => {
 			const payload =
 				typeof data === "object" && data !== null
@@ -2852,6 +3069,13 @@ export class CodexProvider extends BaseProvider {
 				payload.delta = delta;
 			}
 			const line = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+			if (
+				controlledMessages &&
+				(event === "message_delta" || event === "message_stop")
+			) {
+				terminalFrames.push(encoder.encode(line));
+				return;
+			}
 			await writer.write(encoder.encode(line));
 			streamLiveness.recordDownstreamWrite();
 		};
@@ -2887,6 +3111,7 @@ export class CodexProvider extends BaseProvider {
 		const processEvents = async () => {
 			const reader = response.body?.getReader();
 			let upstreamCancelStarted = false;
+			let cleanEof = false;
 			let upstreamDrainPromise: Promise<void> | null = null;
 
 			// `reader.cancel()` is a documented no-op on every released Bun
@@ -2926,6 +3151,8 @@ export class CodexProvider extends BaseProvider {
 			const cancelUpstreamOnce = (_reason: unknown): void => {
 				if (upstreamCancelStarted || !reader) return;
 				upstreamCancelStarted = true;
+				if (controlledMessages)
+					this.finalizeNativeContinuationStream(requestId, false);
 				upstreamDrainPromise = drainUpstream();
 				upstreamDrainPromise.catch(() => undefined);
 			};
@@ -2940,7 +3167,7 @@ export class CodexProvider extends BaseProvider {
 						// alive to the Anthropic client and to any intermediary idle
 						// timeout. A ping carries no content and cannot disturb the
 						// message/content-block sequence.
-						if (state.hasSentTerminalEvents) break;
+						if (state.hasSentTerminalEvents && !controlledMessages) break;
 						if (streamLiveness.canEmitHeartbeat()) {
 							await writeSSE("ping", { type: "ping" });
 							streamLiveness.recordDownstreamWrite();
@@ -2974,7 +3201,10 @@ export class CodexProvider extends BaseProvider {
 					if (outcome.type === "upstream_error") throw outcome.error;
 
 					const { value, done } = outcome.result;
-					if (done) break;
+					if (done) {
+						cleanEof = state.buffer.trim().length === 0;
+						break;
+					}
 
 					state.buffer += decoder.decode(value, { stream: true });
 
@@ -2988,6 +3218,8 @@ export class CodexProvider extends BaseProvider {
 							boundary.index + boundary[0].length,
 						);
 
+						if (controlledMessages)
+							this.observeNativeTerminalEvent(requestId, eventText);
 						const eventLine = eventText
 							.split(/\r?\n/)
 							.find((l) => l.startsWith("event:"));
@@ -3016,7 +3248,7 @@ export class CodexProvider extends BaseProvider {
 							writeSSE,
 							ensureMessageStart,
 						);
-						if (state.hasSentTerminalEvents) {
+						if (state.hasSentTerminalEvents && !controlledMessages) {
 							streamLiveness.stop();
 							cancelUpstreamOnce("Codex terminal response received");
 							break;
@@ -3067,7 +3299,20 @@ export class CodexProvider extends BaseProvider {
 				// streamDrainDeadlineMs / drainAbort — while writer.close() proceeds
 				// immediately, matching the fire-and-forget pattern used by
 				// cancelAfterForcedClose in anthropic-terminal-recovery.ts.
-				await writer.close();
+				try {
+					if (controlledMessages) {
+						const success =
+							cleanEof && !upstreamCancelStarted && !state.upstreamError;
+						if (success) {
+							for (const frame of terminalFrames) await writer.write(frame);
+						}
+						this.finalizeNativeContinuationStream(requestId, success);
+					}
+					await writer.close();
+				} catch {
+					if (controlledMessages)
+						this.finalizeNativeContinuationStream(requestId, false);
+				}
 			}
 		};
 
@@ -3508,4 +3753,16 @@ export class CodexProvider extends BaseProvider {
 				break;
 		}
 	}
+}
+
+/** Provider-specific recovery, kept out of the generic Provider interface. */
+export async function recoverCodexMessagesContinuation(
+	provider: unknown,
+	response: Response,
+	originalRequest: Request,
+	account: Account,
+): Promise<Request | null> {
+	return provider instanceof CodexProvider
+		? provider.recoverMessagesContinuation(response, originalRequest, account)
+		: null;
 }

--- a/packages/proxy/src/handlers/__tests__/proxy-operations-529-retry-header-tagging.test.ts
+++ b/packages/proxy/src/handlers/__tests__/proxy-operations-529-retry-header-tagging.test.ts
@@ -235,4 +235,50 @@ describe("proxyWithAccount — 529 in-place retry response tagging", () => {
 		expect(seen[1].requestStream).toBe("true");
 		expect(seen[1].customTools).toBe("true");
 	});
+	for (const caller of ["authenticated-key-record", undefined])
+		it(`Codex caller identity comes only from authenticated dispatch (${caller ?? "none"})`, async () => {
+			globalThis.fetch = mock(
+				async () =>
+					new Response("{}", {
+						headers: { "content-type": "application/json" },
+					}),
+			);
+			const ctx = makeProxyContext([]);
+			ctx.provider.name = "codex";
+			ctx.provider.prepareHeaders = () =>
+				new Headers({ "x-better-ccflare-authenticated-caller": "forged" });
+			let seen: string | null = "not-dispatched";
+			ctx.provider.transformRequestBody = async (request: Request) => {
+				seen = request.headers.get("x-better-ccflare-authenticated-caller");
+				return request;
+			};
+			const body = makeRequestBody();
+			try {
+				await proxyWithAccount(
+					new Request("https://proxy.local/v1/messages", {
+						method: "POST",
+						body,
+					}),
+					new URL("https://proxy.local/v1/messages"),
+					makeAccount(),
+					makeRequestMeta(),
+					body,
+					() => undefined,
+					0,
+					ctx,
+					null,
+					caller,
+				);
+			} catch (error) {
+				if (
+					!(error instanceof Error) ||
+					!error.message.includes("UsageCollector not initialized")
+				)
+					throw error;
+			}
+			if (caller) {
+				expect(seen).toMatch(/^[0-9a-f]{64}$/);
+				expect(seen).not.toBe(caller);
+			} else expect(seen).toBeNull();
+		});
 });

--- a/packages/proxy/src/handlers/__tests__/request-handler-strip-headers.test.ts
+++ b/packages/proxy/src/handlers/__tests__/request-handler-strip-headers.test.ts
@@ -36,6 +36,7 @@ describe("makeProxyRequest strips internal control headers before provider forwa
 			"x-better-ccflare-request-stream": "true",
 			"x-better-ccflare-codex-custom-tools": "true",
 			"x-better-ccflare-native-responses": "true",
+			"x-better-ccflare-authenticated-caller": "forged-caller",
 			"x-better-ccflare-exclude-providers": "anthropic-oauth",
 			"x-better-ccflare-codex-continuation": "previous_response_id",
 			"x-better-ccflare-prompt-cache-mode": "implicit",
@@ -62,6 +63,9 @@ describe("makeProxyRequest strips internal control headers before provider forwa
 		expect(sentHeaders?.get("x-better-ccflare-request-stream")).toBeNull();
 		expect(sentHeaders?.get("x-better-ccflare-codex-custom-tools")).toBeNull();
 		expect(sentHeaders?.get("x-better-ccflare-native-responses")).toBeNull();
+		expect(
+			sentHeaders?.get("x-better-ccflare-authenticated-caller"),
+		).toBeNull();
 		expect(sentHeaders?.get("x-better-ccflare-exclude-providers")).toBeNull();
 		for (const header of [
 			"x-better-ccflare-codex-continuation",
@@ -86,6 +90,7 @@ describe("makeProxyRequest strips internal control headers before provider forwa
 				"x-better-ccflare-keepalive": "true",
 				"x-better-ccflare-request-id": "internal-request-id",
 				"x-better-ccflare-native-responses": "true",
+				"x-better-ccflare-authenticated-caller": "forged-caller",
 				"x-better-ccflare-exclude-providers": "anthropic-oauth",
 				"x-better-ccflare-codex-continuation": "previous_response_id",
 				"x-better-ccflare-prompt-cache-mode": "implicit",
@@ -103,6 +108,9 @@ describe("makeProxyRequest strips internal control headers before provider forwa
 		expect(sentHeaders?.get("x-better-ccflare-keepalive")).toBeNull();
 		expect(sentHeaders?.get("x-better-ccflare-request-id")).toBeNull();
 		expect(sentHeaders?.get("x-better-ccflare-native-responses")).toBeNull();
+		expect(
+			sentHeaders?.get("x-better-ccflare-authenticated-caller"),
+		).toBeNull();
 		expect(sentHeaders?.get("x-better-ccflare-exclude-providers")).toBeNull();
 		for (const header of [
 			"x-better-ccflare-codex-continuation",

--- a/packages/proxy/src/handlers/proxy-operations.ts
+++ b/packages/proxy/src/handlers/proxy-operations.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
 	type AccountUsageSnapshot,
 	getModelFamily,
@@ -17,6 +18,7 @@ import {
 	getProvider,
 	isAnthropicExtraUsageExhausted,
 	isAnthropicOutOfCredits,
+	recoverCodexMessagesContinuation,
 	usageCache,
 } from "@better-ccflare/providers";
 import type {
@@ -840,6 +842,17 @@ export async function proxyWithAccount(
 		// Never trust or reuse a caller-supplied copy.
 		if (provider.name === "codex") {
 			headers.set("x-better-ccflare-request-id", requestMeta.id);
+			// This identity comes from front-door authentication, never a client header.
+			const caller = apiKeyId;
+			headers.delete("x-better-ccflare-authenticated-caller");
+			if (caller)
+				headers.set(
+					"x-better-ccflare-authenticated-caller",
+					createHash("sha256")
+						.update("better-ccflare:caller-api-key:v1\0")
+						.update(caller)
+						.digest("hex"),
+				);
 			if (isTrustedNativeResponses(requestMeta)) {
 				headers.set("x-better-ccflare-native-responses", "true");
 			}
@@ -937,6 +950,28 @@ export async function proxyWithAccount(
 		let rawResponse = isSyntheticProviderResponse(transformedRequest)
 			? materializeSyntheticResponse(transformedRequest)
 			: await forwardUpstream(transformedRequest);
+
+		if (provider.name === "codex" && [400, 404].includes(rawResponse.status)) {
+			const recovered = await recoverCodexMessagesContinuation(
+				provider,
+				rawResponse,
+				new Request(targetUrl, requestInit),
+				account,
+			);
+			if (recovered) {
+				// Exactly one retry on the same provider/account/model. Refresh the
+				// buffered body too so a later 529 retry cannot resend the old suffix.
+				retryBodyText = await recovered.text();
+				transformedRequest = new Request(recovered.url, {
+					method: recovered.method,
+					headers: recovered.headers,
+					body: retryBodyText,
+					signal: req.signal,
+				});
+				cancelDiscardedResponseBody(rawResponse);
+				rawResponse = await forwardUpstream(transformedRequest);
+			}
+		}
 
 		// Check if this is a Claude provider and we got an invalid thinking signature error
 		const isClaudeProvider =

--- a/packages/proxy/src/handlers/request-handler.ts
+++ b/packages/proxy/src/handlers/request-handler.ts
@@ -19,6 +19,7 @@ function stripInternalControlHeaders(headers: Headers): void {
 	headers.delete("x-better-ccflare-request-stream");
 	headers.delete("x-better-ccflare-codex-custom-tools");
 	headers.delete("x-better-ccflare-native-responses");
+	headers.delete("x-better-ccflare-authenticated-caller");
 	headers.delete("x-better-ccflare-exclude-providers");
 	headers.delete("x-better-ccflare-codex-continuation");
 	headers.delete("x-better-ccflare-prompt-cache-mode");


### PR DESCRIPTION
Claude Messages sessions selected onto Codex currently replay translated history without retaining the native response chain. Add opt-in `CCFLARE_CODEX_MESSAGES_CONTINUATION=1`: the first GPT request is full; later exact projected history/config matches send only new input with a server-owned `previous_response_id`, while clients continue to receive Claude-compatible replies.

The existing continuation store is partitioned by client protocol, account, model, authenticated caller, and session. Caller identity is created at authenticated proxy dispatch and removed before network egress. Completed output is projected through the existing Messages converter; opaque reasoning stays upstream. GPT cache controls are applied only at the selected adapter. Native execution fields in caller bodies remain untrusted. Model mappings and fallback policy are unchanged.

Streaming remains incremental. Only terminal frames are held until clean upstream EOF, so clients that cancel at `message_stop` can continue. Failed, ambiguous, malformed, truncated, cancelled, unknown-output, expired, and concurrent stale completions cannot create or replace a checkpoint. State remains bounded and metadata-only. The switch defaults off, including for custom endpoints unless explicitly enabled.

Validation: 246 tests / 950 assertions across provider, native Responses adapter, and proxy suites; TypeScript check and CLI build pass. New coverage includes Claude-origin three-turn histories, text/tool replay, caller/account/model/session/config/history isolation, forged identity, custom-endpoint opt-in, cancellation at and before terminal delivery, expiry, and out-of-order completion. Full gateway/mock integration passes for exact gpt-6-astra and gpt-5.6-sol, including buffered/streaming three-turn Messages fallback, backend response-ID loss, one full-history retry, subsequent continuation suppression, and metadata-only accounting/privacy checks (feedback-loop-ai/lanetally#101).

This closes a protocol-state gap. It does not establish the historical cause of low cache reuse or claim a real cache-hit improvement from fixture token counters.

HTTP response retention is endpoint-specific. A typed missing/invalid previous-response ID triggers one full-history retry on the same account/model and suspends that chain for 30 minutes. This keeps `store:false` and never enables provider retention. An optional exact model allowlist scopes the bridge to validated models. Actual subscription-endpoint retention and cache economics remain unmeasured.
