### PR TITLE
fix(proxy): preserve requested model aliases in Messages responses

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -162,4 +162,6 @@ The model mappings include both current and legacy model versions:
 
 better-ccflare supports agent-specific model preferences through the agent system. When an agent is detected in a request, the system can automatically override the model selection based on the agent's configured preference.
 
+For Anthropic Messages-compatible responses, the client-facing `model` field retains the model id from the original request, including when the selected account translates that request to a different provider or backend model. This is an API-compatibility alias only: it is not proof of backend identity. Provider processing, pricing, usage accounting, and logs continue to use the actual upstream model and response before the alias is applied.
+
 See the [Agents Package section](./architecture.md#3-agents-package-packagesagents) in the architecture docs for more details on how agents work with model preferences.

--- a/docs/models.md
+++ b/docs/models.md
@@ -162,6 +162,6 @@ The model mappings include both current and legacy model versions:
 
 better-ccflare supports agent-specific model preferences through the agent system. When an agent is detected in a request, the system can automatically override the model selection based on the agent's configured preference.
 
-For Anthropic Messages-compatible responses, the client-facing `model` field retains the model id from the original request, including when the selected account translates that request to a different provider or backend model. This is an API-compatibility alias only: it is not proof of backend identity. Provider processing, pricing, usage accounting, and logs continue to use the actual upstream model and response before the alias is applied.
+For Anthropic Messages-compatible responses, the client-facing `model` field retains the model id from the original request, including when the selected account translates that request to a different provider or backend model. This is an API-compatibility alias only: it is not proof of backend identity. Provider processing, pricing, usage accounting, and logs continue to use the actual upstream model and response before the alias is applied. Non-streaming response bodies larger than 256 KiB are passed through without this alias to keep proxy memory bounded.
 
 See the [Agents Package section](./architecture.md#3-agents-package-packagesagents) in the architecture docs for more details on how agents work with model preferences.

--- a/packages/proxy/src/__tests__/response-handler-worker-protocol.test.ts
+++ b/packages/proxy/src/__tests__/response-handler-worker-protocol.test.ts
@@ -65,6 +65,52 @@ describe("forwardToClient usage-collector protocol", () => {
 		} as unknown as import("../handlers").ProxyContext;
 	}
 
+	it("aliases the client model without changing accounting bytes", async () => {
+		const { starts, ends } = createMockCollector();
+		const ctx = createCtx();
+		const upstream = JSON.stringify({
+			id: "msg_backend",
+			type: "message",
+			role: "assistant",
+			model: "gpt-5.3-codex",
+			content: [{ type: "text", text: "unchanged" }],
+		});
+
+		const response = await forwardToClient(
+			{
+				requestId: "req-model-alias",
+				method: "POST",
+				path: "/v1/messages",
+				account: null,
+				requestHeaders: new Headers({ "content-type": "application/json" }),
+				requestBody: new TextEncoder().encode(
+					JSON.stringify({ model: "claude-opus-4-6", messages: [] }),
+				),
+				response: new Response(upstream, {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				}),
+				timestamp: Date.now(),
+				retryAttempt: 0,
+				failoverAttempts: 0,
+				// Equal original/applied metadata is intentional: a provider can map
+				// this alias later, without an agent-preference rewrite.
+				originalModel: "claude-opus-4-6",
+				appliedModel: "claude-opus-4-6",
+			},
+			ctx,
+		);
+
+		const clientJson = await response.json();
+		expect(clientJson.model).toBe("claude-opus-4-6");
+		expect(starts[0].originalModel).toBeNull();
+		expect(starts[0].appliedModel).toBeNull();
+		await waitFor(() => ends.length === 1);
+		expect(
+			Buffer.from(ends[0].responseBody as string, "base64").toString(),
+		).toBe(upstream);
+	});
+
 	it("calls handleStart with messageId", async () => {
 		const { starts } = createMockCollector();
 		const ctx = createCtx();

--- a/packages/proxy/src/__tests__/response-model-alias.test.ts
+++ b/packages/proxy/src/__tests__/response-model-alias.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, spyOn } from "bun:test";
+import {
+	rewriteAnthropicMessageJsonModel,
+	rewriteAnthropicMessageJsonModelStream,
+	rewriteAnthropicMessageSseModel,
+} from "../response-model-alias";
+
+const encoder = new TextEncoder();
+
+async function collect(stream: ReadableStream<Uint8Array>): Promise<string> {
+	return new Response(stream).text();
+}
+
+describe("Anthropic response model aliasing", () => {
+	it("rewrites only the top-level model in a non-streaming Message", () => {
+		const body = JSON.stringify({
+			id: "msg_backend",
+			type: "message",
+			role: "assistant",
+			model: "gpt-5.3-codex",
+			content: [
+				{ type: "text", text: "the model string gpt-5.3-codex stays here" },
+				{ type: "tool_use", id: "toolu_gpt-5.3-codex", name: "run", input: {} },
+			],
+			stop_reason: "tool_use",
+			usage: { input_tokens: 10, output_tokens: 5 },
+		});
+
+		const rewritten = rewriteAnthropicMessageJsonModel(body, "claude-opus-4-6");
+		const parsed = JSON.parse(rewritten);
+		expect(parsed.model).toBe("claude-opus-4-6");
+		expect(parsed.id).toBe("msg_backend");
+		expect(parsed.content[0].text).toBe(
+			"the model string gpt-5.3-codex stays here",
+		);
+		expect(parsed.content[1].id).toBe("toolu_gpt-5.3-codex");
+	});
+
+	it("leaves errors and malformed JSON byte-for-byte unchanged", () => {
+		const error = '{"type":"error","error":{"message":"model gpt-5"}}';
+		expect(rewriteAnthropicMessageJsonModel(error, "client-alias")).toBe(error);
+		expect(rewriteAnthropicMessageJsonModel("{broken", "client-alias")).toBe(
+			"{broken",
+		);
+	});
+
+	it("rewrites only message_start across arbitrary chunk boundaries", async () => {
+		const source = [
+			": upstream heartbeat\n\n",
+			'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_gpt","type":"message","role":"assistant","model":"gpt-5.3-codex","content":[],"stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}\n\n',
+			'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_gpt-5.3-codex","name":"run","input":{}}}\n\n',
+			'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"model\\":\\"gpt-5.3-codex\\"}"}}\n\n',
+			'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+		].join("");
+		const chunks = [
+			source.slice(0, 17),
+			source.slice(17, 93),
+			source.slice(93),
+		];
+		const upstream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+				controller.close();
+			},
+		});
+
+		const output = await collect(
+			rewriteAnthropicMessageSseModel(upstream, "claude-opus-4-6"),
+		);
+		expect(output).toContain('"model":"claude-opus-4-6"');
+		expect(output).toContain('"id":"toolu_gpt-5.3-codex"');
+		expect(output).toContain(
+			'"partial_json":"{\\"model\\":\\"gpt-5.3-codex\\"}"',
+		);
+		expect(output).toStartWith(": upstream heartbeat\n\n");
+	});
+
+	it("preserves multibyte UTF-8 split after message_start byte-for-byte", async () => {
+		const messageStart = encoder.encode(
+			'event: message_start\ndata: {"type":"message_start","message":{"type":"message","model":"backend"}}\n\n',
+		);
+		const following = encoder.encode(
+			'event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"type":"text_delta","text":"héllo 🌍"}}\n\n',
+		);
+		const emoji = encoder.encode("🌍");
+		const emojiStart = following.indexOf(emoji[0]);
+		expect(emojiStart).toBeGreaterThan(0);
+		const splitAt = emojiStart + 1;
+		const first = new Uint8Array(messageStart.length + splitAt);
+		first.set(messageStart);
+		first.set(following.slice(0, splitAt), messageStart.length);
+		const upstream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(first);
+				controller.enqueue(following.slice(splitAt, following.length - 2));
+				controller.enqueue(following.slice(following.length - 2));
+				controller.close();
+			},
+		});
+
+		const output = new Uint8Array(
+			await new Response(
+				rewriteAnthropicMessageSseModel(upstream, "client-alias"),
+			).arrayBuffer(),
+		);
+		const rewrittenStart = encoder.encode(
+			'event: message_start\ndata: {"type":"message_start","message":{"type":"message","model":"client-alias"}}\n\n',
+		);
+		expect(output.slice(0, rewrittenStart.length)).toEqual(rewrittenStart);
+		expect(output.slice(rewrittenStart.length)).toEqual(following);
+	});
+
+	it("forwards cancellation without transforming after a pending JSON read", async () => {
+		const parseSpy = spyOn(JSON, "parse");
+		let cancelReason: unknown;
+		let resolveRead: (() => void) | undefined;
+		const cancelled = new Promise<void>((resolve) => {
+			resolveRead = resolve;
+		});
+		const upstream = new ReadableStream<Uint8Array>({
+			pull() {
+				return new Promise<void>(() => {});
+			},
+			cancel(reason) {
+				cancelReason = reason;
+				resolveRead?.();
+			},
+		});
+		const downstream = rewriteAnthropicMessageJsonModelStream(
+			upstream,
+			"client-alias",
+		);
+		const reader = downstream.getReader();
+		const pendingRead = reader.read().catch(() => undefined);
+		const parseCallsBeforeCancel = parseSpy.mock.calls.length;
+		await reader.cancel("client left");
+		await cancelled;
+		expect(cancelReason).toBe("client left");
+		await pendingRead;
+		await Promise.resolve();
+		expect(parseSpy.mock.calls.length).toBe(parseCallsBeforeCancel);
+		parseSpy.mockRestore();
+	});
+
+	it("preserves CRLF framing and passes non-message_start frames unchanged", async () => {
+		const untouched =
+			'event: content_block_delta\r\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"gpt-5.3-codex"}}\r\n\r\n';
+		const upstream = new Response(encoder.encode(untouched)).body;
+		expect(upstream).not.toBeNull();
+		expect(
+			await collect(
+				rewriteAnthropicMessageSseModel(
+					upstream as ReadableStream<Uint8Array>,
+					"client-alias",
+				),
+			),
+		).toBe(untouched);
+	});
+});

