### PR TITLE
fix: support current Codex VS Code clients through the proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,8 @@ claude
 
 ### Codex CLI as a Client
 
+The Codex VS Code extension uses the same provider configuration. See the [VS Code setup and compatibility guide](docs/codex-vscode.md).
+
 better-ccflare supports [Codex CLI](https://github.com/openai/codex) as a client. Codex speaks the OpenAI Responses API; better-ccflare intercepts requests to `/v1/responses` and `/v1/responses/compact` and translates them to Anthropic `POST /v1/messages` internally, routing through your configured account pool.
 
 Configure Codex CLI to point at better-ccflare in `~/.codex/config.toml`:
@@ -399,7 +401,7 @@ Codex CLI requires an API key to start — use `dummy-key` if better-ccflare API
 Known limitations:
 
 - Regular HTTP does not trust an arbitrary caller-supplied `previous_response_id`. On the authenticated, native outbound Codex route, an operator-controlled gateway request can enable gateway-managed continuation: better-ccflare retains only the last upstream response ID and cryptographic input/configuration digests, resumes only after an exact ordered-prefix match, and otherwise sends the full input without a response ID. This bounded state is in memory, so a restart safely cold-starts. WebSocket transport is not implemented.
-- Built-in tool types (`web_search_preview`, `code_interpreter`, `file_search`) are preserved on the native outbound Codex route. Routes translated to Anthropic skip built-in tools and forward only `type: "function"` tools.
+- Built-in tool types (`web_search_preview`, `code_interpreter`, `file_search`) are preserved on the native outbound Codex route. Routes translated to Anthropic skip built-in tools, forward function tools, and bridge freeform custom tools such as Codex's `apply_patch` through a string input schema. Custom tool grammars are described to the model but cannot be enforced by the Anthropic API.
 - `/v1/responses` rejects unknown top-level request fields with `400 invalid_request_error` instead of silently dropping them. The canonical ChatGPT subscription endpoint also rejects an explicitly supplied `max_output_tokens`; omit it and let the served model choose its output limit. Custom OpenAI-compatible endpoints may accept it.
 - Claude OAuth accounts (Claude Pro/Team, `provider=anthropic` with OAuth tokens) are automatically excluded from Codex CLI traffic — Anthropic bans these when used outside Claude CLI. Anthropic API key accounts are fine and will be used normally.
 

--- a/docs/codex-vscode.md
+++ b/docs/codex-vscode.md
@@ -1,0 +1,58 @@
+# Codex VS Code client
+
+The Codex extension and CLI share `config.toml`. Open the extension's settings and select **Open config.toml** to edit the configuration used by its agent. For Remote SSH or containers, use the file on the host where that agent runs. See [official OpenAI documentation](https://learn.chatgpt.com/docs/developer-settings?surface=ide).
+
+Define a custom provider in the user-level configuration:
+
+```toml
+model = "gpt-6-astra"
+model_provider = "better_ccflare"
+
+[model_providers.better_ccflare]
+name = "better-ccflare"
+base_url = "https://YOUR-PROXY-HOST/v1"
+wire_api = "responses"
+env_key = "BETTER_CCFLARE_API_KEY"
+requires_openai_auth = false
+```
+
+Make `BETTER_CCFLARE_API_KEY` available in the environment of the extension's agent process. Setting it only in an already-open integrated terminal does not update the extension host's environment. Use a better-ccflare API key, then restart the extension host and start a new chat. Select a model available to the intended upstream account; the example model is not a guarantee of account access.
+
+The `/v1` suffix is required. Use an HTTP Responses connection; better-ccflare rejects WebSocket upgrades so clients can fall back to HTTP streaming. Do not enable a provider capability that requires WebSockets.
+
+## Routing and compatibility
+
+- A native Codex upstream preserves the requested Responses model, tools, input, and client fields, subject to explicit server-side model mappings. `stream_options`, `client_metadata`, and `access_programs` are forwarded on this trusted native route.
+- Codex upstream requests remove ingress Cloudflare/forwarding headers and client cookies. These describe the connection to the proxy, not the separate connection to OpenAI; forwarding them can cause upstream `403` responses. The proxy adds its own upstream authentication and host-scoped cookies afterward.
+- Anthropic routes translate the conversation and map GPT model names to configured Claude families. Function tools are forwarded. Freeform custom tools, including `apply_patch`, use an Anthropic `{input: string}` schema and are converted back to Responses custom tool calls and outputs. Grammar constraints are included as instructions but cannot be enforced by Anthropic.
+- Tool definitions supplied inside Responses Lite `additional_tools` items are also supported. Namespaced tools, including `functions.exec` in Codex code mode, are given Anthropic-compatible names and restored to their original namespace in Responses output.
+- Anthropic routes do not implement OpenAI hosted tools such as web search, file search, or code interpreter. Use an upstream supporting native Responses when these are required.
+- Claude subscription OAuth accounts are excluded from Responses traffic by the existing account policy. Configure an eligible API-key or other supported upstream account.
+- New or unsupported top-level request fields still receive a `400`; this change supports specific current client fields without silently discarding unknown controls.
+
+## Diagnosing a connection
+
+`GET /health` checks the running proxy version and health. `GET /v1/models` is not a reliable Responses compatibility check: it can be forwarded to an Anthropic endpoint requiring Anthropic-specific headers.
+
+Test `POST /v1/responses` with a short prompt. A working connection must complete the response stream, not merely return HTTP 200. A client-side compatibility patch cannot fix upstream account entitlement, quota, or access-denial errors.
+
+The Responses adapter preserves structured upstream error messages, including native Codex `detail` errors and provider error codes. Unrecognized error bodies return the upstream HTTP status and direct the operator to request logs. HTML error pages are not echoed to the client. Use a dashboard-authorized key or server logs to inspect the selected account and original error; an API-only key cannot read dashboard endpoints.
+
+## Local regression checks
+
+```sh
+bun install --frozen-lockfile
+bun test packages/openai-responses-adapter/src/__tests__ packages/providers/src/providers/codex/provider.test.ts packages/providers/src/providers/codex/provider.responses.test.ts packages/providers/src/providers/codex/provider.fidelity.test.ts
+```
+
+These tests use mocked upstream responses. They establish protocol behavior without proving a particular deployed account can serve a model.
+
+To exercise the actual app-server bundled with the VS Code extension:
+
+```sh
+bun scripts/smoke-codex-vscode.ts /path/to/extension/bin/codex
+```
+
+The smoke test uses a loopback server, a temporary workspace, and isolated Codex configuration. It drives the same `initialize`, `thread/start`, and `turn/start` RPC flow used by the editor and supplies deterministic Anthropic streaming responses. It checks a file edit and the following tool-result request without contacting an inference service or using production credentials.
+
+Validated with the VS Code extension's Codex 0.153.4 app-server requesting `gpt-6-astra`: namespaced `functions.exec` ran `tools.apply_patch`, the tool result was replayed, and the final assistant message completed. The same client against unmodified v3.5.78 failed with `400 Unsupported Responses request field(s): client_metadata`.

--- a/packages/openai-responses-adapter/src/__tests__/custom-tools.test.ts
+++ b/packages/openai-responses-adapter/src/__tests__/custom-tools.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "bun:test";
+import {
+	getRequestTools,
+	getResponseToolIdentity,
+	getTranslatedToolName,
+} from "../custom-tools";
+import { translateRequestToAnthropic } from "../request-translator";
+import { translateAnthropicResponseToResponses } from "../response-translator";
+import type { ResponsesRequest } from "../types";
+
+describe("Responses Lite tool declarations", () => {
+	test("extracts additional_tools namespaces and round-trips calls with their identities", () => {
+		const req: ResponsesRequest = {
+			model: "gpt-6-astra",
+			input: [
+				{
+					type: "additional_tools",
+					id: "at_1",
+					role: "developer",
+					tools: [
+						{
+							type: "namespace",
+							name: "functions",
+							tools: [
+								{
+									type: "custom",
+									name: "exec",
+									description: "Execute JavaScript.",
+								},
+								{
+									type: "function",
+									name: "wait",
+									parameters: { type: "object" },
+								},
+							],
+						},
+						{
+							type: "namespace",
+							name: "clock",
+							description: "Time tools",
+							tools: [
+								{
+									type: "function",
+									name: "wait",
+									parameters: { type: "object" },
+								},
+							],
+						},
+					],
+				},
+				{ type: "message", role: "user", content: "Edit a file" },
+			],
+		};
+		const original = structuredClone(req);
+		const translated = translateRequestToAnthropic(req);
+		const tools = getRequestTools(req);
+		const exec = getTranslatedToolName("exec", "functions");
+		const functionWait = getTranslatedToolName("wait", "functions");
+		const clockWait = getTranslatedToolName("wait", "clock");
+		expect(translated.tools?.map((tool) => tool.name)).toEqual([
+			exec,
+			functionWait,
+			clockWait,
+		]);
+		expect(functionWait).not.toBe(clockWait);
+		expect(translated.tools?.[0].input_schema).toMatchObject({
+			properties: { input: { type: "string" } },
+		});
+		expect(translated.messages).toEqual([
+			{ role: "user", content: [{ type: "text", text: "Edit a file" }] },
+		]);
+		expect(req).toEqual(original);
+
+		const code =
+			'text(await tools.apply_patch("*** Begin Patch\\n*** End Patch"));';
+		const response = translateAnthropicResponseToResponses(
+			{
+				id: "msg_1",
+				type: "message",
+				role: "assistant",
+				model: "claude-sonnet-4-6",
+				content: [
+					{
+						type: "tool_use",
+						id: "call_exec",
+						name: exec,
+						input: { input: code },
+					},
+					{
+						type: "tool_use",
+						id: "call_wait",
+						name: clockWait,
+						input: { duration_ms: 10 },
+					},
+				],
+				stop_reason: "tool_use",
+				stop_sequence: null,
+				usage: { input_tokens: 10, output_tokens: 20 },
+			},
+			"resp_1",
+			req.model,
+			tools,
+		);
+		expect(response.output[0]).toMatchObject({
+			type: "custom_tool_call",
+			name: "exec",
+			namespace: "functions",
+			input: code,
+		});
+		expect(response.output[1]).toMatchObject({
+			type: "function_call",
+			name: "wait",
+			namespace: "clock",
+			arguments: '{"duration_ms":10}',
+		});
+		const replay = translateRequestToAnthropic({
+			...req,
+			input: [
+				...(original.input as Exclude<ResponsesRequest["input"], string>),
+				...response.output,
+			],
+		});
+		expect(replay.messages[1].content).toEqual([
+			{ type: "tool_use", id: "call_exec", name: exec, input: { input: code } },
+			{
+				type: "tool_use",
+				id: "call_wait",
+				name: clockWait,
+				input: { duration_ms: 10 },
+			},
+		]);
+	});
+
+	test("later tool declarations replace repeated names while keeping distinct namespaces", () => {
+		const tools = getRequestTools({
+			input: [
+				{
+					type: "additional_tools",
+					role: "developer",
+					tools: [
+						{ type: "custom", name: "exec", description: "old" },
+						{
+							type: "namespace",
+							name: "functions",
+							tools: [{ type: "custom", name: "exec" }],
+						},
+					],
+				},
+			],
+			tools: [{ type: "custom", name: "exec", description: "new" }],
+		});
+		expect(tools).toHaveLength(2);
+		expect(tools[0]).toMatchObject({ name: "exec", description: "new" });
+		expect(tools[1]).toMatchObject({ name: "exec", namespace: "functions" });
+	});
+
+	test("namespace aliases meet Anthropic limits and resolve exactly for long names", () => {
+		const name = "tool_".repeat(40);
+		const namespace = "mcp__app.with.special/chars";
+		const alias = getTranslatedToolName(name, namespace);
+		expect(alias).toMatch(/^[a-zA-Z0-9_-]{1,64}$/);
+		expect(
+			getResponseToolIdentity(alias, [{ type: "custom", name, namespace }]),
+		).toEqual({ name, namespace });
+	});
+});

--- a/packages/openai-responses-adapter/src/__tests__/handler.test.ts
+++ b/packages/openai-responses-adapter/src/__tests__/handler.test.ts
@@ -357,6 +357,9 @@ describe("handleResponsesRequest", () => {
 			service_tier: "priority",
 			context_management: [{ type: "compaction", compact_threshold: 100_000 }],
 			max_output_tokens: 2048,
+			stream_options: { reasoning_summary_delivery: "sequential_cutoff" },
+			client_metadata: { "x-codex-turn-metadata": "vscode-test-turn" },
+			access_programs: { cyber: "standard" },
 		};
 		const req = new Request("http://localhost/v1/responses", {
 			method: "POST",
@@ -615,6 +618,210 @@ describe("handleResponsesRequest", () => {
 		expect(
 			resp.headers.get("x-better-ccflare-codex-response-format"),
 		).toBeNull();
+	});
+
+	test.each([
+		{
+			upstream: {
+				detail: "This model is unavailable for the selected account",
+			},
+			message: "This model is unavailable for the selected account",
+			type: "api_error",
+			code: "api_error",
+		},
+		{
+			upstream: {
+				error: {
+					message: "Account access denied",
+					type: "permission_error",
+					code: "account_denied",
+				},
+			},
+			message: "Account access denied",
+			type: "permission_error",
+			code: "account_denied",
+		},
+		{
+			upstream: { error: "Provider rejected the request" },
+			message: "Provider rejected the request",
+			type: "api_error",
+			code: "api_error",
+		},
+	])("preserves actionable upstream 403 errors: $message", async ({
+		upstream,
+		message,
+		type,
+		code,
+	}) => {
+		const req = new Request("http://localhost/v1/responses", {
+			method: "POST",
+			body: JSON.stringify({ model: "gpt-6-astra", input: "Hi" }),
+		});
+		const response = await handleResponsesRequest(
+			req,
+			new URL(req.url),
+			async () =>
+				new Response(JSON.stringify(upstream), {
+					status: 403,
+					headers: {
+						"content-type": "application/json",
+						"content-length": "123",
+						"content-encoding": "gzip",
+						"x-request-id": "upstream-request-id",
+					},
+				}),
+			{},
+		);
+		expect(response.status).toBe(403);
+		expect(await response.json()).toEqual({ error: { message, type, code } });
+		expect(response.headers.get("content-length")).toBeNull();
+		expect(response.headers.get("content-encoding")).toBeNull();
+		expect(response.headers.get("x-request-id")).toBe("upstream-request-id");
+	});
+
+	test.each([
+		["text/html", "<html>Upstream access denied</html>"],
+		["application/json", "invalid JSON"],
+		["application/json", "null"],
+	])("reports upstream HTTP status for unrecognized %s errors", async (contentType, upstreamBody) => {
+		const req = new Request("http://localhost/v1/responses", {
+			method: "POST",
+			body: JSON.stringify({ model: "gpt-6-astra", input: "Hi" }),
+		});
+		const response = await handleResponsesRequest(
+			req,
+			new URL(req.url),
+			async () =>
+				new Response(upstreamBody, {
+					status: 403,
+					headers: { "content-type": contentType },
+				}),
+			{},
+		);
+		const body = await response.json();
+		expect(response.status).toBe(403);
+		expect(body.error.message).toContain("HTTP 403");
+		expect(body.error.message).toContain("proxy request logs");
+		expect(body.error.message).not.toContain(upstreamBody);
+	});
+
+	test.each([
+		true,
+		false,
+	])("validates non-streaming custom tool bridge input (valid: %s)", async (valid) => {
+		const patch =
+			"*** Begin Patch\n*** Add File: example.txt\n+hello\n*** End Patch";
+		const req = new Request("http://localhost/v1/responses", {
+			method: "POST",
+			body: JSON.stringify({
+				model: "gpt-6-astra",
+				input: "Create example.txt",
+				stream: false,
+				tools: [{ type: "custom", name: "apply_patch" }],
+			}),
+		});
+		const response = await handleResponsesRequest(
+			req,
+			new URL(req.url),
+			async () =>
+				new Response(
+					JSON.stringify({
+						...JSON.parse(ANTHROPIC_MESSAGE_BODY),
+						content: [
+							{
+								type: "tool_use",
+								id: "call_patch",
+								name: "apply_patch",
+								input: valid
+									? { input: patch }
+									: { unexpected: "invalid input" },
+							},
+						],
+						stop_reason: "tool_use",
+					}),
+					{ headers: { "content-type": "application/json" } },
+				),
+			{},
+		);
+		const body = await response.json();
+		if (valid) {
+			expect(response.status).toBe(200);
+			expect(body.output[0]).toMatchObject({
+				type: "custom_tool_call",
+				name: "apply_patch",
+				call_id: "call_patch",
+				input: patch,
+			});
+		} else {
+			expect(response.status).toBe(502);
+			expect(body.error.type).toBe("invalid_response_error");
+			expect(body.output).toBeUndefined();
+		}
+	});
+
+	test("translates VS Code additional_tools namespaces without changing native input", async () => {
+		const input = [
+			{
+				type: "additional_tools",
+				role: "developer",
+				tools: [
+					{
+						type: "namespace",
+						name: "functions",
+						tools: [
+							{ type: "custom", name: "exec", description: "Execute code" },
+						],
+					},
+				],
+			},
+			{
+				type: "message",
+				role: "user",
+				content: [{ type: "input_text", text: "Create a file" }],
+			},
+		];
+		const req = new Request("http://localhost/v1/responses", {
+			method: "POST",
+			body: JSON.stringify({ model: "gpt-6-astra", input, stream: false }),
+		});
+		const code =
+			'await tools.apply_patch("*** Begin Patch\\n*** Add File: example.txt\\n+hello\\n*** End Patch")';
+		const response = await handleResponsesRequest(
+			req,
+			new URL(req.url),
+			async (upstream) => {
+				const body = await upstream.json();
+				expect(body.__better_ccflare_codex_passthrough.native_input).toEqual(
+					input,
+				);
+				expect(body.tools).toHaveLength(1);
+				expect(body.tools[0].input_schema.properties.input.type).toBe("string");
+				return new Response(
+					JSON.stringify({
+						...JSON.parse(ANTHROPIC_MESSAGE_BODY),
+						content: [
+							{
+								type: "tool_use",
+								id: "call_exec",
+								name: body.tools[0].name,
+								input: { input: code },
+							},
+						],
+						stop_reason: "tool_use",
+					}),
+					{ headers: { "content-type": "application/json" } },
+				);
+			},
+			{},
+		);
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.output[0]).toMatchObject({
+			type: "custom_tool_call",
+			name: "exec",
+			namespace: "functions",
+			input: code,
+		});
 	});
 
 	test("Test 4: streaming path → returns a text/event-stream response", async () => {

--- a/packages/openai-responses-adapter/src/__tests__/request-translator.test.ts
+++ b/packages/openai-responses-adapter/src/__tests__/request-translator.test.ts
@@ -451,7 +451,9 @@ describe("translateRequestToAnthropic", () => {
 		expect(toolUse.input).toEqual({});
 	});
 
-	test("custom_tool_call appended like function_call", () => {
+	test("custom_tool_call preserves raw patch input in a JSON wrapper", () => {
+		const patch =
+			'*** Begin Patch\n*** Add File: hello.txt\n+"héllo"\n*** End Patch';
 		const req: ResponsesRequest = {
 			model: "claude-3-5-sonnet-20241022",
 			input: [
@@ -459,7 +461,7 @@ describe("translateRequestToAnthropic", () => {
 					type: "custom_tool_call",
 					call_id: "call_custom",
 					name: "custom_fn",
-					arguments: '{"a":1}',
+					input: patch,
 				},
 			],
 		};
@@ -468,8 +470,79 @@ describe("translateRequestToAnthropic", () => {
 			type: "tool_use",
 			id: "call_custom",
 			name: "custom_fn",
-			input: { a: 1 },
+			input: { input: patch },
 		});
+	});
+
+	test("custom tools expose a raw input string alongside regular function tools", () => {
+		const grammar = 'start: "*** Begin Patch" /[\\s\\S]*/ "*** End Patch"';
+		const result = translateRequestToAnthropic({
+			model: "gpt-5.4",
+			input: [],
+			tools: [
+				{
+					type: "custom",
+					name: "apply_patch",
+					description: "Apply a patch to the workspace.",
+					format: { type: "grammar", syntax: "lark", definition: grammar },
+				},
+				{
+					type: "function",
+					name: "read_file",
+					parameters: {
+						type: "object",
+						properties: { path: { type: "string" } },
+					},
+				},
+			],
+			tool_choice: { type: "custom", name: "apply_patch" },
+		});
+		expect(result.tools).toHaveLength(2);
+		expect(result.tools?.[0]).toMatchObject({
+			name: "apply_patch",
+			input_schema: {
+				type: "object",
+				properties: { input: { type: "string" } },
+				required: ["input"],
+				additionalProperties: false,
+			},
+		});
+		expect(result.tools?.[0].description).toContain(grammar);
+		expect(result.tools?.[1]).toMatchObject({
+			name: "read_file",
+			input_schema: {
+				type: "object",
+				properties: { path: { type: "string" } },
+			},
+		});
+		expect(result.tool_choice).toEqual({ type: "tool", name: "apply_patch" });
+	});
+
+	test("easy message input preserves strings and system/developer instructions", () => {
+		const result = translateRequestToAnthropic({
+			model: "gpt-5.4",
+			input: [
+				{ role: "system", content: "System instruction" },
+				{
+					type: "message",
+					role: "developer",
+					content: "Developer instruction",
+				},
+				{ role: "user", content: "Please inspect the code" },
+				{ type: "message", role: "assistant", content: "Inspecting now" },
+			],
+		});
+		expect(result.system).toBe("System instruction\n\nDeveloper instruction");
+		expect(result.messages).toEqual([
+			{
+				role: "user",
+				content: [{ type: "text", text: "Please inspect the code" }],
+			},
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "Inspecting now" }],
+			},
+		]);
 	});
 
 	test("custom_tool_call_output → user message with tool_result", () => {
@@ -489,6 +562,49 @@ describe("translateRequestToAnthropic", () => {
 			tool_use_id: "call_custom",
 			content: "custom result",
 		});
+	});
+
+	test("structured custom/function outputs translate text and images into Anthropic blocks", () => {
+		for (const type of [
+			"custom_tool_call_output",
+			"function_call_output",
+		] as const) {
+			const result = translateRequestToAnthropic({
+				model: "gpt-6-astra",
+				input: [
+					{
+						type,
+						call_id: "call_exec",
+						output: [
+							{ type: "input_text", text: "Script completed" },
+							{ type: "input_text", text: "{}" },
+							{
+								type: "input_image",
+								image_url: "data:image/png;base64,aGVsbG8=",
+							},
+						],
+					},
+				],
+			});
+			expect(result.messages[0].content).toEqual([
+				{
+					type: "tool_result",
+					tool_use_id: "call_exec",
+					content: [
+						{ type: "text", text: "Script completed" },
+						{ type: "text", text: "{}" },
+						{
+							type: "image",
+							source: {
+								type: "base64",
+								media_type: "image/png",
+								data: "aGVsbG8=",
+							},
+						},
+					],
+				},
+			]);
+		}
 	});
 
 	test("model passthrough for non-gpt-5 names", () => {

--- a/packages/openai-responses-adapter/src/__tests__/response-translator.test.ts
+++ b/packages/openai-responses-adapter/src/__tests__/response-translator.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { translateRequestToAnthropic } from "../request-translator";
 import { translateAnthropicResponseToResponses } from "../response-translator";
 import type { AnthropicResponse } from "../types";
 
@@ -19,6 +20,117 @@ function makeBaseResponse(
 }
 
 describe("translateAnthropicResponseToResponses", () => {
+	test("custom patch calls round-trip raw text and retain ordinary function calls", () => {
+		const patch =
+			'*** Begin Patch\n*** Add File: hello.txt\n+"héllo"\\world\n*** End Patch';
+		const tools = [
+			{ type: "custom" as const, name: "apply_patch" },
+			{ type: "function" as const, name: "read_file" },
+		];
+		const result = translateAnthropicResponseToResponses(
+			makeBaseResponse({
+				content: [
+					{
+						type: "tool_use",
+						id: "call_patch",
+						name: "apply_patch",
+						input: { input: patch },
+					},
+					{
+						type: "tool_use",
+						id: "call_read",
+						name: "read_file",
+						input: { path: "hello.txt" },
+					},
+				],
+			}),
+			"resp_custom",
+			"gpt-5.4",
+			tools,
+		);
+		expect(result.output).toEqual([
+			{
+				type: "custom_tool_call",
+				id: "resp_custom_ctc_0",
+				call_id: "call_patch",
+				name: "apply_patch",
+				input: patch,
+				status: "completed",
+			},
+			{
+				type: "function_call",
+				id: "resp_custom_fc_1",
+				call_id: "call_read",
+				name: "read_file",
+				arguments: '{"path":"hello.txt"}',
+				status: "completed",
+			},
+		]);
+		const replay = translateRequestToAnthropic({
+			model: "gpt-5.4",
+			tools,
+			input: [
+				...result.output,
+				{
+					type: "custom_tool_call_output",
+					call_id: "call_patch",
+					output: "Patch applied",
+				},
+				{
+					type: "function_call_output",
+					call_id: "call_read",
+					output: "File contents",
+				},
+			],
+		});
+		expect(replay.messages[0].content).toEqual([
+			{
+				type: "tool_use",
+				id: "call_patch",
+				name: "apply_patch",
+				input: { input: patch },
+			},
+			{
+				type: "tool_use",
+				id: "call_read",
+				name: "read_file",
+				input: { path: "hello.txt" },
+			},
+		]);
+		expect(replay.messages[1].content).toEqual([
+			{
+				type: "tool_result",
+				tool_use_id: "call_patch",
+				content: "Patch applied",
+			},
+			{
+				type: "tool_result",
+				tool_use_id: "call_read",
+				content: "File contents",
+			},
+		]);
+	});
+
+	test("rejects malformed custom tool input instead of emitting an executable call", () => {
+		expect(() =>
+			translateAnthropicResponseToResponses(
+				makeBaseResponse({
+					content: [
+						{
+							type: "tool_use",
+							id: "call_patch",
+							name: "apply_patch",
+							input: { input: 42 },
+						},
+					],
+				}),
+				"resp_custom",
+				"gpt-5.4",
+				[{ type: "custom", name: "apply_patch" }],
+			),
+		).toThrow("Upstream custom tool call did not contain a text input");
+	});
+
 	test("text-only response → single OutputMessageItem in output[]", () => {
 		const resp = makeBaseResponse({
 			content: [{ type: "text", text: "Hello world" }],

--- a/packages/openai-responses-adapter/src/__tests__/stream-translator.test.ts
+++ b/packages/openai-responses-adapter/src/__tests__/stream-translator.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { logBus } from "@better-ccflare/logger";
+import { getTranslatedToolName } from "../custom-tools";
 import { translateAnthropicStreamToResponses } from "../stream-translator";
 
 async function collectSseEvents(
@@ -7,9 +8,7 @@ async function collectSseEvents(
 ): Promise<Array<{ event: string; data: unknown }>> {
 	const text = await response.text();
 	const events: Array<{ event: string; data: unknown }> = [];
-	const rawEvents = text
-		.split(/\r?\n\r?\n/)
-		.filter((s) => s.trim().length > 0);
+	const rawEvents = text.split(/\r?\n\r?\n/).filter((s) => s.trim().length > 0);
 
 	for (const rawEvent of rawEvents) {
 		const lines = rawEvent.split(/\r?\n/);
@@ -42,6 +41,211 @@ function sseEvent(type: string, data: unknown): string {
 }
 
 describe("translateAnthropicStreamToResponses", () => {
+	test("namespaced custom and function calls restore name and namespace in SSE", async () => {
+		const events = [
+			sseEvent("message_start", { message: { id: "msg_namespaces" } }),
+		];
+		for (const [index, name, namespace, input] of [
+			[0, "exec", "functions", { input: "text(1)" }],
+			[1, "wait", "clock", { duration_ms: 10 }],
+		] as const) {
+			events.push(
+				sseEvent("content_block_start", {
+					index,
+					content_block: {
+						type: "tool_use",
+						id: `call_${index}`,
+						name: getTranslatedToolName(name, namespace),
+						input: {},
+					},
+				}),
+				sseEvent("content_block_delta", {
+					index,
+					delta: {
+						type: "input_json_delta",
+						partial_json: JSON.stringify(input),
+					},
+				}),
+				sseEvent("content_block_stop", { index }),
+			);
+		}
+		events.push(sseEvent("message_stop", {}));
+		const parsed = await collectSseEvents(
+			translateAnthropicStreamToResponses(
+				makeAnthropicStream(events),
+				"resp_namespaces",
+				"gpt-6-astra",
+				[
+					{
+						type: "namespace",
+						name: "functions",
+						tools: [{ type: "custom", name: "exec" }],
+					},
+					{
+						type: "namespace",
+						name: "clock",
+						tools: [{ type: "function", name: "wait" }],
+					},
+				],
+			),
+		);
+		for (const eventType of [
+			"response.output_item.added",
+			"response.output_item.done",
+		]) {
+			const items = parsed.filter((event) => event.event === eventType);
+			expect(items[0].data).toMatchObject({
+				item: {
+					type: "custom_tool_call",
+					name: "exec",
+					namespace: "functions",
+				},
+			});
+			expect(items[1].data).toMatchObject({
+				item: { type: "function_call", name: "wait", namespace: "clock" },
+			});
+		}
+		expect(parsed.at(-1)?.data).toMatchObject({
+			response: {
+				output: [
+					{
+						type: "custom_tool_call",
+						name: "exec",
+						namespace: "functions",
+						input: "text(1)",
+					},
+					{
+						type: "function_call",
+						name: "wait",
+						namespace: "clock",
+						arguments: '{"duration_ms":10}',
+					},
+				],
+			},
+		});
+	});
+
+	test("custom tool SSE decodes split JSON escapes into raw input and complete output", async () => {
+		const patch =
+			'*** Begin Patch\n*** Add File: hello.txt\n+"héllo" \\ 🚀\n*** End Patch';
+		const json = JSON.stringify({ input: patch }).replace(
+			"🚀",
+			"\\ud83d\\ude80",
+		);
+		const events = [
+			sseEvent("message_start", {
+				message: { id: "msg_custom", usage: { input_tokens: 12 } },
+			}),
+			sseEvent("content_block_start", {
+				index: 0,
+				content_block: {
+					type: "tool_use",
+					id: "call_patch",
+					name: "apply_patch",
+					input: {},
+				},
+			}),
+			...Array.from(json, (partial_json) =>
+				sseEvent("content_block_delta", {
+					index: 0,
+					delta: { type: "input_json_delta", partial_json },
+				}),
+			),
+			sseEvent("content_block_stop", { index: 0 }),
+			sseEvent("message_delta", { usage: { output_tokens: 30 } }),
+			sseEvent("message_stop", {}),
+		];
+		const parsed = await collectSseEvents(
+			translateAnthropicStreamToResponses(
+				makeAnthropicStream(events),
+				"resp_custom",
+				"gpt-5.4",
+				[{ type: "custom", name: "apply_patch" }],
+			),
+		);
+		expect(parsed.map((event) => event.event)).toEqual([
+			"response.created",
+			"response.in_progress",
+			"response.output_item.added",
+			"response.custom_tool_call_input.delta",
+			"response.custom_tool_call_input.done",
+			"response.output_item.done",
+			"response.completed",
+		]);
+		expect(parsed[2].data).toMatchObject({
+			item: {
+				type: "custom_tool_call",
+				call_id: "call_patch",
+				name: "apply_patch",
+				input: "",
+			},
+		});
+		expect(parsed[3].data).toMatchObject({
+			delta: patch,
+			call_id: "call_patch",
+		});
+		expect(parsed[4].data).toMatchObject({ input: patch });
+		const completedItem = {
+			type: "custom_tool_call",
+			id: "resp_custom_ctc_0",
+			call_id: "call_patch",
+			name: "apply_patch",
+			input: patch,
+			status: "completed",
+		};
+		expect(parsed[5].data).toMatchObject({ item: completedItem });
+		expect(parsed[6].data).toMatchObject({
+			response: { output: [completedItem] },
+		});
+	});
+
+	test("custom tool SSE accepts initial input and fails malformed input without completing a call", async () => {
+		for (const input of [
+			{ input: "" },
+			{ input: "complete patch" },
+			{ input: 42 },
+		]) {
+			const parsed = await collectSseEvents(
+				translateAnthropicStreamToResponses(
+					makeAnthropicStream([
+						sseEvent("message_start", { message: { id: "msg_custom" } }),
+						sseEvent("content_block_start", {
+							index: 0,
+							content_block: {
+								type: "tool_use",
+								id: "call_patch",
+								name: "apply_patch",
+								input,
+							},
+						}),
+						sseEvent("content_block_stop", { index: 0 }),
+						sseEvent("message_stop", {}),
+					]),
+					"resp_custom",
+					"gpt-5.4",
+					[{ type: "custom", name: "apply_patch" }],
+				),
+			);
+			if (typeof input.input === "string") {
+				expect(
+					parsed.find((event) => event.event === "response.output_item.done")
+						?.data,
+				).toMatchObject({
+					item: { type: "custom_tool_call", input: input.input },
+				});
+				expect(parsed.at(-1)?.event).toBe("response.completed");
+			} else {
+				expect(parsed.at(-1)?.event).toBe("response.failed");
+				expect(
+					parsed.some((event) => event.event === "response.output_item.done"),
+				).toBe(false);
+				expect(
+					parsed.some((event) => event.event === "response.completed"),
+				).toBe(false);
+			}
+		}
+	});
+
 	test("simple text streaming — correct event sequence and content", async () => {
 		const events = [
 			sseEvent("message_start", {

--- a/packages/openai-responses-adapter/src/custom-tools.ts
+++ b/packages/openai-responses-adapter/src/custom-tools.ts
@@ -1,0 +1,107 @@
+import { createHash } from "node:crypto";
+import type { ResponsesRequest, ResponsesTool } from "./types";
+
+/** Collect Responses Lite tool declarations without changing native input. */
+export function getRequestTools(
+	req: Pick<ResponsesRequest, "tools" | "input">,
+): ResponsesTool[] {
+	const declarations: ResponsesTool[] = [];
+	if (Array.isArray(req.input)) {
+		for (const item of req.input) {
+			if (item.type === "additional_tools" && Array.isArray(item.tools)) {
+				declarations.push(...item.tools);
+			}
+		}
+	}
+	if (Array.isArray(req.tools)) declarations.push(...req.tools);
+	return flattenTools(declarations);
+}
+
+function flattenTools(tools: ResponsesTool[]): ResponsesTool[] {
+	const result = new Map<string, ResponsesTool>();
+	const visit = (
+		declarations: ResponsesTool[],
+		namespace?: string,
+		description?: string,
+	): void => {
+		for (const tool of declarations) {
+			if (tool.type === "namespace") {
+				visit(
+					tool.tools,
+					namespace ? `${namespace}.${tool.name}` : tool.name,
+					[description, tool.description].filter(Boolean).join("\n\n"),
+				);
+			} else if (tool.type === "function" || tool.type === "custom") {
+				const effectiveNamespace = namespace ?? tool.namespace;
+				const effectiveTool = effectiveNamespace
+					? {
+							...tool,
+							namespace: effectiveNamespace,
+							description: [description, tool.description]
+								.filter(Boolean)
+								.join("\n\n"),
+						}
+					: tool;
+				result.set(
+					JSON.stringify([effectiveNamespace, tool.name]),
+					effectiveTool,
+				);
+			} else {
+				result.set(JSON.stringify([namespace, tool.type]), tool);
+			}
+		}
+	};
+	visit(tools);
+	return [...result.values()];
+}
+
+/** Anthropic names are flat and limited to 64 ASCII identifier characters. */
+export function getTranslatedToolName(
+	name: string,
+	namespace?: string,
+): string {
+	if (!namespace) return name;
+	const digest = createHash("sha256")
+		.update(JSON.stringify([namespace, name]))
+		.digest("hex")
+		.slice(0, 24);
+	return `ns_${digest}_${name.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 36)}`;
+}
+
+export function getResponseToolIdentity(
+	name: string,
+	tools: ResponsesTool[] = [],
+): { name: string; namespace?: string } {
+	for (const tool of flattenTools(tools)) {
+		if (
+			(tool.type === "function" || tool.type === "custom") &&
+			getTranslatedToolName(tool.name, tool.namespace) === name
+		) {
+			return tool.namespace
+				? { name: tool.name, namespace: tool.namespace }
+				: { name: tool.name };
+		}
+	}
+	return { name };
+}
+
+export function getCustomToolNames(tools: ResponsesTool[] = []): Set<string> {
+	return new Set(
+		flattenTools(tools)
+			.filter((tool) => tool.type === "custom")
+			.map((tool) => getTranslatedToolName(tool.name, tool.namespace)),
+	);
+}
+
+/** Unwrap the JSON schema bridge without changing the tool's raw text. */
+export function unwrapCustomToolInput(input: unknown): string {
+	if (
+		input !== null &&
+		typeof input === "object" &&
+		"input" in input &&
+		typeof input.input === "string"
+	) {
+		return input.input;
+	}
+	throw new Error("Upstream custom tool call did not contain a text input");
+}

--- a/packages/openai-responses-adapter/src/handler.ts
+++ b/packages/openai-responses-adapter/src/handler.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import { Logger } from "@better-ccflare/logger";
+import { getRequestTools } from "./custom-tools";
 import { translateRequestToAnthropic } from "./request-translator";
 import { translateAnthropicResponseToResponses } from "./response-translator";
 import { translateAnthropicStreamToResponses } from "./stream-translator";
@@ -48,6 +49,9 @@ const SUPPORTED_RESPONSES_REQUEST_FIELDS = new Set([
 	"metadata",
 	"service_tier",
 	"context_management",
+	"stream_options",
+	"client_metadata",
+	"access_programs",
 ]);
 const NATIVE_GENERATION_FIELDS = [
 	"text",
@@ -59,6 +63,9 @@ const NATIVE_GENERATION_FIELDS = [
 	"service_tier",
 	"context_management",
 	"max_output_tokens",
+	"stream_options",
+	"client_metadata",
+	"access_programs",
 ] as const satisfies readonly (keyof ResponsesRequest)[];
 
 type CacheDiagnostic = {
@@ -666,47 +673,43 @@ export async function handleResponsesRequest(
 		);
 	}
 
-	// 7. Translate non-200 Anthropic errors to OpenAI error shape
+	// 7. Normalize upstream errors, including native Codex/FastAPI errors.
 	if (anthropicResp.status !== 200) {
-		let errorBody: { error: { message: string; type: string; code: string } };
 		const contentType = anthropicResp.headers.get("content-type") ?? "";
-		if (contentType.includes("application/json")) {
+		let message = `Upstream request failed with HTTP ${anthropicResp.status}. Check the proxy request logs for the upstream account and response.`;
+		let type = "api_error";
+		let code = type;
+		if (
+			contentType.includes("application/json") ||
+			contentType.includes("+json")
+		) {
 			try {
-				const anthropicError = (await anthropicResp.json()) as {
-					type?: string;
-					error?: { type?: string; message?: string };
-				};
-				const errType = anthropicError?.error?.type ?? "api_error";
-				errorBody = {
-					error: {
-						message: anthropicError?.error?.message ?? "Unknown error",
-						type: errType,
-						code: errType,
-					},
-				};
+				const upstream = (await anthropicResp.json()) as Record<
+					string,
+					unknown
+				> | null;
+				const nested = upstream?.error;
+				const error =
+					nested !== null && typeof nested === "object"
+						? (nested as Record<string, unknown>)
+						: undefined;
+				const candidate =
+					error?.message ?? upstream?.detail ?? upstream?.message ?? nested;
+				if (typeof candidate === "string" && candidate.trim())
+					message = candidate;
+				if (typeof error?.type === "string") type = error.type;
+				code = typeof error?.code === "string" ? error.code : type;
 			} catch {
-				errorBody = {
-					error: {
-						message: "Unknown error",
-						type: "api_error",
-						code: "api_error",
-					},
-				};
+				// Keep a useful status-based error when the upstream body is malformed.
 			}
-		} else {
-			errorBody = {
-				error: {
-					message: "Unknown error",
-					type: "api_error",
-					code: "api_error",
-				},
-			};
 		}
-		return new Response(JSON.stringify(errorBody), {
+		return new Response(JSON.stringify({ error: { message, type, code } }), {
 			status: anthropicResp.status,
 			headers: (() => {
 				const headers = new Headers(anthropicResp.headers);
 				headers.delete("x-better-ccflare-codex-response-format");
+				headers.delete("content-length");
+				headers.delete("content-encoding");
 				headers.set("content-type", "application/json");
 				return headers;
 			})(),
@@ -774,6 +777,7 @@ export async function handleResponsesRequest(
 			anthropicResp,
 			responseId,
 			body.model,
+			getRequestTools(body),
 		);
 	}
 
@@ -793,11 +797,27 @@ export async function handleResponsesRequest(
 			{ status: 502, headers: { "Content-Type": "application/json" } },
 		);
 	}
-	const translated = translateAnthropicResponseToResponses(
-		respBody as Parameters<typeof translateAnthropicResponseToResponses>[0],
-		responseId,
-		body.model,
-	);
+	let translated: ReturnType<typeof translateAnthropicResponseToResponses>;
+	try {
+		translated = translateAnthropicResponseToResponses(
+			respBody as Parameters<typeof translateAnthropicResponseToResponses>[0],
+			responseId,
+			body.model,
+			getRequestTools(body),
+		);
+	} catch {
+		return new Response(
+			JSON.stringify({
+				error: {
+					message:
+						"Failed to translate upstream response: invalid tool input or response body",
+					type: "invalid_response_error",
+					code: "invalid_response_error",
+				},
+			}),
+			{ status: 502, headers: { "Content-Type": "application/json" } },
+		);
+	}
 	return new Response(JSON.stringify(translated), {
 		status: 200,
 		headers: { "Content-Type": "application/json" },

--- a/packages/openai-responses-adapter/src/request-translator.ts
+++ b/packages/openai-responses-adapter/src/request-translator.ts
@@ -4,10 +4,13 @@ import {
 	LATEST_SONNET_MODEL,
 } from "@better-ccflare/core";
 import { Logger } from "@better-ccflare/logger";
+import { getRequestTools, getTranslatedToolName } from "./custom-tools";
 import type {
 	AnthropicContent,
+	AnthropicImageContent,
 	AnthropicMessage,
 	AnthropicRequest,
+	AnthropicTextContent,
 	AnthropicTool,
 	AnthropicToolChoice,
 	ResponseItem,
@@ -45,12 +48,34 @@ function parseArguments(args: string): unknown {
 function translateTools(tools: ResponsesTool[]): AnthropicTool[] {
 	const result: AnthropicTool[] = [];
 	for (const tool of tools) {
+		if (tool.type === "custom") {
+			const description = [
+				tool.description,
+				"Pass the tool's complete raw text in the input string.",
+				tool.format?.type === "grammar"
+					? `The input must follow this ${tool.format.syntax} grammar:\n${tool.format.definition}`
+					: undefined,
+			]
+				.filter(Boolean)
+				.join("\n\n");
+			result.push({
+				name: getTranslatedToolName(tool.name, tool.namespace),
+				description,
+				input_schema: {
+					type: "object",
+					properties: { input: { type: "string" } },
+					required: ["input"],
+					additionalProperties: false,
+				},
+			});
+			continue;
+		}
 		if (tool.type !== "function") {
 			logger.warn(`Skipping unsupported/built-in tool type: ${tool.type}`);
 			continue;
 		}
 		result.push({
-			name: tool.name,
+			name: getTranslatedToolName(tool.name, tool.namespace),
 			description: tool.description,
 			input_schema: tool.parameters ?? {},
 		});
@@ -65,8 +90,14 @@ function translateToolChoice(
 	if (choice === "auto") return { type: "auto" };
 	if (choice === "required") return { type: "any" };
 	if (choice === "none") return { type: "none" };
-	if (typeof choice === "object" && choice.type === "function") {
-		return { type: "tool", name: choice.name };
+	if (
+		typeof choice === "object" &&
+		(choice.type === "function" || choice.type === "custom")
+	) {
+		return {
+			type: "tool",
+			name: getTranslatedToolName(choice.name, choice.namespace),
+		};
 	}
 	return undefined;
 }
@@ -77,7 +108,7 @@ function translateContentItem(c: {
 	refusal?: string;
 	image_url?: string;
 	file_id?: string;
-}): AnthropicContent {
+}): AnthropicTextContent | AnthropicImageContent {
 	if (c.type === "input_text" || c.type === "output_text") {
 		return { type: "text", text: c.text ?? "" };
 	}
@@ -139,14 +170,15 @@ export function translateRequestToAnthropic(
 	const developerBlocks: string[] = [];
 
 	for (const item of req.input) {
-		if (item.type === "message") {
-			const content: AnthropicContent[] = item.content.map((c) =>
-				translateContentItem(c),
-			);
+		if (item.type === "message" || item.type === undefined) {
+			const content: AnthropicContent[] =
+				typeof item.content === "string"
+					? [{ type: "text", text: item.content }]
+					: item.content.map((c) => translateContentItem(c));
 			// developer role is used by Codex CLI for system-level instructions.
 			// Anthropic /v1/messages does not accept this role in the messages array
 			// so we extract the text and merge it into the system prompt instead.
-			if ((item.role as string) === "developer") {
+			if (item.role === "developer" || item.role === "system") {
 				for (const c of content) {
 					if (c.type === "text") developerBlocks.push(c.text);
 				}
@@ -160,8 +192,11 @@ export function translateRequestToAnthropic(
 			const toolUseBlock: AnthropicContent = {
 				type: "tool_use",
 				id: item.call_id,
-				name: item.name,
-				input: parseArguments(item.arguments),
+				name: getTranslatedToolName(item.name, item.namespace),
+				input:
+					item.type === "custom_tool_call"
+						? { input: item.input }
+						: parseArguments(item.arguments),
 			};
 			const last = messages[messages.length - 1];
 			if (last && last.role === "assistant") {
@@ -182,7 +217,10 @@ export function translateRequestToAnthropic(
 					{
 						type: "tool_result",
 						tool_use_id: item.call_id,
-						content: item.output,
+						content:
+							typeof item.output === "string"
+								? item.output
+								: item.output.map((c) => translateContentItem(c)),
 					},
 				],
 			});
@@ -208,8 +246,7 @@ export function translateRequestToAnthropic(
 		result.stream = req.stream;
 	}
 
-	const translatedTools =
-		req.tools && req.tools.length > 0 ? translateTools(req.tools) : [];
+	const translatedTools = translateTools(getRequestTools(req));
 	if (translatedTools.length > 0) {
 		result.tools = translatedTools;
 		const toolChoice = translateToolChoice(req.tool_choice);

--- a/packages/openai-responses-adapter/src/response-translator.ts
+++ b/packages/openai-responses-adapter/src/response-translator.ts
@@ -1,16 +1,24 @@
+import {
+	getCustomToolNames,
+	getResponseToolIdentity,
+	unwrapCustomToolInput,
+} from "./custom-tools";
 import type {
 	AnthropicResponse,
 	OutputFunctionCallItem,
 	OutputMessageItem,
 	ResponsesResponse,
+	ResponsesTool,
 } from "./types";
 
 export function translateAnthropicResponseToResponses(
 	resp: AnthropicResponse,
 	responseId: string,
 	model: string,
+	tools?: ResponsesTool[],
 ): ResponsesResponse {
 	const output: ResponsesResponse["output"] = [];
+	const customToolNames = getCustomToolNames(tools);
 
 	let outputIdx = 0;
 	for (const block of resp.content) {
@@ -25,11 +33,23 @@ export function translateAnthropicResponseToResponses(
 			output.push(msgItem);
 			outputIdx++;
 		} else if (block.type === "tool_use") {
+			if (customToolNames.has(block.name)) {
+				output.push({
+					type: "custom_tool_call",
+					id: `${responseId}_ctc_${outputIdx}`,
+					call_id: block.id,
+					...getResponseToolIdentity(block.name, tools),
+					input: unwrapCustomToolInput(block.input),
+					status: "completed",
+				});
+				outputIdx++;
+				continue;
+			}
 			const fcItem: OutputFunctionCallItem = {
 				type: "function_call",
 				id: `${responseId}_fc_${outputIdx}`,
 				call_id: block.id,
-				name: block.name,
+				...getResponseToolIdentity(block.name, tools),
 				arguments: JSON.stringify(block.input),
 				status: "completed",
 			};

--- a/packages/openai-responses-adapter/src/stream-translator.ts
+++ b/packages/openai-responses-adapter/src/stream-translator.ts
@@ -1,4 +1,10 @@
 import { Logger } from "@better-ccflare/logger";
+import {
+	getCustomToolNames,
+	getResponseToolIdentity,
+	unwrapCustomToolInput,
+} from "./custom-tools";
+import type { ResponsesTool } from "./types";
 
 const log = new Logger("openai-responses-adapter");
 
@@ -11,7 +17,19 @@ interface State {
 	sequenceNumber: number;
 	blockIndexToOutput: Map<number, number>;
 	textByBlock: Map<number, string>;
-	toolByBlock: Map<number, { callId: string; name: string; argsBuf: string }>;
+	toolByBlock: Map<
+		number,
+		{
+			callId: string;
+			name: string;
+			namespace?: string;
+			argsBuf: string;
+			custom: boolean;
+			initialInput: unknown;
+		}
+	>;
+	customToolNames: Set<string>;
+	tools: ResponsesTool[];
 	inputTokens: number;
 	outputTokens: number;
 	doneSent: boolean;
@@ -72,6 +90,7 @@ function processEvent(
 	controller: TransformStreamDefaultController,
 	state: State,
 ): void {
+	if (state.streamError) return;
 	if (eventType === "message_start") {
 		const message = data.message as Record<string, unknown> | undefined;
 		const usage = message?.usage as Record<string, number> | undefined;
@@ -151,10 +170,17 @@ function processEvent(
 				state,
 			);
 		} else if (contentBlock.type === "tool_use") {
+			const custom = state.customToolNames.has(contentBlock.name as string);
+			const identity = getResponseToolIdentity(
+				contentBlock.name as string,
+				state.tools,
+			);
 			state.toolByBlock.set(blockIndex, {
 				callId: contentBlock.id as string,
-				name: contentBlock.name as string,
+				...identity,
 				argsBuf: "",
+				custom,
+				initialInput: contentBlock.input,
 			});
 			emitSse(
 				controller,
@@ -163,11 +189,11 @@ function processEvent(
 					type: "response.output_item.added",
 					output_index: outputIdx,
 					item: {
-						type: "function_call",
-						id: `${state.responseId}_fc_${outputIdx}`,
+						type: custom ? "custom_tool_call" : "function_call",
+						id: `${state.responseId}_${custom ? "ctc" : "fc"}_${outputIdx}`,
 						call_id: contentBlock.id as string,
-						name: contentBlock.name as string,
-						arguments: "",
+						...identity,
+						...(custom ? { input: "" } : { arguments: "" }),
 						status: "in_progress",
 					},
 				},
@@ -209,6 +235,9 @@ function processEvent(
 			const tool = state.toolByBlock.get(blockIndex);
 			if (tool) {
 				tool.argsBuf += partial;
+				// Custom input is wrapped in JSON upstream. Wait for the whole
+				// string so escaped newlines, quotes and Unicode remain lossless.
+				if (tool.custom) return;
 				emitSse(
 					controller,
 					"response.function_call_arguments.delta",
@@ -282,6 +311,76 @@ function processEvent(
 		} else if (state.toolByBlock.has(blockIndex)) {
 			// biome-ignore lint/style/noNonNullAssertion: guarded by the has() check above — TS can't narrow Map.get() from a prior has() call.
 			const tool = state.toolByBlock.get(blockIndex)!;
+			if (tool.custom) {
+				let input: string;
+				try {
+					input = unwrapCustomToolInput(
+						tool.argsBuf ? JSON.parse(tool.argsBuf) : tool.initialInput,
+					);
+				} catch {
+					processEvent(
+						"error",
+						{
+							error: {
+								type: "invalid_response_error",
+								message:
+									"Upstream custom tool call did not contain a text input",
+							},
+						},
+						controller,
+						state,
+					);
+					return;
+				}
+				const itemId = `${state.responseId}_ctc_${outputIdx}`;
+				if (input.length > 0) {
+					emitSse(
+						controller,
+						"response.custom_tool_call_input.delta",
+						{
+							type: "response.custom_tool_call_input.delta",
+							item_id: itemId,
+							output_index: outputIdx,
+							call_id: tool.callId,
+							delta: input,
+						},
+						state,
+					);
+				}
+				emitSse(
+					controller,
+					"response.custom_tool_call_input.done",
+					{
+						type: "response.custom_tool_call_input.done",
+						item_id: itemId,
+						output_index: outputIdx,
+						call_id: tool.callId,
+						input,
+					},
+					state,
+				);
+				const doneItem = {
+					type: "custom_tool_call",
+					id: itemId,
+					call_id: tool.callId,
+					name: tool.name,
+					...(tool.namespace ? { namespace: tool.namespace } : {}),
+					input,
+					status: "completed",
+				};
+				state.outputItems.push(doneItem);
+				emitSse(
+					controller,
+					"response.output_item.done",
+					{
+						type: "response.output_item.done",
+						output_index: outputIdx,
+						item: doneItem,
+					},
+					state,
+				);
+				return;
+			}
 			emitSse(
 				controller,
 				"response.function_call_arguments.done",
@@ -291,6 +390,7 @@ function processEvent(
 					output_index: outputIdx,
 					call_id: tool.callId,
 					name: tool.name,
+					...(tool.namespace ? { namespace: tool.namespace } : {}),
 					arguments: tool.argsBuf,
 				},
 				state,
@@ -300,6 +400,7 @@ function processEvent(
 				id: `${state.responseId}_fc_${outputIdx}`,
 				call_id: tool.callId,
 				name: tool.name,
+				...(tool.namespace ? { namespace: tool.namespace } : {}),
 				arguments: tool.argsBuf,
 				status: "completed",
 			};
@@ -409,6 +510,7 @@ export function translateAnthropicStreamToResponses(
 	anthropicResponse: Response,
 	responseId: string,
 	model: string,
+	tools?: ResponsesTool[],
 ): Response {
 	if (!anthropicResponse.body) {
 		return new Response(null, { status: anthropicResponse.status });
@@ -428,6 +530,8 @@ export function translateAnthropicStreamToResponses(
 		blockIndexToOutput: new Map(),
 		textByBlock: new Map(),
 		toolByBlock: new Map(),
+		customToolNames: getCustomToolNames(tools),
+		tools: tools ?? [],
 		inputTokens: 0,
 		outputTokens: 0,
 		doneSent: false,

--- a/packages/openai-responses-adapter/src/types.ts
+++ b/packages/openai-responses-adapter/src/types.ts
@@ -22,6 +22,11 @@ export interface ResponsesRequest {
 	metadata?: Record<string, unknown>;
 	service_tier?: string;
 	context_management?: unknown;
+	stream_options?: { reasoning_summary_delivery?: "sequential_cutoff" };
+	client_metadata?: Record<string, string>;
+	access_programs?: {
+		cyber: "standard" | "daybreak_blue" | "daybreak_red";
+	};
 	/** Codex CLI's stable conversation identity for prompt-cache routing. */
 	prompt_cache_key?: string;
 	/** GPT-5.6+ cache controls. Implicit mode is represented by omitting mode. */
@@ -35,16 +40,24 @@ export interface ResponsesRequest {
 // ResponseItem union — all item types codex can send
 export type ResponseItem =
 	| ResponseMessageItem
+	| AdditionalToolsItem
 	| FunctionCallItem
 	| FunctionCallOutputItem
 	| CustomToolCallItem
 	| CustomToolCallOutputItem;
 
-export interface ResponseMessageItem {
-	type: "message";
-	role: "user" | "assistant";
+export interface AdditionalToolsItem {
+	type: "additional_tools";
 	id?: string;
-	content: ResponseContent[];
+	role: string;
+	tools: ResponsesTool[];
+}
+
+export interface ResponseMessageItem {
+	type?: "message";
+	role: "user" | "assistant" | "developer" | "system";
+	id?: string;
+	content: string | ResponseContent[];
 }
 
 export type ResponseContent =
@@ -81,13 +94,14 @@ export interface FunctionCallItem {
 	id?: string;
 	call_id: string;
 	name: string;
+	namespace?: string;
 	arguments: string; // JSON string
 }
 
 export interface FunctionCallOutputItem {
 	type: "function_call_output";
 	call_id: string;
-	output: string; // JSON string
+	output: string | ResponseContent[];
 }
 
 export interface CustomToolCallItem {
@@ -95,21 +109,44 @@ export interface CustomToolCallItem {
 	id?: string;
 	call_id: string;
 	name: string;
-	arguments: string;
+	namespace?: string;
+	input: string;
 }
 
 export interface CustomToolCallOutputItem {
 	type: "custom_tool_call_output";
 	call_id: string;
-	output: string;
+	output: string | ResponseContent[];
 }
 
 // Tool definition
-export type ResponsesTool = ResponsesFunctionTool | ResponsesBuiltinTool;
+export type ResponsesTool =
+	| ResponsesFunctionTool
+	| ResponsesCustomTool
+	| ResponsesNamespaceTool
+	| ResponsesBuiltinTool;
+
+export interface ResponsesNamespaceTool {
+	type: "namespace";
+	name: string;
+	description?: string;
+	tools: ResponsesTool[];
+}
+
+export interface ResponsesCustomTool {
+	type: "custom";
+	name: string;
+	namespace?: string;
+	description?: string;
+	format?:
+		| { type: "text" }
+		| { type: "grammar"; syntax: "lark" | "regex"; definition: string };
+}
 
 export interface ResponsesFunctionTool {
 	type: "function";
 	name: string;
+	namespace?: string;
 	description?: string;
 	parameters?: Record<string, unknown>; // JSON Schema
 	strict?: boolean;
@@ -121,8 +158,9 @@ export interface ResponsesBuiltinTool {
 }
 
 export interface ResponsesToolChoice {
-	type: "function";
+	type: "function" | "custom";
 	name: string;
+	namespace?: string;
 }
 
 export interface ResponsesReasoning {
@@ -146,7 +184,20 @@ export interface ResponsesResponse {
 	error?: ResponsesError;
 }
 
-export type OutputItem = OutputMessageItem | OutputFunctionCallItem;
+export type OutputItem =
+	| OutputMessageItem
+	| OutputFunctionCallItem
+	| OutputCustomToolCallItem;
+
+export interface OutputCustomToolCallItem {
+	type: "custom_tool_call";
+	id: string;
+	call_id: string;
+	name: string;
+	namespace?: string;
+	input: string;
+	status: "completed";
+}
 
 export interface OutputMessageItem {
 	type: "message";
@@ -173,6 +224,7 @@ export interface OutputFunctionCallItem {
 	id: string;
 	call_id: string;
 	name: string;
+	namespace?: string;
 	arguments: string; // JSON string
 	status: "completed";
 }
@@ -237,7 +289,7 @@ export interface AnthropicToolUseContent {
 export interface AnthropicToolResultContent {
 	type: "tool_result";
 	tool_use_id: string;
-	content: string | AnthropicTextContent[];
+	content: string | (AnthropicTextContent | AnthropicImageContent)[];
 }
 
 export interface AnthropicTool {

--- a/packages/providers/src/providers/codex/provider.test.ts
+++ b/packages/providers/src/providers/codex/provider.test.ts
@@ -79,6 +79,56 @@ async function waitForAbort(
 	}
 }
 
+describe("CodexProvider request headers", () => {
+	it("removes ingress proxy headers and cookies while preserving Codex session metadata", () => {
+		const provider = new CodexProvider();
+		const ingressHeaders = {
+			"CF-Connecting-IP": "192.0.2.1",
+			"CF-IPCountry": "IE",
+			"CF-Ray": "ingress-ray",
+			"CF-Visitor": '{"scheme":"https"}',
+			"CDN-Loop": "cloudflare; loops=1",
+			Forwarded: 'for=192.0.2.1;host="proxy.example.com";proto=https',
+			"X-Forwarded-For": "192.0.2.1",
+			"X-Forwarded-Host": "proxy.example.com",
+			"X-Forwarded-Port": "443",
+			"X-Forwarded-Proto": "https",
+			"X-Real-IP": "192.0.2.1",
+			Cookie: "proxy_session=ingress-session; __cf_bm=ingress-cookie",
+		};
+		const clientMetadata = {
+			"content-type": "application/json",
+			"session-id": "session-123",
+			"x-client-request-id": "request-123",
+			"x-codex-turn-metadata": '{"turn_id":"turn-123"}',
+		};
+		const original = new Headers({
+			...ingressHeaders,
+			...clientMetadata,
+			Authorization: "Bearer proxy-client-token",
+			"x-api-key": "proxy-client-key",
+			"x-better-ccflare-native-responses": "true",
+		});
+		const originalEntries = [...original.entries()];
+
+		const prepared = provider.prepareHeaders(original, "upstream-access-token");
+
+		for (const name of Object.keys(ingressHeaders)) {
+			expect(prepared.get(name)).toBeNull();
+		}
+		for (const [name, value] of Object.entries(clientMetadata)) {
+			expect(prepared.get(name)).toBe(value);
+		}
+		expect(prepared.get("authorization")).toBe("Bearer upstream-access-token");
+		expect(prepared.get("x-api-key")).toBeNull();
+		expect(prepared.get("x-better-ccflare-native-responses")).toBeNull();
+		expect(prepared.get("version")).toBe(CODEX_VERSION);
+		expect(prepared.get("openai-beta")).toBe("responses=experimental");
+		expect(prepared.get("originator")).toBe("codex_cli_rs");
+		expect([...original.entries()]).toEqual(originalEntries);
+	});
+});
+
 describe("CodexProvider stream liveness", () => {
 	it("keeps a silent SSE stream alive until response.completed arrives", async () => {
 		const provider = new CodexProvider({
@@ -3393,6 +3443,30 @@ describe("CodexProvider native Responses preservation", () => {
 		).toHaveLength(1);
 	});
 
+	it("preserves current Codex client controls on the subscription endpoint", async () => {
+		const provider = new CodexProvider();
+		for (const nativeFields of [
+			{
+				stream_options: { reasoning_summary_delivery: "sequential_cutoff" },
+				client_metadata: { turn_id: "turn-123", empty_value: "" },
+				access_programs: { cyber: "standard" },
+			},
+			{ client_metadata: {} },
+			{},
+		]) {
+			const body = await transformContinuationTurn(provider, {
+				requestId: "request-codex-client-controls",
+				input: [inputItem("hello")],
+				continuation: false,
+				nativeFields,
+			});
+			expect(body.stream).toBe(true);
+			expect(body.stream_options).toEqual(nativeFields.stream_options);
+			expect(body.client_metadata).toEqual(nativeFields.client_metadata);
+			expect(body.access_programs).toEqual(nativeFields.access_programs);
+		}
+	});
+
 	it("rejects native max_output_tokens on the canonical subscription endpoint", async () => {
 		const provider = new CodexProvider();
 		const request = new Request("https://example.com/v1/messages", {
@@ -3450,6 +3524,9 @@ describe("CodexProvider native Responses preservation", () => {
 					previous_response_id: "resp_cross_tenant",
 					prompt_cache_options: { ttl: "30m" },
 					tools: [{ type: "custom", name: "attacker-tool" }],
+					stream_options: { reasoning_summary_delivery: "sequential_cutoff" },
+					client_metadata: { turn_id: "injected-turn" },
+					access_programs: { cyber: "daybreak_red" },
 					store: true,
 				},
 			}),
@@ -3470,6 +3547,9 @@ describe("CodexProvider native Responses preservation", () => {
 		expect(body.previous_response_id).toBeUndefined();
 		expect(body.prompt_cache_options).toBeUndefined();
 		expect(body.tools).toBeUndefined();
+		expect(body.stream_options).toBeUndefined();
+		expect(body.client_metadata).toBeUndefined();
+		expect(body.access_programs).toBeUndefined();
 		expect(body.store).toBe(false);
 	});
 
@@ -4224,6 +4304,52 @@ describe("CodexProvider native Responses preservation", () => {
 			expect(mismatch.previous_response_id).toBeUndefined();
 			expect(mismatch.input).toHaveLength(2);
 		}
+	});
+
+	it("reuses continuation while forwarding each response's client controls", async () => {
+		const provider = new CodexProvider();
+		const base = [inputItem("base")];
+		await transformContinuationTurn(provider, {
+			requestId: "request-client-metadata-seed",
+			input: base,
+			nativeFields: {
+				client_metadata: { turn_id: "turn-1" },
+				access_programs: { cyber: "standard" },
+			},
+		});
+		await completeContinuationTurn(
+			provider,
+			"request-client-metadata-seed",
+			"resp_client_metadata_seed",
+		);
+
+		const next = await transformContinuationTurn(provider, {
+			requestId: "request-client-metadata-next",
+			input: [...base, inputItem("tail")],
+			nativeFields: {
+				client_metadata: { turn_id: "turn-2" },
+				access_programs: { cyber: "standard" },
+			},
+		});
+		expect(next.previous_response_id).toBe("resp_client_metadata_seed");
+		expect(next.input).toEqual([inputItem("tail")]);
+		expect(next.client_metadata).toEqual({ turn_id: "turn-2" });
+
+		const changed = await transformContinuationTurn(provider, {
+			requestId: "request-access-program-change",
+			input: [...base, inputItem("tail")],
+			nativeFields: {
+				access_programs: { cyber: "daybreak_blue" },
+				stream_options: { reasoning_summary_delivery: "sequential_cutoff" },
+			},
+		});
+		expect(changed.previous_response_id).toBe("resp_client_metadata_seed");
+		expect(changed.input).toEqual([inputItem("tail")]);
+		expect(changed.client_metadata).toBeUndefined();
+		expect(changed.access_programs).toEqual({ cyber: "daybreak_blue" });
+		expect(changed.stream_options).toEqual({
+			reasoning_summary_delivery: "sequential_cutoff",
+		});
 	});
 
 	it("treats absent and empty prompt cache options as the same configuration", async () => {

--- a/packages/providers/src/providers/codex/provider.ts
+++ b/packages/providers/src/providers/codex/provider.ts
@@ -321,6 +321,9 @@ interface CodexRequest {
 	metadata?: unknown;
 	service_tier?: unknown;
 	context_management?: unknown;
+	stream_options?: unknown;
+	client_metadata?: unknown;
+	access_programs?: unknown;
 }
 
 type ContinuationResult =
@@ -719,11 +722,23 @@ export class CodexProvider extends BaseProvider {
 		newHeaders.delete("x-api-key");
 		newHeaders.delete("host");
 
+		// These describe the client's connection to this proxy, not the proxy's
+		// connection to Codex. Ingress cookies belong to the proxy's domain;
+		// makeProxyRequest adds any host-scoped ChatGPT cookies separately.
+		newHeaders.delete("cookie");
+		newHeaders.delete("cdn-loop");
+		newHeaders.delete("forwarded");
+		newHeaders.delete("x-real-ip");
+
 		// Remove internal proxy headers. Every control and identity header this
 		// proxy understands lives under the one namespace, so the prefix is the
-		// whole rule.
+		// whole rule. Also remove headers supplied by ingress proxies/CDNs.
 		for (const key of [...newHeaders.keys()]) {
-			if (key.startsWith("x-better-ccflare-")) {
+			if (
+				key.startsWith("x-better-ccflare-") ||
+				key.startsWith("cf-") ||
+				key.startsWith("x-forwarded-")
+			) {
 				newHeaders.delete(key);
 			}
 		}
@@ -2719,6 +2734,9 @@ export class CodexProvider extends BaseProvider {
 			"metadata",
 			"service_tier",
 			"context_management",
+			"stream_options",
+			"client_metadata",
+			"access_programs",
 		] as const) {
 			if (passthrough?.[field] !== undefined) {
 				codexRequest[field] = passthrough[field];

--- a/scripts/smoke-codex-vscode.ts
+++ b/scripts/smoke-codex-vscode.ts
@@ -1,0 +1,444 @@
+/**
+ * Exercise the VS Code extension's Codex app-server against the real Responses
+ * adapter with a local, deterministic Anthropic upstream. No credentials or
+ * external inference services are used. All Codex state lives in a temporary
+ * directory which is removed when the test finishes.
+ *
+ * bun scripts/smoke-codex-vscode.ts /path/to/vscode/extension/bin/codex
+ * Add --text-only to skip the harmless apply_patch round trip.
+ */
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { handleResponsesRequest } from "../packages/openai-responses-adapter/src/handler";
+
+const binary = process.argv[2];
+if (!binary || binary.startsWith("--")) {
+	throw new Error(
+		"Usage: bun scripts/smoke-codex-vscode.ts /path/to/codex [--text-only]",
+	);
+}
+const textOnly = process.argv.includes("--text-only");
+const temp = await mkdtemp(join(tmpdir(), "ccflare-vscode-smoke-"));
+const codexState = join(temp, "codex");
+const workspace = join(temp, "workspace");
+await mkdir(codexState);
+await mkdir(workspace);
+
+const marker = "better-ccflare VS Code smoke passed";
+const patch =
+	"*** Begin Patch\n*** Add File: smoke.txt\n+local adapter smoke\n*** End Patch";
+const customInput = `text(await tools.apply_patch(${JSON.stringify(patch)}));`;
+let upstreamToolName = "";
+const requests: Array<Record<string, unknown>> = [];
+const translated: Array<Record<string, any>> = [];
+const errors: string[] = [];
+const completedItems: Array<Record<string, any>> = [];
+const methods = new Set<string>();
+const pending = new Map<
+	number,
+	{ resolve: (value: any) => void; reject: (error: Error) => void }
+>();
+let nextId = 1;
+let child: ReturnType<typeof Bun.spawn> | undefined;
+let resolveTurn: (value: any) => void;
+const turnCompleted = new Promise<any>((resolve) => {
+	resolveTurn = resolve;
+});
+
+function anthropicStream(tool: boolean): Response {
+	const events = [
+		{
+			type: "message_start",
+			message: {
+				id: "msg_smoke",
+				type: "message",
+				role: "assistant",
+				model: "claude-sonnet-4-5",
+				content: [],
+				stop_reason: null,
+				stop_sequence: null,
+				usage: { input_tokens: 10, output_tokens: 0 },
+			},
+		},
+		{
+			type: "content_block_start",
+			index: 0,
+			content_block: tool
+				? {
+						type: "tool_use",
+						id: "toolu_smoke",
+						name: upstreamToolName,
+						input: {},
+					}
+				: { type: "text", text: "" },
+		},
+		{
+			type: "content_block_delta",
+			index: 0,
+			delta: tool
+				? {
+						type: "input_json_delta",
+						partial_json: JSON.stringify({ input: customInput }),
+					}
+				: { type: "text_delta", text: marker },
+		},
+		{ type: "content_block_stop", index: 0 },
+		{
+			type: "message_delta",
+			delta: {
+				stop_reason: tool ? "tool_use" : "end_turn",
+				stop_sequence: null,
+			},
+			usage: { output_tokens: 10 },
+		},
+		{ type: "message_stop" },
+	];
+	const bytes = new TextEncoder().encode(
+		events
+			.map(
+				(event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`,
+			)
+			.join(""),
+	);
+	return new Response(
+		new ReadableStream({
+			start(controller) {
+				// Deliberately split SSE frames and JSON strings across byte chunks.
+				for (let offset = 0; offset < bytes.length; offset += 17)
+					controller.enqueue(bytes.slice(offset, offset + 17));
+				controller.close();
+			},
+		}),
+		{ headers: { "content-type": "text/event-stream" } },
+	);
+}
+
+async function decodeBody(request: Request): Promise<Record<string, unknown>> {
+	let bytes = new Uint8Array(await request.arrayBuffer());
+	switch (request.headers.get("content-encoding")) {
+		case "zstd":
+			bytes = new Uint8Array(Bun.zstdDecompressSync(bytes));
+			break;
+		case "gzip":
+			bytes = new Uint8Array(Bun.gunzipSync(bytes));
+			break;
+		case "deflate":
+			bytes = new Uint8Array(Bun.inflateSync(bytes));
+			break;
+	}
+	return JSON.parse(new TextDecoder().decode(bytes));
+}
+
+const server = Bun.serve({
+	hostname: "127.0.0.1",
+	port: 0,
+	async fetch(request) {
+		const url = new URL(request.url);
+		if (request.method === "GET" && url.pathname === "/v1/responses") {
+			return new Response("Use HTTP SSE", { status: 426 });
+		}
+		if (request.method !== "POST" || url.pathname !== "/v1/responses") {
+			errors.push(
+				`Unexpected local request: ${request.method} ${url.pathname}`,
+			);
+			return new Response("Unexpected endpoint", { status: 404 });
+		}
+		requests.push(await decodeBody(request.clone()));
+		const response = await handleResponsesRequest(
+			request,
+			url,
+			async (upstream) => {
+				const body = (await upstream.json()) as Record<string, any>;
+				translated.push(body);
+				if (!textOnly && translated.length === 1) {
+					const tool = body.tools?.find((tool: any) =>
+						tool.name.endsWith("_exec"),
+					);
+					assert.equal(
+						tool?.input_schema?.properties?.input?.type,
+						"string",
+						"functions.exec must be exposed to Anthropic through its custom text bridge",
+					);
+					upstreamToolName = tool.name;
+				}
+				if (!textOnly && translated.length === 2) {
+					const result = body.messages
+						.flatMap((message: any) => message.content)
+						.find(
+							(block: any) =>
+								block.type === "tool_result" &&
+								block.tool_use_id === "toolu_smoke",
+						);
+					assert.ok(
+						result,
+						"Codex's custom tool result must translate back to Anthropic",
+					);
+					assert.ok(
+						Array.isArray(result.content) &&
+							result.content.every((block: any) => block.type === "text"),
+						"Custom tool output content must use Anthropic text blocks",
+					);
+				}
+				return anthropicStream(!textOnly && translated.length === 1);
+			},
+			{},
+			"local-smoke",
+		);
+		if (!response.ok)
+			errors.push(
+				`Adapter HTTP ${response.status}: ${await response.clone().text()}`,
+			);
+		return response;
+	},
+	error(error) {
+		errors.push(String(error));
+		return new Response(JSON.stringify({ error: { message: String(error) } }), {
+			status: 500,
+		});
+	},
+});
+
+function send(message: Record<string, unknown>) {
+	assert.ok(child && typeof child.stdin !== "number" && child.stdin);
+	child.stdin.write(`${JSON.stringify(message)}\n`);
+}
+
+function rpc(method: string, params: Record<string, unknown>): Promise<any> {
+	const id = nextId++;
+	return new Promise((resolve, reject) => {
+		pending.set(id, { resolve, reject });
+		send({ id, method, params });
+	});
+}
+
+async function readMessages(stream: ReadableStream<Uint8Array>) {
+	const reader = stream.getReader();
+	const decoder = new TextDecoder();
+	let buffered = "";
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		buffered += decoder.decode(value, { stream: true });
+		let newline: number;
+		while ((newline = buffered.indexOf("\n")) !== -1) {
+			const line = buffered.slice(0, newline);
+			buffered = buffered.slice(newline + 1);
+			if (!line) continue;
+			const message = JSON.parse(line);
+			if (message.id !== undefined && pending.has(message.id)) {
+				const waiter = pending.get(message.id)!;
+				pending.delete(message.id);
+				if (message.error)
+					waiter.reject(new Error(JSON.stringify(message.error)));
+				else waiter.resolve(message.result);
+			} else if (message.method) {
+				methods.add(message.method);
+				if (message.method === "item/completed")
+					completedItems.push(message.params.item);
+				if (message.method === "turn/completed")
+					resolveTurn(message.params.turn);
+				if (message.method === "error")
+					errors.push(JSON.stringify(message.params));
+				if (message.id !== undefined) {
+					errors.push(`Unexpected client request: ${message.method}`);
+					send({
+						id: message.id,
+						error: {
+							code: -32601,
+							message: "Unexpected request in isolated smoke test",
+						},
+					});
+				}
+			}
+		}
+	}
+}
+
+let timeout: ReturnType<typeof setTimeout> | undefined;
+try {
+	await writeFile(
+		join(codexState, "config.toml"),
+		[
+			'model = "gpt-6-astra"',
+			'model_provider = "smoke"',
+			'approval_policy = "never"',
+			'sandbox_mode = "workspace-write"',
+			"[model_providers.smoke]",
+			'name = "Loopback adapter smoke"',
+			`base_url = "http://127.0.0.1:${server.port}/v1"`,
+			'wire_api = "responses"',
+			'env_key = "CCFLARE_SMOKE_API_KEY"',
+			"requires_openai_auth = false",
+			"request_max_retries = 0",
+			"stream_max_retries = 0",
+			"supports_websockets = false",
+			"[analytics]",
+			"enabled = false",
+			"[feedback]",
+			"enabled = false",
+		].join("\n"),
+	);
+	child = Bun.spawn([resolve(binary), "app-server", "--stdio"], {
+		cwd: workspace,
+		// Explicit child environment prevents inherited API keys or proxy settings
+		// from reaching the smoke process. It never reads the user's Codex home.
+		env: {
+			PATH: process.env.PATH ?? "/usr/bin:/bin",
+			HOME: process.env.HOME,
+			CODEX_HOME: codexState,
+			CCFLARE_SMOKE_API_KEY: "local-smoke-only",
+			RUST_LOG: "error",
+		},
+		stdin: "pipe",
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const stderr = new Response(
+		child.stderr as ReadableStream<Uint8Array>,
+	).text();
+	const reader = readMessages(child.stdout as ReadableStream<Uint8Array>);
+	const exercise = async () => {
+		const initialized = await rpc("initialize", {
+			clientInfo: {
+				name: "codex_vscode",
+				title: "Local adapter smoke",
+				version: "1.0.0",
+			},
+			capabilities: { experimentalApi: true, requestAttestation: false },
+		});
+		send({ method: "initialized" });
+		const started = await rpc("thread/start", {
+			cwd: workspace,
+			ephemeral: true,
+			approvalPolicy: "never",
+			sandbox: "workspace-write",
+			baseInstructions:
+				"This is a deterministic local protocol test. Follow the synthetic user request.",
+			experimentalRawEvents: true,
+		});
+		await rpc("turn/start", {
+			threadId: started.thread.id,
+			input: [
+				{
+					type: "text",
+					text: textOnly
+						? `Reply with ${marker}.`
+						: `Create smoke.txt containing local adapter smoke, then reply with ${marker}.`,
+				},
+			],
+			responsesapiClientMetadata: { smoke: "local-only" },
+		});
+		const turn = await turnCompleted;
+		assert.equal(
+			turn.status,
+			"completed",
+			`Turn failed: ${JSON.stringify(turn.error)}`,
+		);
+		assert.deepEqual(errors, []);
+		assert.equal(requests.length, textOnly ? 1 : 2);
+		assert.ok(
+			completedItems.some(
+				(item) => item.type === "agentMessage" && item.text === marker,
+			),
+			"VS Code app-server must receive translated final text",
+		);
+		if (!textOnly)
+			assert.equal(
+				await readFile(join(workspace, "smoke.txt"), "utf8"),
+				"local adapter smoke\n",
+			);
+		console.log(
+			JSON.stringify(
+				{
+					result: "passed",
+					userAgent: initialized.userAgent,
+					mode: textOnly
+						? "text"
+						: "namespaced custom exec/apply_patch round trip",
+					requestCount: requests.length,
+					requestFields: Object.keys(requests[0]).sort(),
+					tools: (
+						requests[0].tools as Array<Record<string, unknown>> | undefined
+					)?.map(({ type, name }) => ({ type, name })),
+					additionalTools: (requests[0].input as Array<Record<string, any>>)
+						.filter((item) => item.type === "additional_tools")
+						.flatMap((item) => item.tools)
+						.map((tool) => ({
+							type: tool.type,
+							name: tool.name,
+							tools: tool.tools?.map((nested: any) => ({
+								type: nested.type,
+								name: nested.name,
+							})),
+						})),
+					inputItemTypes: requests.map((request) => [
+						...new Set(
+							(request.input as Array<Record<string, unknown>>).map(
+								(item) => item.type,
+							),
+						),
+					]),
+					completedItemTypes: completedItems.map((item) => item.type),
+					translatedModel: translated[0].model,
+				},
+				null,
+				2,
+			),
+		);
+	};
+	await Promise.race([
+		exercise(),
+		new Promise((_, reject) => {
+			timeout = setTimeout(
+				() =>
+					reject(
+						new Error(
+							`Smoke timed out. Adapter errors: ${JSON.stringify(errors)}; notifications: ${[...methods].join(", ")}`,
+						),
+					),
+				40_000,
+			);
+		}),
+		child.exited.then(async (code) => {
+			throw new Error(
+				`Codex exited with ${code}: ${(await stderr).slice(-2000)}`,
+			);
+		}),
+		reader.then(() => {
+			throw new Error("Codex closed app-server output before test completed");
+		}),
+	]);
+} catch (error) {
+	console.error(
+		JSON.stringify(
+			{
+				result: "failed",
+				error: String(error),
+				adapterErrors: errors,
+				toolResults: translated.flatMap((body) =>
+					body.messages
+						.flatMap((message: any) => message.content)
+						.filter((block: any) => block.type === "tool_result"),
+				),
+				completedItemTypes: completedItems.map((item) => item.type),
+				requestFields: requests.map((body) => Object.keys(body).sort()),
+				tools: requests.map((body) =>
+					(body.tools as Array<Record<string, unknown>> | undefined)?.map(
+						({ type, name }) => ({ type, name }),
+					),
+				),
+			},
+			null,
+			2,
+		),
+	);
+	process.exitCode = 1;
+} finally {
+	if (timeout) clearTimeout(timeout);
+	child?.kill();
+	if (child) await child.exited;
+	server.stop(true);
+	await rm(temp, { recursive: true, force: true });
+}


### PR DESCRIPTION
Accept current Responses request metadata and preserve native provider controls. Translate Responses Lite tool declarations, namespaces, custom tool calls, and structured tool results for Anthropic routes while preserving native inputs. Strip ingress forwarding headers and cookies before Codex upstream requests, and retain useful provider error diagnostics.

Add regression coverage, a reproducible app-server smoke test, and VS Code setup documentation.

Validation: 262 targeted tests, TypeScript and formatting checks; Codex 0.153.4 app-server completed a file-edit turn with mocked and live upstream requests.