--- a/packages/proxy/src/__tests__/response-model-alias.test.ts
+++ b/packages/proxy/src/__tests__/response-model-alias.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, spyOn } from "bun:test";
 import {
+	MAX_ANTHROPIC_MESSAGE_JSON_ALIAS_BYTES,
 	rewriteAnthropicMessageJsonModel,
 	rewriteAnthropicMessageJsonModelStream,
 	rewriteAnthropicMessageSseModel,
@@ -108,6 +109,190 @@ describe("Anthropic response model aliasing", () => {
 		);
 		expect(output.slice(0, rewrittenStart.length)).toEqual(rewrittenStart);
 		expect(output.slice(rewrittenStart.length)).toEqual(following);
+	});
+
+	it("rewrites a JSON response exactly at the buffering limit", async () => {
+		const prefix = '{"type":"message","model":"backend","content":"';
+		const suffix = '"}';
+		const padding = "x".repeat(
+			MAX_ANTHROPIC_MESSAGE_JSON_ALIAS_BYTES -
+				encoder.encode(prefix + suffix).length,
+		);
+		const body = prefix + padding + suffix;
+		expect(encoder.encode(body).length).toBe(
+			MAX_ANTHROPIC_MESSAGE_JSON_ALIAS_BYTES,
+		);
+		const upstream = new Response(encoder.encode(body)).body;
+		expect(upstream).not.toBeNull();
+
+		const output = await collect(
+			rewriteAnthropicMessageJsonModelStream(
+				upstream as ReadableStream<Uint8Array>,
+				"client-alias",
+			),
+		);
+		expect(JSON.parse(output).model).toBe("client-alias");
+	});
+
+	it("owns buffered Node Buffer subarrays before the source mutates", async () => {
+		const source = Buffer.from(
+			JSON.stringify({ type: "message", model: "backend", content: "stable" }),
+		);
+		let closeUpstream: (() => void) | undefined;
+		let firstPull = true;
+		const waitingToClose = new Promise<void>((resolve) => {
+			closeUpstream = resolve;
+		});
+		let chunkBuffered: (() => void) | undefined;
+		const buffered = new Promise<void>((resolve) => {
+			chunkBuffered = resolve;
+		});
+		const upstream = new ReadableStream<Uint8Array>({
+			async pull(controller) {
+				if (firstPull) {
+					firstPull = false;
+					controller.enqueue(source.subarray(0));
+					return;
+				}
+				chunkBuffered?.();
+				await waitingToClose;
+				controller.close();
+			},
+		});
+		const output = collect(
+			rewriteAnthropicMessageJsonModelStream(upstream, "client-alias"),
+		);
+
+		await buffered;
+		source.fill(120);
+		closeUpstream?.();
+		expect(JSON.parse(await output)).toEqual({
+			type: "message",
+			model: "client-alias",
+			content: "stable",
+		});
+	});
+
+	it("passes one oversized JSON chunk through byte-for-byte without parsing", async () => {
+		const parseSpy = spyOn(JSON, "parse");
+		const body = encoder.encode(
+			JSON.stringify({
+				type: "message",
+				model: "backend",
+				content: "x".repeat(MAX_ANTHROPIC_MESSAGE_JSON_ALIAS_BYTES),
+			}),
+		);
+		const parseCallsBefore = parseSpy.mock.calls.length;
+		const upstream = new Response(body).body;
+		expect(upstream).not.toBeNull();
+
+		const output = new Uint8Array(
+			await new Response(
+				rewriteAnthropicMessageJsonModelStream(
+					upstream as ReadableStream<Uint8Array>,
+					"client-alias",
+				),
+			).arrayBuffer(),
+		);
+		expect(output).toEqual(body);
+		expect(parseSpy.mock.calls.length).toBe(parseCallsBefore);
+		parseSpy.mockRestore();
+	});
+
+	it("falls back after many small chunks and preserves UTF-8 bytes", async () => {
+		const parseSpy = spyOn(JSON, "parse");
+		const fragment = encoder.encode("héllo 🌍 ".repeat(64));
+		const chunks: Uint8Array[] = [];
+		let size = 0;
+		while (size <= MAX_ANTHROPIC_MESSAGE_JSON_ALIAS_BYTES) {
+			const backing = new Uint8Array(fragment.length + 128);
+			backing.set(fragment, 64);
+			const chunk = backing.subarray(64, 64 + fragment.length);
+			chunks.push(chunk);
+			size += chunk.length;
+		}
+		const expected = new Uint8Array(size);
+		let offset = 0;
+		for (const chunk of chunks) {
+			expected.set(chunk, offset);
+			offset += chunk.length;
+		}
+		const parseCallsBefore = parseSpy.mock.calls.length;
+		const upstream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				for (const chunk of chunks) controller.enqueue(chunk);
+				controller.close();
+			},
+		});
+
+		const output = new Uint8Array(
+			await new Response(
+				rewriteAnthropicMessageJsonModelStream(upstream, "client-alias"),
+			).arrayBuffer(),
+		);
+		expect(output).toEqual(expected);
+		expect(new TextDecoder().decode(output)).toBe(
+			new TextDecoder().decode(expected),
+		);
+		expect(parseSpy.mock.calls.length).toBe(parseCallsBefore);
+		parseSpy.mockRestore();
+	});
+
+	it("forwards upstream errors after switching to pass-through", async () => {
+		const upstreamError = new Error("upstream failed");
+		let reads = 0;
+		const upstream = new ReadableStream<Uint8Array>({
+			pull(controller) {
+				reads++;
+				if (reads === 1) {
+					controller.enqueue(
+						new Uint8Array(MAX_ANTHROPIC_MESSAGE_JSON_ALIAS_BYTES + 1),
+					);
+					return;
+				}
+				controller.error(upstreamError);
+			},
+		});
+		const reader = rewriteAnthropicMessageJsonModelStream(
+			upstream,
+			"client-alias",
+		).getReader();
+
+		expect((await reader.read()).done).toBe(false);
+		await expect(reader.read()).rejects.toBe(upstreamError);
+	});
+
+	it("forwards cancellation while pass-through is pending after fallback", async () => {
+		let cancelReason: unknown;
+		let reads = 0;
+		const oversized = new Uint8Array(
+			MAX_ANTHROPIC_MESSAGE_JSON_ALIAS_BYTES + 1,
+		).fill(120);
+		const upstream = new ReadableStream<Uint8Array>({
+			pull(controller) {
+				reads++;
+				if (reads === 1) {
+					controller.enqueue(oversized);
+					return;
+				}
+				return new Promise<void>(() => {});
+			},
+			cancel(reason) {
+				cancelReason = reason;
+			},
+		});
+		const reader = rewriteAnthropicMessageJsonModelStream(
+			upstream,
+			"client-alias",
+		).getReader();
+
+		const first = await reader.read();
+		expect(first.value).toEqual(oversized);
+		const pendingRead = reader.read().catch(() => undefined);
+		await Promise.resolve();
+		await reader.cancel("client left after fallback");
+		await pendingRead;
+		expect(cancelReason).toBe("client left after fallback");
 	});
 
 	it("forwards cancellation without transforming after a pending JSON read", async () => {

--- a/packages/proxy/src/response-handler.ts
+++ b/packages/proxy/src/response-handler.ts
@@ -18,6 +18,10 @@ import { isInternalProbe, type ProxyContext } from "./handlers";
 import { applyRateLimitCooldown } from "./handlers/rate-limit-cooldown";
 import { createSseRateLimitSniffer } from "./handlers/sse-rate-limit-sniffer";
 import { ingestModelsListing } from "./model-catalog";
+import {
+	rewriteAnthropicMessageJsonModelStream,
+	rewriteAnthropicMessageSseModel,
+} from "./response-model-alias";
 import { combineChunks, teeStream } from "./stream-tee";
 import { getUsageCollector } from "./usage-collector";
 import {
@@ -455,6 +459,14 @@ export async function forwardToClient(
 			onClose,
 			onError,
 		});
+		// Keep provider/accounting observers on the unmodified upstream bytes.
+		// Only the final client-facing stream presents the model id requested by
+		// the client. This alias is wire compatibility, not evidence that the
+		// upstream backend ran that model.
+		const clientBody =
+			isAnthropicMessagesSseResponse && originalModel
+				? rewriteAnthropicMessageSseModel(passthroughBody, originalModel)
+				: passthroughBody;
 
 		const headers = withModelRewriteHeader(
 			response.headers,
@@ -462,8 +474,9 @@ export async function forwardToClient(
 			appliedModel,
 		);
 		headers.delete("x-better-ccflare-request-path");
+		if (clientBody !== passthroughBody) headers.delete("content-length");
 
-		return new Response(passthroughBody, {
+		return new Response(clientBody, {
 			status: response.status,
 			statusText: response.statusText,
 			headers,
@@ -538,14 +551,31 @@ export async function forwardToClient(
 		},
 	});
 
+	const isAnthropicMessagesJsonResponse =
+		method === "POST" &&
+		path === "/v1/messages" &&
+		response.ok &&
+		(response.headers
+			.get("content-type")
+			?.toLowerCase()
+			.includes("application/json") ??
+			false);
+	// As with SSE above, this transform is downstream of analytics so logs,
+	// pricing and usage retain the provider's real response model.
+	const clientBody =
+		isAnthropicMessagesJsonResponse && originalModel
+			? rewriteAnthropicMessageJsonModelStream(passthroughBody, originalModel)
+			: passthroughBody;
+
 	const headers = withModelRewriteHeader(
 		response.headers,
 		originalModel,
 		appliedModel,
 	);
 	headers.delete("x-better-ccflare-request-path");
+	if (clientBody !== passthroughBody) headers.delete("content-length");
 
-	return new Response(passthroughBody, {
+	return new Response(clientBody, {
 		status: response.status,
 		statusText: response.statusText,
 		headers,

--- a/packages/proxy/src/response-model-alias.ts
+++ b/packages/proxy/src/response-model-alias.ts
@@ -1,5 +1,7 @@
 const encoder = new TextEncoder();
 
+export const MAX_ANTHROPIC_MESSAGE_JSON_ALIAS_BYTES = 256 * 1024;
+
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -177,9 +179,9 @@ export function rewriteAnthropicMessageSseModel(
 }
 
 /**
- * Buffer one non-streaming response, then rewrite only a valid Message object.
- * JSON cannot be safely changed before the complete object is available, so
- * this intentionally retains the response body just as Response.json() would.
+ * Buffer one bounded non-streaming response, then rewrite only a valid Message
+ * object. JSON cannot be safely changed before the complete object is available.
+ * Responses over the limit are passed through byte-for-byte without aliasing.
  */
 export function rewriteAnthropicMessageJsonModelStream(
 	upstream: ReadableStream<Uint8Array>,
@@ -188,51 +190,92 @@ export function rewriteAnthropicMessageJsonModelStream(
 	const reader = upstream.getReader();
 	let chunks: Uint8Array[] = [];
 	let totalBytes = 0;
+	let passthrough = false;
 	let settled = false;
+	let released = false;
+
+	const release = (): void => {
+		if (released) return;
+		released = true;
+		reader.releaseLock();
+	};
+
+	const discardBuffered = (): void => {
+		chunks = [];
+		totalBytes = 0;
+	};
 
 	return new ReadableStream<Uint8Array>({
 		async pull(controller) {
 			if (settled) return;
 			try {
+				if (passthrough) {
+					const { value, done } = await reader.read();
+					if (settled) return;
+					if (done) {
+						settled = true;
+						release();
+						controller.close();
+					} else {
+						controller.enqueue(value);
+					}
+					return;
+				}
+
 				while (true) {
 					const { value, done } = await reader.read();
 					if (settled) return;
 					if (done) break;
-					chunks.push(value);
+					if (value.length === 0) continue;
+					if (
+						value.length >
+						MAX_ANTHROPIC_MESSAGE_JSON_ALIAS_BYTES - totalBytes
+					) {
+						passthrough = true;
+						for (const chunk of chunks) controller.enqueue(chunk);
+						discardBuffered();
+						controller.enqueue(value);
+						return;
+					}
+					// Copy only this view so a small chunk cannot retain a much larger
+					// upstream backing buffer for the duration of the bounded read. Do not
+					// call .slice(): Node Buffers override it to return another view.
+					chunks.push(new Uint8Array(value));
 					totalBytes += value.length;
 				}
-				settled = true;
-				reader.releaseLock();
+
 				const bodyBytes = new Uint8Array(totalBytes);
 				let offset = 0;
 				for (const chunk of chunks) {
 					bodyBytes.set(chunk, offset);
 					offset += chunk.length;
 				}
-				chunks = [];
-				totalBytes = 0;
+				discardBuffered();
 				const body = new TextDecoder().decode(bodyBytes);
 				controller.enqueue(
 					encoder.encode(
 						rewriteAnthropicMessageJsonModel(body, requestedModel),
 					),
 				);
+				settled = true;
+				release();
 				controller.close();
 			} catch (error) {
+				if (settled) return;
 				settled = true;
-				reader.releaseLock();
+				discardBuffered();
+				release();
 				controller.error(error);
 			}
 		},
 		async cancel(reason) {
 			if (settled) return;
 			settled = true;
-			chunks = [];
-			totalBytes = 0;
+			discardBuffered();
 			try {
 				await reader.cancel(reason);
 			} finally {
-				reader.releaseLock();
+				release();
 			}
 		},
 	});

--- a/packages/proxy/src/response-model-alias.ts
+++ b/packages/proxy/src/response-model-alias.ts
@@ -1,0 +1,239 @@
+const encoder = new TextEncoder();
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Present an Anthropic Messages response under the model id the client used.
+ * This is a wire-compatibility alias only; upstream accounting keeps the
+ * provider's original response before this client-facing transform.
+ */
+export function rewriteAnthropicMessageJsonModel(
+	body: string,
+	requestedModel: string,
+): string {
+	try {
+		const parsed: unknown = JSON.parse(body);
+		if (
+			!isRecord(parsed) ||
+			parsed.type !== "message" ||
+			typeof parsed.model !== "string"
+		) {
+			return body;
+		}
+		parsed.model = requestedModel;
+		return JSON.stringify(parsed);
+	} catch {
+		return body;
+	}
+}
+
+function rewriteSseEvent(event: string, requestedModel: string): string {
+	const newline = event.includes("\r\n") ? "\r\n" : "\n";
+	const lines = event.split(newline);
+	const eventName = lines
+		.find((line) => line.startsWith("event:"))
+		?.slice("event:".length)
+		.trim();
+	if (eventName !== "message_start") return event;
+
+	const dataIndexes = lines
+		.map((line, index) => (line.startsWith("data:") ? index : -1))
+		.filter((index) => index >= 0);
+	if (dataIndexes.length !== 1) return event;
+
+	const dataIndex = dataIndexes[0];
+	const line = lines[dataIndex];
+	const prefixMatch = /^data:\s?/.exec(line);
+	if (!prefixMatch) return event;
+	const prefix = prefixMatch[0];
+
+	try {
+		const parsed: unknown = JSON.parse(line.slice(prefix.length));
+		if (
+			!isRecord(parsed) ||
+			parsed.type !== "message_start" ||
+			!isRecord(parsed.message) ||
+			parsed.message.type !== "message" ||
+			typeof parsed.message.model !== "string"
+		) {
+			return event;
+		}
+		parsed.message.model = requestedModel;
+		lines[dataIndex] = `${prefix}${JSON.stringify(parsed)}`;
+		return lines.join(newline);
+	} catch {
+		return event;
+	}
+}
+
+/** Rewrite only the Message.model inside Anthropic's message_start SSE event. */
+export function rewriteAnthropicMessageSseModel(
+	upstream: ReadableStream<Uint8Array>,
+	requestedModel: string,
+): ReadableStream<Uint8Array> {
+	const reader = upstream.getReader();
+	let buffered = new Uint8Array();
+	let finished = false;
+
+	const append = (chunk: Uint8Array): void => {
+		const combined = new Uint8Array(buffered.length + chunk.length);
+		combined.set(buffered);
+		combined.set(chunk, buffered.length);
+		buffered = combined;
+	};
+
+	const findDelimiter = (): { index: number; length: number } | null => {
+		for (let index = 0; index < buffered.length - 1; index++) {
+			if (buffered[index] !== 10) continue;
+			if (buffered[index + 1] === 10) return { index, length: 2 };
+			if (
+				index >= 1 &&
+				buffered[index - 1] === 13 &&
+				buffered[index + 1] === 13 &&
+				buffered[index + 2] === 10
+			) {
+				return { index: index - 1, length: 4 };
+			}
+		}
+		return null;
+	};
+
+	const flushNextEvent = (
+		controller: ReadableStreamDefaultController<Uint8Array>,
+	): "none" | "emitted" | "finished" => {
+		const delimiter = findDelimiter();
+		if (!delimiter) return "none";
+
+		const eventBytes = buffered.slice(0, delimiter.index);
+		const delimiterBytes = buffered.slice(
+			delimiter.index,
+			delimiter.index + delimiter.length,
+		);
+		buffered = buffered.slice(delimiter.index + delimiter.length);
+		const event = new TextDecoder().decode(eventBytes);
+		const rewritten = rewriteSseEvent(event, requestedModel);
+		controller.enqueue(
+			rewritten === event ? eventBytes : encoder.encode(rewritten),
+		);
+		controller.enqueue(delimiterBytes);
+		if (rewritten === event) return "emitted";
+
+		// Once message_start is rewritten, every subsequent upstream byte is
+		// opaque pass-through. Flush the already-read suffix as bytes rather than
+		// text so an incomplete multibyte UTF-8 sequence cannot be corrupted.
+		finished = true;
+		if (buffered.length > 0) {
+			controller.enqueue(buffered);
+			buffered = new Uint8Array();
+		}
+		return "finished";
+	};
+
+	return new ReadableStream<Uint8Array>({
+		async pull(controller) {
+			try {
+				if (finished) {
+					const { value, done } = await reader.read();
+					if (done) {
+						controller.close();
+						reader.releaseLock();
+					} else {
+						controller.enqueue(value);
+					}
+					return;
+				}
+
+				while (true) {
+					const flushed = flushNextEvent(controller);
+					if (flushed !== "none") return;
+					if (buffered.length > 64 * 1024) {
+						finished = true;
+						controller.enqueue(buffered);
+						buffered = new Uint8Array();
+						return;
+					}
+
+					const { value, done } = await reader.read();
+					if (done) {
+						if (buffered.length > 0) controller.enqueue(buffered);
+						buffered = new Uint8Array();
+						controller.close();
+						reader.releaseLock();
+						return;
+					}
+					append(value);
+				}
+			} catch (error) {
+				controller.error(error);
+				reader.releaseLock();
+			}
+		},
+		cancel(reason) {
+			return reader.cancel(reason).finally(() => reader.releaseLock());
+		},
+	});
+}
+
+/**
+ * Buffer one non-streaming response, then rewrite only a valid Message object.
+ * JSON cannot be safely changed before the complete object is available, so
+ * this intentionally retains the response body just as Response.json() would.
+ */
+export function rewriteAnthropicMessageJsonModelStream(
+	upstream: ReadableStream<Uint8Array>,
+	requestedModel: string,
+): ReadableStream<Uint8Array> {
+	const reader = upstream.getReader();
+	let chunks: Uint8Array[] = [];
+	let totalBytes = 0;
+	let settled = false;
+
+	return new ReadableStream<Uint8Array>({
+		async pull(controller) {
+			if (settled) return;
+			try {
+				while (true) {
+					const { value, done } = await reader.read();
+					if (settled) return;
+					if (done) break;
+					chunks.push(value);
+					totalBytes += value.length;
+				}
+				settled = true;
+				reader.releaseLock();
+				const bodyBytes = new Uint8Array(totalBytes);
+				let offset = 0;
+				for (const chunk of chunks) {
+					bodyBytes.set(chunk, offset);
+					offset += chunk.length;
+				}
+				chunks = [];
+				totalBytes = 0;
+				const body = new TextDecoder().decode(bodyBytes);
+				controller.enqueue(
+					encoder.encode(
+						rewriteAnthropicMessageJsonModel(body, requestedModel),
+					),
+				);
+				controller.close();
+			} catch (error) {
+				settled = true;
+				reader.releaseLock();
+				controller.error(error);
+			}
+		},
+		async cancel(reason) {
+			if (settled) return;
+			settled = true;
+			chunks = [];
+			totalBytes = 0;
+			try {
+				await reader.cancel(reason);
+			} finally {
+				reader.releaseLock();
+			}
+		},
+	});
+}


### PR DESCRIPTION
### Problem
Claude clients are detecting responses coming back from OpenAI providers as GPT models instead of requested models

### Solution
Return the original client-requested model in successful Anthropic Messages JSON and message_start SSE responses, including provider-side model remaps. Apply aliasing after usage observation so accounting retains upstream bytes.

Preserve tool content, IDs, SSE framing, split UTF-8 sequences and subsequent stream bytes. Forward cancellation and remove stale content-length headers. Document that the returned alias does not establish backend identity.

Add focused response, cancellation and accounting integration coverage. Verified with 74 passing focused tests, full typecheck and formatting checks. No heartbeat or timeout behavior is changed.